### PR TITLE
feat: add data freshness metadata and CLI status command (#292)

### DIFF
--- a/data/modules/bsee/_metadata.json
+++ b/data/modules/bsee/_metadata.json
@@ -1,0 +1,168 @@
+{
+  "module": "bsee",
+  "last_refresh": "2026-03-15T00:00:00Z",
+  "record_count": 65045,
+  "file_count": 28,
+  "total_size_bytes": 157257578,
+  "source_url": "",
+  "format": "csv",
+  "files": [
+    {
+      "name": ".local/borehole/BoreholeRawData.zip",
+      "size_bytes": 3480073,
+      "modified": "2026-02-09"
+    },
+    {
+      "name": ".local/borehole/BoreholeRawData/mv_boreholes_all.txt",
+      "size_bytes": 13587325,
+      "modified": "2026-02-09"
+    },
+    {
+      "name": ".local/borehole/download_metadata.json",
+      "size_bytes": 393,
+      "modified": "2026-02-09"
+    },
+    {
+      "name": ".local/data_index.json",
+      "size_bytes": 316,
+      "modified": "2026-02-09"
+    },
+    {
+      "name": ".local/rig_fleet/rig_fleet_full.bin",
+      "size_bytes": 422385,
+      "modified": "2026-02-13"
+    },
+    {
+      "name": ".local/rig_fleet/rig_fleet_metadata.json",
+      "size_bytes": 584,
+      "modified": "2026-02-09"
+    },
+    {
+      "name": ".local/rig_fleet/subsets/rig_fleet.bin",
+      "size_bytes": 5149,
+      "modified": "2026-02-13"
+    },
+    {
+      "name": ".local/war/download_metadata.json",
+      "size_bytes": 249,
+      "modified": "2026-02-09"
+    },
+    {
+      "name": ".local/war/eWellWARRawData.zip",
+      "size_bytes": 127933804,
+      "modified": "2026-02-09"
+    },
+    {
+      "name": ".local/war/war_borehole_view.pkl",
+      "size_bytes": 6020228,
+      "modified": "2026-02-09"
+    },
+    {
+      "name": "current/completions/completion_perforations.csv",
+      "size_bytes": 3997,
+      "modified": "2025-07-31",
+      "rows": 100
+    },
+    {
+      "name": "current/completions/completion_properties.csv",
+      "size_bytes": 5825,
+      "modified": "2025-07-31",
+      "rows": 100
+    },
+    {
+      "name": "current/completions/completion_summary.csv",
+      "size_bytes": 4048,
+      "modified": "2025-07-31",
+      "rows": 100
+    },
+    {
+      "name": "current/geology/geology_markers.csv",
+      "size_bytes": 3335,
+      "modified": "2025-07-31",
+      "rows": 100
+    },
+    {
+      "name": "current/geology/hydrocarbon_bearing_interval.csv",
+      "size_bytes": 5477,
+      "modified": "2025-07-31",
+      "rows": 100
+    },
+    {
+      "name": "current/infrastructure/all_bsee_blocks.csv",
+      "size_bytes": 607,
+      "modified": "2025-07-31",
+      "rows": 100
+    },
+    {
+      "name": "current/operations/ST_BP_and_tree_height.csv",
+      "size_bytes": 2706,
+      "modified": "2025-07-31",
+      "rows": 100
+    },
+    {
+      "name": "current/operations/cut_casings.csv",
+      "size_bytes": 4497,
+      "modified": "2025-07-31",
+      "rows": 100
+    },
+    {
+      "name": "current/operations/well_activity_bop_tests.csv",
+      "size_bytes": 5180,
+      "modified": "2025-07-31",
+      "rows": 100
+    },
+    {
+      "name": "current/operations/well_activity_open_hole.csv",
+      "size_bytes": 6583,
+      "modified": "2025-07-31",
+      "rows": 100
+    },
+    {
+      "name": "current/operations/well_activity_remarks.csv",
+      "size_bytes": 68237,
+      "modified": "2026-03-15",
+      "rows": 100
+    },
+    {
+      "name": "current/operations/well_activity_summary.csv",
+      "size_bytes": 9431,
+      "modified": "2025-07-31",
+      "rows": 100
+    },
+    {
+      "name": "current/production/production.csv",
+      "size_bytes": 2361,
+      "modified": "2025-07-31",
+      "rows": 100
+    },
+    {
+      "name": "current/wells/well_data.csv",
+      "size_bytes": 4135645,
+      "modified": "2025-07-31",
+      "rows": 57281
+    },
+    {
+      "name": "current/wells/well_directional_surveys.csv",
+      "size_bytes": 129,
+      "modified": "2025-07-31",
+      "rows": 2
+    },
+    {
+      "name": "current/wells/well_tubulars.csv",
+      "size_bytes": 12155,
+      "modified": "2025-07-31",
+      "rows": 100
+    },
+    {
+      "name": "paleowells/Lower Tertiary Wells.txt",
+      "size_bytes": 890680,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "paleowells/Paleowells.csv",
+      "size_bytes": 646179,
+      "modified": "2026-03-15",
+      "rows": 6362
+    }
+  ]
+}

--- a/data/modules/fdas/_metadata.json
+++ b/data/modules/fdas/_metadata.json
@@ -1,0 +1,17 @@
+{
+  "module": "fdas",
+  "last_refresh": "2025-10-04T00:00:00Z",
+  "record_count": 57281,
+  "file_count": 1,
+  "total_size_bytes": 4593879,
+  "source_url": "",
+  "format": "csv",
+  "files": [
+    {
+      "name": "enhanced/wells/well_data_enhanced.csv",
+      "size_bytes": 4593879,
+      "modified": "2025-10-04",
+      "rows": 57281
+    }
+  ]
+}

--- a/data/modules/lng_terminals/_metadata.json
+++ b/data/modules/lng_terminals/_metadata.json
@@ -1,0 +1,72 @@
+{
+  "module": "lng_terminals",
+  "last_refresh": "2026-02-16T00:00:00Z",
+  "record_count": 227,
+  "file_count": 12,
+  "total_size_bytes": 208450,
+  "source_url": "",
+  "format": "json",
+  "files": [
+    {
+      "name": "cache/ferc_cache.json",
+      "size_bytes": 3,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "cache/ferc_meta.json",
+      "size_bytes": 89,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "cache/gie_cache.json",
+      "size_bytes": 3,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "cache/gie_meta.json",
+      "size_bytes": 88,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "cache/giignl_cache.json",
+      "size_bytes": 3,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "cache/giignl_meta.json",
+      "size_bytes": 91,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "cache/seed_dataset_cache.json",
+      "size_bytes": 102831,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "cache/seed_dataset_meta.json",
+      "size_bytes": 99,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "cache/web_cache.json",
+      "size_bytes": 3,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "cache/web_meta.json",
+      "size_bytes": 88,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "curated/terminals_seed.csv",
+      "size_bytes": 32265,
+      "modified": "2026-02-16",
+      "rows": 227
+    },
+    {
+      "name": "reports/lng_terminals_list.html",
+      "size_bytes": 72887,
+      "modified": "2026-02-08"
+    }
+  ]
+}

--- a/data/modules/marine_safety/_metadata.json
+++ b/data/modules/marine_safety/_metadata.json
@@ -1,0 +1,359 @@
+{
+  "module": "marine_safety",
+  "last_refresh": "2026-03-15T00:00:00Z",
+  "record_count": 65,
+  "file_count": 69,
+  "total_size_bytes": 112161441,
+  "source_url": "",
+  "format": "html",
+  "files": [
+    {
+      "name": "checkpoints/uscg_scraper.json",
+      "size_bytes": 96,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "database/marine_safety.db",
+      "size_bytes": 62283776,
+      "modified": "2025-10-06"
+    },
+    {
+      "name": "input/fatality_incidents.csv",
+      "size_bytes": 3324,
+      "modified": "2025-10-23",
+      "rows": 20
+    },
+    {
+      "name": "input/foundering_incidents.csv",
+      "size_bytes": 2464,
+      "modified": "2025-10-23",
+      "rows": 15
+    },
+    {
+      "name": "input/hatch_incidents.csv",
+      "size_bytes": 4577,
+      "modified": "2025-10-23",
+      "rows": 30
+    },
+    {
+      "name": "marine_safety.db",
+      "size_bytes": 48365568,
+      "modified": "2025-10-08"
+    },
+    {
+      "name": "raw/bsee_incident_statistics.html",
+      "size_bytes": 99097,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/bsee_offshore/.claude-flow/metrics/agent-metrics.json",
+      "size_bytes": 2,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/bsee_offshore/.claude-flow/metrics/performance.json",
+      "size_bytes": 157,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/bsee_offshore/.claude-flow/metrics/task-metrics.json",
+      "size_bytes": 177,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/bsee_offshore/bsee_data_dataset.json",
+      "size_bytes": 28166,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/bsee_offshore/bsee_data_package_search_q=incidents.json",
+      "size_bytes": 28191,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/bsee_offshore/excel/.claude-flow/metrics/agent-metrics.json",
+      "size_bytes": 2,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/bsee_offshore/excel/.claude-flow/metrics/performance.json",
+      "size_bytes": 157,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/bsee_offshore/excel/.claude-flow/metrics/task-metrics.json",
+      "size_bytes": 169,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/bsee_offshore/pdf/.claude-flow/metrics/agent-metrics.json",
+      "size_bytes": 2,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/bsee_offshore/pdf/.claude-flow/metrics/performance.json",
+      "size_bytes": 157,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/bsee_offshore/pdf/.claude-flow/metrics/task-metrics.json",
+      "size_bytes": 177,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/canadian_tsb/tsb_page.html",
+      "size_bytes": 36477,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/data_gov_maritime_search.json",
+      "size_bytes": 34620,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/data_gov_osha_search.json",
+      "size_bytes": 12440,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/data_gov_pipeline_search.json",
+      "size_bytes": 550753,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/dlp_historical/.claude-flow/metrics/agent-metrics.json",
+      "size_bytes": 2,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/dlp_historical/.claude-flow/metrics/performance.json",
+      "size_bytes": 157,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/dlp_historical/.claude-flow/metrics/task-metrics.json",
+      "size_bytes": 177,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/doe_pipelines/bsee_accident_database_page.html",
+      "size_bytes": 28134,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/doe_pipelines/phmsa_pipeline_data.html",
+      "size_bytes": 0,
+      "modified": "2025-10-07"
+    },
+    {
+      "name": "raw/download_log.json",
+      "size_bytes": 4174,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imca_dp/imca_annual_analysis_page_2024.html",
+      "size_bytes": 54872,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/.claude-flow/metrics/agent-metrics.json",
+      "size_bytes": 2,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/imo_gisis/.claude-flow/metrics/performance.json",
+      "size_bytes": 157,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/imo_gisis/.claude-flow/metrics/task-metrics.json",
+      "size_bytes": 177,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/imo_gisis/COMPLETION_SUMMARY.txt",
+      "size_bytes": 5551,
+      "modified": "2025-10-11"
+    },
+    {
+      "name": "raw/imo_gisis/QUICK_MANUAL_DOWNLOAD.txt",
+      "size_bytes": 2150,
+      "modified": "2025-10-09"
+    },
+    {
+      "name": "raw/imo_gisis/collation_summary.json",
+      "size_bytes": 1815,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/download_summary.json",
+      "size_bytes": 999,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/no_results_2010.html",
+      "size_bytes": 27135,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/no_results_2011.html",
+      "size_bytes": 27482,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/no_results_2012.html",
+      "size_bytes": 27482,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/no_results_2013.html",
+      "size_bytes": 27135,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/no_results_2014.html",
+      "size_bytes": 27482,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/no_results_2015.html",
+      "size_bytes": 27135,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/no_results_2016.html",
+      "size_bytes": 27135,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/no_results_2017.html",
+      "size_bytes": 27135,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/no_results_2018.html",
+      "size_bytes": 27135,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/no_results_2019.html",
+      "size_bytes": 27135,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/page_structure_2010.html",
+      "size_bytes": 27135,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/page_structure_2011.html",
+      "size_bytes": 27482,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/page_structure_2012.html",
+      "size_bytes": 27482,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/page_structure_2013.html",
+      "size_bytes": 27135,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/page_structure_2014.html",
+      "size_bytes": 27482,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/page_structure_2015.html",
+      "size_bytes": 27135,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/page_structure_2016.html",
+      "size_bytes": 27135,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/page_structure_2017.html",
+      "size_bytes": 27135,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/page_structure_2018.html",
+      "size_bytes": 27135,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/page_structure_2019.html",
+      "size_bytes": 27135,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/imo_gisis/page_structure_2020.html",
+      "size_bytes": 27135,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/noaa_spills/noaa_spills_index.html",
+      "size_bytes": 17814,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/osha_maritime/OSHA_Maritime_Inspections.json",
+      "size_bytes": 4288,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/osha_maritime/osha_fatalities.html",
+      "size_bytes": 0,
+      "modified": "2025-10-07"
+    },
+    {
+      "name": "raw/phmsa_hazmat/.claude-flow/metrics/agent-metrics.json",
+      "size_bytes": 2,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/phmsa_hazmat/.claude-flow/metrics/performance.json",
+      "size_bytes": 157,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/phmsa_hazmat/.claude-flow/metrics/task-metrics.json",
+      "size_bytes": 169,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/phmsa_hazmat/Index Data Sources.txt",
+      "size_bytes": 1088,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/phmsa_hazmat/phmsa_hazmat_main.html",
+      "size_bytes": 0,
+      "modified": "2025-10-07"
+    },
+    {
+      "name": "raw/uk_maib/maib_page.html",
+      "size_bytes": 13861,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/uscg/test_scrape_2024.json",
+      "size_bytes": 2,
+      "modified": "2026-03-15"
+    },
+    {
+      "name": "raw/uscg_misle/acquisition_manifest.json",
+      "size_bytes": 3227,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/uscg_misle/misle_data_page.html",
+      "size_bytes": 0,
+      "modified": "2025-10-05"
+    }
+  ]
+}

--- a/data/modules/oil_price/_metadata.json
+++ b/data/modules/oil_price/_metadata.json
@@ -1,0 +1,21 @@
+{
+  "module": "oil_price",
+  "last_refresh": "2025-07-31T00:00:00Z",
+  "record_count": 0,
+  "file_count": 2,
+  "total_size_bytes": 86528,
+  "source_url": "",
+  "format": "xls",
+  "files": [
+    {
+      "name": "F000000__3a.xls",
+      "size_bytes": 33280,
+      "modified": "2025-07-31"
+    },
+    {
+      "name": "F000000__3m.xls",
+      "size_bytes": 53248,
+      "modified": "2025-07-31"
+    }
+  ]
+}

--- a/data/modules/pipeline/_metadata.json
+++ b/data/modules/pipeline/_metadata.json
@@ -1,0 +1,17 @@
+{
+  "module": "pipeline",
+  "last_refresh": "2026-03-03T00:00:00Z",
+  "record_count": 43,
+  "file_count": 1,
+  "total_size_bytes": 3861,
+  "source_url": "",
+  "format": "csv",
+  "files": [
+    {
+      "name": "api_5l_pipe_schedule.csv",
+      "size_bytes": 3861,
+      "modified": "2026-03-03",
+      "rows": 43
+    }
+  ]
+}

--- a/data/modules/pipeline_safety/_metadata.json
+++ b/data/modules/pipeline_safety/_metadata.json
@@ -1,0 +1,91 @@
+{
+  "module": "pipeline_safety",
+  "last_refresh": "2026-02-08T00:00:00Z",
+  "record_count": 0,
+  "file_count": 16,
+  "total_size_bytes": 21068858,
+  "source_url": "",
+  "format": "xlsx",
+  "files": [
+    {
+      "name": "raw/phmsa/.claude-flow/metrics/agent-metrics.json",
+      "size_bytes": 2,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/phmsa/.claude-flow/metrics/performance.json",
+      "size_bytes": 157,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/phmsa/.claude-flow/metrics/task-metrics.json",
+      "size_bytes": 177,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/phmsa/extracted/EightCauseMappingMethods.xlsx",
+      "size_bytes": 28187,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/phmsa/extracted/Index Data Sources.txt",
+      "size_bytes": 1031,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/phmsa/extracted/SevenCauseMappingMethods.xlsx",
+      "size_bytes": 28314,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/phmsa/extracted/gd1986tofeb2004.xlsx",
+      "size_bytes": 1362003,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/phmsa/extracted/gd2010toPresent.xlsx",
+      "size_bytes": 2083538,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/phmsa/extracted/gdmar2004to2009.xlsx",
+      "size_bytes": 756015,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/phmsa/extracted/gtgg1986to2001.xlsx",
+      "size_bytes": 778945,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/phmsa/extracted/gtgg2002to2009.xlsx",
+      "size_bytes": 897606,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/phmsa/extracted/gtggungs2010toPresent.xlsx",
+      "size_bytes": 3025658,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/phmsa/extracted/hl1986to2001.xlsx",
+      "size_bytes": 1964564,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/phmsa/extracted/hl2002to2009.xlsx",
+      "size_bytes": 2427297,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/phmsa/extracted/hl2010toPresent.xlsx",
+      "size_bytes": 7627417,
+      "modified": "2026-02-08"
+    },
+    {
+      "name": "raw/phmsa/extracted/lng2011toPresent.xlsx",
+      "size_bytes": 87947,
+      "modified": "2026-02-08"
+    }
+  ]
+}

--- a/data/modules/subsea/_metadata.json
+++ b/data/modules/subsea/_metadata.json
@@ -1,0 +1,23 @@
+{
+  "module": "subsea",
+  "last_refresh": "2026-03-26T00:00:00Z",
+  "record_count": 28,
+  "file_count": 2,
+  "total_size_bytes": 3116,
+  "source_url": "",
+  "format": "csv",
+  "files": [
+    {
+      "name": "curated/mooring_components.csv",
+      "size_bytes": 1504,
+      "modified": "2026-03-26",
+      "rows": 14
+    },
+    {
+      "name": "curated/rigid_jumper_specs.csv",
+      "size_bytes": 1612,
+      "modified": "2026-03-26",
+      "rows": 14
+    }
+  ]
+}

--- a/data/modules/vessel_fleet/_metadata.json
+++ b/data/modules/vessel_fleet/_metadata.json
@@ -1,0 +1,49 @@
+{
+  "module": "vessel_fleet",
+  "last_refresh": "2026-03-03T00:00:00Z",
+  "record_count": 2263,
+  "file_count": 7,
+  "total_size_bytes": 275460,
+  "source_url": "",
+  "format": "csv",
+  "files": [
+    {
+      "name": "curated/construction_vessels.csv",
+      "size_bytes": 4860,
+      "modified": "2026-03-03",
+      "rows": 17
+    },
+    {
+      "name": "curated/construction_vessels.parquet",
+      "size_bytes": 23402,
+      "modified": "2026-03-03"
+    },
+    {
+      "name": "curated/drilling_rigs.csv",
+      "size_bytes": 201262,
+      "modified": "2026-03-03",
+      "rows": 2210
+    },
+    {
+      "name": "curated/drilling_riser_components.csv",
+      "size_bytes": 6598,
+      "modified": "2026-03-03",
+      "rows": 36
+    },
+    {
+      "name": "raw/contractor_scrape/noble.json",
+      "size_bytes": 19507,
+      "modified": "2026-02-13"
+    },
+    {
+      "name": "raw/contractor_scrape/scrape_summary.json",
+      "size_bytes": 1322,
+      "modified": "2026-02-13"
+    },
+    {
+      "name": "raw/contractor_scrape/seadrill.json",
+      "size_bytes": 18509,
+      "modified": "2026-02-13"
+    }
+  ]
+}

--- a/data/modules/vessel_hull_models/_metadata.json
+++ b/data/modules/vessel_hull_models/_metadata.json
@@ -1,0 +1,17 @@
+{
+  "module": "vessel_hull_models",
+  "last_refresh": "2026-02-13T00:00:00Z",
+  "record_count": 5,
+  "file_count": 1,
+  "total_size_bytes": 1024,
+  "source_url": "",
+  "format": "csv",
+  "files": [
+    {
+      "name": "csv/rig_hulls/sample_rigs.csv",
+      "size_bytes": 1024,
+      "modified": "2026-02-13",
+      "rows": 5
+    }
+  ]
+}

--- a/data/modules/wind/_metadata.json
+++ b/data/modules/wind/_metadata.json
@@ -1,0 +1,31 @@
+{
+  "module": "wind",
+  "last_refresh": "2025-07-31T00:00:00Z",
+  "record_count": 0,
+  "file_count": 4,
+  "total_size_bytes": 7356656,
+  "source_url": "",
+  "format": "zip",
+  "files": [
+    {
+      "name": "uswtdbCSV.zip",
+      "size_bytes": 1458710,
+      "modified": "2025-07-31"
+    },
+    {
+      "name": "uswtdbGeoJSON.zip",
+      "size_bytes": 1430239,
+      "modified": "2025-07-31"
+    },
+    {
+      "name": "uswtdbSHP.zip",
+      "size_bytes": 4451928,
+      "modified": "2025-07-31"
+    },
+    {
+      "name": "uswtdb_v3_2_20201014_codebook.xlsx",
+      "size_bytes": 15779,
+      "modified": "2025-07-31"
+    }
+  ]
+}

--- a/scripts/generate_metadata.py
+++ b/scripts/generate_metadata.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Generate _metadata.json for each data module under data/modules/.
+
+Scans every module directory for data files, computes row counts for CSVs
+(using csv.reader, not pandas), and writes a self-documenting metadata file
+that powers the ``worldenergydata status`` CLI command.
+
+Usage:
+    python3 scripts/generate_metadata.py
+"""
+
+import csv
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Data file extensions to include in metadata
+DATA_EXTENSIONS = {
+    ".csv", ".parquet", ".db", ".json", ".xls", ".xlsx",
+    ".zip", ".txt", ".bin", ".pkl", ".html",
+}
+
+# Extensions where row counting makes sense
+ROW_COUNTABLE = {".csv"}
+
+# Repo root: one level up from scripts/
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MODULES_DIR = REPO_ROOT / "data" / "modules"
+
+
+def count_csv_rows(filepath: Path) -> int:
+    """Count data rows in a CSV file (excludes header).
+
+    Uses csv.reader for lightweight counting -- no pandas dependency.
+    Returns 0 on any read error.
+    """
+    try:
+        with open(filepath, newline="", encoding="utf-8", errors="replace") as f:
+            reader = csv.reader(f)
+            header = next(reader, None)
+            if header is None:
+                return 0
+            return sum(1 for _ in reader)
+    except Exception:
+        return 0
+
+
+def gather_file_info(module_dir: Path) -> list[dict]:
+    """Walk *module_dir* and return metadata for every data file."""
+    files = []
+    for root, _dirs, filenames in os.walk(module_dir):
+        for name in filenames:
+            fp = Path(root) / name
+            suffix = fp.suffix.lower()
+            if suffix not in DATA_EXTENSIONS:
+                continue
+            # Skip hidden/metadata files we generate ourselves
+            if name.startswith("_metadata"):
+                continue
+            stat = fp.stat()
+            entry: dict = {
+                "name": str(fp.relative_to(module_dir)),
+                "size_bytes": stat.st_size,
+                "modified": datetime.fromtimestamp(
+                    stat.st_mtime, tz=timezone.utc
+                ).strftime("%Y-%m-%d"),
+            }
+            if suffix in ROW_COUNTABLE:
+                entry["rows"] = count_csv_rows(fp)
+            files.append(entry)
+    # Sort by path for deterministic output
+    files.sort(key=lambda f: f["name"])
+    return files
+
+
+def dominant_format(files: list[dict]) -> str:
+    """Return the most common file extension across *files*."""
+    from collections import Counter
+
+    if not files:
+        return "none"
+    exts = [Path(f["name"]).suffix.lower() for f in files]
+    most_common = Counter(exts).most_common(1)
+    return most_common[0][0].lstrip(".") if most_common else "mixed"
+
+
+def build_metadata(module_name: str, module_dir: Path) -> dict:
+    """Build the metadata dict for a single module."""
+    files = gather_file_info(module_dir)
+
+    if not files:
+        return {
+            "module": module_name,
+            "last_refresh": None,
+            "record_count": 0,
+            "file_count": 0,
+            "total_size_bytes": 0,
+            "source_url": "",
+            "format": "none",
+            "note": "no data files -- run 'make data'",
+            "files": [],
+        }
+
+    total_size = sum(f["size_bytes"] for f in files)
+    record_count = sum(f.get("rows", 0) for f in files)
+
+    # last_refresh = most recent file modification
+    all_dates = [f["modified"] for f in files]
+    last_refresh_date = max(all_dates) if all_dates else None
+    # Build an ISO timestamp from the date (midnight UTC)
+    last_refresh = (
+        f"{last_refresh_date}T00:00:00Z" if last_refresh_date else None
+    )
+
+    return {
+        "module": module_name,
+        "last_refresh": last_refresh,
+        "record_count": record_count,
+        "file_count": len(files),
+        "total_size_bytes": total_size,
+        "source_url": "",
+        "format": dominant_format(files),
+        "files": files,
+    }
+
+
+def main() -> None:
+    if not MODULES_DIR.is_dir():
+        print(f"ERROR: modules directory not found: {MODULES_DIR}", file=sys.stderr)
+        sys.exit(1)
+
+    modules = sorted(
+        p for p in MODULES_DIR.iterdir() if p.is_dir()
+    )
+    print(f"Scanning {len(modules)} module(s) under {MODULES_DIR} ...")
+
+    for module_dir in modules:
+        module_name = module_dir.name
+        metadata = build_metadata(module_name, module_dir)
+        out_path = module_dir / "_metadata.json"
+        out_path.write_text(json.dumps(metadata, indent=2) + "\n")
+        fc = metadata["file_count"]
+        rc = metadata["record_count"]
+        print(f"  {module_name:25s}  files={fc:4d}  rows={rc:>10,}")
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_metadata.py
+++ b/scripts/generate_metadata.py
@@ -18,8 +18,17 @@ from pathlib import Path
 
 # Data file extensions to include in metadata
 DATA_EXTENSIONS = {
-    ".csv", ".parquet", ".db", ".json", ".xls", ".xlsx",
-    ".zip", ".txt", ".bin", ".pkl", ".html",
+    ".csv",
+    ".parquet",
+    ".db",
+    ".json",
+    ".xls",
+    ".xlsx",
+    ".zip",
+    ".txt",
+    ".bin",
+    ".pkl",
+    ".html",
 }
 
 # Extensions where row counting makes sense
@@ -110,9 +119,7 @@ def build_metadata(module_name: str, module_dir: Path) -> dict:
     all_dates = [f["modified"] for f in files]
     last_refresh_date = max(all_dates) if all_dates else None
     # Build an ISO timestamp from the date (midnight UTC)
-    last_refresh = (
-        f"{last_refresh_date}T00:00:00Z" if last_refresh_date else None
-    )
+    last_refresh = f"{last_refresh_date}T00:00:00Z" if last_refresh_date else None
 
     return {
         "module": module_name,
@@ -131,9 +138,7 @@ def main() -> None:
         print(f"ERROR: modules directory not found: {MODULES_DIR}", file=sys.stderr)
         sys.exit(1)
 
-    modules = sorted(
-        p for p in MODULES_DIR.iterdir() if p.is_dir()
-    )
+    modules = sorted(p for p in MODULES_DIR.iterdir() if p.is_dir())
     print(f"Scanning {len(modules)} module(s) under {MODULES_DIR} ...")
 
     for module_dir in modules:

--- a/src/worldenergydata/cli/main.py
+++ b/src/worldenergydata/cli/main.py
@@ -231,47 +231,117 @@ def info() -> None:
 
 @app.command()
 def status() -> None:
-    """Display system status and data availability."""
+    """Show data freshness status for all modules.
+
+    Reads ``_metadata.json`` from each module under ``data/modules/`` and
+    displays a colour-coded freshness table.  Green = refreshed within
+    30 days, yellow = 30-90 days, red = older than 90 days or never.
+
+    Run ``python3 scripts/generate_metadata.py`` to regenerate metadata.
+    """
+    import json
+    from datetime import datetime, timezone
     from pathlib import Path
 
-    from worldenergydata.common.data_resolver import DataNotFoundError, get_data_root, get_module_data
+    from worldenergydata.common.data_resolver import DataNotFoundError, get_data_root
 
-    console.print(Panel("[bold]System Status[/bold]", border_style="green"))
+    console.print(Panel("[bold]Data Freshness Status[/bold]", border_style="green"))
 
-    # Check data directories
     try:
         _data_root = get_data_root()
     except DataNotFoundError:
         _data_root = Path("data")
 
-    data_paths = {
-        "BSEE Data": _data_root / "bsee",
-        "Marine Safety Data": _data_root / "marine_safety",
-        "SODIR Data": _data_root / "sodir",
-        "Metocean Data": _data_root / "metocean",
-        "Texas RRC Data": _data_root / "texas_rrc",
-        "Canada Data": _data_root / "canada",
-        "Mexico CNH Data": _data_root / "mexico_cnh",
-        "Landman Data": _data_root / "landman",
-        "LNG Terminals Data": _data_root / "modules" / "lng_terminals",
-        "Reports": Path("reports"),
-    }
+    modules_dir = _data_root / "modules"
+    if not modules_dir.is_dir():
+        console.print("[red]No data/modules directory found.[/red]")
+        console.print("[dim]Run 'make data' or 'python3 scripts/generate_metadata.py' first.[/dim]")
+        return
 
-    status_table = Table(show_header=True, header_style="bold")
-    status_table.add_column("Component")
-    status_table.add_column("Status")
-    status_table.add_column("Details", style="dim")
+    now = datetime.now(tz=timezone.utc)
 
-    for name, path in data_paths.items():
-        if path.exists():
-            file_count = len(list(path.rglob("*"))) if path.is_dir() else 1
+    status_table = Table(
+        title="Module Freshness",
+        show_header=True,
+        header_style="bold cyan",
+    )
+    status_table.add_column("Module", style="bold")
+    status_table.add_column("Last Refresh", justify="center")
+    status_table.add_column("Age (days)", justify="right")
+    status_table.add_column("Records", justify="right")
+    status_table.add_column("Files", justify="right")
+    status_table.add_column("Size", justify="right")
+
+    def _human_size(n: int) -> str:
+        for unit in ("B", "KB", "MB", "GB"):
+            if abs(n) < 1024:
+                return f"{n:.0f} {unit}" if unit == "B" else f"{n:.1f} {unit}"
+            n /= 1024  # type: ignore[assignment]
+        return f"{n:.1f} TB"
+
+    module_dirs = sorted(p for p in modules_dir.iterdir() if p.is_dir())
+
+    for mod_dir in module_dirs:
+        meta_path = mod_dir / "_metadata.json"
+        module_name = mod_dir.name
+
+        if not meta_path.exists():
             status_table.add_row(
-                name, "[green]Available[/green]", f"{file_count} files"
+                module_name, "[dim]no metadata[/dim]", "-", "-", "-", "-",
             )
+            continue
+
+        try:
+            meta = json.loads(meta_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            status_table.add_row(
+                module_name, "[red]read error[/red]", "-", "-", "-", "-",
+            )
+            continue
+
+        last_refresh = meta.get("last_refresh")
+        if last_refresh:
+            try:
+                lr_dt = datetime.fromisoformat(last_refresh.replace("Z", "+00:00"))
+                age_days = (now - lr_dt).days
+            except (ValueError, TypeError):
+                lr_dt = None
+                age_days = None
         else:
-            status_table.add_row(name, "[yellow]Not Found[/yellow]", f"Path: {path}")
+            lr_dt = None
+            age_days = None
+
+        # Colour-code by freshness
+        if age_days is not None:
+            if age_days <= 30:
+                age_style = "green"
+            elif age_days <= 90:
+                age_style = "yellow"
+            else:
+                age_style = "red"
+            age_str = f"[{age_style}]{age_days}[/{age_style}]"
+            lr_str = f"[{age_style}]{last_refresh[:10]}[/{age_style}]"
+        else:
+            age_str = "[red]never[/red]"
+            lr_str = "[red]never[/red]"
+
+        record_count = meta.get("record_count", 0)
+        file_count = meta.get("file_count", 0)
+        total_size = meta.get("total_size_bytes", 0)
+
+        status_table.add_row(
+            module_name,
+            lr_str,
+            age_str,
+            f"{record_count:,}",
+            str(file_count),
+            _human_size(total_size),
+        )
 
     console.print(status_table)
+    console.print(
+        "\n[dim]Regenerate metadata: python3 scripts/generate_metadata.py[/dim]"
+    )
 
 
 @app.callback(invoke_without_command=True)

--- a/src/worldenergydata/cli/main.py
+++ b/src/worldenergydata/cli/main.py
@@ -255,7 +255,9 @@ def status() -> None:
     modules_dir = _data_root / "modules"
     if not modules_dir.is_dir():
         console.print("[red]No data/modules directory found.[/red]")
-        console.print("[dim]Run 'make data' or 'python3 scripts/generate_metadata.py' first.[/dim]")
+        console.print(
+            "[dim]Run 'make data' or 'python3 scripts/generate_metadata.py' first.[/dim]"
+        )
         return
 
     now = datetime.now(tz=timezone.utc)
@@ -287,7 +289,12 @@ def status() -> None:
 
         if not meta_path.exists():
             status_table.add_row(
-                module_name, "[dim]no metadata[/dim]", "-", "-", "-", "-",
+                module_name,
+                "[dim]no metadata[/dim]",
+                "-",
+                "-",
+                "-",
+                "-",
             )
             continue
 
@@ -295,7 +302,12 @@ def status() -> None:
             meta = json.loads(meta_path.read_text())
         except (json.JSONDecodeError, OSError):
             status_table.add_row(
-                module_name, "[red]read error[/red]", "-", "-", "-", "-",
+                module_name,
+                "[red]read error[/red]",
+                "-",
+                "-",
+                "-",
+                "-",
             )
             continue
 

--- a/src/worldenergydata/scheduler/jobs/__init__.py
+++ b/src/worldenergydata/scheduler/jobs/__init__.py
@@ -1,6 +1,6 @@
 """Job adapter implementations for the data collection scheduler."""
 
-from worldenergydata.scheduler.jobs.base import AbstractJob, JobResult
+from worldenergydata.scheduler.jobs.base import AbstractJob, JobResult, write_refresh_metadata
 from worldenergydata.scheduler.jobs.bsee_refresh import BseeRefreshJob
 from worldenergydata.scheduler.jobs.sodir_refresh import SodirRefreshJob
 from worldenergydata.scheduler.jobs.eia_us_refresh import EiaUsRefreshJob
@@ -12,6 +12,7 @@ from worldenergydata.scheduler.jobs.lng_terminals_refresh import LngTerminalsRef
 __all__ = [
     "AbstractJob",
     "JobResult",
+    "write_refresh_metadata",
     "BseeRefreshJob",
     "SodirRefreshJob",
     "EiaUsRefreshJob",

--- a/src/worldenergydata/scheduler/jobs/__init__.py
+++ b/src/worldenergydata/scheduler/jobs/__init__.py
@@ -1,6 +1,10 @@
 """Job adapter implementations for the data collection scheduler."""
 
-from worldenergydata.scheduler.jobs.base import AbstractJob, JobResult, write_refresh_metadata
+from worldenergydata.scheduler.jobs.base import (
+    AbstractJob,
+    JobResult,
+    write_refresh_metadata,
+)
 from worldenergydata.scheduler.jobs.bsee_refresh import BseeRefreshJob
 from worldenergydata.scheduler.jobs.sodir_refresh import SodirRefreshJob
 from worldenergydata.scheduler.jobs.eia_us_refresh import EiaUsRefreshJob

--- a/src/worldenergydata/scheduler/jobs/base.py
+++ b/src/worldenergydata/scheduler/jobs/base.py
@@ -1,8 +1,9 @@
 """Base classes for scheduler jobs: JobResult dataclass and AbstractJob interface."""
+import json
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -68,3 +69,46 @@ class AbstractJob(ABC):
 
         elapsed = datetime.now() - last_run
         return elapsed >= threshold
+
+
+def write_refresh_metadata(
+    module_name: str,
+    output_dir: Path,
+    records_updated: int,
+) -> None:
+    """Write a ``_metadata.json`` file after a successful refresh.
+
+    This provides a lightweight signal for the CLI ``status`` command and
+    any downstream freshness dashboards.
+
+    Args:
+        module_name: Logical module identifier (e.g. ``"bsee"``).
+        output_dir: Module data directory where ``_metadata.json`` is written.
+        records_updated: Total records written during this refresh.
+    """
+    try:
+        file_count = sum(
+            1
+            for p in output_dir.rglob("*")
+            if p.is_file() and p.name != "_metadata.json"
+        )
+        total_size = sum(
+            p.stat().st_size
+            for p in output_dir.rglob("*")
+            if p.is_file() and p.name != "_metadata.json"
+        )
+        metadata = {
+            "module": module_name,
+            "last_refresh": datetime.now(tz=timezone.utc).isoformat(),
+            "record_count": records_updated,
+            "file_count": file_count,
+            "total_size_bytes": total_size,
+            "source_url": "",
+            "format": "parquet",
+            "files": [],
+        }
+        meta_path = output_dir / "_metadata.json"
+        meta_path.write_text(json.dumps(metadata, indent=2) + "\n")
+        logger.info("Wrote %s", meta_path)
+    except Exception as exc:
+        logger.warning("Failed to write _metadata.json for %s: %s", module_name, exc)

--- a/src/worldenergydata/scheduler/jobs/base.py
+++ b/src/worldenergydata/scheduler/jobs/base.py
@@ -1,4 +1,5 @@
 """Base classes for scheduler jobs: JobResult dataclass and AbstractJob interface."""
+
 import json
 import logging
 from abc import ABC, abstractmethod

--- a/src/worldenergydata/scheduler/jobs/bsee_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/bsee_refresh.py
@@ -15,7 +15,7 @@ import pandas as pd
 
 from worldenergydata.bsee.data.scrapers.bsee_web import BSEEWebScraper
 from worldenergydata.common.data_resolver import get_module_data_safe
-from worldenergydata.scheduler.jobs.base import AbstractJob, JobResult
+from worldenergydata.scheduler.jobs.base import AbstractJob, JobResult, write_refresh_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +84,7 @@ class BseeRefreshJob(AbstractJob):
                     "BSEE refresh partial: failed datasets=%s",
                     failed_datasets,
                 )
+            write_refresh_metadata("bsee", output_dir, total_records)
             return JobResult(
                 job_name=self.name,
                 start_time=start,

--- a/src/worldenergydata/scheduler/jobs/bsee_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/bsee_refresh.py
@@ -15,7 +15,11 @@ import pandas as pd
 
 from worldenergydata.bsee.data.scrapers.bsee_web import BSEEWebScraper
 from worldenergydata.common.data_resolver import get_module_data_safe
-from worldenergydata.scheduler.jobs.base import AbstractJob, JobResult, write_refresh_metadata
+from worldenergydata.scheduler.jobs.base import (
+    AbstractJob,
+    JobResult,
+    write_refresh_metadata,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/worldenergydata/scheduler/jobs/eia_us_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/eia_us_refresh.py
@@ -13,7 +13,11 @@ import pandas as pd
 
 from worldenergydata.common.data_resolver import get_module_data_safe
 from worldenergydata.eia.ingestion import EIAIngestionSync
-from worldenergydata.scheduler.jobs.base import AbstractJob, JobResult, write_refresh_metadata
+from worldenergydata.scheduler.jobs.base import (
+    AbstractJob,
+    JobResult,
+    write_refresh_metadata,
+)
 from worldenergydata.scheduler.parquet_output import write_parquet
 
 logger = logging.getLogger(__name__)

--- a/src/worldenergydata/scheduler/jobs/eia_us_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/eia_us_refresh.py
@@ -13,7 +13,7 @@ import pandas as pd
 
 from worldenergydata.common.data_resolver import get_module_data_safe
 from worldenergydata.eia.ingestion import EIAIngestionSync
-from worldenergydata.scheduler.jobs.base import AbstractJob, JobResult
+from worldenergydata.scheduler.jobs.base import AbstractJob, JobResult, write_refresh_metadata
 from worldenergydata.scheduler.parquet_output import write_parquet
 
 logger = logging.getLogger(__name__)
@@ -61,6 +61,7 @@ class EiaUsRefreshJob(AbstractJob):
                 total_records,
                 len(results),
             )
+            write_refresh_metadata("eia", output_dir, total_records)
             return JobResult(
                 job_name=self.name,
                 start_time=start,

--- a/src/worldenergydata/scheduler/jobs/sodir_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/sodir_refresh.py
@@ -8,7 +8,7 @@ from typing import Dict
 import pandas as pd
 
 from worldenergydata.common.data_resolver import get_module_data_safe
-from worldenergydata.scheduler.jobs.base import AbstractJob, JobResult
+from worldenergydata.scheduler.jobs.base import AbstractJob, JobResult, write_refresh_metadata
 from worldenergydata.sodir.api_client import SodirAPIClient
 from worldenergydata.sodir.endpoints import SODIR_ENDPOINTS
 from worldenergydata.sodir.errors import SodirAPIError
@@ -111,6 +111,7 @@ class SodirRefreshJob(AbstractJob):
                 ", ".join(failures),
             )
 
+        write_refresh_metadata("sodir", output_dir, total_records)
         return JobResult(
             job_name=self.name,
             start_time=start,

--- a/src/worldenergydata/scheduler/jobs/sodir_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/sodir_refresh.py
@@ -8,7 +8,11 @@ from typing import Dict
 import pandas as pd
 
 from worldenergydata.common.data_resolver import get_module_data_safe
-from worldenergydata.scheduler.jobs.base import AbstractJob, JobResult, write_refresh_metadata
+from worldenergydata.scheduler.jobs.base import (
+    AbstractJob,
+    JobResult,
+    write_refresh_metadata,
+)
 from worldenergydata.sodir.api_client import SodirAPIClient
 from worldenergydata.sodir.endpoints import SODIR_ENDPOINTS
 from worldenergydata.sodir.errors import SodirAPIError

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,114 @@
+"""Tests for data freshness metadata generation and CLI status command."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MODULES_DIR = REPO_ROOT / "data" / "modules"
+GENERATE_SCRIPT = REPO_ROOT / "scripts" / "generate_metadata.py"
+
+
+# ---------------------------------------------------------------------------
+# Metadata generation script
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateMetadata:
+    """Verify scripts/generate_metadata.py runs and produces valid output."""
+
+    def test_script_runs_without_error(self):
+        """The generate_metadata.py script exits 0."""
+        result = subprocess.run(
+            [sys.executable, str(GENERATE_SCRIPT)],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+        assert result.returncode == 0, (
+            f"generate_metadata.py failed:\n{result.stderr}"
+        )
+
+    def test_metadata_json_created_for_each_module(self):
+        """Every module directory should have a _metadata.json after running."""
+        # Run the script first to ensure files exist
+        subprocess.run(
+            [sys.executable, str(GENERATE_SCRIPT)],
+            capture_output=True,
+            cwd=str(REPO_ROOT),
+        )
+        if not MODULES_DIR.is_dir():
+            pytest.skip("data/modules/ not present")
+
+        for mod_dir in sorted(MODULES_DIR.iterdir()):
+            if not mod_dir.is_dir():
+                continue
+            meta_path = mod_dir / "_metadata.json"
+            assert meta_path.exists(), f"Missing _metadata.json in {mod_dir.name}"
+
+    def test_metadata_json_has_required_fields(self):
+        """Each _metadata.json must contain the expected top-level keys."""
+        required_keys = {
+            "module",
+            "last_refresh",
+            "record_count",
+            "file_count",
+            "total_size_bytes",
+            "source_url",
+            "format",
+            "files",
+        }
+        if not MODULES_DIR.is_dir():
+            pytest.skip("data/modules/ not present")
+
+        for mod_dir in sorted(MODULES_DIR.iterdir()):
+            if not mod_dir.is_dir():
+                continue
+            meta_path = mod_dir / "_metadata.json"
+            if not meta_path.exists():
+                continue
+            data = json.loads(meta_path.read_text())
+            missing = required_keys - set(data.keys())
+            assert not missing, (
+                f"{mod_dir.name}/_metadata.json missing keys: {missing}"
+            )
+
+    def test_metadata_record_count_non_negative(self):
+        """record_count must be >= 0 for every module."""
+        if not MODULES_DIR.is_dir():
+            pytest.skip("data/modules/ not present")
+
+        for mod_dir in sorted(MODULES_DIR.iterdir()):
+            if not mod_dir.is_dir():
+                continue
+            meta_path = mod_dir / "_metadata.json"
+            if not meta_path.exists():
+                continue
+            data = json.loads(meta_path.read_text())
+            assert data["record_count"] >= 0, (
+                f"{mod_dir.name} has negative record_count"
+            )
+
+
+# ---------------------------------------------------------------------------
+# CLI status command
+# ---------------------------------------------------------------------------
+
+
+class TestCLIStatus:
+    """Verify the ``worldenergydata status`` command doesn't crash."""
+
+    def test_status_command_exits_zero(self):
+        """CLI status command should exit 0."""
+        result = subprocess.run(
+            [sys.executable, "-m", "worldenergydata.cli.main", "status"],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+        assert result.returncode == 0, (
+            f"CLI status failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+        )

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -28,9 +28,7 @@ class TestGenerateMetadata:
             text=True,
             cwd=str(REPO_ROOT),
         )
-        assert result.returncode == 0, (
-            f"generate_metadata.py failed:\n{result.stderr}"
-        )
+        assert result.returncode == 0, f"generate_metadata.py failed:\n{result.stderr}"
 
     def test_metadata_json_created_for_each_module(self):
         """Every module directory should have a _metadata.json after running."""
@@ -72,9 +70,7 @@ class TestGenerateMetadata:
                 continue
             data = json.loads(meta_path.read_text())
             missing = required_keys - set(data.keys())
-            assert not missing, (
-                f"{mod_dir.name}/_metadata.json missing keys: {missing}"
-            )
+            assert not missing, f"{mod_dir.name}/_metadata.json missing keys: {missing}"
 
     def test_metadata_record_count_non_negative(self):
         """record_count must be >= 0 for every module."""
@@ -88,9 +84,9 @@ class TestGenerateMetadata:
             if not meta_path.exists():
                 continue
             data = json.loads(meta_path.read_text())
-            assert data["record_count"] >= 0, (
-                f"{mod_dir.name} has negative record_count"
-            )
+            assert (
+                data["record_count"] >= 0
+            ), f"{mod_dir.name} has negative record_count"
 
 
 # ---------------------------------------------------------------------------
@@ -109,6 +105,6 @@ class TestCLIStatus:
             text=True,
             cwd=str(REPO_ROOT),
         )
-        assert result.returncode == 0, (
-            f"CLI status failed:\nstdout={result.stdout}\nstderr={result.stderr}"
-        )
+        assert (
+            result.returncode == 0
+        ), f"CLI status failed:\nstdout={result.stdout}\nstderr={result.stderr}"


### PR DESCRIPTION
## Summary
- **`scripts/generate_metadata.py`** (152 lines) — scans all 12 module directories, computes file counts, sizes, CSV row counts (via `csv.reader`, no pandas), writes `_metadata.json` per module
- **CLI `status` command** — Rich Table showing: Module, Last Refresh, Age (days), Records, Files, Size. Color-coded: green (≤30d), yellow (31-90d), red (>90d or never)
- **`write_refresh_metadata()` utility** in `scheduler/jobs/base.py` — shared function scheduler jobs call on success
- **Scheduler integration** — wired into `bsee_refresh`, `eia_us_refresh`, `sodir_refresh`
- **12 `_metadata.json` files** generated for all existing data modules

## Files: 19 changed, +1,281 / -32

## Test plan
- [ ] `PYTHONPATH=src python3 -m pytest tests/test_metadata.py --noconftest -v` (5 tests)
- [ ] `cd worldenergydata && python3 scripts/generate_metadata.py` generates valid JSON
- [ ] `PYTHONPATH=src python3 -m worldenergydata status` displays Rich table

Closes #292