### PR TITLE
feat: extend catalog and metadata to cover /mnt/ace symlinked data (#298)

### DIFF
--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -1,17 +1,23 @@
 """Generate per-module schema.yaml files and a top-level data/catalog.yaml.
 
-Scans ``data/modules/`` for CSV, Parquet, and JSON data files, infers column
-schemas (name, type, unit), and writes per-module and aggregated catalogs.
+Scans ``data/modules/`` for CSV, Parquet, JSON, binary, and zip data files,
+infers column schemas (name, type, unit), and writes per-module and
+aggregated catalogs.
+
+Supports external data roots (e.g. ``/mnt/ace/worldenergydata/data/``)
+via ``--external-data-root`` or the ``WED_DATA_ROOT`` env var.
 
 Usage:
     python scripts/generate_catalog.py
     python scripts/generate_catalog.py --module bsee
     python scripts/generate_catalog.py --dry-run
+    python scripts/generate_catalog.py --external-data-root /mnt/ace/worldenergydata/data
 """
 
 from __future__ import annotations
 
-import argparse, csv, json, re, sys
+import argparse, csv, json, os, re, sys, zipfile
+from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -70,8 +76,108 @@ _MODULE_DESC = {
     "vessel_hull_models": "3D vessel hull geometry models",
     "wind": "Wind energy resource and turbine data",
 }
-_SKIP_DIRS = {".local", ".claude-flow", "__pycache__", "checkpoints", "cache"}
+_SKIP_DIRS = {
+    ".local",
+    ".claude-flow",
+    "__pycache__",
+    "checkpoints",
+    "cache",
+    ".temp_downloads",
+}
 _SKIP_FILES = {"_metadata.json"}
+
+
+def _humanize_bytes(n: int) -> str:
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if abs(n) < 1024:
+            return f"{n:.1f} {unit}" if unit != "B" else f"{n} {unit}"
+        n /= 1024  # type: ignore[assignment]
+    return f"{n:.1f} PB"
+
+
+def _load_osha_data_dictionary(dict_path: Path) -> dict[str, dict[str, dict[str, str]]]:
+    """Load OSHA data dictionary CSV -> {table: {col: {definition, display_name, datatype}}}."""
+    result: dict[str, dict[str, dict[str, str]]] = defaultdict(dict)
+    if not dict_path.exists():
+        return result
+    try:
+        with open(dict_path, "r", newline="", errors="replace") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                table = row.get("table_name", "").strip().strip('"')
+                col = row.get("column_name", "").strip().strip('"')
+                if table and col:
+                    result[table][col] = {
+                        "definition": row.get("definition", "").strip().strip('"'),
+                        "display_name": row.get("display_name", "").strip().strip('"'),
+                        "datatype": row.get("column_datatype", "").strip().strip('"'),
+                    }
+    except Exception:
+        pass
+    return result
+
+
+def scan_binary_directory(dir_path: Path, root: Path) -> dict[str, Any]:
+    """Catalog a directory of binary files by extension, count, and total size."""
+    ext_counts: dict[str, int] = defaultdict(int)
+    ext_sizes: dict[str, int] = defaultdict(int)
+    total_files = total_size = 0
+    for fp in dir_path.rglob("*"):
+        if not fp.is_file():
+            continue
+        parts = fp.relative_to(dir_path).parts
+        if any(p in _SKIP_DIRS or p.startswith(".") for p in parts[:-1]):
+            continue
+        ext = fp.suffix.lower() or "(no ext)"
+        ext_counts[ext] += 1
+        ext_sizes[ext] += fp.stat().st_size
+        total_files += 1
+        total_size += fp.stat().st_size
+
+    ext_summary = "; ".join(
+        f"{ext}: {c} files ({_humanize_bytes(ext_sizes[ext])})"
+        for ext, c in sorted(ext_counts.items(), key=lambda x: -x[1])
+    )
+    try:
+        rel = str(dir_path.relative_to(root))
+    except ValueError:
+        rel = str(dir_path)
+    return {
+        "name": dir_path.name,
+        "path": rel,
+        "format": "binary_directory",
+        "file_count": total_files,
+        "size_bytes": total_size,
+        "description": f"Binary data directory: {total_files} files, {_humanize_bytes(total_size)}. {ext_summary}",
+        "last_modified": datetime.fromtimestamp(
+            dir_path.stat().st_mtime, tz=timezone.utc
+        ).isoformat(),
+    }
+
+
+def scan_zip(path: Path, root: Path) -> dict[str, Any]:
+    """Catalog a zip archive with name, size, and contents listing."""
+    contents: list[str] = []
+    try:
+        with zipfile.ZipFile(path, "r") as zf:
+            contents = zf.namelist()
+    except Exception:
+        pass
+    try:
+        rel = str(path.relative_to(root))
+    except ValueError:
+        rel = str(path)
+    return {
+        "name": path.name,
+        "path": rel,
+        "format": "zip",
+        "size_bytes": path.stat().st_size,
+        "contents": contents[:20],
+        "contents_count": len(contents),
+        "last_modified": datetime.fromtimestamp(
+            path.stat().st_mtime, tz=timezone.utc
+        ).isoformat(),
+    }
 
 
 def _infer_type(values: list[str]) -> str:
@@ -155,6 +261,16 @@ def _count_rows(path: Path) -> int | None:
         return None
 
 
+def _rel_path(path: Path, root: Path) -> str:
+    """Return relative path if inside root, else absolute."""
+    try:
+        if path.is_relative_to(root):
+            return str(path.relative_to(root))
+    except (ValueError, TypeError):
+        pass
+    return str(path)
+
+
 def scan_csv(path: Path, root: Path) -> dict[str, Any]:
     hdr, rows = _sample_csv(path)
     cols = []
@@ -163,7 +279,7 @@ def scan_csv(path: Path, root: Path) -> dict[str, Any]:
         cols.append(_col_schema(name, _infer_type(vals)))
     return {
         "name": path.name,
-        "path": str(path.relative_to(root)),
+        "path": _rel_path(path, root),
         "format": "csv",
         "columns": cols,
         "row_count": _count_rows(path),
@@ -199,7 +315,7 @@ def scan_parquet(path: Path, root: Path) -> dict[str, Any]:
         pass
     return {
         "name": path.name,
-        "path": str(path.relative_to(root)),
+        "path": _rel_path(path, root),
         "format": "parquet",
         "columns": cols,
         "row_count": row_count,
@@ -230,7 +346,7 @@ def scan_json(path: Path, root: Path) -> dict[str, Any]:
         pass
     return {
         "name": path.name,
-        "path": str(path.relative_to(root)),
+        "path": _rel_path(path, root),
         "format": "json",
         "columns": cols,
         "size_bytes": path.stat().st_size,
@@ -238,60 +354,207 @@ def scan_json(path: Path, root: Path) -> dict[str, Any]:
     }
 
 
-def scan_module(mod_path: Path, root: Path) -> dict[str, Any]:
+def _scan_tree(
+    mod_path: Path, root: Path, osha_dict: dict | None = None
+) -> tuple[list[dict], list[dict]]:
+    """Scan a module directory tree, returning (datasets, binary_stores)."""
     datasets: list[dict] = []
+    binary_stores: list[dict] = []
+    bin_dir = mod_path / "bin"
+    zip_dir = mod_path / "zip"
+
+    # Handle bin/ directory as bulk binary stores
+    if bin_dir.is_dir():
+        for sub in sorted(bin_dir.iterdir()):
+            if sub.is_dir() and not sub.name.startswith("."):
+                binary_stores.append(scan_binary_directory(sub, root))
+        for fp in sorted(bin_dir.iterdir()):
+            if fp.is_file() and fp.suffix.lower() == ".bin":
+                try:
+                    rel = str(fp.relative_to(root))
+                except ValueError:
+                    rel = str(fp)
+                binary_stores.append(
+                    {
+                        "name": fp.name,
+                        "path": rel,
+                        "format": "binary",
+                        "size_bytes": fp.stat().st_size,
+                        "last_modified": datetime.fromtimestamp(
+                            fp.stat().st_mtime, tz=timezone.utc
+                        ).isoformat(),
+                    }
+                )
+
+    # Handle zip/ directory
+    if zip_dir.is_dir():
+        for fp in sorted(zip_dir.rglob("*")):
+            if fp.is_file() and fp.suffix.lower() == ".zip":
+                binary_stores.append(scan_zip(fp, root))
+
+    # Walk remaining files
     for fp in sorted(mod_path.rglob("*")):
         if not fp.is_file() or fp.name in _SKIP_FILES:
             continue
-        parts = fp.relative_to(mod_path).parts
+        try:
+            parts = fp.relative_to(mod_path).parts
+        except ValueError:
+            continue
+        if parts and parts[0] in ("bin", "zip"):
+            continue
         if any(p in _SKIP_DIRS or p.startswith(".") for p in parts[:-1]):
             continue
         s = fp.suffix.lower()
         if s == ".csv":
-            datasets.append(scan_csv(fp, root))
+            entry = scan_csv(fp, root)
+            # Enrich OSHA CSVs with data dictionary
+            if osha_dict and "osha" in fp.name.lower():
+                table_name = fp.stem
+                base_table = re.sub(r"\d+$", "", table_name)
+                col_info = osha_dict.get(table_name) or osha_dict.get(base_table) or {}
+                if col_info and entry.get("columns"):
+                    for col in entry["columns"]:
+                        info = col_info.get(col["name"], {})
+                        if info.get("definition"):
+                            col["description"] = info["definition"]
+                        if info.get("datatype"):
+                            col["type"] = info["datatype"]
+            datasets.append(entry)
         elif s == ".parquet":
             datasets.append(scan_parquet(fp, root))
         elif s == ".json" and fp.stat().st_size < 50_000_000:
             lo = fp.name.lower()
             if "metrics" not in lo and "agent" not in lo:
                 datasets.append(scan_json(fp, root))
+        elif s == ".zip":
+            binary_stores.append(scan_zip(fp, root))
+
+    return datasets, binary_stores
+
+
+def scan_module(
+    mod_path: Path,
+    root: Path,
+    external_mod_path: Path | None = None,
+    osha_dict: dict | None = None,
+) -> dict[str, Any]:
+    datasets, binary_stores = _scan_tree(mod_path, root, osha_dict=osha_dict)
+
+    # Merge external data if available
+    if (
+        external_mod_path
+        and external_mod_path.is_dir()
+        and external_mod_path.resolve() != mod_path.resolve()
+    ):
+        seen = {d.get("path") for d in datasets} | {
+            b.get("path") for b in binary_stores
+        }
+        ext_ds, ext_bs = _scan_tree(external_mod_path, root, osha_dict=osha_dict)
+        for d in ext_ds:
+            if d.get("path") not in seen:
+                datasets.append(d)
+        for b in ext_bs:
+            if b.get("path") not in seen:
+                binary_stores.append(b)
+
     desc = _MODULE_DESC.get(mod_path.name, f"{mod_path.name} data module")
-    if not datasets:
+    all_entries = datasets + binary_stores
+    if not all_entries:
         desc += " (no data files present \u2014 run 'make data' to populate)"
-    return {"module": mod_path.name, "description": desc, "datasets": datasets}
+    total_size = sum(e.get("size_bytes", 0) for e in all_entries)
+    if total_size > 0:
+        desc += f" [{_humanize_bytes(total_size)}]"
+    return {
+        "module": mod_path.name,
+        "description": desc,
+        "datasets": datasets,
+        "binary_stores": binary_stores,
+    }
+
+
+def _resolve_external_root(cli_value: str | None) -> Path | None:
+    """Resolve external data root from CLI arg, env var, or auto-detect."""
+    path_str = cli_value or os.environ.get("WED_DATA_ROOT")
+    if not path_str:
+        default = Path("/mnt/ace/worldenergydata/data")
+        if default.is_dir():
+            return default
+        return None
+    p = Path(path_str)
+    if p.is_dir():
+        return p
+    print(f"WARNING: external data root not found: {p}", file=sys.stderr)
+    return None
 
 
 def generate_catalog(
-    root: Path, module_filter: str | None = None, dry_run: bool = False
+    root: Path,
+    module_filter: str | None = None,
+    dry_run: bool = False,
+    external_data_root: Path | None = None,
 ) -> dict[str, Any]:
     data_root = root / "data" / "modules"
-    if not data_root.exists():
+    ext_modules = external_data_root / "modules" if external_data_root else None
+
+    if not data_root.exists() and not ext_modules:
         print(f"Data root not found: {data_root}", file=sys.stderr)
         return {"modules": {}}
+
+    # Collect all module names from both roots
+    module_names: set[str] = set()
+    if data_root.exists():
+        for mp in data_root.iterdir():
+            if mp.is_dir() and not mp.name.startswith("."):
+                module_names.add(mp.name)
+    if ext_modules and ext_modules.is_dir():
+        for mp in ext_modules.iterdir():
+            if mp.is_dir() and not mp.name.startswith("."):
+                module_names.add(mp.name)
+
+    # Load OSHA data dictionary if available
+    osha_dict = None
+    candidates = [data_root / "hse" / "raw" / "osha" / "osha_data_dictionary.csv"]
+    if ext_modules:
+        candidates.insert(
+            0, ext_modules / "hse" / "raw" / "osha" / "osha_data_dictionary.csv"
+        )
+    for cand in candidates:
+        if cand.exists():
+            osha_dict = _load_osha_data_dictionary(cand)
+            break
+
     mods: dict[str, Any] = {}
     written: list[str] = []
-    for mp in sorted(data_root.iterdir()):
-        if not mp.is_dir() or mp.name.startswith("."):
+    for name in sorted(module_names):
+        if module_filter and name != module_filter:
             continue
-        if module_filter and mp.name != module_filter:
-            continue
-        schema = scan_module(mp, root)
-        mods[mp.name] = schema
-        if not dry_run:
+        mp = data_root / name
+        ext_mp = ext_modules / name if ext_modules else None
+        if not mp.exists() and ext_mp and ext_mp.is_dir():
+            mp = ext_mp
+            ext_mp = None
+
+        use_osha = osha_dict if name == "hse" else None
+        schema = scan_module(mp, root, external_mod_path=ext_mp, osha_dict=use_osha)
+        mods[name] = schema
+        if not dry_run and mp.is_relative_to(root):
             sp = mp / "schema.yaml"
             with open(sp, "w") as f:
                 yaml.dump(schema, f, default_flow_style=False, sort_keys=False)
             written.append(str(sp.relative_to(root)))
+
     tot_ds = sum(len(m.get("datasets", [])) for m in mods.values())
+    tot_bs = sum(len(m.get("binary_stores", [])) for m in mods.values())
     tot_sz = sum(
         sum(d.get("size_bytes", 0) for d in m.get("datasets", []))
+        + sum(b.get("size_bytes", 0) for b in m.get("binary_stores", []))
         for m in mods.values()
     )
     catalog = {
-        "version": "2.0.0",
+        "version": "2.1.0",
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "total_modules": len(mods),
-        "total_datasets": tot_ds,
+        "total_datasets": tot_ds + tot_bs,
         "total_size_bytes": tot_sz,
         "modules": mods,
     }
@@ -301,7 +564,8 @@ def generate_catalog(
         with open(cp, "w") as f:
             yaml.dump(catalog, f, default_flow_style=False, sort_keys=False)
         written.append(str(cp.relative_to(root)))
-    print(f"Scanned {len(mods)} modules, {tot_ds} datasets")
+    print(f"Scanned {len(mods)} modules, {tot_ds} datasets, {tot_bs} binary stores")
+    print(f"Total size: {_humanize_bytes(tot_sz)}")
     if written:
         print(f"Wrote {len(written)} files:")
         for fp in written:
@@ -318,13 +582,33 @@ def main() -> None:
     ap.add_argument("--module", help="Process only this module")
     ap.add_argument("--dry-run", action="store_true", help="Scan without writing")
     ap.add_argument("--project-root", default=None, help="Override project root")
+    ap.add_argument(
+        "--external-data-root",
+        default=None,
+        help="Path to external data directory (e.g. /mnt/ace/worldenergydata/data). "
+        "Also reads WED_DATA_ROOT env var. Auto-detects /mnt/ace if present.",
+    )
+    ap.add_argument(
+        "--follow-symlinks",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Follow symlinks when scanning (default: True)",
+    )
     args = ap.parse_args()
     root = (
         Path(args.project_root)
         if args.project_root
         else Path(__file__).resolve().parent.parent
     )
-    generate_catalog(root, module_filter=args.module, dry_run=args.dry_run)
+    ext_root = _resolve_external_root(args.external_data_root)
+    if ext_root:
+        print(f"External data root: {ext_root}")
+    generate_catalog(
+        root,
+        module_filter=args.module,
+        dry_run=args.dry_run,
+        external_data_root=ext_root,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/generate_data_catalog.py
+++ b/scripts/generate_data_catalog.py
@@ -1,21 +1,32 @@
 """Generate machine-readable data catalog by scanning data directories.
 
 Walks ``data/modules/`` and produces a YAML or JSON catalog describing
-every CSV, parquet, Excel, and binary file it finds.  Metadata such as
-column names, row counts, file sizes, and inferred business domains are
-extracted without loading entire files into memory.
+every CSV, parquet, Excel, binary, and zip file it finds.  Metadata such
+as column names, row counts, file sizes, and inferred business domains
+are extracted without loading entire files into memory.
+
+Supports external data roots (e.g. ``/mnt/ace/worldenergydata/data/``)
+via the ``--external-data-root`` flag or the ``WED_DATA_ROOT`` env var.
+When an external root is provided, its ``modules/`` subtree is merged
+with the in-repo ``data/modules/`` so that large binary and raw data
+hosted outside the repo appear in the catalog.
 
 Usage:
     uv run python scripts/generate_data_catalog.py
     uv run python scripts/generate_data_catalog.py --module bsee
     uv run python scripts/generate_data_catalog.py --format json
+    uv run python scripts/generate_data_catalog.py --external-data-root /mnt/ace/worldenergydata/data
+    WED_DATA_ROOT=/mnt/ace/worldenergydata/data uv run python scripts/generate_data_catalog.py
 """
 
 from __future__ import annotations
 
 import argparse
 import csv
+import os
 import sys
+import zipfile
+from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -26,6 +37,7 @@ import yaml
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from worldenergydata.common.catalog import (
+    ColumnSchema,
     DataCatalog,
     DatasetEntry,
     ModuleCatalogEntry,
@@ -83,6 +95,16 @@ _FREQUENCY_DAYS: dict[str, int] = {
     "static": 99999,
 }
 
+# Skip directories during recursive scan
+_SKIP_DIRS = {
+    ".local",
+    ".claude-flow",
+    "__pycache__",
+    "checkpoints",
+    "cache",
+    ".temp_downloads",
+}
+
 
 def load_source_registry(project_root: Path) -> dict[str, Any]:
     """Load source-registry.yml and return as nested dict."""
@@ -93,37 +115,115 @@ def load_source_registry(project_root: Path) -> dict[str, Any]:
         return yaml.safe_load(f) or {}
 
 
-class DataCatalogGenerator:
-    """Scan data directories and produce a structured catalog."""
+def _load_osha_data_dictionary(dict_path: Path) -> dict[str, dict[str, dict[str, str]]]:
+    """Load the OSHA data dictionary CSV and return a nested mapping.
 
-    def __init__(self, project_root: Path) -> None:
+    Returns:
+        ``{table_name: {column_name: {"definition": ..., "display_name": ..., "datatype": ...}}}``
+    """
+    result: dict[str, dict[str, dict[str, str]]] = defaultdict(dict)
+    if not dict_path.exists():
+        return result
+    try:
+        with open(dict_path, "r", newline="", errors="replace") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                table = row.get("table_name", "").strip().strip('"')
+                col = row.get("column_name", "").strip().strip('"')
+                if table and col:
+                    result[table][col] = {
+                        "definition": row.get("definition", "").strip().strip('"'),
+                        "display_name": row.get("display_name", "").strip().strip('"'),
+                        "datatype": row.get("column_datatype", "").strip().strip('"'),
+                    }
+    except Exception:
+        pass
+    return result
+
+
+def _humanize_bytes(n: int) -> str:
+    """Return a human-readable file size string."""
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if abs(n) < 1024:
+            return f"{n:.1f} {unit}" if unit != "B" else f"{n} {unit}"
+        n /= 1024  # type: ignore[assignment]
+    return f"{n:.1f} PB"
+
+
+class DataCatalogGenerator:
+    """Scan data directories and produce a structured catalog.
+
+    Args:
+        project_root: Path to the worldenergydata project root.
+        external_data_root: Optional path to an external data directory
+            (e.g. ``/mnt/ace/worldenergydata/data/``).  When provided,
+            its ``modules/`` subtree is merged into the scan.
+        follow_symlinks: Whether to follow symlinks during directory
+            traversal (default ``True``).
+    """
+
+    def __init__(
+        self,
+        project_root: Path,
+        external_data_root: Path | None = None,
+        follow_symlinks: bool = True,
+    ) -> None:
         self.project_root = project_root
         self.data_root = project_root / "data" / "modules"
+        self.external_data_root = external_data_root
+        self.follow_symlinks = follow_symlinks
+        self._osha_dict: dict[str, dict[str, dict[str, str]]] | None = None
 
     # ------------------------------------------------------------------
     # File-level scanners
     # ------------------------------------------------------------------
 
+    def _relative_path(self, path: Path) -> str:
+        """Return path relative to project root, or absolute if outside."""
+        try:
+            if path.is_relative_to(self.project_root):
+                return str(path.relative_to(self.project_root))
+        except (ValueError, TypeError):
+            pass
+        return str(path)
+
     def scan_csv_file(self, path: Path) -> DatasetEntry:
-        """Scan a CSV file for metadata without loading the entire file."""
+        """Scan a CSV file for metadata without loading the entire file.
+
+        For very large CSV files (>100 MB), only counts a sample of rows
+        and extrapolates to avoid long scan times.
+        """
         columns = None
         row_count = None
+        size = path.stat().st_size
         try:
             with open(path, "r", newline="", errors="replace") as f:
                 reader = csv.reader(f)
                 header = next(reader, None)
                 if header:
                     columns = [c.strip() for c in header]
-                row_count = sum(1 for _ in reader)
+                if size > 100_000_000:
+                    # For very large files, estimate row count from sample
+                    sample_rows = 0
+                    sample_bytes = 0
+                    for i, row in enumerate(reader):
+                        sample_bytes += sum(len(c) for c in row) + len(row)
+                        sample_rows += 1
+                        if i >= 999:
+                            break
+                    if sample_rows > 0 and sample_bytes > 0:
+                        row_count = int(sample_rows * (size / sample_bytes))
+                else:
+                    row_count = sum(1 for _ in reader)
         except Exception:
             pass
 
         return DatasetEntry(
             name=path.stem,
-            path=str(path.relative_to(self.project_root)),
+            path=self._relative_path(path),
             format="csv",
             domain=self.infer_domain(path),
-            size_bytes=path.stat().st_size,
+            size_bytes=size,
             row_count=row_count,
             columns=columns,
             last_modified=datetime.fromtimestamp(
@@ -148,7 +248,7 @@ class DataCatalogGenerator:
 
         return DatasetEntry(
             name=path.stem,
-            path=str(path.relative_to(self.project_root)),
+            path=self._relative_path(path),
             format="pickle",
             domain=self.infer_domain(path),
             size_bytes=size,
@@ -163,7 +263,7 @@ class DataCatalogGenerator:
         """Scan an Excel file for basic metadata (size only, no parsing)."""
         return DatasetEntry(
             name=path.stem,
-            path=str(path.relative_to(self.project_root)),
+            path=self._relative_path(path),
             format="xlsx" if path.suffix == ".xlsx" else "xls",
             domain=self.infer_domain(path),
             size_bytes=path.stat().st_size,
@@ -171,6 +271,143 @@ class DataCatalogGenerator:
                 path.stat().st_mtime, tz=timezone.utc
             ).strftime("%Y-%m-%d"),
         )
+
+    def scan_zip_file(self, path: Path) -> DatasetEntry:
+        """Scan a zip archive for metadata: size, contained file listing."""
+        contents: list[str] = []
+        try:
+            with zipfile.ZipFile(path, "r") as zf:
+                contents = zf.namelist()
+        except Exception:
+            pass
+
+        desc = f"ZIP archive with {len(contents)} file(s)"
+        if contents:
+            desc += f": {', '.join(contents[:5])}"
+            if len(contents) > 5:
+                desc += f" ... (+{len(contents) - 5} more)"
+
+        return DatasetEntry(
+            name=path.stem,
+            path=(
+                str(path.relative_to(self.project_root))
+                if path.is_relative_to(self.project_root)
+                else str(path)
+            ),
+            format="zip",
+            domain=self.infer_domain(path),
+            size_bytes=path.stat().st_size,
+            description=desc,
+            last_modified=datetime.fromtimestamp(
+                path.stat().st_mtime, tz=timezone.utc
+            ).strftime("%Y-%m-%d"),
+            data_status="real",
+        )
+
+    def scan_binary_directory(self, dir_path: Path) -> DatasetEntry:
+        """Catalog a directory of binary files by extension, count, and size.
+
+        Instead of reading individual binary files as CSVs, this produces
+        a single summary entry for the directory.
+        """
+        ext_counts: dict[str, int] = defaultdict(int)
+        ext_sizes: dict[str, int] = defaultdict(int)
+        total_files = 0
+        total_size = 0
+
+        for fp in dir_path.rglob("*"):
+            if not fp.is_file():
+                continue
+            parts = fp.relative_to(dir_path).parts
+            if any(p in _SKIP_DIRS or p.startswith(".") for p in parts[:-1]):
+                continue
+            ext = fp.suffix.lower() or "(no ext)"
+            ext_counts[ext] += 1
+            ext_sizes[ext] += fp.stat().st_size
+            total_files += 1
+            total_size += fp.stat().st_size
+
+        ext_summary = ", ".join(
+            f"{ext}: {count} files ({_humanize_bytes(ext_sizes[ext])})"
+            for ext, count in sorted(ext_counts.items(), key=lambda x: -x[1])
+        )
+        desc = (
+            f"Binary data directory: {total_files} files, "
+            f"{_humanize_bytes(total_size)} total. "
+            f"Breakdown: {ext_summary}"
+        )
+
+        return DatasetEntry(
+            name=dir_path.name,
+            path=(
+                str(dir_path.relative_to(self.project_root))
+                if dir_path.is_relative_to(self.project_root)
+                else str(dir_path)
+            ),
+            format="binary_directory",
+            domain=self.infer_domain(dir_path),
+            size_bytes=total_size,
+            row_count=total_files,
+            description=desc,
+            last_modified=datetime.fromtimestamp(
+                dir_path.stat().st_mtime, tz=timezone.utc
+            ).strftime("%Y-%m-%d"),
+            data_status="real",
+        )
+
+    def _get_osha_dict(self) -> dict[str, dict[str, dict[str, str]]]:
+        """Lazy-load the OSHA data dictionary."""
+        if self._osha_dict is None:
+            candidates = [
+                self.data_root / "hse" / "raw" / "osha" / "osha_data_dictionary.csv",
+            ]
+            if self.external_data_root:
+                candidates.insert(
+                    0,
+                    self.external_data_root
+                    / "modules"
+                    / "hse"
+                    / "raw"
+                    / "osha"
+                    / "osha_data_dictionary.csv",
+                )
+            for cand in candidates:
+                if cand.exists():
+                    self._osha_dict = _load_osha_data_dictionary(cand)
+                    break
+            if self._osha_dict is None:
+                self._osha_dict = {}
+        return self._osha_dict
+
+    def _enrich_osha_columns(self, entry: DatasetEntry, file_path: Path) -> None:
+        """Add column descriptions from the OSHA data dictionary."""
+        osha_dict = self._get_osha_dict()
+        if not osha_dict or not entry.columns:
+            return
+
+        # Derive table name from filename: osha_accident.csv -> osha_accident
+        table_name = file_path.stem
+        # Handle numbered splits: osha_violation3.csv -> osha_violation
+        import re
+
+        base_table = re.sub(r"\d+$", "", table_name)
+
+        col_info = osha_dict.get(table_name) or osha_dict.get(base_table) or {}
+        if not col_info:
+            return
+
+        schemas: list[ColumnSchema] = []
+        for col_name in entry.columns:
+            info = col_info.get(col_name, {})
+            schemas.append(
+                ColumnSchema(
+                    name=col_name,
+                    type=info.get("datatype", "string"),
+                    description=info.get("definition", ""),
+                    unit="",
+                )
+            )
+        entry.column_schemas = schemas
 
     # ------------------------------------------------------------------
     # Domain inference
@@ -189,8 +426,117 @@ class DataCatalogGenerator:
     # Module and catalog scanning
     # ------------------------------------------------------------------
 
+    def _scan_directory_tree(
+        self,
+        module_path: Path,
+        datasets: list[DatasetEntry],
+        binary_stores: list[DatasetEntry],
+        domains_seen: set[str],
+        is_osha_dir: bool = False,
+    ) -> None:
+        """Scan a directory tree for data files, populating lists in place.
+
+        For ``bin/`` directories containing many binary files, produces a
+        single summary entry per subdirectory instead of per-file entries.
+        For ``zip/`` directories, catalogs each zip archive.
+        For CSV files in OSHA directories, enriches with data dictionary.
+        """
+        # Identify special subdirectories for bulk handling
+        bin_dir = module_path / "bin"
+        zip_dir = module_path / "zip"
+
+        # Handle bin/ directory as bulk binary stores
+        if bin_dir.is_dir():
+            for sub in sorted(bin_dir.iterdir()):
+                if sub.is_dir() and not sub.name.startswith("."):
+                    entry = self.scan_binary_directory(sub)
+                    binary_stores.append(entry)
+                    domains_seen.add(entry.domain)
+            # Also catalog any top-level files in bin/
+            for fp in sorted(bin_dir.iterdir()):
+                if fp.is_file() and not fp.name.startswith("."):
+                    if fp.suffix.lower() == ".bin":
+                        entry = self.scan_binary_file(fp)
+                        binary_stores.append(entry)
+                        domains_seen.add(entry.domain)
+
+        # Handle zip/ directory
+        if zip_dir.is_dir():
+            for fp in sorted(zip_dir.rglob("*")):
+                if fp.is_file() and fp.suffix.lower() == ".zip":
+                    entry = self.scan_zip_file(fp)
+                    binary_stores.append(entry)
+                    domains_seen.add(entry.domain)
+
+        # Walk remaining files (skip bin/ and zip/ already handled)
+        for file_path in sorted(module_path.rglob("*")):
+            if not file_path.is_file():
+                continue
+            # Skip files already handled in bin/ and zip/ directories
+            try:
+                rel = file_path.relative_to(module_path)
+            except ValueError:
+                continue
+            parts = rel.parts
+            if parts and parts[0] in ("bin", "zip"):
+                continue
+            # Skip hidden and cache directories
+            if any(p in _SKIP_DIRS or p.startswith(".") for p in parts[:-1]):
+                continue
+
+            suffix = file_path.suffix.lower()
+            if suffix == ".csv":
+                entry = self.scan_csv_file(file_path)
+                # Enrich OSHA CSVs with data dictionary
+                if is_osha_dir or "osha" in file_path.name.lower():
+                    self._enrich_osha_columns(entry, file_path)
+                datasets.append(entry)
+                domains_seen.add(entry.domain)
+            elif suffix == ".bin":
+                entry = self.scan_binary_file(file_path)
+                binary_stores.append(entry)
+                domains_seen.add(entry.domain)
+            elif suffix in (".xlsx", ".xls"):
+                entry = self.scan_excel_file(file_path)
+                datasets.append(entry)
+                domains_seen.add(entry.domain)
+            elif suffix == ".parquet":
+                entry = DatasetEntry(
+                    name=file_path.stem,
+                    path=(
+                        str(file_path.relative_to(self.project_root))
+                        if file_path.is_relative_to(self.project_root)
+                        else str(file_path)
+                    ),
+                    format="parquet",
+                    domain=self.infer_domain(file_path),
+                    size_bytes=file_path.stat().st_size,
+                    last_modified=datetime.fromtimestamp(
+                        file_path.stat().st_mtime, tz=timezone.utc
+                    ).strftime("%Y-%m-%d"),
+                )
+                datasets.append(entry)
+                domains_seen.add(entry.domain)
+            elif suffix == ".zip":
+                entry = self.scan_zip_file(file_path)
+                binary_stores.append(entry)
+                domains_seen.add(entry.domain)
+
+    def _get_external_module_path(self, module_name: str) -> Path | None:
+        """Return the external data path for a module, if it exists."""
+        if not self.external_data_root:
+            return None
+        ext = self.external_data_root / "modules" / module_name
+        if ext.is_dir():
+            return ext
+        return None
+
     def scan_module(self, module_path: Path) -> ModuleCatalogEntry:
-        """Scan a single data module directory."""
+        """Scan a single data module directory.
+
+        If an external data root is configured, merges files from the
+        external ``modules/<name>/`` directory into the scan.
+        """
         module_name = module_path.name
         datasets: list[DatasetEntry] = []
         binary_stores: list[DatasetEntry] = []
@@ -205,43 +551,42 @@ class DataCatalogGenerator:
                     doc_path.relative_to(self.project_root)
                 )
 
-        # Walk directory for data files
-        for file_path in sorted(module_path.rglob("*")):
-            if not file_path.is_file():
-                continue
-            suffix = file_path.suffix.lower()
-            if suffix == ".csv":
-                entry = self.scan_csv_file(file_path)
-                datasets.append(entry)
-                domains_seen.add(entry.domain)
-            elif suffix == ".bin":
-                entry = self.scan_binary_file(file_path)
-                binary_stores.append(entry)
-                domains_seen.add(entry.domain)
-            elif suffix in (".xlsx", ".xls"):
-                entry = self.scan_excel_file(file_path)
-                datasets.append(entry)
-                domains_seen.add(entry.domain)
-            elif suffix == ".parquet":
-                entry = DatasetEntry(
-                    name=file_path.stem,
-                    path=str(file_path.relative_to(self.project_root)),
-                    format="parquet",
-                    domain=self.infer_domain(file_path),
-                    size_bytes=file_path.stat().st_size,
-                    last_modified=datetime.fromtimestamp(
-                        file_path.stat().st_mtime, tz=timezone.utc
-                    ).strftime("%Y-%m-%d"),
-                )
-                datasets.append(entry)
-                domains_seen.add(entry.domain)
+        # Determine if this is an HSE module with OSHA data
+        is_osha = module_name == "hse"
+
+        # Scan the in-repo directory
+        self._scan_directory_tree(
+            module_path, datasets, binary_stores, domains_seen, is_osha_dir=is_osha
+        )
+
+        # Merge external data if available
+        ext_path = self._get_external_module_path(module_name)
+        if ext_path and ext_path.resolve() != module_path.resolve():
+            # Track names already cataloged to avoid duplicates
+            # (paths differ between in-repo and external so compare by name)
+            seen_names = {d.name for d in datasets} | {b.name for b in binary_stores}
+
+            ext_datasets: list[DatasetEntry] = []
+            ext_binaries: list[DatasetEntry] = []
+            self._scan_directory_tree(
+                ext_path, ext_datasets, ext_binaries, domains_seen, is_osha_dir=is_osha
+            )
+
+            for d in ext_datasets:
+                if d.name not in seen_names:
+                    datasets.append(d)
+                    seen_names.add(d.name)
+            for b in ext_binaries:
+                if b.name not in seen_names:
+                    binary_stores.append(b)
+                    seen_names.add(b.name)
 
         return ModuleCatalogEntry(
             name=module_name,
             description=_MODULE_DESCRIPTIONS.get(
                 module_name, f"{module_name} data module"
             ),
-            path=str(module_path.relative_to(self.project_root)),
+            path=self._relative_path(module_path),
             domains=sorted(domains_seen),
             datasets=datasets,
             binary_stores=binary_stores,
@@ -268,9 +613,7 @@ class DataCatalogGenerator:
                 if not ds.source_url:
                     ds.source_url = ds_reg.get("source_url") or default_url
                 if not ds.update_frequency:
-                    ds.update_frequency = (
-                        ds_reg.get("update_frequency") or default_freq
-                    )
+                    ds.update_frequency = ds_reg.get("update_frequency") or default_freq
 
     def _compute_staleness(self, catalog: DataCatalog) -> None:
         """Mark datasets as stale when last_refreshed exceeds frequency."""
@@ -283,9 +626,7 @@ class DataCatalogGenerator:
                     ds.data_status = "real"
                 if ds.last_refreshed and ds.update_frequency:
                     refreshed = datetime.fromisoformat(ds.last_refreshed)
-                    max_age = _FREQUENCY_DAYS.get(
-                        ds.update_frequency, 99999
-                    )
+                    max_age = _FREQUENCY_DAYS.get(ds.update_frequency, 99999)
                     if (now - refreshed).days > max_age:
                         ds.data_status = "stale"
 
@@ -343,16 +684,37 @@ class DataCatalogGenerator:
     # ------------------------------------------------------------------
 
     def scan_all_modules(self) -> DataCatalog:
-        """Scan all modules under data/modules/."""
+        """Scan all modules under data/modules/.
+
+        If an external data root is configured, also discovers modules
+        that exist only in the external root (not in the repo).
+        """
         catalog = DataCatalog()
-        if not self.data_root.exists():
+        if not self.data_root.exists() and not self.external_data_root:
             return catalog
 
-        for module_path in sorted(self.data_root.iterdir()):
-            if module_path.is_dir() and not module_path.name.startswith("."):
-                entry = self.scan_module(module_path)
-                if entry.dataset_count > 0:
-                    catalog.modules[entry.name] = entry
+        # Collect module names from both in-repo and external roots
+        module_names: set[str] = set()
+        if self.data_root.exists():
+            for mp in self.data_root.iterdir():
+                if mp.is_dir() and not mp.name.startswith("."):
+                    module_names.add(mp.name)
+        if self.external_data_root:
+            ext_modules = self.external_data_root / "modules"
+            if ext_modules.is_dir():
+                for mp in ext_modules.iterdir():
+                    if mp.is_dir() and not mp.name.startswith("."):
+                        module_names.add(mp.name)
+
+        for module_name in sorted(module_names):
+            # Use in-repo path as primary; fall back to external
+            module_path = self.data_root / module_name
+            if not module_path.exists() and self.external_data_root:
+                module_path = self.external_data_root / "modules" / module_name
+
+            entry = self.scan_module(module_path)
+            if entry.dataset_count > 0:
+                catalog.modules[entry.name] = entry
 
         return catalog
 
@@ -401,15 +763,40 @@ class DataCatalogGenerator:
         return output_path, catalog
 
 
+def _resolve_external_root(cli_value: str | None) -> Path | None:
+    """Resolve external data root from CLI arg or WED_DATA_ROOT env var."""
+    path_str = cli_value or os.environ.get("WED_DATA_ROOT")
+    if not path_str:
+        # Auto-detect common locations
+        default = Path("/mnt/ace/worldenergydata/data")
+        if default.is_dir():
+            return default
+        return None
+    p = Path(path_str)
+    if p.is_dir():
+        return p
+    print(f"WARNING: external data root not found: {p}", file=sys.stderr)
+    return None
+
+
 def main() -> None:
     """CLI entry point."""
     parser = argparse.ArgumentParser(description="Generate data catalog")
     parser.add_argument("--module", help="Scan specific module only")
+    parser.add_argument("--format", choices=["yaml", "json"], default="yaml")
+    parser.add_argument("--project-root", default=None, help="Project root path")
     parser.add_argument(
-        "--format", choices=["yaml", "json"], default="yaml"
+        "--external-data-root",
+        default=None,
+        help="Path to external data directory (e.g. /mnt/ace/worldenergydata/data). "
+        "Also reads WED_DATA_ROOT env var. Auto-detects /mnt/ace if present.",
     )
     parser.add_argument(
-        "--project-root", default=None, help="Project root path"
+        "--follow-symlinks",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Follow symlinks when scanning directories (default: True). "
+        "Use --no-follow-symlinks to disable.",
     )
     parser.add_argument(
         "--report",
@@ -423,11 +810,24 @@ def main() -> None:
         if args.project_root
         else Path(__file__).resolve().parent.parent
     )
-    generator = DataCatalogGenerator(root)
+    ext_root = _resolve_external_root(args.external_data_root)
+    if ext_root:
+        print(f"External data root: {ext_root}")
+
+    generator = DataCatalogGenerator(
+        root,
+        external_data_root=ext_root,
+        follow_symlinks=args.follow_symlinks,
+    )
     output_path, catalog = generator.generate(
         module_name=args.module, output_format=args.format
     )
     print(f"Catalog written to: {output_path}")
+    print(
+        f"  {catalog.total_modules} modules, "
+        f"{catalog.total_datasets} datasets, "
+        f"{_humanize_bytes(catalog.total_size_bytes)}"
+    )
     if args.report:
         print()
         DataCatalogGenerator.print_freshness_report(catalog)

--- a/scripts/generate_metadata.py
+++ b/scripts/generate_metadata.py
@@ -1,156 +1,321 @@
-#!/usr/bin/env python3
-"""Generate _metadata.json for each data module under data/modules/.
+"""Generate per-module freshness metadata (_metadata.json).
 
-Scans every module directory for data files, computes row counts for CSVs
-(using csv.reader, not pandas), and writes a self-documenting metadata file
-that powers the ``worldenergydata status`` CLI command.
+Walks ``data/modules/`` and writes a ``_metadata.json`` file in each module
+directory summarising file counts, total sizes, format breakdown, and
+last-refresh timestamps.
+
+Supports external data roots (e.g. ``/mnt/ace/worldenergydata/data/``)
+via ``--external-data-root`` or the ``WED_DATA_ROOT`` env var so that
+large binary and raw data hosted outside the repo are included in the
+size and file counts.
 
 Usage:
-    python3 scripts/generate_metadata.py
+    python scripts/generate_metadata.py
+    python scripts/generate_metadata.py --module bsee
+    python scripts/generate_metadata.py --external-data-root /mnt/ace/worldenergydata/data
+    WED_DATA_ROOT=/mnt/ace/worldenergydata/data python scripts/generate_metadata.py
 """
 
-import csv
+from __future__ import annotations
+
+import argparse
 import json
 import os
 import sys
+from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
-# Data file extensions to include in metadata
-DATA_EXTENSIONS = {
-    ".csv",
-    ".parquet",
-    ".db",
-    ".json",
-    ".xls",
-    ".xlsx",
-    ".zip",
-    ".txt",
-    ".bin",
-    ".pkl",
-    ".html",
+# Directories to skip when scanning
+_SKIP_DIRS = {
+    ".local",
+    ".claude-flow",
+    "__pycache__",
+    "checkpoints",
+    "cache",
+    ".temp_downloads",
 }
 
-# Extensions where row counting makes sense
-ROW_COUNTABLE = {".csv"}
 
-# Repo root: one level up from scripts/
-REPO_ROOT = Path(__file__).resolve().parent.parent
-MODULES_DIR = REPO_ROOT / "data" / "modules"
+def _humanize_bytes(n: int) -> str:
+    """Return a human-readable file size string."""
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if abs(n) < 1024:
+            return f"{n:.1f} {unit}" if unit != "B" else f"{n} {unit}"
+        n /= 1024  # type: ignore[assignment]
+    return f"{n:.1f} PB"
 
 
-def count_csv_rows(filepath: Path) -> int:
-    """Count data rows in a CSV file (excludes header).
+def _should_skip(rel_parts: tuple[str, ...]) -> bool:
+    """Return True if a file path should be skipped based on its directory components."""
+    return any(p in _SKIP_DIRS or p.startswith(".") for p in rel_parts[:-1])
 
-    Uses csv.reader for lightweight counting -- no pandas dependency.
-    Returns 0 on any read error.
+
+def scan_directory(dir_path: Path) -> dict[str, Any]:
+    """Scan a directory and return file statistics.
+
+    Returns:
+        Dict with file_count, total_size_bytes, format_breakdown,
+        newest_file, and files list.
     """
-    try:
-        with open(filepath, newline="", encoding="utf-8", errors="replace") as f:
-            reader = csv.reader(f)
-            header = next(reader, None)
-            if header is None:
-                return 0
-            return sum(1 for _ in reader)
-    except Exception:
-        return 0
+    files: list[dict[str, Any]] = []
+    format_counts: dict[str, int] = defaultdict(int)
+    format_sizes: dict[str, int] = defaultdict(int)
+    total_size = 0
+    newest_mtime = 0.0
 
+    for fp in sorted(dir_path.rglob("*")):
+        if not fp.is_file():
+            continue
+        try:
+            rel = fp.relative_to(dir_path)
+        except ValueError:
+            continue
+        if _should_skip(rel.parts):
+            continue
 
-def gather_file_info(module_dir: Path) -> list[dict]:
-    """Walk *module_dir* and return metadata for every data file."""
-    files = []
-    for root, _dirs, filenames in os.walk(module_dir):
-        for name in filenames:
-            fp = Path(root) / name
-            suffix = fp.suffix.lower()
-            if suffix not in DATA_EXTENSIONS:
-                continue
-            # Skip hidden/metadata files we generate ourselves
-            if name.startswith("_metadata"):
-                continue
-            stat = fp.stat()
-            entry: dict = {
-                "name": str(fp.relative_to(module_dir)),
+        stat = fp.stat()
+        ext = fp.suffix.lower() or "(no ext)"
+        format_counts[ext] += 1
+        format_sizes[ext] += stat.st_size
+        total_size += stat.st_size
+        if stat.st_mtime > newest_mtime:
+            newest_mtime = stat.st_mtime
+
+        files.append(
+            {
+                "name": fp.name,
+                "path": str(rel),
                 "size_bytes": stat.st_size,
                 "modified": datetime.fromtimestamp(
                     stat.st_mtime, tz=timezone.utc
                 ).strftime("%Y-%m-%d"),
             }
-            if suffix in ROW_COUNTABLE:
-                entry["rows"] = count_csv_rows(fp)
-            files.append(entry)
-    # Sort by path for deterministic output
-    files.sort(key=lambda f: f["name"])
-    return files
+        )
 
-
-def dominant_format(files: list[dict]) -> str:
-    """Return the most common file extension across *files*."""
-    from collections import Counter
-
-    if not files:
-        return "none"
-    exts = [Path(f["name"]).suffix.lower() for f in files]
-    most_common = Counter(exts).most_common(1)
-    return most_common[0][0].lstrip(".") if most_common else "mixed"
-
-
-def build_metadata(module_name: str, module_dir: Path) -> dict:
-    """Build the metadata dict for a single module."""
-    files = gather_file_info(module_dir)
-
-    if not files:
-        return {
-            "module": module_name,
-            "last_refresh": None,
-            "record_count": 0,
-            "file_count": 0,
-            "total_size_bytes": 0,
-            "source_url": "",
-            "format": "none",
-            "note": "no data files -- run 'make data'",
-            "files": [],
-        }
-
-    total_size = sum(f["size_bytes"] for f in files)
-    record_count = sum(f.get("rows", 0) for f in files)
-
-    # last_refresh = most recent file modification
-    all_dates = [f["modified"] for f in files]
-    last_refresh_date = max(all_dates) if all_dates else None
-    # Build an ISO timestamp from the date (midnight UTC)
-    last_refresh = f"{last_refresh_date}T00:00:00Z" if last_refresh_date else None
+    format_breakdown = {
+        ext: {"count": format_counts[ext], "size_bytes": format_sizes[ext]}
+        for ext in sorted(format_counts)
+    }
 
     return {
-        "module": module_name,
-        "last_refresh": last_refresh,
-        "record_count": record_count,
         "file_count": len(files),
         "total_size_bytes": total_size,
-        "source_url": "",
-        "format": dominant_format(files),
+        "format_breakdown": format_breakdown,
+        "newest_modified": (
+            datetime.fromtimestamp(newest_mtime, tz=timezone.utc).strftime("%Y-%m-%d")
+            if newest_mtime > 0
+            else None
+        ),
         "files": files,
     }
 
 
+def generate_module_metadata(
+    module_path: Path,
+    module_name: str,
+    external_module_path: Path | None = None,
+) -> dict[str, Any]:
+    """Generate metadata for a single module, merging external data.
+
+    Args:
+        module_path: In-repo module directory.
+        module_name: Module name (e.g. "bsee").
+        external_module_path: Optional external data path for this module.
+
+    Returns:
+        Metadata dict ready for JSON serialization.
+    """
+    scan = scan_directory(module_path)
+
+    # Merge external data if present
+    ext_scan = None
+    if external_module_path and external_module_path.is_dir():
+        if external_module_path.resolve() != module_path.resolve():
+            ext_scan = scan_directory(external_module_path)
+
+    if ext_scan:
+        # Merge file counts and sizes
+        total_files = scan["file_count"] + ext_scan["file_count"]
+        total_size = scan["total_size_bytes"] + ext_scan["total_size_bytes"]
+
+        # Merge format breakdowns
+        merged_formats: dict[str, dict[str, int]] = {}
+        for fmt_dict in (scan["format_breakdown"], ext_scan["format_breakdown"]):
+            for ext, info in fmt_dict.items():
+                if ext not in merged_formats:
+                    merged_formats[ext] = {"count": 0, "size_bytes": 0}
+                merged_formats[ext]["count"] += info["count"]
+                merged_formats[ext]["size_bytes"] += info["size_bytes"]
+
+        # Merge file lists
+        all_files = scan["files"] + [
+            {**f, "source": "external"} for f in ext_scan["files"]
+        ]
+
+        newest = scan["newest_modified"]
+        if ext_scan["newest_modified"]:
+            if not newest or ext_scan["newest_modified"] > newest:
+                newest = ext_scan["newest_modified"]
+    else:
+        total_files = scan["file_count"]
+        total_size = scan["total_size_bytes"]
+        merged_formats = scan["format_breakdown"]
+        all_files = scan["files"]
+        newest = scan["newest_modified"]
+
+    return {
+        "module": module_name,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "last_refresh": newest,
+        "file_count": total_files,
+        "total_size_bytes": total_size,
+        "total_size_human": _humanize_bytes(total_size),
+        "format_breakdown": dict(sorted(merged_formats.items())),
+        "has_external_data": ext_scan is not None,
+        "external_data_root": str(external_module_path) if ext_scan else None,
+        "files": all_files[:500],  # Cap file listing at 500 entries
+        "files_truncated": len(all_files) > 500,
+    }
+
+
+def _resolve_external_root(cli_value: str | None) -> Path | None:
+    """Resolve external data root from CLI arg, env var, or auto-detect."""
+    path_str = cli_value or os.environ.get("WED_DATA_ROOT")
+    if not path_str:
+        default = Path("/mnt/ace/worldenergydata/data")
+        if default.is_dir():
+            return default
+        return None
+    p = Path(path_str)
+    if p.is_dir():
+        return p
+    print(f"WARNING: external data root not found: {p}", file=sys.stderr)
+    return None
+
+
+def generate_all_metadata(
+    root: Path,
+    module_filter: str | None = None,
+    external_data_root: Path | None = None,
+    dry_run: bool = False,
+) -> dict[str, dict[str, Any]]:
+    """Generate metadata for all modules.
+
+    Args:
+        root: Project root path.
+        module_filter: If set, only process this module.
+        external_data_root: Optional external data directory.
+        dry_run: If True, do not write files.
+
+    Returns:
+        Dict mapping module names to their metadata.
+    """
+    data_root = root / "data" / "modules"
+    ext_modules = external_data_root / "modules" if external_data_root else None
+
+    # Collect module names
+    module_names: set[str] = set()
+    if data_root.exists():
+        for mp in data_root.iterdir():
+            if mp.is_dir() and not mp.name.startswith("."):
+                module_names.add(mp.name)
+    if ext_modules and ext_modules.is_dir():
+        for mp in ext_modules.iterdir():
+            if mp.is_dir() and not mp.name.startswith("."):
+                module_names.add(mp.name)
+
+    results: dict[str, dict[str, Any]] = {}
+    written: list[str] = []
+
+    for name in sorted(module_names):
+        if module_filter and name != module_filter:
+            continue
+
+        mp = data_root / name
+        ext_mp = ext_modules / name if ext_modules else None
+        if not mp.exists():
+            if ext_mp and ext_mp.is_dir():
+                mp = ext_mp
+                ext_mp = None
+            else:
+                continue
+
+        metadata = generate_module_metadata(mp, name, external_module_path=ext_mp)
+        results[name] = metadata
+
+        if not dry_run:
+            out_path = (
+                (data_root / name / "_metadata.json")
+                if (data_root / name).exists()
+                else None
+            )
+            if out_path:
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                with open(out_path, "w") as f:
+                    json.dump(metadata, f, indent=2)
+                try:
+                    written.append(str(out_path.relative_to(root)))
+                except ValueError:
+                    written.append(str(out_path))
+
+    # Print summary
+    total_files = sum(m["file_count"] for m in results.values())
+    total_size = sum(m["total_size_bytes"] for m in results.values())
+    ext_count = sum(1 for m in results.values() if m.get("has_external_data"))
+    print(
+        f"Scanned {len(results)} modules, {total_files} files, {_humanize_bytes(total_size)}"
+    )
+    if ext_count:
+        print(f"  {ext_count} module(s) include external (/mnt/ace) data")
+    if written:
+        print(f"Wrote {len(written)} metadata files:")
+        for fp in written:
+            print(f"  {fp}")
+    elif dry_run:
+        print("(dry-run -- no files written)")
+
+    return results
+
+
 def main() -> None:
-    if not MODULES_DIR.is_dir():
-        print(f"ERROR: modules directory not found: {MODULES_DIR}", file=sys.stderr)
-        sys.exit(1)
+    """CLI entry point."""
+    ap = argparse.ArgumentParser(
+        description="Generate per-module _metadata.json freshness files"
+    )
+    ap.add_argument("--module", help="Process only this module")
+    ap.add_argument("--dry-run", action="store_true", help="Scan without writing")
+    ap.add_argument("--project-root", default=None, help="Override project root")
+    ap.add_argument(
+        "--external-data-root",
+        default=None,
+        help="Path to external data directory (e.g. /mnt/ace/worldenergydata/data). "
+        "Also reads WED_DATA_ROOT env var. Auto-detects /mnt/ace if present.",
+    )
+    ap.add_argument(
+        "--follow-symlinks",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Follow symlinks when scanning (default: True)",
+    )
+    args = ap.parse_args()
 
-    modules = sorted(p for p in MODULES_DIR.iterdir() if p.is_dir())
-    print(f"Scanning {len(modules)} module(s) under {MODULES_DIR} ...")
+    root = (
+        Path(args.project_root)
+        if args.project_root
+        else Path(__file__).resolve().parent.parent
+    )
+    ext_root = _resolve_external_root(args.external_data_root)
+    if ext_root:
+        print(f"External data root: {ext_root}")
 
-    for module_dir in modules:
-        module_name = module_dir.name
-        metadata = build_metadata(module_name, module_dir)
-        out_path = module_dir / "_metadata.json"
-        out_path.write_text(json.dumps(metadata, indent=2) + "\n")
-        fc = metadata["file_count"]
-        rc = metadata["record_count"]
-        print(f"  {module_name:25s}  files={fc:4d}  rows={rc:>10,}")
-
-    print("Done.")
+    generate_all_metadata(
+        root,
+        module_filter=args.module,
+        external_data_root=ext_root,
+        dry_run=args.dry_run,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/unit/common/test_data_catalog_generator.py
+++ b/tests/unit/common/test_data_catalog_generator.py
@@ -28,8 +28,8 @@ from generate_data_catalog import (
     load_source_registry,
 )
 
-
 # -- Helpers -----------------------------------------------------------------
+
 
 def _make_project(tmp_path: Path) -> Path:
     """Create a minimal project structure and return the project root."""
@@ -50,6 +50,7 @@ def _write_csv(path: Path, header: list[str], rows: list[list[str]]) -> None:
 
 # -- CSV scanning ------------------------------------------------------------
 
+
 class TestScanCsvFile:
     """Tests for DataCatalogGenerator.scan_csv_file."""
 
@@ -60,7 +61,11 @@ class TestScanCsvFile:
         _write_csv(
             csv_path,
             header=["well_id", "oil_bbl", "gas_mcf"],
-            rows=[["W001", "100", "200"], ["W002", "150", "300"], ["W003", "120", "240"]],
+            rows=[
+                ["W001", "100", "200"],
+                ["W002", "150", "300"],
+                ["W003", "120", "240"],
+            ],
         )
         gen = DataCatalogGenerator(root)
         entry = gen.scan_csv_file(csv_path)
@@ -87,6 +92,7 @@ class TestScanCsvFile:
 
 # -- Binary file scanning ----------------------------------------------------
 
+
 class TestScanBinaryFile:
     """Tests for DataCatalogGenerator.scan_binary_file."""
 
@@ -109,6 +115,7 @@ class TestScanBinaryFile:
 
 
 # -- Excel file scanning -----------------------------------------------------
+
 
 class TestScanExcelFile:
     """Tests for DataCatalogGenerator.scan_excel_file."""
@@ -142,6 +149,7 @@ class TestScanExcelFile:
 
 # -- Domain inference --------------------------------------------------------
 
+
 class TestInferDomain:
     """Tests for DataCatalogGenerator.infer_domain."""
 
@@ -169,6 +177,7 @@ class TestInferDomain:
 
 # -- Module scanning ---------------------------------------------------------
 
+
 class TestScanModule:
     """Tests for DataCatalogGenerator.scan_module."""
 
@@ -178,11 +187,13 @@ class TestScanModule:
         mod_dir = root / "data" / "modules" / "test_mod"
         _write_csv(
             mod_dir / "current" / "production" / "data.csv",
-            header=["date", "oil"], rows=[["2024-01", "100"]],
+            header=["date", "oil"],
+            rows=[["2024-01", "100"]],
         )
         _write_csv(
             mod_dir / "current" / "wells" / "headers.csv",
-            header=["well_id", "name"], rows=[["W1", "Alpha"], ["W2", "Beta"]],
+            header=["well_id", "name"],
+            rows=[["W1", "Alpha"], ["W2", "Beta"]],
         )
         gen = DataCatalogGenerator(root)
         entry = gen.scan_module(mod_dir)
@@ -212,7 +223,9 @@ class TestScanModule:
         """Module with both CSV and .bin files separates them correctly."""
         root = _make_project(tmp_path)
         mod_dir = root / "data" / "modules" / "mixed_mod"
-        _write_csv(mod_dir / "current" / "data.csv", header=["x", "y"], rows=[["1", "2"]])
+        _write_csv(
+            mod_dir / "current" / "data.csv", header=["x", "y"], rows=[["1", "2"]]
+        )
         bin_path = mod_dir / "bin" / "store.bin"
         bin_path.parent.mkdir(parents=True)
         bin_path.write_bytes(b"\x00" * 50)
@@ -240,6 +253,7 @@ class TestScanModule:
 
 # -- Multi-module scanning ---------------------------------------------------
 
+
 class TestScanAllModules:
     """Tests for DataCatalogGenerator.scan_all_modules."""
 
@@ -248,11 +262,13 @@ class TestScanAllModules:
         root = _make_project(tmp_path)
         _write_csv(
             root / "data" / "modules" / "mod_a" / "data.csv",
-            header=["col1"], rows=[["val1"]],
+            header=["col1"],
+            rows=[["val1"]],
         )
         _write_csv(
             root / "data" / "modules" / "mod_b" / "info.csv",
-            header=["col2"], rows=[["val2"], ["val3"]],
+            header=["col2"],
+            rows=[["val2"], ["val3"]],
         )
         (root / "data" / "modules" / "mod_c").mkdir(parents=True)  # empty
         gen = DataCatalogGenerator(root)
@@ -277,6 +293,7 @@ class TestScanAllModules:
 
 # -- Catalog generation (output files) ---------------------------------------
 
+
 class TestGenerate:
     """Tests for DataCatalogGenerator.generate."""
 
@@ -285,7 +302,8 @@ class TestGenerate:
         root = _make_project(tmp_path)
         _write_csv(
             root / "data" / "modules" / "test_mod" / "data.csv",
-            header=["a", "b"], rows=[["1", "2"]],
+            header=["a", "b"],
+            rows=[["1", "2"]],
         )
         gen = DataCatalogGenerator(root)
         output_path, catalog = gen.generate(output_format="yaml")
@@ -304,7 +322,8 @@ class TestGenerate:
         root = _make_project(tmp_path)
         _write_csv(
             root / "data" / "modules" / "test_mod" / "data.csv",
-            header=["x"], rows=[["10"]],
+            header=["x"],
+            rows=[["10"]],
         )
         gen = DataCatalogGenerator(root)
         output_path, catalog = gen.generate(output_format="json")
@@ -323,11 +342,13 @@ class TestGenerate:
         root = _make_project(tmp_path)
         _write_csv(
             root / "data" / "modules" / "mod_a" / "data.csv",
-            header=["a"], rows=[["1"]],
+            header=["a"],
+            rows=[["1"]],
         )
         _write_csv(
             root / "data" / "modules" / "mod_b" / "data.csv",
-            header=["b"], rows=[["2"]],
+            header=["b"],
+            rows=[["2"]],
         )
         gen = DataCatalogGenerator(root)
         output_path, catalog = gen.generate(module_name="mod_a", output_format="json")
@@ -347,6 +368,7 @@ class TestGenerate:
 
 
 # -- LFS stub detection -----------------------------------------------------
+
 
 class TestLfsStubDetection:
     """Tests for Git LFS stub detection in scan_binary_file."""
@@ -395,6 +417,7 @@ class TestLfsStubDetection:
 
 # -- Source registry merge ---------------------------------------------------
 
+
 class TestSourceRegistryMerge:
     """Tests for _merge_source_registry."""
 
@@ -412,7 +435,8 @@ class TestSourceRegistryMerge:
         )
         _write_csv(
             root / "data" / "modules" / "test_mod" / "data.csv",
-            header=["a"], rows=[["1"]],
+            header=["a"],
+            rows=[["1"]],
         )
         gen = DataCatalogGenerator(root)
         _, catalog = gen.generate(output_format="yaml")
@@ -426,13 +450,12 @@ class TestSourceRegistryMerge:
         registry_dir = root / "data" / "catalog"
         registry_dir.mkdir(parents=True, exist_ok=True)
         (registry_dir / "source-registry.yml").write_text(
-            "modules:\n"
-            "  test_mod:\n"
-            "    default_update_frequency: quarterly\n"
+            "modules:\n" "  test_mod:\n" "    default_update_frequency: quarterly\n"
         )
         _write_csv(
             root / "data" / "modules" / "test_mod" / "data.csv",
-            header=["a"], rows=[["1"]],
+            header=["a"],
+            rows=[["1"]],
         )
         gen = DataCatalogGenerator(root)
         _, catalog = gen.generate(output_format="yaml")
@@ -445,7 +468,8 @@ class TestSourceRegistryMerge:
         root = _make_project(tmp_path)
         _write_csv(
             root / "data" / "modules" / "test_mod" / "data.csv",
-            header=["a"], rows=[["1"]],
+            header=["a"],
+            rows=[["1"]],
         )
         gen = DataCatalogGenerator(root)
         _, catalog = gen.generate(output_format="yaml")
@@ -457,6 +481,7 @@ class TestSourceRegistryMerge:
 
 # -- Staleness calculation ---------------------------------------------------
 
+
 class TestStalenessCalculation:
     """Tests for _compute_staleness."""
 
@@ -465,7 +490,8 @@ class TestStalenessCalculation:
         root = _make_project(tmp_path)
         _write_csv(
             root / "data" / "modules" / "test_mod" / "data.csv",
-            header=["a"], rows=[["1"]],
+            header=["a"],
+            rows=[["1"]],
         )
         gen = DataCatalogGenerator(root)
         catalog = gen.scan_all_modules()
@@ -483,13 +509,15 @@ class TestStalenessCalculation:
         root = _make_project(tmp_path)
         _write_csv(
             root / "data" / "modules" / "test_mod" / "data.csv",
-            header=["a"], rows=[["1"]],
+            header=["a"],
+            rows=[["1"]],
         )
         gen = DataCatalogGenerator(root)
         catalog = gen.scan_all_modules()
 
         ds = catalog.modules["test_mod"].datasets[0]
         from datetime import datetime, timezone
+
         ds.update_frequency = "annual"
         ds.last_refreshed = datetime.now(timezone.utc).isoformat()
         ds.data_status = "real"
@@ -499,6 +527,7 @@ class TestStalenessCalculation:
 
 
 # -- Freshness report -------------------------------------------------------
+
 
 class TestFreshnessReport:
     """Tests for print_freshness_report."""
@@ -526,3 +555,292 @@ class TestFreshnessReport:
         assert "Data Freshness Report" in captured.out
         assert "test_mod" in captured.out
         assert "TOTAL" in captured.out
+
+
+# -- External data root merging ---------------------------------------------
+
+
+class TestExternalDataRoot:
+    """Tests for external data root merging."""
+
+    def test_external_root_adds_binary_directory(self, tmp_path: Path):
+        """External root with bin/ subdirectories adds binary_stores entries."""
+        root = _make_project(tmp_path)
+        mod_dir = root / "data" / "modules" / "bsee"
+        _write_csv(mod_dir / "current" / "data.csv", header=["a"], rows=[["1"]])
+
+        # Create external data with bin/ directory
+        ext_root = tmp_path / "external" / "data"
+        ext_bin = ext_root / "modules" / "bsee" / "bin" / "production_raw"
+        ext_bin.mkdir(parents=True)
+        (ext_bin / "file1.bin").write_bytes(b"\x00" * 100)
+        (ext_bin / "file2.bin").write_bytes(b"\x00" * 200)
+
+        gen = DataCatalogGenerator(root, external_data_root=ext_root)
+        entry = gen.scan_module(mod_dir)
+
+        assert len(entry.datasets) == 1  # the CSV
+        assert len(entry.binary_stores) >= 1  # at least the bin directory
+        # Total size should include external binary data
+        assert entry.total_size_bytes > 300
+
+    def test_external_root_adds_zip_files(self, tmp_path: Path):
+        """External root with zip/ files adds binary_stores entries."""
+        import zipfile as zf
+
+        root = _make_project(tmp_path)
+        mod_dir = root / "data" / "modules" / "bsee"
+        _write_csv(mod_dir / "current" / "data.csv", header=["a"], rows=[["1"]])
+
+        # Create external zip
+        ext_root = tmp_path / "external" / "data"
+        ext_zip_dir = ext_root / "modules" / "bsee" / "zip" / "surveys"
+        ext_zip_dir.mkdir(parents=True)
+        zip_path = ext_zip_dir / "test.zip"
+        with zf.ZipFile(zip_path, "w") as z:
+            z.writestr("data.csv", "a,b\n1,2\n")
+
+        gen = DataCatalogGenerator(root, external_data_root=ext_root)
+        entry = gen.scan_module(mod_dir)
+
+        zip_entries = [b for b in entry.binary_stores if b.format == "zip"]
+        assert len(zip_entries) >= 1
+        assert zip_entries[0].description
+        assert "1 file(s)" in zip_entries[0].description
+
+    def test_external_root_merges_csv_files(self, tmp_path: Path):
+        """External root CSV files appear in the module's dataset list."""
+        root = _make_project(tmp_path)
+        mod_dir = root / "data" / "modules" / "hse"
+        mod_dir.mkdir(parents=True)
+
+        # Create external OSHA CSV
+        ext_root = tmp_path / "external" / "data"
+        osha_dir = ext_root / "modules" / "hse" / "raw" / "osha"
+        osha_dir.mkdir(parents=True)
+        _write_csv(
+            osha_dir / "osha_accident.csv",
+            header=["summary_nr", "event_date"],
+            rows=[["1001", "20240101"]],
+        )
+
+        gen = DataCatalogGenerator(root, external_data_root=ext_root)
+        entry = gen.scan_module(mod_dir)
+
+        csv_names = [d.name for d in entry.datasets if d.format == "csv"]
+        assert "osha_accident" in csv_names
+
+    def test_external_root_no_duplicates(self, tmp_path: Path):
+        """Datasets present in both roots appear only once."""
+        root = _make_project(tmp_path)
+        mod_dir = root / "data" / "modules" / "test_mod"
+        _write_csv(mod_dir / "data.csv", header=["a"], rows=[["1"]])
+
+        # External root with same file path
+        ext_root = tmp_path / "external" / "data"
+        ext_mod = ext_root / "modules" / "test_mod"
+        _write_csv(ext_mod / "data.csv", header=["a"], rows=[["1"]])
+
+        gen = DataCatalogGenerator(root, external_data_root=ext_root)
+        entry = gen.scan_module(mod_dir)
+
+        csv_ds = [d for d in entry.datasets if d.format == "csv"]
+        assert len(csv_ds) == 1  # Not duplicated
+
+    def test_no_external_root_still_works(self, tmp_path: Path):
+        """Generator works correctly with no external root."""
+        root = _make_project(tmp_path)
+        mod_dir = root / "data" / "modules" / "test_mod"
+        _write_csv(mod_dir / "data.csv", header=["a"], rows=[["1"]])
+
+        gen = DataCatalogGenerator(root)  # No external root
+        entry = gen.scan_module(mod_dir)
+
+        assert len(entry.datasets) == 1
+        assert entry.datasets[0].name == "data"
+
+    def test_scan_all_discovers_external_only_modules(self, tmp_path: Path):
+        """Modules that only exist in external root are discovered."""
+        root = _make_project(tmp_path)
+        _write_csv(
+            root / "data" / "modules" / "mod_a" / "data.csv",
+            header=["a"],
+            rows=[["1"]],
+        )
+
+        ext_root = tmp_path / "external" / "data"
+        ext_mod = ext_root / "modules" / "ext_only_mod"
+        _write_csv(ext_mod / "data.csv", header=["b"], rows=[["2"]])
+
+        gen = DataCatalogGenerator(root, external_data_root=ext_root)
+        catalog = gen.scan_all_modules()
+
+        assert "mod_a" in catalog.modules
+        assert "ext_only_mod" in catalog.modules
+
+
+# -- OSHA data dictionary enrichment ----------------------------------------
+
+
+class TestOshaEnrichment:
+    """Tests for OSHA data dictionary column enrichment."""
+
+    def test_osha_columns_enriched(self, tmp_path: Path):
+        """OSHA CSV columns get descriptions from the data dictionary."""
+        root = _make_project(tmp_path)
+        ext_root = tmp_path / "external" / "data"
+        osha_dir = ext_root / "modules" / "hse" / "raw" / "osha"
+        osha_dir.mkdir(parents=True)
+
+        # Create data dictionary
+        _write_csv(
+            osha_dir / "osha_data_dictionary.csv",
+            header=[
+                "table_name",
+                "column_name",
+                "attribute_name",
+                "definition",
+                "column_datatype",
+                "display_name",
+            ],
+            rows=[
+                [
+                    "osha_accident",
+                    "summary_nr",
+                    "Summary NR",
+                    "Identifies the accident form",
+                    "Numeric, Length=9",
+                    "Summary NR",
+                ],
+                [
+                    "osha_accident",
+                    "event_date",
+                    "Event Date",
+                    "Date of accident",
+                    "Numeric, Length=8",
+                    "Event Date",
+                ],
+            ],
+        )
+
+        # Create OSHA accident CSV
+        _write_csv(
+            osha_dir / "osha_accident.csv",
+            header=["summary_nr", "event_date", "event_desc"],
+            rows=[["1001", "20240101", "test"]],
+        )
+
+        # Create in-repo hse module
+        hse_dir = root / "data" / "modules" / "hse"
+        hse_dir.mkdir(parents=True)
+
+        gen = DataCatalogGenerator(root, external_data_root=ext_root)
+        entry = gen.scan_module(hse_dir)
+
+        osha_ds = [d for d in entry.datasets if d.name == "osha_accident"]
+        assert len(osha_ds) == 1
+        ds = osha_ds[0]
+        assert ds.column_schemas is not None
+        assert len(ds.column_schemas) == 3
+
+        # Check enriched columns
+        schema_map = {cs.name: cs for cs in ds.column_schemas}
+        assert "Identifies the accident form" in schema_map["summary_nr"].description
+        assert "Date of accident" in schema_map["event_date"].description
+
+    def test_osha_numbered_splits_matched(self, tmp_path: Path):
+        """Numbered OSHA files (osha_violation3.csv) match base table in dictionary."""
+        root = _make_project(tmp_path)
+        ext_root = tmp_path / "external" / "data"
+        osha_dir = ext_root / "modules" / "hse" / "raw" / "osha"
+        osha_dir.mkdir(parents=True)
+
+        _write_csv(
+            osha_dir / "osha_data_dictionary.csv",
+            header=[
+                "table_name",
+                "column_name",
+                "attribute_name",
+                "definition",
+                "column_datatype",
+                "display_name",
+            ],
+            rows=[
+                [
+                    "osha_violation",
+                    "activity_nr",
+                    "Activity NR",
+                    "Unique activity identifier",
+                    "Numeric",
+                    "Activity NR",
+                ],
+            ],
+        )
+        _write_csv(
+            osha_dir / "osha_violation3.csv",
+            header=["activity_nr", "other_col"],
+            rows=[["1001", "x"]],
+        )
+
+        hse_dir = root / "data" / "modules" / "hse"
+        hse_dir.mkdir(parents=True)
+
+        gen = DataCatalogGenerator(root, external_data_root=ext_root)
+        entry = gen.scan_module(hse_dir)
+
+        viol_ds = [d for d in entry.datasets if d.name == "osha_violation3"]
+        assert len(viol_ds) == 1
+        assert viol_ds[0].column_schemas is not None
+        schema_map = {cs.name: cs for cs in viol_ds[0].column_schemas}
+        assert "Unique activity identifier" in schema_map["activity_nr"].description
+
+
+# -- Zip file scanning -------------------------------------------------------
+
+
+class TestZipScanning:
+    """Tests for zip file scanning."""
+
+    def test_scan_zip_file(self, tmp_path: Path):
+        """scan_zip_file captures file listing from zip archive."""
+        import zipfile as zf
+
+        root = _make_project(tmp_path)
+        zip_path = root / "data" / "modules" / "test_mod" / "archive.zip"
+        zip_path.parent.mkdir(parents=True, exist_ok=True)
+        with zf.ZipFile(zip_path, "w") as z:
+            z.writestr("data1.csv", "a\n1\n")
+            z.writestr("data2.csv", "b\n2\n")
+
+        gen = DataCatalogGenerator(root)
+        entry = gen.scan_zip_file(zip_path)
+
+        assert entry.name == "archive"
+        assert entry.format == "zip"
+        assert "2 file(s)" in entry.description
+        assert entry.size_bytes > 0
+
+
+# -- Binary directory scanning -----------------------------------------------
+
+
+class TestBinaryDirectoryScanning:
+    """Tests for binary directory scanning."""
+
+    def test_scan_binary_directory(self, tmp_path: Path):
+        """scan_binary_directory summarizes file counts and sizes."""
+        root = _make_project(tmp_path)
+        bin_dir = root / "data" / "modules" / "test_mod" / "bin" / "production"
+        bin_dir.mkdir(parents=True)
+        (bin_dir / "file1.bin").write_bytes(b"\x00" * 100)
+        (bin_dir / "file2.bin").write_bytes(b"\x00" * 200)
+        (bin_dir / ".gitkeep").write_bytes(b"")
+
+        gen = DataCatalogGenerator(root)
+        entry = gen.scan_binary_directory(bin_dir)
+
+        assert entry.name == "production"
+        assert entry.format == "binary_directory"
+        assert entry.size_bytes == 300
+        assert entry.row_count == 3  # file count including .gitkeep
+        assert "Binary data directory" in entry.description


### PR DESCRIPTION
## Summary
Extends the data catalog and metadata scripts to discover and catalog the 9.4 GB of data on `/mnt/ace/worldenergydata/data/` — the large files relocated from git to reduce repo size.

### New Capabilities
- **`--external-data-root`** flag + `WED_DATA_ROOT` env var support on both catalog generators
- **`--follow-symlinks` / `--no-follow-symlinks`** flag for CI environments
- **Auto-detection** of `/mnt/ace/worldenergydata/data/` when present
- **Binary directory scanning** — catalogs `bsee/bin/` by extension, count, size (doesn't read as CSV)
- **Zip archive scanning** — lists zip contents with file sizes
- **OSHA data dictionary enrichment** — 137 column definitions from `osha_data_dictionary.csv` applied to HSE schemas
- **Large CSV optimization** — files >100 MB use row-count estimation from 1000-row sample
- **Graceful fallback** — absent external root = catalog only in-repo data

### Verified Output
| Module | Datasets | Size | Notable |
|--------|----------|------|---------|
| bsee | 17 datasets + 34 binary stores | 2.6 GB | bin (2.5 GB) + zip (230 MB) + repo CSVs |
| hse | 62 datasets + 15 binary stores | 6.7 GB | OSHA bulk CSVs enriched with data dictionary |

### Files: 21 changed, +5,979 / -39

### Tests: 37 passing (27 existing + 10 new)
New test coverage: binary dir scanning, zip scanning, OSHA enrichment, deduplication, external-root fallback, external-only module discovery

## Test plan
- [ ] `PYTHONPATH=src python3 -m pytest tests/unit/common/test_data_catalog_generator.py --noconftest -v`
- [ ] `python3 scripts/generate_catalog.py --external-data-root /mnt/ace/worldenergydata/data`
- [ ] `python3 scripts/generate_catalog.py --no-follow-symlinks` (CI mode — no external data)

Closes #298