### PR TITLE
chore: Add missing dependencies to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,23 @@ dependencies = [
     "pydantic>=2.5.0",
     "pydantic-settings>=2.1.0",
     "tenacity>=8.2.0",
-    # Vessel Hull Models dependencies
+    # Data processing and analysis
     "numpy>=1.24.0",
+    "pandas>=2.0.0",
+    "scipy>=1.11.0",
+    # Visualization
     "plotly>=5.18.0",
+    "seaborn>=0.13.0",
+    # HTTP client
+    "httpx>=0.25.0",
+    # PDF generation
+    "reportlab>=4.0.0",
+    # Excel support
+    "openpyxl>=3.1.0",
+    "xlsxwriter>=3.1.0",
+    # Logging
+    "loguru>=0.7.0",
+    # CLI
     "typer>=0.9.0",
     "rich>=13.0.0",
 ]
@@ -61,9 +75,12 @@ test = [
     "pytest-cov>=4.1.0",
     "pytest-asyncio>=0.21.0",
     "pytest-mock>=3.0",
+    "pytest-timeout>=2.4.0",
     "faker>=20.1.0",
     "factory-boy>=3.3.0",
     "psutil>=5.9.0",
+    "responses>=0.24.0",
+    "hypothesis>=6.100.0",
 ]
 docs = [
     "sphinx>=6.0",


### PR DESCRIPTION
## Summary
Adds missing dependencies discovered during test execution to fix collection errors and import failures.

## Core Dependencies Added
- `scipy>=1.11.0` - Statistical analysis (used in marine_safety)
- `pandas>=2.0.0` - Data processing
- `httpx>=0.25.0` - HTTP client for scrapers
- `seaborn>=0.13.0` - Visualization (used in paleowells)
- `reportlab>=4.0.0` - PDF generation (used in audit reports)
- `openpyxl>=3.1.0` - Excel reading
- `xlsxwriter>=3.1.0` - Excel writing
- `loguru>=0.7.0` - Structured logging

## Test Dependencies Added
- `responses>=0.24.0` - HTTP mocking for tests
- `hypothesis>=6.100.0` - Property-based testing
- `pytest-timeout>=2.4.0` - Test timeouts

## Test plan
- [ ] Verify `uv pip install -e .[test]` succeeds
- [ ] Verify test collection completes without import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)