### PR TITLE
test: add symlink data flow verification and two-tier docs (#299)

### DIFF
--- a/docs/data/TWO_TIER_DATA.md
+++ b/docs/data/TWO_TIER_DATA.md
@@ -1,0 +1,44 @@
+# Two-Tier Data Architecture
+
+## Why
+
+The full dataset (~12 GB) was too large for git. It was slimmed to ~400 MB by
+moving large binary and raw files to a local mount, keeping only small processed
+files in the repository.
+
+## How
+
+`scripts/setup-data-link.sh` creates a symlink from the repo's `data/` directory
+to the external storage mount:
+
+```
+data/ -> /mnt/ace/worldenergydata/data/
+```
+
+The `DataResolver` (`src/worldenergydata/common/data_resolver.py`) resolves
+paths in this order:
+
+1. `WED_DATA_ROOT` env var (explicit override)
+2. Symlink at `data/` (convention on dev machines)
+3. Plain `data/` directory (fallback for CI or lightweight dev)
+
+## What lives where
+
+| Location | Contents | Size |
+|---|---|---|
+| **Git repo** `data/modules/` | Processed CSVs, catalogs, small datasets | ~400 MB |
+| **Mount** `/mnt/ace/.../data/modules/bsee/` | BSEE binary files, zipped archives | ~2.7 GB |
+| **Mount** `/mnt/ace/.../data/modules/hse/` | HSE raw OSHA CSV files | ~6.7 GB |
+
+## CI / testing
+
+No symlink or external mount is needed in CI. Tests that depend on the symlink
+use `@pytest.mark.skipif` guards and degrade gracefully. Set `WED_DATA_ROOT` to
+a temp directory to test the resolver without external data.
+
+See `tests/integration/test_data_symlink.py` for the full verification suite.
+
+## Reference
+
+`RELOCATION-LOG.md` on `/mnt/ace/worldenergydata/` documents the original file
+moves and checksums.

--- a/tests/integration/test_data_symlink.py
+++ b/tests/integration/test_data_symlink.py
@@ -1,0 +1,168 @@
+"""Integration tests for symlink-based data flow.
+
+These tests verify the two-tier data architecture:
+- Git repo holds small data files (~400 MB in data/modules/)
+- /mnt/ace/worldenergydata/data/ holds large files (BSEE bin, HSE raw)
+- A symlink connects them via scripts/setup-data-link.sh
+
+Resolution order tested (from data_resolver.py):
+1. WED_DATA_ROOT environment variable (explicit override)
+2. Symlink at <project_root>/data -> external mount
+3. Fallback to <project_root>/data/ directory (development)
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from worldenergydata.common.data_resolver import (
+    DataNotFoundError,
+    _clear_cache,
+    get_data_root,
+    get_module_data,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DATA_DIR = PROJECT_ROOT / "data"
+SETUP_SCRIPT = PROJECT_ROOT / "scripts" / "setup-data-link.sh"
+
+_is_symlink = DATA_DIR.is_symlink()
+
+
+@pytest.fixture(autouse=True)
+def _clear_resolver_cache():
+    """Clear the lru_cache on get_data_root before each test."""
+    _clear_cache()
+    yield
+    _clear_cache()
+
+
+# ---------------------------------------------------------------------------
+# a) Script existence
+# ---------------------------------------------------------------------------
+
+
+def test_setup_data_link_script_exists():
+    """Verify setup-data-link.sh is present and executable."""
+    assert SETUP_SCRIPT.exists(), f"Missing: {SETUP_SCRIPT}"
+    mode = SETUP_SCRIPT.stat().st_mode
+    assert mode & stat.S_IXUSR, "setup-data-link.sh is not executable (user)"
+
+
+# ---------------------------------------------------------------------------
+# b) DataResolver follows symlink
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _is_symlink, reason="requires data symlink to /mnt/ace")
+@pytest.mark.integration
+def test_data_resolver_follows_symlink():
+    """When data/ is a symlink, DataResolver resolves through it."""
+    root = get_data_root()
+    assert root.is_dir()
+    # The resolved path should NOT be the symlink itself
+    assert root == DATA_DIR.resolve()
+
+
+# ---------------------------------------------------------------------------
+# c) WED_DATA_ROOT env var override
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_data_resolver_with_env_var_override(monkeypatch, tmp_path):
+    """WED_DATA_ROOT overrides both symlink and local data/ directory."""
+    monkeypatch.setenv("WED_DATA_ROOT", str(tmp_path))
+    root = get_data_root()
+    assert root == tmp_path
+
+
+# ---------------------------------------------------------------------------
+# d) BSEE binary accessible via symlink
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _is_symlink, reason="requires data symlink to /mnt/ace")
+@pytest.mark.integration
+def test_bsee_bin_accessible_via_symlink():
+    """BSEE binary data is reachable through the symlink."""
+    bsee_path = get_module_data("bsee")
+    assert bsee_path.is_dir(), f"BSEE module dir missing: {bsee_path}"
+    # Sanity: directory should contain files
+    children = list(bsee_path.iterdir())
+    assert len(children) > 0, "BSEE module dir is empty"
+
+
+# ---------------------------------------------------------------------------
+# e) HSE raw accessible via symlink
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _is_symlink, reason="requires data symlink to /mnt/ace")
+@pytest.mark.integration
+def test_hse_raw_accessible_via_symlink():
+    """HSE OSHA CSVs are reachable through the symlink."""
+    hse_path = get_module_data("hse")
+    assert hse_path.is_dir(), f"HSE module dir missing: {hse_path}"
+    children = list(hse_path.iterdir())
+    assert len(children) > 0, "HSE module dir is empty"
+
+
+# ---------------------------------------------------------------------------
+# f) Graceful degradation — no symlink, no env var
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_graceful_degradation_no_symlink(monkeypatch, tmp_path):
+    """Without a symlink or env var, resolver falls back to local data/ dir."""
+    # Remove WED_DATA_ROOT if set
+    monkeypatch.delenv("WED_DATA_ROOT", raising=False)
+
+    # Create a fake project layout with a plain data/ directory
+    fake_project = tmp_path / "project"
+    fake_project.mkdir()
+    (fake_project / "pyproject.toml").write_text("[project]\nname='test'\n")
+    (fake_project / "data").mkdir()
+
+    # Temporarily patch _get_project_root to return our fake project
+    import worldenergydata.common.data_resolver as dr
+
+    monkeypatch.setattr(dr, "_get_project_root", lambda: fake_project)
+
+    root = get_data_root()
+    assert root == fake_project / "data"
+
+
+# ---------------------------------------------------------------------------
+# g) Broken symlink handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_symlink_target_unavailable(monkeypatch, tmp_path):
+    """A broken symlink (target missing) raises DataNotFoundError."""
+    monkeypatch.delenv("WED_DATA_ROOT", raising=False)
+
+    # Create a fake project with a broken data symlink
+    fake_project = tmp_path / "project"
+    fake_project.mkdir()
+    (fake_project / "pyproject.toml").write_text("[project]\nname='test'\n")
+
+    broken_target = tmp_path / "nonexistent_data_dir"
+    (fake_project / "data").symlink_to(broken_target)
+
+    import worldenergydata.common.data_resolver as dr
+
+    monkeypatch.setattr(dr, "_get_project_root", lambda: fake_project)
+
+    with pytest.raises(DataNotFoundError, match="does not exist"):
+        get_data_root()


### PR DESCRIPTION
## Summary
- **7 integration tests** for the two-tier data architecture (symlink to `/mnt/ace/`)
- **`docs/data/TWO_TIER_DATA.md`** (44 lines) documenting why/how/what of the pattern

### Tests
| Test | Result | Notes |
|------|--------|-------|
| setup_data_link_script_exists | Pass | Script present and executable |
| data_resolver_with_env_var_override | Pass | `WED_DATA_ROOT` overrides symlink |
| graceful_degradation_no_symlink | Pass | Falls back to local `data/` |
| symlink_target_unavailable | Pass | Broken symlink raises `DataNotFoundError` |
| data_resolver_follows_symlink | Skip | Requires active symlink |
| bsee_bin_accessible_via_symlink | Skip | Requires active symlink |
| hse_raw_accessible_via_symlink | Skip | Requires active symlink |

All symlink-dependent tests have `@pytest.mark.skipif` guards. Uses `_clear_cache()` autouse fixture to prevent `lru_cache` bleed between tests.

## Test plan
- [ ] `PYTHONPATH=src python3 -m pytest tests/integration/test_data_symlink.py --noconftest -v`
- [ ] On machine with symlink: all 7 pass

Closes #299