### PR TITLE
refactor: wire DataResolver into all modules (#285)

### DIFF
--- a/src/worldenergydata/bsee/analysis/forecasting/decline_cli.py
+++ b/src/worldenergydata/bsee/analysis/forecasting/decline_cli.py
@@ -21,24 +21,13 @@ from worldenergydata.bsee.analysis.forecasting.decline_analysis import (
 from worldenergydata.bsee.analysis.forecasting.decline_plots import (
     generate_html_report,
 )
+from worldenergydata.common.data_resolver import get_module_data_safe
 
 logger = logging.getLogger(__name__)
 
-# Default paths relative to worldenergydata repo root
-_DEFAULT_PROD_BIN = Path(
-    "data/modules/bsee/bin/production_raw/mv_productionsum.bin"
+_DEFAULT_PROD_BIN = (
+    get_module_data_safe("bsee") / "bin" / "production_raw" / "mv_productionsum.bin"
 )
-
-
-def _find_repo_root() -> Path:
-    """Walk up from this file to find the worldenergydata repo root."""
-    p = Path(__file__).resolve()
-    for parent in p.parents:
-        if (parent / "data" / "modules" / "bsee").is_dir():
-            return parent
-        if (parent / "src" / "worldenergydata").is_dir():
-            return parent
-    return Path.cwd()
 
 
 def _resolve_field_leases(field_name: str) -> list:
@@ -113,8 +102,7 @@ def main(argv=None):
     if args.data_file:
         bin_path = args.data_file
     else:
-        repo_root = _find_repo_root()
-        bin_path = repo_root / _DEFAULT_PROD_BIN
+        bin_path = _DEFAULT_PROD_BIN
 
     production_df = adapter.load_production_binary(bin_path)
     if production_df is None:

--- a/src/worldenergydata/bsee/analysis/forecasting/decline_cli.py
+++ b/src/worldenergydata/bsee/analysis/forecasting/decline_cli.py
@@ -85,9 +85,7 @@ def main(argv=None):
         type=Path,
         help="Path to production .bin file (default: auto-detect)",
     )
-    parser.add_argument(
-        "--verbose", "-v", action="store_true", help="Verbose logging"
-    )
+    parser.add_argument("--verbose", "-v", action="store_true", help="Verbose logging")
 
     args = parser.parse_args(argv)
 

--- a/src/worldenergydata/bsee/data/_legacy/prepare_data_for_analysis.py
+++ b/src/worldenergydata/bsee/data/_legacy/prepare_data_for_analysis.py
@@ -1,9 +1,12 @@
 import os
 import pandas as pd
 
+from worldenergydata.common.data_resolver import get_module_data_safe
 from worldenergydata.common.logging import get_logger
 
 logger = get_logger(__name__)
+
+_BSEE_DATA = str(get_module_data_safe("bsee"))
 
 class PrepareBseeData:
 
@@ -39,7 +42,7 @@ class PrepareBseeData:
         
         merged_df = pd.concat(dataframes, axis=1)
         
-        output_path = os.path.join("data", "modules", "bsee","data_for_analysis", f"{label}.csv")
+        output_path = os.path.join(_BSEE_DATA, "data_for_analysis", f"{label}.csv")
         os.makedirs(os.path.dirname(output_path), exist_ok=True)  
         merged_df.to_csv(output_path, index=False)
 

--- a/src/worldenergydata/bsee/data/_legacy/prepare_data_for_analysis.py
+++ b/src/worldenergydata/bsee/data/_legacy/prepare_data_for_analysis.py
@@ -8,6 +8,7 @@ logger = get_logger(__name__)
 
 _BSEE_DATA = str(get_module_data_safe("bsee"))
 
+
 class PrepareBseeData:
 
     def router(self, cfg):
@@ -16,18 +17,18 @@ class PrepareBseeData:
         config_data = cfg.get("config_data_map", [])
 
         for config in config_data:
-            
+
             label = config["label"]
             files = config["files"]
             output_dfs[label] = self.merge_columns_from_files(cfg, files, label)
-        
+
         return output_dfs
-    
+
     def merge_columns_from_files(self, cfg, files, label):
-        
-        data_dir = cfg['settings']['data_dir']
+
+        data_dir = cfg["settings"]["data_dir"]
         dataframes = []
-        
+
         for file_info in files:
             file_name = file_info["name"]
             columns = file_info["columns"]
@@ -39,14 +40,15 @@ class PrepareBseeData:
                 dataframes.append(df)
             else:
                 logger.warning(f"Warning: File not found - {file_name}")
-        
+
         merged_df = pd.concat(dataframes, axis=1)
-        
+
         output_path = os.path.join(_BSEE_DATA, "data_for_analysis", f"{label}.csv")
-        os.makedirs(os.path.dirname(output_path), exist_ok=True)  
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
         merged_df.to_csv(output_path, index=False)
 
         return merged_df
 
-if __name__ == "__main__": 
+
+if __name__ == "__main__":
     prepare_bsee_data = PrepareBseeData()

--- a/src/worldenergydata/bsee/data/_legacy/production_unclean_code.py
+++ b/src/worldenergydata/bsee/data/_legacy/production_unclean_code.py
@@ -3,6 +3,9 @@
 import pandas as pd
 
 from worldenergydata.common.bsee.retrieve_data_templates import RetrieveDataTemplates
+from worldenergydata.common.data_resolver import get_module_data_safe
+
+_BSEE_DATA = str(get_module_data_safe("bsee"))
 from worldenergydata.bsee.data._legacy.prepare_data_for_analysis import (
     PrepareBseeData,
 )
@@ -65,7 +68,7 @@ class ProductionUncleanCode:
 
         settings = {
             "api12": api12,
-            "files_folder": "data/modules/bsee/production/zip",
+            "files_folder": f"{_BSEE_DATA}/production/zip",
         }
         production_yml["settings"].update(settings)
         production_data = energy_engine(

--- a/src/worldenergydata/bsee/data/enhanced/data_refresh_chunked.py
+++ b/src/worldenergydata/bsee/data/enhanced/data_refresh_chunked.py
@@ -13,6 +13,9 @@ from loguru import logger
 
 # Import chunk manager from cache module
 from worldenergydata.bsee.data.cache import ChunkManager
+from worldenergydata.common.data_resolver import get_module_data_safe
+
+_BSEE_BIN = str(get_module_data_safe("bsee") / "bin")
 from worldenergydata.bsee.data.config import ConfigRouter
 from worldenergydata.bsee.data.processors import MemoryProcessor
 
@@ -331,18 +334,18 @@ class DataRefreshChunked:
             "well": cfg.get("parameters", {})
             .get("filepath", {})
             .get("apm", {})
-            .get("bin", "data/modules/bsee/bin/apd"),
+            .get("bin", f"{_BSEE_BIN}/apd"),
             "production": cfg.get("parameters", {})
             .get("filepath", {})
             .get("production", {})
-            .get("bin", "data/modules/bsee/bin/production_raw"),
+            .get("bin", f"{_BSEE_BIN}/production_raw"),
             "war": cfg.get("parameters", {})
             .get("filepath", {})
             .get("war", {})
-            .get("bin", "data/modules/bsee/bin/war"),
+            .get("bin", f"{_BSEE_BIN}/war"),
         }
 
-        bin_path = path_map.get(data_type, f"data/modules/bsee/bin/{data_type}")
+        bin_path = path_map.get(data_type, f"{_BSEE_BIN}/{data_type}")
 
         # Find project root
         current_dir = Path(__file__).parent

--- a/src/worldenergydata/bsee/data/loaders/api/well.py
+++ b/src/worldenergydata/bsee/data/loaders/api/well.py
@@ -18,6 +18,7 @@ _BSEE_BIN = str(get_module_data_safe("bsee") / "bin")
 wwy = WorkingWithYAML()
 zip_files_to_df = ZipFilestoDf()
 
+
 class WellData:
 
     def __init__(self):
@@ -33,39 +34,53 @@ class WellData:
         BoreholeRawData_df = self.get_BoreholeRawData_from_bin(cfg)
         eWellAPDRawData_df = self.get_eWellAPDRawData_from_bin(cfg)
         eWellEORRawData_df = self.get_eWellEORRawData_from_bin(cfg)
-        eWellWARRawData_mv_war_main_df = self.get_eWellWARRawData_mv_war_main_from_bin(cfg)
-        eWellWARRawData_mv_war_main_prop_df = self.get_eWellWARRawData_mv_war_main_prop_from_bin(cfg)
+        eWellWARRawData_mv_war_main_df = self.get_eWellWARRawData_mv_war_main_from_bin(
+            cfg
+        )
+        eWellWARRawData_mv_war_main_prop_df = (
+            self.get_eWellWARRawData_mv_war_main_prop_from_bin(cfg)
+        )
 
-        bsee_csv_data = {'BoreholeRawData_df': BoreholeRawData_df,
-                         'eWellAPDRawData_df': eWellAPDRawData_df,
-                         'eWellEORRawData_df': eWellEORRawData_df,
-                         'eWellWARRawData_mv_war_main_df': eWellWARRawData_mv_war_main_df,
-                         'eWellWARRawData_mv_war_main_prop_df': eWellWARRawData_mv_war_main_prop_df}
+        bsee_csv_data = {
+            "BoreholeRawData_df": BoreholeRawData_df,
+            "eWellAPDRawData_df": eWellAPDRawData_df,
+            "eWellEORRawData_df": eWellEORRawData_df,
+            "eWellWARRawData_mv_war_main_df": eWellWARRawData_mv_war_main_df,
+            "eWellWARRawData_mv_war_main_prop_df": eWellWARRawData_mv_war_main_prop_df,
+        }
 
-        #TODO assess the need for this data
+        # TODO assess the need for this data
         cfg = self.fetch_well_data(cfg)
         well_data_groups = []
-        for group in cfg[cfg['basename']]['data']['groups'] if 'groups' in cfg[cfg['basename']]['data'] else []:
-            if 'api12' not in group:
+        for group in (
+            cfg[cfg["basename"]]["data"]["groups"]
+            if "groups" in cfg[cfg["basename"]]["data"]
+            else []
+        ):
+            if "api12" not in group:
                 logger.error(f"API12 not found in group: {group}")
-            api12_array = group['api12']
+            api12_array = group["api12"]
             well_data_group = []
             for api12_idx in range(0, len(api12_array)):
-                api12_metadata = group['well_data'][api12_idx].copy()
+                api12_metadata = group["well_data"][api12_idx].copy()
 
-                merged_api12_df = self.get_api12_merged_df_from_all_sources(cfg, bsee_csv_data, api12_metadata)
-                individual_df_data = self.get_api12_data_from_all_sources(cfg, bsee_csv_data, api12_metadata)
+                merged_api12_df = self.get_api12_merged_df_from_all_sources(
+                    cfg, bsee_csv_data, api12_metadata
+                )
+                individual_df_data = self.get_api12_data_from_all_sources(
+                    cfg, bsee_csv_data, api12_metadata
+                )
 
-                api12_metadata.update({'merged_api12_df': merged_api12_df})
+                api12_metadata.update({"merged_api12_df": merged_api12_df})
                 api12_metadata.update(individual_df_data)
 
-                #TODO Other data sources
+                # TODO Other data sources
                 # directional_surveys = self.bsee_data.get_directional_surveys_by_api10(api10)
                 # well_tubulars_data = self.bsee_data.get_well_tubulars_data_by_api10(api10)
                 # completion_data = self.bsee_data.get_completion_data_by_api10(api10)
                 # Maintenance data
                 apm = self.apm_data.get_apm_data(cfg, api12_metadata)
-                api12_metadata.update({'apm': apm})
+                api12_metadata.update({"apm": apm})
 
                 well_data_group.append(api12_metadata)
 
@@ -74,137 +89,184 @@ class WellData:
         return cfg, well_data_groups
 
     def get_api12_merged_df_from_all_sources(self, cfg, bsee_csv_data, api12_metadata):
-        api12 = api12_metadata['api12'][0]
-        BoreholeRawData_df = bsee_csv_data['BoreholeRawData_df']
-        eWellAPDRawData_df = bsee_csv_data['eWellAPDRawData_df']
-        eWellEORRawData_df = bsee_csv_data['eWellEORRawData_df']
-        eWellWARRawData_mv_war_main_df = bsee_csv_data['eWellWARRawData_mv_war_main_df']
-        eWellWARRawData_mv_war_main_prop_df = bsee_csv_data['eWellWARRawData_mv_war_main_prop_df']
+        api12 = api12_metadata["api12"][0]
+        BoreholeRawData_df = bsee_csv_data["BoreholeRawData_df"]
+        eWellAPDRawData_df = bsee_csv_data["eWellAPDRawData_df"]
+        eWellEORRawData_df = bsee_csv_data["eWellEORRawData_df"]
+        eWellWARRawData_mv_war_main_df = bsee_csv_data["eWellWARRawData_mv_war_main_df"]
+        eWellWARRawData_mv_war_main_prop_df = bsee_csv_data[
+            "eWellWARRawData_mv_war_main_prop_df"
+        ]
 
-        api12_well_data = pd.read_csv(api12_metadata['file_name'])
-        api12_eWellEORRawData = eWellEORRawData_df[eWellEORRawData_df['API_WELL_NUMBER'] == api12].copy()
-        api12_eWellWARRawData_mv_war_main = eWellWARRawData_mv_war_main_df[eWellWARRawData_mv_war_main_df['API_WELL_NUMBER'] == api12].copy()
+        api12_well_data = pd.read_csv(api12_metadata["file_name"])
+        api12_eWellEORRawData = eWellEORRawData_df[
+            eWellEORRawData_df["API_WELL_NUMBER"] == api12
+        ].copy()
+        api12_eWellWARRawData_mv_war_main = eWellWARRawData_mv_war_main_df[
+            eWellWARRawData_mv_war_main_df["API_WELL_NUMBER"] == api12
+        ].copy()
         # api12_eWellWARRawData_mv_war_main_prop = eWellWARRawData_mv_war_main_prop_df[eWellWARRawData_mv_war_main_prop_df['API_WELL_NUMBER'] == api12].copy()
 
-        Borehole_apd_df = self.get_Borehole_apd_for_all_wells(BoreholeRawData_df, eWellAPDRawData_df)
-        api12_Borehole_apd = self.get_Borehole_apd_for_api12(cfg, Borehole_apd_df, api12)
+        Borehole_apd_df = self.get_Borehole_apd_for_all_wells(
+            BoreholeRawData_df, eWellAPDRawData_df
+        )
+        api12_Borehole_apd = self.get_Borehole_apd_for_api12(
+            cfg, Borehole_apd_df, api12
+        )
 
         # Merge all dataframes
-        api12_df = pd.merge(api12_Borehole_apd, api12_well_data, how='inner' ,
-                                    left_on=['API_WELL_NUMBER'], right_on=['API Well Number'])
-        api12_df = pd.merge(api12_eWellEORRawData, api12_df, how='outer' ,
-                                    left_on=['API_WELL_NUMBER'], right_on=['API Well Number'])
+        api12_df = pd.merge(
+            api12_Borehole_apd,
+            api12_well_data,
+            how="inner",
+            left_on=["API_WELL_NUMBER"],
+            right_on=["API Well Number"],
+        )
+        api12_df = pd.merge(
+            api12_eWellEORRawData,
+            api12_df,
+            how="outer",
+            left_on=["API_WELL_NUMBER"],
+            right_on=["API Well Number"],
+        )
         api12_df = self.pd_merge_clean_column_names(api12_df)
 
-        api12_df = pd.merge(api12_eWellWARRawData_mv_war_main, api12_df, how='outer' ,
-                                    left_on=['API_WELL_NUMBER'], right_on=['API Well Number'])
+        api12_df = pd.merge(
+            api12_eWellWARRawData_mv_war_main,
+            api12_df,
+            how="outer",
+            left_on=["API_WELL_NUMBER"],
+            right_on=["API Well Number"],
+        )
         api12_df = self.pd_merge_clean_column_names(api12_df)
 
-        api12_df = pd.merge(api12_df, eWellWARRawData_mv_war_main_prop_df, how='left' ,
-                                    left_on=['SN_WAR'], right_on=['SN_WAR'])
+        api12_df = pd.merge(
+            api12_df,
+            eWellWARRawData_mv_war_main_prop_df,
+            how="left",
+            left_on=["SN_WAR"],
+            right_on=["SN_WAR"],
+        )
         api12_df = self.pd_merge_clean_column_names(api12_df)
 
         return api12_df
 
     def get_api12_data_from_all_sources(self, cfg, bsee_csv_data, api12_metadata):
-        api12 = api12_metadata['api12'][0]
-        api12_df = pd.read_csv(api12_metadata['file_name'])
+        api12 = api12_metadata["api12"][0]
+        api12_df = pd.read_csv(api12_metadata["file_name"])
 
-        BoreholeRawData_df = bsee_csv_data['BoreholeRawData_df']
-        eWellAPDRawData_df = bsee_csv_data['eWellAPDRawData_df']
-        eWellEORRawData_df = bsee_csv_data['eWellEORRawData_df']
-        eWellWARRawData_mv_war_main_df = bsee_csv_data['eWellWARRawData_mv_war_main_df']
-        eWellWARRawData_mv_war_main_prop_df = bsee_csv_data['eWellWARRawData_mv_war_main_prop_df']
+        BoreholeRawData_df = bsee_csv_data["BoreholeRawData_df"]
+        eWellAPDRawData_df = bsee_csv_data["eWellAPDRawData_df"]
+        eWellEORRawData_df = bsee_csv_data["eWellEORRawData_df"]
+        eWellWARRawData_mv_war_main_df = bsee_csv_data["eWellWARRawData_mv_war_main_df"]
+        eWellWARRawData_mv_war_main_prop_df = bsee_csv_data[
+            "eWellWARRawData_mv_war_main_prop_df"
+        ]
 
         datasets = {
-            'api12_BoreholeRawData': BoreholeRawData_df,
-            'api12_eWellAPDRawData': eWellAPDRawData_df,
-            'api12_eWellEORRawData': eWellEORRawData_df,
-            'api12_eWellWARRawData_mv_war_main': eWellWARRawData_mv_war_main_df
+            "api12_BoreholeRawData": BoreholeRawData_df,
+            "api12_eWellAPDRawData": eWellAPDRawData_df,
+            "api12_eWellEORRawData": eWellEORRawData_df,
+            "api12_eWellWARRawData_mv_war_main": eWellWARRawData_mv_war_main_df,
         }
-        data = {'api12_df': api12_df}
+        data = {"api12_df": api12_df}
 
         # Filter dataframes by API12 which are not empty
         for key, df in datasets.items():
-            filtered_df = df[df['API_WELL_NUMBER'] == api12].copy()
+            filtered_df = df[df["API_WELL_NUMBER"] == api12].copy()
             data[key] = filtered_df
 
         # Handling api12_eWellWARRawData_mv_war_main_prop separately since it depends on another dataset
-        if 'api12_eWellWARRawData_mv_war_main' in data:
-            api12_eWellWARRawData_mv_war_main_prop = eWellWARRawData_mv_war_main_prop_df[
-                eWellWARRawData_mv_war_main_prop_df['SN_WAR'].isin(data['api12_eWellWARRawData_mv_war_main']['SN_WAR'])
-            ]
-            data['api12_eWellWARRawData_mv_war_main_prop'] = api12_eWellWARRawData_mv_war_main_prop
+        if "api12_eWellWARRawData_mv_war_main" in data:
+            api12_eWellWARRawData_mv_war_main_prop = (
+                eWellWARRawData_mv_war_main_prop_df[
+                    eWellWARRawData_mv_war_main_prop_df["SN_WAR"].isin(
+                        data["api12_eWellWARRawData_mv_war_main"]["SN_WAR"]
+                    )
+                ]
+            )
+            data["api12_eWellWARRawData_mv_war_main_prop"] = (
+                api12_eWellWARRawData_mv_war_main_prop
+            )
 
         return data
 
     def get_Borehole_apd_for_all_wells(self, BoreholeRawData_df, eWellAPDRawData_df):
 
-        self.Borehole_apd_df = self.get_merged_data(BoreholeRawData_df, eWellAPDRawData_df)
+        self.Borehole_apd_df = self.get_merged_data(
+            BoreholeRawData_df, eWellAPDRawData_df
+        )
 
         return self.Borehole_apd_df
 
     def get_Borehole_apd_for_api12(self, cfg, Borehole_apd_df, api12):
-        api12_Borehole_apd = Borehole_apd_df[Borehole_apd_df['API_WELL_NUMBER'] == api12].copy()
-
+        api12_Borehole_apd = Borehole_apd_df[
+            Borehole_apd_df["API_WELL_NUMBER"] == api12
+        ].copy()
 
         return api12_Borehole_apd
 
     def fetch_well_data(self, cfg):
-        cfg[cfg['basename']]['data'].update({'type': 'csv'})
+        cfg[cfg["basename"]]["data"].update({"type": "csv"})
         cfg = self.fetch_well_data_from_local_files(cfg)
 
         return cfg
 
     def fetch_well_data_from_local_files(self, cfg):
-        groups = cfg[cfg['basename']]['data']['groups'] if 'groups' in cfg[cfg['basename']]['data'] else []
+        groups = (
+            cfg[cfg["basename"]]["data"]["groups"]
+            if "groups" in cfg[cfg["basename"]]["data"]
+            else []
+        )
         api_data = APIData()
 
         for group_idx in range(0, len(groups)):
             group = groups[group_idx]
-            api12_array = group.get('api12', [])  # Get API numbers list
+            api12_array = group.get("api12", [])  # Get API numbers list
 
             api12_group_output = []
             for api12_idx in range(0, len(api12_array)):
                 api12 = api12_array[api12_idx]
-                api12_meta_data = {'api12': [api12], 'label': str(api12)}
+                api12_meta_data = {"api12": [api12], "label": str(api12)}
 
                 api_data.router(cfg, api12_meta_data)
                 api12_output_cfg = self.generate_output_item(cfg, api12_meta_data)
                 api12_group_output.append(api12_output_cfg)
 
-            cfg[cfg['basename']]['data']['groups'][group_idx].update({'well_data': api12_group_output})
+            cfg[cfg["basename"]]["data"]["groups"][group_idx].update(
+                {"well_data": api12_group_output}
+            )
 
         return cfg
 
     def generate_output_item(self, cfg, input_item):
 
-        label = input_item['label']
-        output_path = os.path.join(cfg['Analysis']['result_folder'], 'Data')
+        label = input_item["label"]
+        output_path = os.path.join(cfg["Analysis"]["result_folder"], "Data")
         if output_path is None:
-            result_folder = cfg['Analysis']['result_folder']
-            output_path = os.path.join(result_folder, 'Data')
+            result_folder = cfg["Analysis"]["result_folder"]
+            output_path = os.path.join(result_folder, "Data")
 
-        analysis_root_folder = cfg['Analysis']['analysis_root_folder']
+        analysis_root_folder = cfg["Analysis"]["analysis_root_folder"]
         is_dir_valid, output_path = is_dir_valid_func(output_path, analysis_root_folder)
 
-        output_file = os.path.join(output_path, str(label) + '.csv')
+        output_file = os.path.join(output_path, str(label) + ".csv")
 
         input_item_csv_cfg = deepcopy(input_item)
-        input_item_csv_cfg.update({'label': label, 'file_name': output_file})
+        input_item_csv_cfg.update({"label": label, "file_name": output_file})
         output_data = input_item_csv_cfg
 
         return output_data
 
     def get_BoreholeRawData_from_bin(self, cfg):
 
-        file_name = 'mv_boreholes_all.bin'
+        file_name = "mv_boreholes_all.bin"
 
-        library_name = 'worldenergydata'
+        library_name = "worldenergydata"
         library_file_cfg = {
-            'filename': f"{_BSEE_BIN}/borehole/{file_name}",
-            'library_name': library_name,
-            'repository_path': None
+            "filename": f"{_BSEE_BIN}/borehole/{file_name}",
+            "library_name": library_name,
+            "repository_path": None,
         }
 
         file_is_valid, file_name = get_repository_filename(library_file_cfg)
@@ -212,19 +274,19 @@ class WellData:
 
         if file_is_valid:
             df = pd.read_pickle(file_name)
-            borehole_codes = cfg['parameters']['borehole_codes']
+            borehole_codes = cfg["parameters"]["borehole_codes"]
 
-            BOREHOLE_STAT_CD = df['BOREHOLE_STAT_CD']
+            BOREHOLE_STAT_CD = df["BOREHOLE_STAT_CD"]
 
-            df['BOREHOLE_STAT_DESC'] = None
-            BOREHOLE_STAT_DESC = [None]*len(BOREHOLE_STAT_CD)
+            df["BOREHOLE_STAT_DESC"] = None
+            BOREHOLE_STAT_DESC = [None] * len(BOREHOLE_STAT_CD)
             for idx in range(0, len(BOREHOLE_STAT_CD)):
                 code = BOREHOLE_STAT_CD.iloc[idx]
                 for item in borehole_codes:
-                    if code == item['BOREHOLE_STAT_CD']:
-                        BOREHOLE_STAT_DESC[idx] = item['BOREHOLE_STAT_DESC']
+                    if code == item["BOREHOLE_STAT_CD"]:
+                        BOREHOLE_STAT_DESC[idx] = item["BOREHOLE_STAT_DESC"]
 
-            df['BOREHOLE_STAT_DESC'] = BOREHOLE_STAT_DESC
+            df["BOREHOLE_STAT_DESC"] = BOREHOLE_STAT_DESC
         else:
             raise Exception(f"File not found: {file_name}")
 
@@ -232,13 +294,13 @@ class WellData:
 
     def get_eWellEORRawData_from_bin(self, cfg):
 
-        file_name = 'mv_eor_mainquery.bin'
+        file_name = "mv_eor_mainquery.bin"
 
-        library_name = 'worldenergydata'
+        library_name = "worldenergydata"
         library_file_cfg = {
-            'filename': f"{_BSEE_BIN}/eor/{file_name}",
-            'library_name': library_name,
-            'repository_path': None
+            "filename": f"{_BSEE_BIN}/eor/{file_name}",
+            "library_name": library_name,
+            "repository_path": None,
         }
 
         file_is_valid, file_name = get_repository_filename(library_file_cfg)
@@ -253,13 +315,13 @@ class WellData:
     def get_eWellAPDRawData_from_bin(self, cfg):
 
         # Load CSV files
-        file_name = 'mv_apd_main.bin'
+        file_name = "mv_apd_main.bin"
 
-        library_name = 'worldenergydata'
+        library_name = "worldenergydata"
         library_file_cfg = {
-            'filename': f"{_BSEE_BIN}/ewellapd/{file_name}",
-            'library_name': library_name,
-            'repository_path': None
+            "filename": f"{_BSEE_BIN}/ewellapd/{file_name}",
+            "library_name": library_name,
+            "repository_path": None,
         }
 
         file_is_valid, file_name = get_repository_filename(library_file_cfg)
@@ -274,13 +336,13 @@ class WellData:
     def get_eWellWARRawData_mv_war_main_from_bin(self, cfg):
 
         # Load CSV files
-        file_name = 'mv_war_main.bin'
+        file_name = "mv_war_main.bin"
 
-        library_name = 'worldenergydata'
+        library_name = "worldenergydata"
         library_file_cfg = {
-            'filename': f"{_BSEE_BIN}/war/{file_name}",
-            'library_name': library_name,
-            'repository_path': None
+            "filename": f"{_BSEE_BIN}/war/{file_name}",
+            "library_name": library_name,
+            "repository_path": None,
         }
 
         file_is_valid, file_name = get_repository_filename(library_file_cfg)
@@ -295,13 +357,13 @@ class WellData:
     def get_eWellWARRawData_mv_war_main_prop_from_bin(self, cfg):
 
         # Load CSV files
-        file_name = 'mv_war_main_prop.bin'
+        file_name = "mv_war_main_prop.bin"
 
-        library_name = 'worldenergydata'
+        library_name = "worldenergydata"
         library_file_cfg = {
-            'filename': f"{_BSEE_BIN}/war/{file_name}",
-            'library_name': library_name,
-            'repository_path': None
+            "filename": f"{_BSEE_BIN}/war/{file_name}",
+            "library_name": library_name,
+            "repository_path": None,
         }
 
         file_is_valid, file_name = get_repository_filename(library_file_cfg)
@@ -326,8 +388,8 @@ class WellData:
         return merged_df
 
     def pd_merge_clean_column_names(self, merged_df):
-        merged_df = merged_df.loc[:, ~merged_df.columns.str.endswith('_y')]
-        merged_df.columns = merged_df.columns.str.replace('_x', '', regex=True)
+        merged_df = merged_df.loc[:, ~merged_df.columns.str.endswith("_y")]
+        merged_df.columns = merged_df.columns.str.replace("_x", "", regex=True)
         return merged_df
 
     # Old methods that are not used anymore, but kept for reference
@@ -355,20 +417,22 @@ class WellData:
 
     def get_eWellAPMRawData_from_zip(self, cfg):
 
-        columns = [MMS_COMPANY_NUM,
-                    API_WELL_NUMBER,
-                    WATER_DEPTH,
-                    WELL_NM_BP_SFIX,
-                    WELL_NM_ST_SFIX,
-                    SURF_AREA_CODE,
-                    SURF_BLOCK_NUM,
-                    SURF_LEASE_NUM,
-                    BOTM_AREA_CODE,
-                    BOTM_BLOCK_NUM,
-                    BOTM_LEASE_NUM,
-                    RIG_ID_NUM,
-                    BOREHOLE_STAT_CD,
-                    WELL_TYPE_CODE,
-                    BUS_ASC_NAME]
+        columns = [
+            MMS_COMPANY_NUM,
+            API_WELL_NUMBER,
+            WATER_DEPTH,
+            WELL_NM_BP_SFIX,
+            WELL_NM_ST_SFIX,
+            SURF_AREA_CODE,
+            SURF_BLOCK_NUM,
+            SURF_LEASE_NUM,
+            BOTM_AREA_CODE,
+            BOTM_BLOCK_NUM,
+            BOTM_LEASE_NUM,
+            RIG_ID_NUM,
+            BOREHOLE_STAT_CD,
+            WELL_TYPE_CODE,
+            BUS_ASC_NAME,
+        ]
 
-        #TODO
+        # TODO

--- a/src/worldenergydata/bsee/data/loaders/api/well.py
+++ b/src/worldenergydata/bsee/data/loaders/api/well.py
@@ -11,6 +11,10 @@ from assetutilities.common.yml_utilities import WorkingWithYAML  # noqa
 from assetutilities.modules.zip_utilities.zip_files_to_dataframe import ZipFilestoDf
 from assetutilities.common.utilities import get_repository_filename
 
+from worldenergydata.common.data_resolver import get_module_data_safe
+
+_BSEE_BIN = str(get_module_data_safe("bsee") / "bin")
+
 wwy = WorkingWithYAML()
 zip_files_to_df = ZipFilestoDf()
 
@@ -198,7 +202,7 @@ class WellData:
 
         library_name = 'worldenergydata'
         library_file_cfg = {
-            'filename': f"data/modules/bsee/bin/borehole/{file_name}",
+            'filename': f"{_BSEE_BIN}/borehole/{file_name}",
             'library_name': library_name,
             'repository_path': None
         }
@@ -232,7 +236,7 @@ class WellData:
 
         library_name = 'worldenergydata'
         library_file_cfg = {
-            'filename': f"data/modules/bsee/bin/eor/{file_name}",
+            'filename': f"{_BSEE_BIN}/eor/{file_name}",
             'library_name': library_name,
             'repository_path': None
         }
@@ -253,7 +257,7 @@ class WellData:
 
         library_name = 'worldenergydata'
         library_file_cfg = {
-            'filename': f"data/modules/bsee/bin/ewellapd/{file_name}",
+            'filename': f"{_BSEE_BIN}/ewellapd/{file_name}",
             'library_name': library_name,
             'repository_path': None
         }
@@ -274,7 +278,7 @@ class WellData:
 
         library_name = 'worldenergydata'
         library_file_cfg = {
-            'filename': f"data/modules/bsee/bin/war/{file_name}",
+            'filename': f"{_BSEE_BIN}/war/{file_name}",
             'library_name': library_name,
             'repository_path': None
         }
@@ -295,7 +299,7 @@ class WellData:
 
         library_name = 'worldenergydata'
         library_file_cfg = {
-            'filename': f"data/modules/bsee/bin/war/{file_name}",
+            'filename': f"{_BSEE_BIN}/war/{file_name}",
             'library_name': library_name,
             'repository_path': None
         }

--- a/src/worldenergydata/bsee/data/loaders/company/company_loader.py
+++ b/src/worldenergydata/bsee/data/loaders/company/company_loader.py
@@ -20,9 +20,11 @@ from typing import Optional, Union
 
 import pandas as pd
 
+from worldenergydata.common.data_resolver import get_module_data_safe
+
 logger = logging.getLogger(__name__)
 
-_DEFAULT_BIN_DIR = "data/modules/bsee/bin/companydetails"
+_DEFAULT_BIN_DIR = str(get_module_data_safe("bsee") / "bin" / "companydetails")
 
 _REGION_COL_MAP = {
     "GOM": "GOM_REGION_CODE",

--- a/src/worldenergydata/bsee/data/loaders/infrastructure/pipeline_loader.py
+++ b/src/worldenergydata/bsee/data/loaders/infrastructure/pipeline_loader.py
@@ -18,8 +18,12 @@ class PipelineLoader:
     def __init__(self):
         self.permit_data: Optional[pd.DataFrame] = None
         self.location_data: Optional[pd.DataFrame] = None
-        self._permit_bin_dir = str(get_module_data_safe("bsee") / "bin" / "pipeline_permit")
-        self._location_bin_dir = str(get_module_data_safe("bsee") / "bin" / "pipeline_location")
+        self._permit_bin_dir = str(
+            get_module_data_safe("bsee") / "bin" / "pipeline_permit"
+        )
+        self._location_bin_dir = str(
+            get_module_data_safe("bsee") / "bin" / "pipeline_location"
+        )
 
     def _load_permit_data(self, cfg: Optional[Dict] = None) -> Optional[pd.DataFrame]:
         """Load pipeline permit data from binary file."""

--- a/src/worldenergydata/bsee/data/loaders/infrastructure/pipeline_loader.py
+++ b/src/worldenergydata/bsee/data/loaders/infrastructure/pipeline_loader.py
@@ -9,6 +9,8 @@ from typing import Dict, Optional
 import pandas as pd
 from loguru import logger
 
+from worldenergydata.common.data_resolver import get_module_data_safe
+
 
 class PipelineLoader:
     """Load pipeline permit and location data from binary files."""
@@ -16,8 +18,8 @@ class PipelineLoader:
     def __init__(self):
         self.permit_data: Optional[pd.DataFrame] = None
         self.location_data: Optional[pd.DataFrame] = None
-        self._permit_bin_dir = "data/modules/bsee/bin/pipeline_permit"
-        self._location_bin_dir = "data/modules/bsee/bin/pipeline_location"
+        self._permit_bin_dir = str(get_module_data_safe("bsee") / "bin" / "pipeline_permit")
+        self._location_bin_dir = str(get_module_data_safe("bsee") / "bin" / "pipeline_location")
 
     def _load_permit_data(self, cfg: Optional[Dict] = None) -> Optional[pd.DataFrame]:
         """Load pipeline permit data from binary file."""

--- a/src/worldenergydata/bsee/data/loaders/infrastructure/platform_loader.py
+++ b/src/worldenergydata/bsee/data/loaders/infrastructure/platform_loader.py
@@ -9,13 +9,15 @@ from typing import Dict, Optional
 import pandas as pd
 from loguru import logger
 
+from worldenergydata.common.data_resolver import get_module_data_safe
+
 
 class PlatformLoader:
     """Load platform structure data from binary files."""
 
     def __init__(self):
         self.data: Optional[pd.DataFrame] = None
-        self._bin_dir = "data/modules/bsee/bin/platform"
+        self._bin_dir = str(get_module_data_safe("bsee") / "bin" / "platform")
 
     def _load_data(self, cfg: Optional[Dict] = None) -> Optional[pd.DataFrame]:
         """Load platform data from binary file."""

--- a/src/worldenergydata/bsee/data/loaders/production/production_loader.py
+++ b/src/worldenergydata/bsee/data/loaders/production/production_loader.py
@@ -21,9 +21,11 @@ from typing import Any, Dict, Optional, Union
 
 import pandas as pd
 
+from worldenergydata.common.data_resolver import get_module_data_safe
+
 logger = logging.getLogger(__name__)
 
-_DEFAULT_BIN_DIR = "data/modules/bsee/bin/production_raw"
+_DEFAULT_BIN_DIR = str(get_module_data_safe("bsee") / "bin" / "production_raw")
 
 
 class ProductionLoader:

--- a/src/worldenergydata/bsee/data/loaders/rig_fleet/rig_fleet_loader.py
+++ b/src/worldenergydata/bsee/data/loaders/rig_fleet/rig_fleet_loader.py
@@ -87,9 +87,7 @@ class RigFleetLoader:
             return self.data
         return None
 
-    def build_fleet_from_war(
-        self, war_df: pd.DataFrame
-    ) -> pd.DataFrame:
+    def build_fleet_from_war(self, war_df: pd.DataFrame) -> pd.DataFrame:
         """Extract unique rigs from WAR data and build fleet inventory.
 
         Args:
@@ -138,9 +136,7 @@ class RigFleetLoader:
         if agg_dict:
             fleet_df = filtered.groupby("RIG_NAME", as_index=False).agg(agg_dict)
         else:
-            fleet_df = (
-                filtered[["RIG_NAME"]].drop_duplicates().reset_index(drop=True)
-            )
+            fleet_df = filtered[["RIG_NAME"]].drop_duplicates().reset_index(drop=True)
 
         # Rename aggregated columns to domain-meaningful names
         rename_map = {
@@ -271,8 +267,6 @@ class RigFleetLoader:
         """
         if "RIG_NAME" not in war_df.columns:
             return None
-        mask = (
-            war_df["RIG_NAME"].str.strip().str.upper() == rig_name.strip().upper()
-        )
+        mask = war_df["RIG_NAME"].str.strip().str.upper() == rig_name.strip().upper()
         result = war_df[mask]
         return result if not result.empty else None

--- a/src/worldenergydata/bsee/data/loaders/rig_fleet/rig_fleet_loader.py
+++ b/src/worldenergydata/bsee/data/loaders/rig_fleet/rig_fleet_loader.py
@@ -12,6 +12,9 @@ from loguru import logger
 from worldenergydata.bsee.data.loaders.rig_fleet.constants import (
     classify_rig_type,
 )
+from worldenergydata.common.data_resolver import get_module_data_safe
+
+_BSEE_DATA = get_module_data_safe("bsee")
 
 
 class RigFleetLoader:
@@ -19,8 +22,8 @@ class RigFleetLoader:
 
     def __init__(self):
         self.data: Optional[pd.DataFrame] = None
-        self._bin_dir = "data/modules/bsee/bin/rig_fleet"
-        self._local_dir = "data/modules/bsee/.local/rig_fleet"
+        self._bin_dir = str(_BSEE_DATA / "bin" / "rig_fleet")
+        self._local_dir = str(_BSEE_DATA / ".local" / "rig_fleet")
 
     def _load_data(self, cfg: Optional[Dict] = None) -> Optional[pd.DataFrame]:
         """Load rig fleet data from binary file.

--- a/src/worldenergydata/bsee/data/loaders/rig_fleet/war_acquirer.py
+++ b/src/worldenergydata/bsee/data/loaders/rig_fleet/war_acquirer.py
@@ -71,9 +71,7 @@ class WARDataAcquirer:
             return None
 
         merged = pd.concat(dataframes.values(), ignore_index=True)
-        logger.info(
-            f"Merged {len(dataframes)} WAR files -> {len(merged)} total rows"
-        )
+        logger.info(f"Merged {len(dataframes)} WAR files -> {len(merged)} total rows")
 
         return self._normalize_columns(merged)
 
@@ -84,9 +82,7 @@ class WARDataAcquirer:
         columns are silently skipped.
         """
         rename = {
-            old: new
-            for old, new in _COLUMN_RENAME_MAP.items()
-            if old in df.columns
+            old: new for old, new in _COLUMN_RENAME_MAP.items() if old in df.columns
         }
         if rename:
             df = df.rename(columns=rename)
@@ -120,9 +116,7 @@ class WARDataAcquirer:
             try:
                 meta = json.loads(meta_file.read_text())
                 downloaded_at = datetime.fromisoformat(meta["downloaded_at"])
-                age_days = (
-                    datetime.now(tz=timezone.utc) - downloaded_at
-                ).days
+                age_days = (datetime.now(tz=timezone.utc) - downloaded_at).days
                 if age_days > _CACHE_MAX_AGE_DAYS:
                     logger.info(
                         f"Cached WAR data is {age_days} days old "

--- a/src/worldenergydata/bsee/data/loaders/rig_fleet/war_acquirer.py
+++ b/src/worldenergydata/bsee/data/loaders/rig_fleet/war_acquirer.py
@@ -15,12 +15,9 @@ from typing import Optional
 import pandas as pd
 from loguru import logger
 
-from worldenergydata.common.data_resolver import DataNotFoundError, get_module_data
+from worldenergydata.common.data_resolver import get_module_data_safe
 
-try:
-    _DEFAULT_LOCAL_DIR = get_module_data("bsee") / ".local"
-except DataNotFoundError:
-    _DEFAULT_LOCAL_DIR = Path("data/modules/bsee/.local")
+_DEFAULT_LOCAL_DIR = get_module_data_safe("bsee") / ".local"
 
 # Column rename map: WAR raw names -> standardised names
 _COLUMN_RENAME_MAP: dict[str, str] = {

--- a/src/worldenergydata/bsee/data/loaders/well/borehole_acquirer.py
+++ b/src/worldenergydata/bsee/data/loaders/well/borehole_acquirer.py
@@ -20,12 +20,9 @@ from loguru import logger
 from worldenergydata.bsee.data.utils.api_well_normalizer import (
     normalize_api_well_number,
 )
-from worldenergydata.common.data_resolver import DataNotFoundError, get_module_data
+from worldenergydata.common.data_resolver import get_module_data_safe
 
-try:
-    _DEFAULT_LOCAL_DIR = get_module_data("bsee") / ".local"
-except DataNotFoundError:
-    _DEFAULT_LOCAL_DIR = Path("data/modules/bsee/.local")
+_DEFAULT_LOCAL_DIR = get_module_data_safe("bsee") / ".local"
 _CACHE_FILENAME = "BoreholeRawData.zip"
 _CACHE_MAX_AGE_DAYS = 30
 _SOURCE_URL = "https://www.data.bsee.gov/Well/Files/BoreholeRawData.zip"

--- a/src/worldenergydata/bsee/data/loaders/well/borehole_acquirer.py
+++ b/src/worldenergydata/bsee/data/loaders/well/borehole_acquirer.py
@@ -130,9 +130,7 @@ class BoreholeDataAcquirer:
         df = df[keep].copy()
 
         # Normalize API_WELL_NUMBER to string
-        df["API_WELL_NUMBER"] = normalize_api_well_number(
-            df["API_WELL_NUMBER"]
-        )
+        df["API_WELL_NUMBER"] = normalize_api_well_number(df["API_WELL_NUMBER"])
 
         # Parse dates
         for col in ("WELL_SPUD_DATE", "TOTAL_DEPTH_DATE"):
@@ -144,9 +142,7 @@ class BoreholeDataAcquirer:
         # Numeric columns to float32
         for col in ("BH_TOTAL_MD", "WELL_BORE_TVD", "WATER_DEPTH"):
             if col in df.columns:
-                df[col] = pd.to_numeric(df[col], errors="coerce").astype(
-                    "float32"
-                )
+                df[col] = pd.to_numeric(df[col], errors="coerce").astype("float32")
 
         # Coordinates to float
         for col in (
@@ -177,9 +173,7 @@ class BoreholeDataAcquirer:
             try:
                 meta = json.loads(meta_file.read_text())
                 downloaded_at = datetime.fromisoformat(meta["downloaded_at"])
-                age_days = (
-                    datetime.now(tz=timezone.utc) - downloaded_at
-                ).days
+                age_days = (datetime.now(tz=timezone.utc) - downloaded_at).days
                 if age_days > _CACHE_MAX_AGE_DAYS:
                     logger.info(
                         f"Cached borehole data is {age_days} days old "
@@ -205,6 +199,4 @@ class BoreholeDataAcquirer:
         }
         meta_file = self._cache_dir / "download_metadata.json"
         meta_file.write_text(json.dumps(meta, indent=2))
-        logger.info(
-            f"Cached borehole zip ({len(zip_data)} bytes) to {cache_file}"
-        )
+        logger.info(f"Cached borehole zip ({len(zip_data)} bytes) to {cache_file}")

--- a/src/worldenergydata/bsee/data/refresh/data_refresh_enhanced.py
+++ b/src/worldenergydata/bsee/data/refresh/data_refresh_enhanced.py
@@ -21,6 +21,9 @@ from typing import Any, Dict
 from loguru import logger
 
 from worldenergydata.bsee.data.config import ConfigRouter
+from worldenergydata.common.data_resolver import get_module_data_safe
+
+_BSEE_BIN = str(get_module_data_safe("bsee") / "bin")
 from worldenergydata.bsee.data.processors import MemoryProcessor
 
 # Import the new components
@@ -458,7 +461,7 @@ class DataRefreshEnhanced:
                 cfg.get("parameters", {})
                 .get("filepath", {})
                 .get("apm", {})
-                .get("bin", "data/modules/bsee/bin/apd")
+                .get("bin", f"{_BSEE_BIN}/apd")
             )
 
             # Convert to absolute path relative to project root
@@ -500,7 +503,7 @@ class DataRefreshEnhanced:
                 cfg.get("parameters", {})
                 .get("filepath", {})
                 .get("war", {})
-                .get("bin", "data/modules/bsee/bin/war")
+                .get("bin", f"{_BSEE_BIN}/war")
             )
 
             # Convert to absolute path relative to project root
@@ -542,7 +545,7 @@ class DataRefreshEnhanced:
                 cfg.get("parameters", {})
                 .get("filepath", {})
                 .get("production", {})
-                .get("bin", "data/modules/bsee/bin/production_raw")
+                .get("bin", f"{_BSEE_BIN}/production_raw")
             )
 
             # Convert to absolute path relative to project root
@@ -771,7 +774,7 @@ class DataRefreshEnhanced:
                 cfg.get("parameters", {})
                 .get("filepath", {})
                 .get("platform", {})
-                .get("bin", "data/modules/bsee/bin/platform")
+                .get("bin", f"{_BSEE_BIN}/platform")
             )
             current_dir = Path(__file__).parent
             while current_dir != current_dir.parent:
@@ -797,7 +800,7 @@ class DataRefreshEnhanced:
                 cfg.get("parameters", {})
                 .get("filepath", {})
                 .get("pipeline_permit", {})
-                .get("bin", "data/modules/bsee/bin/pipeline_permit")
+                .get("bin", f"{_BSEE_BIN}/pipeline_permit")
             )
             current_dir = Path(__file__).parent
             while current_dir != current_dir.parent:
@@ -825,7 +828,7 @@ class DataRefreshEnhanced:
                 cfg.get("parameters", {})
                 .get("filepath", {})
                 .get("deepwater_structure", {})
-                .get("bin", "data/modules/bsee/bin/deepwater_structure")
+                .get("bin", f"{_BSEE_BIN}/deepwater_structure")
             )
             current_dir = Path(__file__).parent
             while current_dir != current_dir.parent:
@@ -853,7 +856,7 @@ class DataRefreshEnhanced:
                 cfg.get("parameters", {})
                 .get("filepath", {})
                 .get("pipeline_location", {})
-                .get("bin", "data/modules/bsee/bin/pipeline_location")
+                .get("bin", f"{_BSEE_BIN}/pipeline_location")
             )
             current_dir = Path(__file__).parent
             while current_dir != current_dir.parent:

--- a/src/worldenergydata/bsee/data/sources/zip/deepwater_structure_data.py
+++ b/src/worldenergydata/bsee/data/sources/zip/deepwater_structure_data.py
@@ -6,6 +6,10 @@ from typing import Any, Dict
 
 from loguru import logger
 
+from worldenergydata.common.data_resolver import get_module_data_safe
+
+_BSEE_BIN = str(get_module_data_safe("bsee") / "bin")
+
 
 class DeepwaterStructureDataFromZip:
     """Load and process deepwater structure data from ZIP files."""
@@ -53,7 +57,7 @@ class DeepwaterStructureDataFromZip:
                         cfg.get("parameters", {})
                         .get("filepath", {})
                         .get("deepwater_structure", {})
-                        .get("bin", "data/modules/bsee/bin/deepwater_structure")
+                        .get("bin", f"{_BSEE_BIN}/deepwater_structure")
                     )
                     processor.save_to_binary(
                         processed, bin_path, "deepwater_structure_data"

--- a/src/worldenergydata/bsee/data/sources/zip/pipeline_data.py
+++ b/src/worldenergydata/bsee/data/sources/zip/pipeline_data.py
@@ -6,6 +6,10 @@ from typing import Any, Dict
 
 from loguru import logger
 
+from worldenergydata.common.data_resolver import get_module_data_safe
+
+_BSEE_BIN = str(get_module_data_safe("bsee") / "bin")
+
 
 class PipelinePermitDataFromZip:
     """Load and process pipeline permit data from ZIP files."""
@@ -54,7 +58,7 @@ class PipelinePermitDataFromZip:
                         cfg.get("parameters", {})
                         .get("filepath", {})
                         .get("pipeline_permit", {})
-                        .get("bin", "data/modules/bsee/bin/pipeline_permit")
+                        .get("bin", f"{_BSEE_BIN}/pipeline_permit")
                     )
                     processor.save_to_binary(
                         processed, bin_path, "pipeline_permit_data"

--- a/src/worldenergydata/bsee/data/sources/zip/pipeline_location_data.py
+++ b/src/worldenergydata/bsee/data/sources/zip/pipeline_location_data.py
@@ -6,6 +6,10 @@ from typing import Any, Dict
 
 from loguru import logger
 
+from worldenergydata.common.data_resolver import get_module_data_safe
+
+_BSEE_BIN = str(get_module_data_safe("bsee") / "bin")
+
 
 class PipelineLocationDataFromZip:
     """Load and process pipeline location data from ZIP files."""
@@ -45,7 +49,7 @@ class PipelineLocationDataFromZip:
                         cfg.get("parameters", {})
                         .get("filepath", {})
                         .get("pipeline_location", {})
-                        .get("bin", "data/modules/bsee/bin/pipeline_location")
+                        .get("bin", f"{_BSEE_BIN}/pipeline_location")
                     )
                     processor.save_to_binary(
                         processed, bin_path, "pipeline_location_data"

--- a/src/worldenergydata/bsee/data/sources/zip/platform_data.py
+++ b/src/worldenergydata/bsee/data/sources/zip/platform_data.py
@@ -6,6 +6,10 @@ from typing import Any, Dict
 
 from loguru import logger
 
+from worldenergydata.common.data_resolver import get_module_data_safe
+
+_BSEE_BIN = str(get_module_data_safe("bsee") / "bin")
+
 
 class PlatformDataFromZip:
     """Load and process platform structure data from ZIP files."""
@@ -64,7 +68,7 @@ class PlatformDataFromZip:
                         cfg.get("parameters", {})
                         .get("filepath", {})
                         .get("platform", {})
-                        .get("bin", "data/modules/bsee/bin/platform")
+                        .get("bin", f"{_BSEE_BIN}/platform")
                     )
                     processor.save_to_binary(processed, bin_path, "platform_data")
                     logger.info(f"Platform data saved to {bin_path}")

--- a/src/worldenergydata/bsee/paleowells/cli.py
+++ b/src/worldenergydata/bsee/paleowells/cli.py
@@ -11,7 +11,10 @@ import sys
 from pathlib import Path
 
 from worldenergydata.common import get_logger
+from worldenergydata.common.data_resolver import get_module_data_safe
 from worldenergydata.common.logging import configure_logging
+
+_BSEE_DATA = str(get_module_data_safe("bsee"))
 
 from .data_downloader import BSEEDataDownloader
 from .data_processor import PaleowellsDataProcessor
@@ -168,8 +171,8 @@ def main():
     process_parser.add_argument(
         "--data-directory",
         "-d",
-        default="data/modules/bsee/paleowells",
-        help="Data directory (default: data/modules/bsee/paleowells)",
+        default=f"{_BSEE_DATA}/paleowells",
+        help="Data directory (default: <bsee_module>/paleowells)",
     )
     process_parser.add_argument(
         "--output-directory", "-o", help="Output directory for processed files"
@@ -192,7 +195,7 @@ def main():
     download_parser.add_argument(
         "--data-directory",
         "-d",
-        default="data/modules/bsee/downloads",
+        default=f"{_BSEE_DATA}/downloads",
         help="Directory to store downloads",
     )
     download_parser.add_argument(
@@ -219,7 +222,7 @@ def main():
     viz_parser.add_argument(
         "--data-directory",
         "-d",
-        default="data/modules/bsee/paleowells",
+        default=f"{_BSEE_DATA}/paleowells",
         help="Data directory",
     )
     viz_parser.add_argument(

--- a/src/worldenergydata/common/config.py
+++ b/src/worldenergydata/common/config.py
@@ -179,12 +179,16 @@ class Settings(BaseSettings):
     log_json: bool = Field(default=False, description="Output logs as JSON")
 
     # Data directories
-    data_dir: Path = Field(default_factory=get_data_root_safe, description="Base data directory")
+    data_dir: Path = Field(
+        default_factory=get_data_root_safe, description="Base data directory"
+    )
     raw_data_dir: Path = Field(
-        default_factory=lambda: get_data_root_safe() / "raw", description="Raw data directory"
+        default_factory=lambda: get_data_root_safe() / "raw",
+        description="Raw data directory",
     )
     processed_data_dir: Path = Field(
-        default_factory=lambda: get_data_root_safe() / "processed", description="Processed data directory"
+        default_factory=lambda: get_data_root_safe() / "processed",
+        description="Processed data directory",
     )
     reports_dir: Path = Field(
         default=Path("reports"), description="Reports output directory"

--- a/src/worldenergydata/common/config.py
+++ b/src/worldenergydata/common/config.py
@@ -14,6 +14,8 @@ Example usage:
     logger.info(settings.bsee_api_base_url)
 """
 
+from worldenergydata.common.data_resolver import get_data_root_safe
+
 import os
 from functools import lru_cache
 from pathlib import Path
@@ -177,12 +179,12 @@ class Settings(BaseSettings):
     log_json: bool = Field(default=False, description="Output logs as JSON")
 
     # Data directories
-    data_dir: Path = Field(default=Path("data"), description="Base data directory")
+    data_dir: Path = Field(default_factory=get_data_root_safe, description="Base data directory")
     raw_data_dir: Path = Field(
-        default=Path("data/raw"), description="Raw data directory"
+        default_factory=lambda: get_data_root_safe() / "raw", description="Raw data directory"
     )
     processed_data_dir: Path = Field(
-        default=Path("data/processed"), description="Processed data directory"
+        default_factory=lambda: get_data_root_safe() / "processed", description="Processed data directory"
     )
     reports_dir: Path = Field(
         default=Path("reports"), description="Reports output directory"

--- a/src/worldenergydata/common/data_resolver.py
+++ b/src/worldenergydata/common/data_resolver.py
@@ -77,6 +77,33 @@ def get_module_data(module: str) -> Path:
     )
 
 
+def get_data_root_safe() -> Path:
+    """Resolve the data root, falling back to ``<project_root>/data`` on error.
+
+    Unlike :func:`get_data_root`, this helper **never** raises
+    :class:`DataNotFoundError`.  It is designed for use as a
+    ``default_factory`` in pydantic ``Field`` declarations where
+    raising at import time would be undesirable.
+    """
+    try:
+        return get_data_root()
+    except DataNotFoundError:
+        return _get_project_root() / "data"
+
+
+def get_module_data_safe(module: str) -> Path:
+    """Get the module data directory without raising.
+
+    Falls back to ``<data_root>/modules/<module>`` when the directory
+    does not yet exist on disk.  Useful for module-level constants and
+    ``default_factory`` callables.
+    """
+    try:
+        return get_module_data(module)
+    except DataNotFoundError:
+        return get_data_root_safe() / "modules" / module
+
+
 def _clear_cache() -> None:
     """Clear the cached data root. Used in tests."""
     get_data_root.cache_clear()

--- a/src/worldenergydata/hse/importers/osha_importer.py
+++ b/src/worldenergydata/hse/importers/osha_importer.py
@@ -37,12 +37,13 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
 from worldenergydata.common import get_logger
+from worldenergydata.common.data_resolver import get_module_data_safe
 from worldenergydata.hse.database.models import Base, HSEIncident
 
 logger = get_logger(__name__)
 
 # Default database URL (SQLite)
-DEFAULT_DB_URL = "sqlite:///data/modules/hse/hse_incidents.db"
+DEFAULT_DB_URL = f"sqlite:///{get_module_data_safe('hse') / 'hse_incidents.db'}"
 
 # OSHA inspection type to severity mapping
 INSPECTION_TYPE_SEVERITY = {

--- a/src/worldenergydata/lower_tertiary/v30_reproducer.py
+++ b/src/worldenergydata/lower_tertiary/v30_reproducer.py
@@ -3,6 +3,7 @@
 ABOUTME: Reproduces FDAS V30 lower tertiary results from raw BSEE OGOR data
 ABOUTME: Uses V30 assumptions and methodology for WRK-009 repeatability verification
 """
+
 from __future__ import annotations
 
 import zipfile

--- a/src/worldenergydata/lower_tertiary/v30_reproducer.py
+++ b/src/worldenergydata/lower_tertiary/v30_reproducer.py
@@ -11,13 +11,14 @@ from pathlib import Path
 import pandas as pd
 import yaml
 
+from worldenergydata.common.data_resolver import get_module_data_safe
 from worldenergydata.common.logging import get_logger
 
 logger = get_logger(__name__)
 
 PROJECT_ROOT = Path(__file__).resolve().parents[4]
 FDAS_V30_DIR = PROJECT_ROOT / "docs/modules/bsee/analysis/production/FDAS_V30"
-OGOR_ZIP_DIR = PROJECT_ROOT / "data/modules/bsee/zip/historical_production_yearly"
+OGOR_ZIP_DIR = get_module_data_safe("bsee") / "zip" / "historical_production_yearly"
 GOLDEN_BASELINE_PATH = (
     PROJECT_ROOT / "config/analysis/lower_tertiary/golden_baseline_v30.yml"
 )

--- a/src/worldenergydata/marine_safety/acquirers/uscg_misle_acquirer.py
+++ b/src/worldenergydata/marine_safety/acquirers/uscg_misle_acquirer.py
@@ -34,8 +34,11 @@ from tenacity import (
 )
 
 from worldenergydata.common import get_logger
+from worldenergydata.common.data_resolver import get_module_data_safe
 
 logger = get_logger(__name__)
+
+_MARINE_SAFETY_DATA = get_module_data_safe("marine_safety")
 
 # Known USCG MISLE download URLs in order of preference
 MISLE_URLS = [
@@ -501,7 +504,7 @@ class USCGMISLEAcquirer:
                     "Data Liberation Project historical extracts (1995-2012) "
                     "are available in the dlp_historical directory"
                 ),
-                "path": "data/modules/marine_safety/raw/dlp_historical/",
+                "path": str(_MARINE_SAFETY_DATA / "raw" / "dlp_historical") + "/",
                 "files": [
                     "Accidents_1995-2012.csv",
                     "Vessels_1995-2012.csv",

--- a/src/worldenergydata/marine_safety/config.py
+++ b/src/worldenergydata/marine_safety/config.py
@@ -10,6 +10,8 @@ from typing import Any, Optional
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from worldenergydata.common.data_resolver import get_data_root_safe
+
 
 class DatabaseConfig(BaseSettings):
     """Database connection configuration"""
@@ -87,14 +89,16 @@ class StorageConfig(BaseSettings):
     """Storage configuration for documents and files"""
 
     base_path: Path = Field(
-        default=Path("data/marine_safety"), description="Base path for data storage"
+        default_factory=lambda: get_data_root_safe() / "marine_safety",
+        description="Base path for data storage",
     )
     documents_path: Path = Field(
-        default=Path("data/marine_safety/documents"),
+        default_factory=lambda: get_data_root_safe() / "marine_safety" / "documents",
         description="Path for storing documents",
     )
     cache_path: Path = Field(
-        default=Path("data/marine_safety/cache"), description="Path for caching data"
+        default_factory=lambda: get_data_root_safe() / "marine_safety" / "cache",
+        description="Path for caching data",
     )
     max_file_size: int = Field(
         default=100 * 1024 * 1024, description="Maximum file size in bytes"  # 100MB

--- a/src/worldenergydata/metocean/config.py
+++ b/src/worldenergydata/metocean/config.py
@@ -9,6 +9,8 @@ from typing import Any, Optional
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from worldenergydata.common.data_resolver import get_data_root_safe
+
 
 class DatabaseConfig(BaseSettings):
     """Database connection configuration for metocean data storage."""
@@ -87,7 +89,8 @@ class CacheConfig(BaseSettings):
     ttl_hours: int = Field(default=24, description="Cache time-to-live in hours")
     max_size_mb: int = Field(default=500, description="Maximum cache size in MB")
     cache_path: Path = Field(
-        default=Path("data/metocean/cache"), description="Path for cache storage"
+        default_factory=lambda: get_data_root_safe() / "metocean" / "cache",
+        description="Path for cache storage",
     )
     enabled: bool = Field(default=True, description="Enable caching")
 
@@ -112,13 +115,16 @@ class StorageConfig(BaseSettings):
     """Configuration for data storage."""
 
     base_path: Path = Field(
-        default=Path("data/metocean"), description="Base path for data storage"
+        default_factory=lambda: get_data_root_safe() / "metocean",
+        description="Base path for data storage",
     )
     raw_path: Path = Field(
-        default=Path("data/metocean/raw"), description="Path for raw data"
+        default_factory=lambda: get_data_root_safe() / "metocean" / "raw",
+        description="Path for raw data",
     )
     processed_path: Path = Field(
-        default=Path("data/metocean/processed"), description="Path for processed data"
+        default_factory=lambda: get_data_root_safe() / "metocean" / "processed",
+        description="Path for processed data",
     )
 
     model_config = SettingsConfigDict(

--- a/src/worldenergydata/safety_analysis/config.py
+++ b/src/worldenergydata/safety_analysis/config.py
@@ -11,6 +11,8 @@ from typing import List, Optional
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings
 
+from worldenergydata.common.data_resolver import get_data_root_safe
+
 
 class NLPConfig(BaseModel):
     """Configuration for NLP text processing."""
@@ -51,7 +53,7 @@ class AnalysisConfig(BaseSettings):
     model_config = {"env_prefix": "SAFETY_", "case_sensitive": False}
 
     # Data paths
-    data_dir: Path = Path("data/safety_analysis")
+    data_dir: Path = Field(default_factory=lambda: get_data_root_safe() / "safety_analysis")
     model_dir: Path = Path("models/safety_analysis")
     report_dir: Path = Path("reports/safety_analysis")
 

--- a/src/worldenergydata/safety_analysis/config.py
+++ b/src/worldenergydata/safety_analysis/config.py
@@ -53,7 +53,9 @@ class AnalysisConfig(BaseSettings):
     model_config = {"env_prefix": "SAFETY_", "case_sensitive": False}
 
     # Data paths
-    data_dir: Path = Field(default_factory=lambda: get_data_root_safe() / "safety_analysis")
+    data_dir: Path = Field(
+        default_factory=lambda: get_data_root_safe() / "safety_analysis"
+    )
     model_dir: Path = Path("models/safety_analysis")
     report_dir: Path = Path("reports/safety_analysis")
 

--- a/src/worldenergydata/scheduler/jobs/brazil_anp_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/brazil_anp_refresh.py
@@ -6,6 +6,7 @@ TODO: Implement data fetching for Brazil ANP production data.
 - Write Parquet output to data/brazil_anp/ directory
 - Add tests in tests/unit/scheduler/test_brazil_anp_adapter.py
 """
+
 import logging
 from datetime import datetime
 from pathlib import Path

--- a/src/worldenergydata/scheduler/jobs/brazil_anp_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/brazil_anp_refresh.py
@@ -10,15 +10,12 @@ import logging
 from datetime import datetime
 from pathlib import Path
 
-from worldenergydata.common.data_resolver import DataNotFoundError, get_module_data
+from worldenergydata.common.data_resolver import get_module_data_safe
 from worldenergydata.scheduler.jobs.base import AbstractJob, JobResult
 
 logger = logging.getLogger(__name__)
 
-try:
-    _DEFAULT_OUTPUT_DIR = get_module_data("brazil_anp")
-except DataNotFoundError:
-    _DEFAULT_OUTPUT_DIR = Path("data/modules/brazil_anp")
+_DEFAULT_OUTPUT_DIR = get_module_data_safe("brazil_anp")
 
 
 class BrazilAnpRefreshJob(AbstractJob):

--- a/src/worldenergydata/scheduler/jobs/bsee_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/bsee_refresh.py
@@ -14,7 +14,7 @@ from typing import Optional
 import pandas as pd
 
 from worldenergydata.bsee.data.scrapers.bsee_web import BSEEWebScraper
-from worldenergydata.common.data_resolver import DataNotFoundError, get_module_data
+from worldenergydata.common.data_resolver import get_module_data_safe
 from worldenergydata.scheduler.jobs.base import AbstractJob, JobResult
 
 logger = logging.getLogger(__name__)
@@ -38,10 +38,7 @@ BSEE_DATASETS = {
     },
 }
 
-try:
-    _DEFAULT_OUTPUT_DIR = get_module_data("bsee")
-except DataNotFoundError:
-    _DEFAULT_OUTPUT_DIR = Path("data/modules/bsee")
+_DEFAULT_OUTPUT_DIR = get_module_data_safe("bsee")
 
 
 class BseeRefreshJob(AbstractJob):

--- a/src/worldenergydata/scheduler/jobs/bsee_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/bsee_refresh.py
@@ -69,17 +69,13 @@ class BseeRefreshJob(AbstractJob):
 
         for dataset_name, info in BSEE_DATASETS.items():
             try:
-                records = self._process_dataset(
-                    scraper, dataset_name, info, output_dir
-                )
+                records = self._process_dataset(scraper, dataset_name, info, output_dir)
                 if records is not None:
                     total_records += records
                 else:
                     failed_datasets.append(dataset_name)
             except Exception as exc:
-                logger.warning(
-                    "BSEE %s processing error: %s", dataset_name, exc
-                )
+                logger.warning("BSEE %s processing error: %s", dataset_name, exc)
                 failed_datasets.append(dataset_name)
 
         if total_records > 0:
@@ -97,9 +93,7 @@ class BseeRefreshJob(AbstractJob):
                 error_msg=None,
             )
 
-        error_msg = (
-            f"All BSEE downloads failed: {', '.join(failed_datasets)}"
-        )
+        error_msg = f"All BSEE downloads failed: {', '.join(failed_datasets)}"
         logger.error(error_msg)
         return JobResult(
             job_name=self.name,
@@ -125,26 +119,18 @@ class BseeRefreshJob(AbstractJob):
         url = BSEEWebScraper.URLS[info["url_key"]]
         logger.info("BSEE downloading %s from %s", dataset_name, url)
 
-        zip_bytes = scraper.download_zip_to_memory(
-            url, data_type=info["url_key"]
-        )
+        zip_bytes = scraper.download_zip_to_memory(url, data_type=info["url_key"])
         if zip_bytes is None:
             logger.warning("BSEE %s download returned None", dataset_name)
             return None
 
         with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
-            csv_names = [
-                n for n in zf.namelist() if n.lower().endswith(".csv")
-            ]
+            csv_names = [n for n in zf.namelist() if n.lower().endswith(".csv")]
             if not csv_names:
-                logger.warning(
-                    "BSEE %s zip contains no CSV files", dataset_name
-                )
+                logger.warning("BSEE %s zip contains no CSV files", dataset_name)
                 return None
             csv_name = csv_names[0]
-            logger.info(
-                "BSEE %s extracting %s", dataset_name, csv_name
-            )
+            logger.info("BSEE %s extracting %s", dataset_name, csv_name)
             df = pd.read_csv(zf.open(csv_name))
 
         out_path = output_dir / info["output_file"]

--- a/src/worldenergydata/scheduler/jobs/eia_us_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/eia_us_refresh.py
@@ -11,17 +11,14 @@ from pathlib import Path
 
 import pandas as pd
 
-from worldenergydata.common.data_resolver import DataNotFoundError, get_module_data
+from worldenergydata.common.data_resolver import get_module_data_safe
 from worldenergydata.eia.ingestion import EIAIngestionSync
 from worldenergydata.scheduler.jobs.base import AbstractJob, JobResult
 from worldenergydata.scheduler.parquet_output import write_parquet
 
 logger = logging.getLogger(__name__)
 
-try:
-    _DEFAULT_OUTPUT_DIR = get_module_data("eia")
-except DataNotFoundError:
-    _DEFAULT_OUTPUT_DIR = Path("data/modules/eia")
+_DEFAULT_OUTPUT_DIR = get_module_data_safe("eia")
 
 
 class EiaUsRefreshJob(AbstractJob):

--- a/src/worldenergydata/scheduler/jobs/lng_terminals_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/lng_terminals_refresh.py
@@ -10,15 +10,12 @@ import logging
 from datetime import datetime
 from pathlib import Path
 
-from worldenergydata.common.data_resolver import DataNotFoundError, get_module_data
+from worldenergydata.common.data_resolver import get_module_data_safe
 from worldenergydata.scheduler.jobs.base import AbstractJob, JobResult
 
 logger = logging.getLogger(__name__)
 
-try:
-    _DEFAULT_OUTPUT_DIR = get_module_data("lng_terminals")
-except DataNotFoundError:
-    _DEFAULT_OUTPUT_DIR = Path("data/modules/lng_terminals")
+_DEFAULT_OUTPUT_DIR = get_module_data_safe("lng_terminals")
 
 
 class LngTerminalsRefreshJob(AbstractJob):

--- a/src/worldenergydata/scheduler/jobs/lng_terminals_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/lng_terminals_refresh.py
@@ -6,6 +6,7 @@ TODO: Implement data fetching for LNG terminal data.
 - Write Parquet output to data/lng_terminals/ directory
 - Add tests in tests/unit/scheduler/test_lng_terminals_adapter.py
 """
+
 import logging
 from datetime import datetime
 from pathlib import Path

--- a/src/worldenergydata/scheduler/jobs/metocean_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/metocean_refresh.py
@@ -6,6 +6,7 @@ TODO: Implement data fetching for metocean sources.
 - Write Parquet output to data/metocean/ directory
 - Add tests in tests/unit/scheduler/test_metocean_adapter.py
 """
+
 import logging
 from datetime import datetime
 from pathlib import Path

--- a/src/worldenergydata/scheduler/jobs/metocean_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/metocean_refresh.py
@@ -10,15 +10,12 @@ import logging
 from datetime import datetime
 from pathlib import Path
 
-from worldenergydata.common.data_resolver import DataNotFoundError, get_module_data
+from worldenergydata.common.data_resolver import get_module_data_safe
 from worldenergydata.scheduler.jobs.base import AbstractJob, JobResult
 
 logger = logging.getLogger(__name__)
 
-try:
-    _DEFAULT_OUTPUT_DIR = get_module_data("metocean")
-except DataNotFoundError:
-    _DEFAULT_OUTPUT_DIR = Path("data/modules/metocean")
+_DEFAULT_OUTPUT_DIR = get_module_data_safe("metocean")
 
 
 class MetoceanRefreshJob(AbstractJob):

--- a/src/worldenergydata/scheduler/jobs/sodir_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/sodir_refresh.py
@@ -7,7 +7,7 @@ from typing import Dict
 
 import pandas as pd
 
-from worldenergydata.common.data_resolver import DataNotFoundError, get_module_data
+from worldenergydata.common.data_resolver import get_module_data_safe
 from worldenergydata.scheduler.jobs.base import AbstractJob, JobResult
 from worldenergydata.sodir.api_client import SodirAPIClient
 from worldenergydata.sodir.endpoints import SODIR_ENDPOINTS
@@ -22,10 +22,7 @@ SODIR_DATASETS: Dict[str, str] = {
     "fields": "sodir_fields.parquet",
 }
 
-try:
-    _DEFAULT_OUTPUT_DIR = get_module_data("sodir")
-except DataNotFoundError:
-    _DEFAULT_OUTPUT_DIR = Path("data/modules/sodir")
+_DEFAULT_OUTPUT_DIR = get_module_data_safe("sodir")
 
 
 class SodirRefreshJob(AbstractJob):

--- a/src/worldenergydata/scheduler/jobs/sodir_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/sodir_refresh.py
@@ -64,9 +64,7 @@ class SodirRefreshJob(AbstractJob):
                 endpoint_path = endpoint_cfg["endpoint"]
                 table_id = endpoint_cfg["table_id"]
 
-                response = client.get(
-                    endpoint_path, params={"table": table_id}
-                )
+                response = client.get(endpoint_path, params={"table": table_id})
                 rows = response.get("data", [])
 
                 if rows:

--- a/src/worldenergydata/scheduler/jobs/ukcs_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/ukcs_refresh.py
@@ -6,6 +6,7 @@ TODO: Implement data fetching for UKCS production data.
 - Write Parquet output to data/ukcs/ directory
 - Add tests in tests/unit/scheduler/test_ukcs_adapter.py
 """
+
 import logging
 from datetime import datetime
 from pathlib import Path

--- a/src/worldenergydata/scheduler/jobs/ukcs_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/ukcs_refresh.py
@@ -10,15 +10,12 @@ import logging
 from datetime import datetime
 from pathlib import Path
 
-from worldenergydata.common.data_resolver import DataNotFoundError, get_module_data
+from worldenergydata.common.data_resolver import get_module_data_safe
 from worldenergydata.scheduler.jobs.base import AbstractJob, JobResult
 
 logger = logging.getLogger(__name__)
 
-try:
-    _DEFAULT_OUTPUT_DIR = get_module_data("ukcs")
-except DataNotFoundError:
-    _DEFAULT_OUTPUT_DIR = Path("data/modules/ukcs")
+_DEFAULT_OUTPUT_DIR = get_module_data_safe("ukcs")
 
 
 class UkcsRefreshJob(AbstractJob):

--- a/src/worldenergydata/vessel_fleet/router.py
+++ b/src/worldenergydata/vessel_fleet/router.py
@@ -6,15 +6,12 @@ import logging
 from pathlib import Path
 from typing import Any, Optional
 
-from worldenergydata.common.data_resolver import DataNotFoundError, get_module_data
+from worldenergydata.common.data_resolver import get_module_data_safe
 from worldenergydata.vessel_fleet.storage.parquet import ParquetStore
 
 logger = logging.getLogger(__name__)
 
-try:
-    _DEFAULT_DATA_DIR = get_module_data("vessel_fleet") / "curated"
-except DataNotFoundError:
-    _DEFAULT_DATA_DIR = Path("data/modules/vessel_fleet/curated")
+_DEFAULT_DATA_DIR = get_module_data_safe("vessel_fleet") / "curated"
 
 
 class FleetRouter:

--- a/src/worldenergydata/vessel_fleet/router.py
+++ b/src/worldenergydata/vessel_fleet/router.py
@@ -57,12 +57,14 @@ class FleetRouter:
         if owner:
             owner_lower = owner.lower()
             results = [
-                r for r in results
+                r
+                for r in results
                 if r.get("OWNER") and owner_lower in r["OWNER"].lower()
             ]
         if min_water_depth_ft is not None:
             results = [
-                r for r in results
+                r
+                for r in results
                 if r.get("WATER_DEPTH_RATING_FT") is not None
                 and r["WATER_DEPTH_RATING_FT"] >= min_water_depth_ft
             ]
@@ -87,12 +89,14 @@ class FleetRouter:
         if owner:
             owner_lower = owner.lower()
             results = [
-                r for r in results
+                r
+                for r in results
                 if r.get("OWNER") and owner_lower in r["OWNER"].lower()
             ]
         if min_crane_capacity_t is not None:
             results = [
-                r for r in results
+                r
+                for r in results
                 if r.get("MAIN_CRANE_CAPACITY_T") is not None
                 and r["MAIN_CRANE_CAPACITY_T"] >= min_crane_capacity_t
             ]

--- a/src/worldenergydata/vessel_hull_models/config.py
+++ b/src/worldenergydata/vessel_hull_models/config.py
@@ -12,25 +12,27 @@ from typing import Optional, Any
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from worldenergydata.common.data_resolver import get_module_data_safe
+
 
 class StorageConfig(BaseSettings):
     """Storage configuration for hull models and cache"""
 
     base_path: Path = Field(
-        default=Path("data/modules/vessel_hull_models"),
-        description="Base path for hull model storage"
+        default_factory=lambda: get_module_data_safe("vessel_hull_models"),
+        description="Base path for hull model storage",
     )
     hulls_path: Path = Field(
-        default=Path("data/modules/vessel_hull_models/hulls"),
-        description="Path for storing acquired hull models"
+        default_factory=lambda: get_module_data_safe("vessel_hull_models") / "hulls",
+        description="Path for storing acquired hull models",
     )
     synthetic_path: Path = Field(
-        default=Path("data/modules/vessel_hull_models/synthetic"),
-        description="Path for parametrically generated hulls"
+        default_factory=lambda: get_module_data_safe("vessel_hull_models") / "synthetic",
+        description="Path for parametrically generated hulls",
     )
     cache_path: Path = Field(
-        default=Path("data/modules/vessel_hull_models/cache"),
-        description="Path for caching data"
+        default_factory=lambda: get_module_data_safe("vessel_hull_models") / "cache",
+        description="Path for caching data",
     )
     max_file_size: int = Field(
         default=500 * 1024 * 1024,  # 500MB

--- a/src/worldenergydata/vessel_hull_models/config.py
+++ b/src/worldenergydata/vessel_hull_models/config.py
@@ -27,7 +27,8 @@ class StorageConfig(BaseSettings):
         description="Path for storing acquired hull models",
     )
     synthetic_path: Path = Field(
-        default_factory=lambda: get_module_data_safe("vessel_hull_models") / "synthetic",
+        default_factory=lambda: get_module_data_safe("vessel_hull_models")
+        / "synthetic",
         description="Path for parametrically generated hulls",
     )
     cache_path: Path = Field(
@@ -35,18 +36,19 @@ class StorageConfig(BaseSettings):
         description="Path for caching data",
     )
     max_file_size: int = Field(
-        default=500 * 1024 * 1024,  # 500MB
-        description="Maximum file size in bytes"
+        default=500 * 1024 * 1024, description="Maximum file size in bytes"  # 500MB
     )
 
     model_config = SettingsConfigDict(
         env_prefix="VESSEL_HULL_STORAGE_",
         env_file=".env",
         env_file_encoding="utf-8",
-        extra="ignore"
+        extra="ignore",
     )
 
-    @field_validator("base_path", "hulls_path", "synthetic_path", "cache_path", mode="before")
+    @field_validator(
+        "base_path", "hulls_path", "synthetic_path", "cache_path", mode="before"
+    )
     @classmethod
     def resolve_paths(cls, v: Any) -> Path:
         """Resolve paths"""
@@ -59,14 +61,15 @@ class AcquisitionConfig(BaseSettings):
 
     user_agent: str = Field(
         default="WorldEnergyData-VesselHullModels/1.0",
-        description="User agent for HTTP requests"
+        description="User agent for HTTP requests",
     )
     request_timeout: int = Field(default=60, description="Request timeout in seconds")
     max_retries: int = Field(default=3, description="Maximum retry attempts")
-    retry_delay: float = Field(default=2.0, description="Delay between retries in seconds")
+    retry_delay: float = Field(
+        default=2.0, description="Delay between retries in seconds"
+    )
     rate_limit_delay: float = Field(
-        default=1.0,
-        description="Delay between requests in seconds"
+        default=1.0, description="Delay between requests in seconds"
     )
 
     # Repository-specific settings
@@ -75,13 +78,15 @@ class AcquisitionConfig(BaseSettings):
     grabcad_enabled: bool = Field(default=True, description="Enable GrabCAD search")
 
     # API keys (optional - for premium features)
-    sketchfab_api_key: Optional[str] = Field(default=None, description="SketchFab API key")
+    sketchfab_api_key: Optional[str] = Field(
+        default=None, description="SketchFab API key"
+    )
 
     model_config = SettingsConfigDict(
         env_prefix="VESSEL_HULL_ACQUISITION_",
         env_file=".env",
         env_file_encoding="utf-8",
-        extra="ignore"
+        extra="ignore",
     )
 
 
@@ -89,27 +94,23 @@ class GeometryConfig(BaseSettings):
     """Configuration for geometry processing"""
 
     dimension_tolerance: float = Field(
-        default=0.05,
-        description="Tolerance for dimension validation (0.05 = 5%)"
+        default=0.05, description="Tolerance for dimension validation (0.05 = 5%)"
     )
     default_decimation: int = Field(
-        default=50_000,
-        description="Default face count for mesh decimation"
+        default=50_000, description="Default face count for mesh decimation"
     )
     enable_mesh_repair: bool = Field(
-        default=True,
-        description="Enable automatic mesh repair"
+        default=True, description="Enable automatic mesh repair"
     )
     max_vertex_count: int = Field(
-        default=10_000_000,
-        description="Maximum vertex count to process"
+        default=10_000_000, description="Maximum vertex count to process"
     )
 
     model_config = SettingsConfigDict(
         env_prefix="VESSEL_HULL_GEOMETRY_",
         env_file=".env",
         env_file_encoding="utf-8",
-        extra="ignore"
+        extra="ignore",
     )
 
 
@@ -117,27 +118,26 @@ class VisualizationConfig(BaseSettings):
     """Configuration for 3D visualization"""
 
     default_colorscale: str = Field(
-        default="Viridis",
-        description="Default Plotly colorscale for depth coloring"
+        default="Viridis", description="Default Plotly colorscale for depth coloring"
     )
     show_waterline: bool = Field(
-        default=True,
-        description="Show waterline plane by default"
+        default=True, description="Show waterline plane by default"
     )
     background_color: str = Field(
-        default="rgb(230, 240, 250)",
-        description="Default background color"
+        default="rgb(230, 240, 250)", description="Default background color"
     )
     html_template_dir: Path = Field(
-        default=Path("src/worldenergydata/modules/vessel_hull_models/visualization/templates"),
-        description="Directory for HTML templates"
+        default=Path(
+            "src/worldenergydata/modules/vessel_hull_models/visualization/templates"
+        ),
+        description="Directory for HTML templates",
     )
 
     model_config = SettingsConfigDict(
         env_prefix="VESSEL_HULL_VIZ_",
         env_file=".env",
         env_file_encoding="utf-8",
-        extra="ignore"
+        extra="ignore",
     )
 
 
@@ -159,7 +159,7 @@ class VesselHullModelsConfig(BaseSettings):
         env_file=".env",
         env_file_encoding="utf-8",
         case_sensitive=False,
-        extra="ignore"
+        extra="ignore",
     )
 
 

--- a/src/worldenergydata/well_production_dashboard/query_optimizer.py
+++ b/src/worldenergydata/well_production_dashboard/query_optimizer.py
@@ -22,7 +22,7 @@ from ..bsee.data.sources.bin.lease_data import LeaseData
 
 # Import BSEE data loaders
 from ..bsee.reports.comprehensive.data_loader_enhanced import HierarchicalDataLoader
-from ..common.data_resolver import DataNotFoundError, get_data_root
+from ..common.data_resolver import get_data_root_safe
 
 logger = logging.getLogger(__name__)
 
@@ -177,10 +177,7 @@ class QueryOptimizer:
         Args:
             data_path: Path to BSEE data directory
         """
-        try:
-            self.data_path = data_path or get_data_root() / "bsee"
-        except DataNotFoundError:
-            self.data_path = data_path or Path("data/bsee")
+        self.data_path = data_path or get_data_root_safe() / "bsee"
 
         # Initialize BSEE data loaders
         self.hierarchical_loader = HierarchicalDataLoader(data_path)


### PR DESCRIPTION
## Summary
- Added `get_data_root_safe()` and `get_module_data_safe()` to `common/data_resolver.py` — safe variants that fall back to sensible defaults instead of raising
- Wired DataResolver into **36 files** across configs, scheduler jobs, BSEE loaders, data processing, CLI, and other modules
- Removed all hardcoded `Path("data/...")` references from executable code
- `WED_DATA_ROOT` env var now works everywhere — users can relocate data directory

## Changes by category
- **Config files (5)**: pydantic `default_factory` uses resolver
- **Scheduler jobs (7)**: replaced `try/except` + hardcoded fallback with single `get_module_data_safe()` call
- **BSEE loaders (7)**: resolver calls replace string paths
- **BSEE data processing (7)**: `_BSEE_BIN` constant from resolver
- **Other modules (10)**: CLI, fleet, marine safety, HSE importers

## Test plan
- [ ] Verify existing tests pass with `PYTHONPATH=src python3 -m pytest tests/ --noconftest`
- [ ] Test `WED_DATA_ROOT=/tmp/test-data` env var is respected
- [ ] Confirm no remaining hardcoded `Path("data/` in src/

Closes #285