### PR TITLE
docs: create quickstart notebooks for top 5 modules (#293)

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,31 @@
+# Quickstart Notebooks
+
+Percent-format Python scripts (`# %%` cells) that work in VS Code, JupyterLab, or any Jupytext-compatible editor.
+
+## Notebooks
+
+| File | Module | Description |
+|------|--------|-------------|
+| `quickstart_bsee.py` | BSEE | Gulf of Mexico wells, water depths, operator analysis |
+| `quickstart_fdas.py` | FDAS | NPV, IRR, MIRR, payback, sensitivity analysis |
+| `quickstart_marine_safety.py` | Marine Safety | Fatality, foundering, and hatch incident analysis |
+| `quickstart_sodir.py` | SODIR | Norwegian Continental Shelf API and field data |
+| `quickstart_eia.py` | EIA | US petroleum production and state-level trends |
+
+## How to run
+
+- **VS Code**: Open file, click "Run Cell" above any `# %%` marker
+- **JupyterLab**: `pip install jupytext`, then open `.py` files as notebooks
+- **Command line**: `python notebooks/quickstart_fdas.py` (runs all cells sequentially)
+
+## Prerequisites
+
+```bash
+pip install pandas matplotlib numpy numpy-financial
+# For API notebooks (SODIR, EIA): pip install requests
+# For EIA: export EIA_API_KEY=your_key
+```
+
+BSEE and Marine Safety notebooks load CSV files from `data/modules/` and work without additional setup.
+FDAS is purely computational and needs no data files.
+SODIR and EIA fetch from public APIs and require network access (or cached data).

--- a/notebooks/quickstart_bsee.py
+++ b/notebooks/quickstart_bsee.py
@@ -1,0 +1,144 @@
+# %% [markdown]
+# # BSEE Data -- Quickstart
+#
+# Explore Gulf of Mexico well and production data from the Bureau of Safety
+# and Environmental Enforcement (BSEE).  This notebook loads CSV files
+# shipped in the repository so it works without running `make data`.
+#
+# ## Prerequisites
+# - Python 3.11+
+# - pandas, matplotlib
+# - Data files in `data/modules/bsee/current/` (included in the repo)
+
+# %%
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+# Resolve repo-relative data path
+DATA_DIR = Path(__file__).resolve().parent.parent / "data" / "modules" / "bsee" / "current"
+
+# %% [markdown]
+# ## 1. Load well data
+#
+# The `well_data.csv` file contains ~57 000 OCS well records with location,
+# depth, operator, and status information.
+
+# %%
+wells = pd.read_csv(DATA_DIR / "wells" / "well_data.csv")
+print(f"Loaded {len(wells):,} well records with {wells.shape[1]} columns")
+wells.head()
+
+# %%
+print("Columns:", list(wells.columns))
+
+# %% [markdown]
+# ## 2. Water depth distribution
+#
+# Deepwater wells (> 1 000 ft) dominate the modern Gulf of Mexico portfolio.
+
+# %%
+fig, ax = plt.subplots(figsize=(10, 5))
+wells["WATER_DEPTH"].dropna().hist(bins=60, ax=ax, edgecolor="white")
+ax.set_xlabel("Water Depth (ft)")
+ax.set_ylabel("Number of Wells")
+ax.set_title("BSEE Wells — Water Depth Distribution")
+ax.axvline(1000, color="red", linestyle="--", label="Deepwater threshold (1 000 ft)")
+ax.legend()
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+# ## 3. Top operators by well count
+
+# %%
+top_operators = (
+    wells["COMPANY_NAME"]
+    .value_counts()
+    .head(15)
+)
+
+fig, ax = plt.subplots(figsize=(10, 6))
+top_operators.plot.barh(ax=ax, color="steelblue")
+ax.set_xlabel("Number of Wells")
+ax.set_title("Top 15 Operators by Well Count")
+ax.invert_yaxis()
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+# ## 4. Spud activity over time
+#
+# Parse spud dates and look at drilling activity by year.
+
+# %%
+wells["spud_date"] = pd.to_datetime(wells["WELL_SPUD_DATE"], errors="coerce")
+wells["spud_year"] = wells["spud_date"].dt.year
+
+spud_by_year = wells.dropna(subset=["spud_year"]).groupby("spud_year").size()
+spud_by_year = spud_by_year[spud_by_year.index >= 1980]
+
+fig, ax = plt.subplots(figsize=(10, 5))
+spud_by_year.plot(ax=ax, marker="o", markersize=3)
+ax.set_xlabel("Year")
+ax.set_ylabel("Wells Spudded")
+ax.set_title("BSEE — Annual Well Spud Activity")
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+# ## 5. Deepwater vs. shelf wells
+
+# %%
+wells["depth_class"] = pd.cut(
+    wells["WATER_DEPTH"],
+    bins=[0, 500, 1000, 5000, 15000],
+    labels=["Shallow (<500 ft)", "Mid-water (500-1000 ft)",
+            "Deepwater (1000-5000 ft)", "Ultra-deep (>5000 ft)"],
+)
+depth_counts = wells["depth_class"].value_counts().sort_index()
+
+fig, ax = plt.subplots(figsize=(8, 5))
+depth_counts.plot.bar(ax=ax, color=["#2ecc71", "#f1c40f", "#e67e22", "#e74c3c"])
+ax.set_ylabel("Number of Wells")
+ax.set_title("Wells by Water Depth Classification")
+ax.set_xticklabels(ax.get_xticklabels(), rotation=30, ha="right")
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+# ## 6. Production data (small sample)
+#
+# The repo includes a small production CSV (~100 rows).  Full production
+# data requires `make data` to download BSEE binary files.
+
+# %%
+prod = pd.read_csv(DATA_DIR / "production" / "production.csv")
+print(f"Production sample: {len(prod)} records")
+prod.head()
+
+# %% [markdown]
+# ## 7. Using the query API (optional)
+#
+# If you have installed the package and run `make data`, you can use the
+# query API for richer access:
+#
+# ```python
+# import worldenergydata as wed
+#
+# df = wed.bsee.production.query(year=2022)
+# df = wed.bsee.wells.query(area_code="MC")
+# df = wed.bsee.companies.query(name="Shell")
+# summary = wed.bsee.production.annual_summary(2022)
+# ```
+
+# %% [markdown]
+# ## Summary
+#
+# This notebook covered:
+# - Loading BSEE well data from CSV
+# - Water depth distribution analysis
+# - Top operators and drilling trends
+# - Deepwater vs. shelf classification
+# - How to use the query API for deeper analysis

--- a/notebooks/quickstart_bsee.py
+++ b/notebooks/quickstart_bsee.py
@@ -17,7 +17,9 @@ import matplotlib.pyplot as plt
 import pandas as pd
 
 # Resolve repo-relative data path
-DATA_DIR = Path(__file__).resolve().parent.parent / "data" / "modules" / "bsee" / "current"
+DATA_DIR = (
+    Path(__file__).resolve().parent.parent / "data" / "modules" / "bsee" / "current"
+)
 
 # %% [markdown]
 # ## 1. Load well data
@@ -53,11 +55,7 @@ plt.show()
 # ## 3. Top operators by well count
 
 # %%
-top_operators = (
-    wells["COMPANY_NAME"]
-    .value_counts()
-    .head(15)
-)
+top_operators = wells["COMPANY_NAME"].value_counts().head(15)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 top_operators.plot.barh(ax=ax, color="steelblue")
@@ -94,8 +92,12 @@ plt.show()
 wells["depth_class"] = pd.cut(
     wells["WATER_DEPTH"],
     bins=[0, 500, 1000, 5000, 15000],
-    labels=["Shallow (<500 ft)", "Mid-water (500-1000 ft)",
-            "Deepwater (1000-5000 ft)", "Ultra-deep (>5000 ft)"],
+    labels=[
+        "Shallow (<500 ft)",
+        "Mid-water (500-1000 ft)",
+        "Deepwater (1000-5000 ft)",
+        "Ultra-deep (>5000 ft)",
+    ],
 )
 depth_counts = wells["depth_class"].value_counts().sort_index()
 

--- a/notebooks/quickstart_eia.py
+++ b/notebooks/quickstart_eia.py
@@ -100,17 +100,35 @@ except Exception as exc:
 
 # %%
 # Synthetic US crude production data (annual, thousand barrels per day)
-us_crude = pd.DataFrame({
-    "year": list(range(2010, 2026)),
-    "production_kbd": [
-        5482, 5646, 6506, 7441, 8774, 9431, 8853, 9356,
-        10964, 12247, 11316, 11254, 11886, 12927, 13201, 13400,
-    ],
-})
+us_crude = pd.DataFrame(
+    {
+        "year": list(range(2010, 2026)),
+        "production_kbd": [
+            5482,
+            5646,
+            6506,
+            7441,
+            8774,
+            9431,
+            8853,
+            9356,
+            10964,
+            12247,
+            11316,
+            11254,
+            11886,
+            12927,
+            13201,
+            13400,
+        ],
+    }
+)
 
 fig, ax = plt.subplots(figsize=(10, 5))
 ax.plot(us_crude["year"], us_crude["production_kbd"], marker="o", color="steelblue")
-ax.fill_between(us_crude["year"], us_crude["production_kbd"], alpha=0.15, color="steelblue")
+ax.fill_between(
+    us_crude["year"], us_crude["production_kbd"], alpha=0.15, color="steelblue"
+)
 ax.set_xlabel("Year")
 ax.set_ylabel("Production (kbd)")
 ax.set_title("US Crude Oil Production (EIA Data)")
@@ -132,11 +150,23 @@ plt.show()
 
 # %%
 # Synthetic top producing states
-states = pd.DataFrame({
-    "state": ["Texas", "New Mexico", "North Dakota", "Alaska", "Colorado",
-              "Oklahoma", "California", "Wyoming", "Louisiana", "Utah"],
-    "production_kbd": [5600, 1900, 1200, 440, 430, 380, 340, 250, 105, 100],
-})
+states = pd.DataFrame(
+    {
+        "state": [
+            "Texas",
+            "New Mexico",
+            "North Dakota",
+            "Alaska",
+            "Colorado",
+            "Oklahoma",
+            "California",
+            "Wyoming",
+            "Louisiana",
+            "Utah",
+        ],
+        "production_kbd": [5600, 1900, 1200, 440, 430, 380, 340, 250, 105, 100],
+    }
+)
 
 fig, ax = plt.subplots(figsize=(10, 5))
 ax.barh(states["state"], states["production_kbd"], color="steelblue")

--- a/notebooks/quickstart_eia.py
+++ b/notebooks/quickstart_eia.py
@@ -1,0 +1,180 @@
+# %% [markdown]
+# # EIA (US Energy Information Administration) -- Quickstart
+#
+# Access US energy statistics from the EIA API v2.  The EIA provides weekly
+# petroleum supply/demand data, natural gas storage reports, state-level
+# production, and international energy data.
+#
+# ## Prerequisites
+# - Python 3.11+
+# - pandas, matplotlib, requests
+# - An EIA API key (free from https://www.eia.gov/opendata/register.php)
+# - Set the environment variable: `export EIA_API_KEY=your_key_here`
+
+# %%
+import os
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+# %% [markdown]
+# ## 1. Check API key
+#
+# The EIA API v2 requires a free API key.
+
+# %%
+api_key = os.environ.get("EIA_API_KEY")
+if api_key:
+    print(f"EIA API key found ({api_key[:4]}...{api_key[-4:]})")
+else:
+    print("EIA_API_KEY not set.")
+    print("Get a free key at: https://www.eia.gov/opendata/register.php")
+    print("Then: export EIA_API_KEY=your_key_here")
+
+# %% [markdown]
+# ## 2. Available endpoints
+#
+# The worldenergydata EIA client covers these weekly feeds:
+#
+# | Endpoint                        | Description                           |
+# |---------------------------------|---------------------------------------|
+# | `petroleum/sum/snd/w`           | Weekly petroleum status (crude, stocks, imports) |
+# | `natural-gas/stor/sum/dcu/nus/w`| Weekly natural gas storage            |
+#
+# The `eia_us` module adds:
+# - State-level production data
+# - Basin-level production and decline analysis
+# - Drilling productivity reports
+# - International country production
+
+# %% [markdown]
+# ## 3. Using the EIA feed client
+
+# %%
+try:
+    from worldenergydata.eia.client import EIAFeedClient
+
+    if api_key:
+        client = EIAFeedClient(api_key=api_key)
+        print("EIA client initialized successfully")
+    else:
+        print("Skipping client init — no API key")
+        print("Set EIA_API_KEY to enable live data fetching")
+except ImportError as exc:
+    print(f"Could not import EIA client: {exc}")
+except Exception as exc:
+    print(f"Client error: {exc}")
+
+# %% [markdown]
+# ## 4. Fetching weekly petroleum data
+#
+# The code below fetches the most recent weekly petroleum status report.
+# It is wrapped in try/except so the notebook runs cleanly without an API
+# key.
+
+# %%
+try:
+    if api_key:
+        from worldenergydata.eia.client import EIAFeedClient, PETROLEUM_WEEKLY_PATH
+
+        client = EIAFeedClient(api_key=api_key)
+        data = client.fetch(PETROLEUM_WEEKLY_PATH, params={"length": 52})
+
+        if data:
+            df = pd.DataFrame(data)
+            print(f"Fetched {len(df)} weekly petroleum records")
+            df.head()
+        else:
+            print("No data returned")
+    else:
+        print("Skipped — set EIA_API_KEY to fetch live data")
+except Exception as exc:
+    print(f"Fetch error: {exc}")
+    print("This is expected without a valid API key or network access.")
+
+# %% [markdown]
+# ## 5. Example: US crude oil production trends
+#
+# Since live data requires an API key, here is a synthetic example showing
+# the type of analysis the EIA module supports.
+
+# %%
+# Synthetic US crude production data (annual, thousand barrels per day)
+us_crude = pd.DataFrame({
+    "year": list(range(2010, 2026)),
+    "production_kbd": [
+        5482, 5646, 6506, 7441, 8774, 9431, 8853, 9356,
+        10964, 12247, 11316, 11254, 11886, 12927, 13201, 13400,
+    ],
+})
+
+fig, ax = plt.subplots(figsize=(10, 5))
+ax.plot(us_crude["year"], us_crude["production_kbd"], marker="o", color="steelblue")
+ax.fill_between(us_crude["year"], us_crude["production_kbd"], alpha=0.15, color="steelblue")
+ax.set_xlabel("Year")
+ax.set_ylabel("Production (kbd)")
+ax.set_title("US Crude Oil Production (EIA Data)")
+ax.set_ylim(bottom=0)
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+# ## 6. State-level production
+#
+# The `eia_us` module provides state-level breakdowns:
+#
+# ```python
+# from worldenergydata.eia_us.production.state_production import StateProduction
+#
+# sp = StateProduction(api_key=api_key)
+# df = sp.fetch(state="TX", start_year=2020)
+# ```
+
+# %%
+# Synthetic top producing states
+states = pd.DataFrame({
+    "state": ["Texas", "New Mexico", "North Dakota", "Alaska", "Colorado",
+              "Oklahoma", "California", "Wyoming", "Louisiana", "Utah"],
+    "production_kbd": [5600, 1900, 1200, 440, 430, 380, 340, 250, 105, 100],
+})
+
+fig, ax = plt.subplots(figsize=(10, 5))
+ax.barh(states["state"], states["production_kbd"], color="steelblue")
+ax.set_xlabel("Production (kbd)")
+ax.set_title("Top 10 US Oil-Producing States (EIA Estimate)")
+ax.invert_yaxis()
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+# ## 7. Basin decline analysis
+#
+# ```python
+# from worldenergydata.eia_us.analysis.basin_decline import BasinDeclineAnalysis
+#
+# bda = BasinDeclineAnalysis(api_key=api_key)
+# results = bda.analyze(basin="Permian", vintage_years=[2020, 2021, 2022])
+# ```
+
+# %% [markdown]
+# ## 8. Automated ingestion
+#
+# For scheduled data collection:
+#
+# ```bash
+# # Ingest latest weekly petroleum data
+# uv run python -m worldenergydata.eia.ingestion_runner
+#
+# # Or via Make
+# make data-eia
+# ```
+
+# %% [markdown]
+# ## Summary
+#
+# This notebook covered:
+# - EIA API key setup and client initialization
+# - Weekly petroleum and natural gas data endpoints
+# - US crude oil production trends
+# - State-level and basin-level analysis modules
+# - Automated ingestion for scheduled updates

--- a/notebooks/quickstart_fdas.py
+++ b/notebooks/quickstart_fdas.py
@@ -1,0 +1,165 @@
+# %% [markdown]
+# # FDAS Financial Analysis -- Quickstart
+#
+# Run field-development economics calculations using the FDAS module.
+# This notebook is entirely computational — no data files are needed.
+#
+# ## Prerequisites
+# - Python 3.11+
+# - numpy, numpy-financial, matplotlib, pandas
+
+# %%
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from worldenergydata.fdas.api import EconomicsQuery
+
+econ = EconomicsQuery()
+
+# %% [markdown]
+# ## 1. Net Present Value (NPV)
+#
+# A simple deepwater development: $500 M upfront capex followed by 20 years
+# of annual production revenue.
+
+# %%
+capex = -500  # $M invested at t=0
+annual_revenue = [60] * 20  # $60 M/yr for 20 years
+cashflows = [capex] + annual_revenue
+
+npv_10 = econ.npv(cashflows, discount_rate=0.10, period="annual")
+npv_08 = econ.npv(cashflows, discount_rate=0.08, period="annual")
+npv_12 = econ.npv(cashflows, discount_rate=0.12, period="annual")
+
+print(f"NPV @ 10%: ${npv_10:,.1f} M")
+print(f"NPV @  8%: ${npv_08:,.1f} M")
+print(f"NPV @ 12%: ${npv_12:,.1f} M")
+
+# %% [markdown]
+# ## 2. Internal Rate of Return (IRR)
+
+# %%
+period_irr, annual_irr = econ.irr(cashflows, period="annual")
+print(f"Annual IRR: {annual_irr:.2%}")
+
+# %% [markdown]
+# ## 3. Modified Internal Rate of Return (MIRR)
+#
+# MIRR avoids the multiple-IRR problem by specifying separate financing and
+# reinvestment rates.
+
+# %%
+mirr_m, mirr_a = econ.mirr(cashflows, discount_rate=0.10, reinvestment_rate=0.06)
+print(f"Annual MIRR (finance=10%, reinvest=6%): {mirr_a:.2%}")
+
+# %% [markdown]
+# ## 4. Payback period
+
+# %%
+periods, years = econ.payback_period(cashflows, period="annual")
+print(f"Payback: {years:.1f} years (period {periods})")
+
+# %% [markdown]
+# ## 5. All metrics at once
+#
+# `all_metrics()` returns a dictionary with NPV, IRR, MIRR, and payback in
+# a single call.
+
+# %%
+metrics = econ.all_metrics(cashflows, discount_rate=0.10, period="annual")
+for key in ["npv", "irr_annual", "mirr_annual", "payback_years"]:
+    val = metrics.get(key)
+    if isinstance(val, float):
+        print(f"  {key}: {val:,.4f}")
+    else:
+        print(f"  {key}: {val}")
+
+# %% [markdown]
+# ## 6. Sensitivity analysis — NPV vs. discount rate
+
+# %%
+rates = np.arange(0.02, 0.21, 0.01)
+npvs = [econ.npv(cashflows, discount_rate=r, period="annual") for r in rates]
+
+fig, ax = plt.subplots(figsize=(10, 5))
+ax.plot(rates * 100, npvs, marker="o", markersize=4)
+ax.axhline(0, color="gray", linestyle="--", linewidth=0.8)
+ax.fill_between(rates * 100, npvs, 0, where=[n > 0 for n in npvs],
+                alpha=0.15, color="green", label="NPV > 0")
+ax.fill_between(rates * 100, npvs, 0, where=[n <= 0 for n in npvs],
+                alpha=0.15, color="red", label="NPV < 0")
+ax.set_xlabel("Discount Rate (%)")
+ax.set_ylabel("NPV ($M)")
+ax.set_title("NPV Sensitivity to Discount Rate")
+ax.legend()
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+# ## 7. Comparing investment scenarios
+#
+# Compare three hypothetical field-development concepts side by side.
+
+# %%
+scenarios = {
+    "Base case": {"capex": -500, "revenue": 60, "years": 20},
+    "High capex / high revenue": {"capex": -800, "revenue": 110, "years": 20},
+    "Low capex / low revenue": {"capex": -250, "revenue": 35, "years": 15},
+}
+
+records = []
+for name, s in scenarios.items():
+    cf = [s["capex"]] + [s["revenue"]] * s["years"]
+    m = econ.all_metrics(cf, discount_rate=0.10, period="annual")
+    records.append({
+        "Scenario": name,
+        "Capex ($M)": abs(s["capex"]),
+        "Annual Rev ($M)": s["revenue"],
+        "Years": s["years"],
+        "NPV ($M)": round(m["npv"], 1),
+        "IRR (%)": round((m.get("irr_annual") or 0) * 100, 1),
+        "Payback (yr)": round(m.get("payback_years") or 0, 1),
+    })
+
+comparison = pd.DataFrame(records)
+print(comparison.to_string(index=False))
+
+# %% [markdown]
+# ## 8. Cashflow waterfall chart
+
+# %%
+cumulative = np.cumsum(cashflows)
+
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 5))
+
+# Bar chart of periodic cashflows
+colors = ["#e74c3c" if c < 0 else "#2ecc71" for c in cashflows]
+ax1.bar(range(len(cashflows)), cashflows, color=colors, edgecolor="white")
+ax1.set_xlabel("Year")
+ax1.set_ylabel("Cashflow ($M)")
+ax1.set_title("Annual Cashflows")
+ax1.axhline(0, color="gray", linewidth=0.8)
+
+# Cumulative cashflow
+ax2.plot(range(len(cumulative)), cumulative, marker="o", markersize=4, color="steelblue")
+ax2.axhline(0, color="gray", linestyle="--", linewidth=0.8)
+ax2.fill_between(range(len(cumulative)), cumulative, 0,
+                 where=cumulative >= 0, alpha=0.15, color="green")
+ax2.fill_between(range(len(cumulative)), cumulative, 0,
+                 where=cumulative < 0, alpha=0.15, color="red")
+ax2.set_xlabel("Year")
+ax2.set_ylabel("Cumulative Cashflow ($M)")
+ax2.set_title("Cumulative Cashflow")
+
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+# ## Summary
+#
+# This notebook covered:
+# - NPV, IRR, MIRR, and payback period calculations
+# - Sensitivity analysis across discount rates
+# - Scenario comparison for multiple development concepts
+# - Cashflow waterfall visualization

--- a/notebooks/quickstart_fdas.py
+++ b/notebooks/quickstart_fdas.py
@@ -85,10 +85,24 @@ npvs = [econ.npv(cashflows, discount_rate=r, period="annual") for r in rates]
 fig, ax = plt.subplots(figsize=(10, 5))
 ax.plot(rates * 100, npvs, marker="o", markersize=4)
 ax.axhline(0, color="gray", linestyle="--", linewidth=0.8)
-ax.fill_between(rates * 100, npvs, 0, where=[n > 0 for n in npvs],
-                alpha=0.15, color="green", label="NPV > 0")
-ax.fill_between(rates * 100, npvs, 0, where=[n <= 0 for n in npvs],
-                alpha=0.15, color="red", label="NPV < 0")
+ax.fill_between(
+    rates * 100,
+    npvs,
+    0,
+    where=[n > 0 for n in npvs],
+    alpha=0.15,
+    color="green",
+    label="NPV > 0",
+)
+ax.fill_between(
+    rates * 100,
+    npvs,
+    0,
+    where=[n <= 0 for n in npvs],
+    alpha=0.15,
+    color="red",
+    label="NPV < 0",
+)
 ax.set_xlabel("Discount Rate (%)")
 ax.set_ylabel("NPV ($M)")
 ax.set_title("NPV Sensitivity to Discount Rate")
@@ -112,15 +126,17 @@ records = []
 for name, s in scenarios.items():
     cf = [s["capex"]] + [s["revenue"]] * s["years"]
     m = econ.all_metrics(cf, discount_rate=0.10, period="annual")
-    records.append({
-        "Scenario": name,
-        "Capex ($M)": abs(s["capex"]),
-        "Annual Rev ($M)": s["revenue"],
-        "Years": s["years"],
-        "NPV ($M)": round(m["npv"], 1),
-        "IRR (%)": round((m.get("irr_annual") or 0) * 100, 1),
-        "Payback (yr)": round(m.get("payback_years") or 0, 1),
-    })
+    records.append(
+        {
+            "Scenario": name,
+            "Capex ($M)": abs(s["capex"]),
+            "Annual Rev ($M)": s["revenue"],
+            "Years": s["years"],
+            "NPV ($M)": round(m["npv"], 1),
+            "IRR (%)": round((m.get("irr_annual") or 0) * 100, 1),
+            "Payback (yr)": round(m.get("payback_years") or 0, 1),
+        }
+    )
 
 comparison = pd.DataFrame(records)
 print(comparison.to_string(index=False))
@@ -142,12 +158,21 @@ ax1.set_title("Annual Cashflows")
 ax1.axhline(0, color="gray", linewidth=0.8)
 
 # Cumulative cashflow
-ax2.plot(range(len(cumulative)), cumulative, marker="o", markersize=4, color="steelblue")
+ax2.plot(
+    range(len(cumulative)), cumulative, marker="o", markersize=4, color="steelblue"
+)
 ax2.axhline(0, color="gray", linestyle="--", linewidth=0.8)
-ax2.fill_between(range(len(cumulative)), cumulative, 0,
-                 where=cumulative >= 0, alpha=0.15, color="green")
-ax2.fill_between(range(len(cumulative)), cumulative, 0,
-                 where=cumulative < 0, alpha=0.15, color="red")
+ax2.fill_between(
+    range(len(cumulative)),
+    cumulative,
+    0,
+    where=cumulative >= 0,
+    alpha=0.15,
+    color="green",
+)
+ax2.fill_between(
+    range(len(cumulative)), cumulative, 0, where=cumulative < 0, alpha=0.15, color="red"
+)
 ax2.set_xlabel("Year")
 ax2.set_ylabel("Cumulative Cashflow ($M)")
 ax2.set_title("Cumulative Cashflow")

--- a/notebooks/quickstart_marine_safety.py
+++ b/notebooks/quickstart_marine_safety.py
@@ -1,0 +1,159 @@
+# %% [markdown]
+# # Marine Safety Incidents -- Quickstart
+#
+# Analyze marine safety incident data from CSV files included in the
+# repository.  The repo ships three small curated datasets covering
+# fatalities, foundering events, and hatch-related incidents.
+#
+# ## Prerequisites
+# - Python 3.11+
+# - pandas, matplotlib
+# - Data files in `data/modules/marine_safety/input/` (included in the repo)
+
+# %%
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+DATA_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "data" / "modules" / "marine_safety" / "input"
+)
+
+# %% [markdown]
+# ## 1. Load incident datasets
+#
+# Three CSV files are available without running any data pipelines.
+
+# %%
+fatalities = pd.read_csv(DATA_DIR / "fatality_incidents.csv")
+foundering = pd.read_csv(DATA_DIR / "foundering_incidents.csv")
+hatch = pd.read_csv(DATA_DIR / "hatch_incidents.csv")
+
+print(f"Fatality incidents:   {len(fatalities)}")
+print(f"Foundering incidents: {len(foundering)}")
+print(f"Hatch incidents:      {len(hatch)}")
+
+# %%
+fatalities.head()
+
+# %% [markdown]
+# ## 2. Fatality analysis — causes of death
+
+# %%
+cause_counts = fatalities["cause_of_death"].value_counts()
+
+fig, ax = plt.subplots(figsize=(10, 5))
+cause_counts.plot.barh(ax=ax, color="indianred")
+ax.set_xlabel("Number of Incidents")
+ax.set_title("Marine Fatalities by Cause of Death")
+ax.invert_yaxis()
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+# ## 3. Fatality timeline
+
+# %%
+fatalities["date"] = pd.to_datetime(fatalities["date"], errors="coerce")
+fatalities["month"] = fatalities["date"].dt.to_period("M")
+
+monthly = fatalities.groupby("month")["fatalities"].sum()
+
+fig, ax = plt.subplots(figsize=(10, 4))
+monthly.plot(kind="bar", ax=ax, color="steelblue", edgecolor="white")
+ax.set_xlabel("Month")
+ax.set_ylabel("Fatalities")
+ax.set_title("Monthly Fatality Count")
+ax.set_xticklabels([str(p) for p in monthly.index], rotation=45, ha="right")
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+# ## 4. Foundering incidents
+#
+# Foundering means a vessel sinking or capsizing.
+
+# %%
+foundering["date"] = pd.to_datetime(foundering["date"], errors="coerce")
+print(f"Total foundering fatalities: {foundering['fatalities'].sum()}")
+foundering[["incident_id", "date", "vessel_name", "fatalities", "location"]]
+
+# %% [markdown]
+# ## 5. Hatch-related incidents by severity
+
+# %%
+severity_counts = hatch["severity"].value_counts()
+
+fig, ax = plt.subplots(figsize=(7, 5))
+colors = {"Critical": "#e74c3c", "High": "#e67e22", "Medium": "#f1c40f", "Low": "#2ecc71"}
+bar_colors = [colors.get(s, "gray") for s in severity_counts.index]
+severity_counts.plot.bar(ax=ax, color=bar_colors, edgecolor="white")
+ax.set_xlabel("Severity")
+ax.set_ylabel("Number of Incidents")
+ax.set_title("Hatch Incidents by Severity")
+ax.set_xticklabels(ax.get_xticklabels(), rotation=0)
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+# ## 6. Combined overview
+#
+# Merge all three datasets into a single view with a common category column.
+
+# %%
+fatalities_slim = fatalities[["incident_id", "date", "vessel_name", "description"]].copy()
+fatalities_slim["category"] = "Fatality"
+
+foundering_slim = foundering[["incident_id", "date", "vessel_name", "description"]].copy()
+foundering_slim["category"] = "Foundering"
+
+hatch_slim = hatch[["incident_id", "date", "vessel_name", "description"]].copy()
+hatch_slim["category"] = "Hatch"
+
+combined = pd.concat([fatalities_slim, foundering_slim, hatch_slim], ignore_index=True)
+combined["date"] = pd.to_datetime(combined["date"], errors="coerce")
+
+fig, ax = plt.subplots(figsize=(8, 4))
+combined["category"].value_counts().plot.bar(ax=ax, color=["indianred", "steelblue", "goldenrod"])
+ax.set_ylabel("Number of Incidents")
+ax.set_title("Incidents by Category")
+ax.set_xticklabels(ax.get_xticklabels(), rotation=0)
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+# ## 7. Using the query API (optional)
+#
+# The marine safety query API connects to the full SQLite database
+# (requires running the data pipeline first):
+#
+# ```python
+# import worldenergydata as wed
+#
+# # Query across all sources
+# df = wed.marine_safety_api.incidents.query(source="maib", year=2022)
+#
+# # Multi-source, multi-year query
+# df = wed.marine_safety_api.incidents.query(
+#     vessel_type="tanker", start_year=2020, end_year=2023
+# )
+#
+# # Trend analysis
+# trends = wed.marine_safety_api.incidents.trends(df)
+#
+# # Risk hotspots
+# hotspots = wed.marine_safety_api.incidents.risk_hotspots(df)
+# ```
+
+# %% [markdown]
+# ## Summary
+#
+# This notebook covered:
+# - Loading three marine safety CSV datasets
+# - Fatality cause analysis and timeline
+# - Foundering event overview
+# - Hatch incident severity classification
+# - Combined incident overview
+# - How to use the query API for full-database analysis

--- a/notebooks/quickstart_marine_safety.py
+++ b/notebooks/quickstart_marine_safety.py
@@ -18,7 +18,10 @@ import pandas as pd
 
 DATA_DIR = (
     Path(__file__).resolve().parent.parent
-    / "data" / "modules" / "marine_safety" / "input"
+    / "data"
+    / "modules"
+    / "marine_safety"
+    / "input"
 )
 
 # %% [markdown]
@@ -87,7 +90,12 @@ foundering[["incident_id", "date", "vessel_name", "fatalities", "location"]]
 severity_counts = hatch["severity"].value_counts()
 
 fig, ax = plt.subplots(figsize=(7, 5))
-colors = {"Critical": "#e74c3c", "High": "#e67e22", "Medium": "#f1c40f", "Low": "#2ecc71"}
+colors = {
+    "Critical": "#e74c3c",
+    "High": "#e67e22",
+    "Medium": "#f1c40f",
+    "Low": "#2ecc71",
+}
 bar_colors = [colors.get(s, "gray") for s in severity_counts.index]
 severity_counts.plot.bar(ax=ax, color=bar_colors, edgecolor="white")
 ax.set_xlabel("Severity")
@@ -103,10 +111,14 @@ plt.show()
 # Merge all three datasets into a single view with a common category column.
 
 # %%
-fatalities_slim = fatalities[["incident_id", "date", "vessel_name", "description"]].copy()
+fatalities_slim = fatalities[
+    ["incident_id", "date", "vessel_name", "description"]
+].copy()
 fatalities_slim["category"] = "Fatality"
 
-foundering_slim = foundering[["incident_id", "date", "vessel_name", "description"]].copy()
+foundering_slim = foundering[
+    ["incident_id", "date", "vessel_name", "description"]
+].copy()
 foundering_slim["category"] = "Foundering"
 
 hatch_slim = hatch[["incident_id", "date", "vessel_name", "description"]].copy()
@@ -116,7 +128,9 @@ combined = pd.concat([fatalities_slim, foundering_slim, hatch_slim], ignore_inde
 combined["date"] = pd.to_datetime(combined["date"], errors="coerce")
 
 fig, ax = plt.subplots(figsize=(8, 4))
-combined["category"].value_counts().plot.bar(ax=ax, color=["indianred", "steelblue", "goldenrod"])
+combined["category"].value_counts().plot.bar(
+    ax=ax, color=["indianred", "steelblue", "goldenrod"]
+)
 ax.set_ylabel("Number of Incidents")
 ax.set_title("Incidents by Category")
 ax.set_xticklabels(ax.get_xticklabels(), rotation=0)

--- a/notebooks/quickstart_sodir.py
+++ b/notebooks/quickstart_sodir.py
@@ -1,0 +1,150 @@
+# %% [markdown]
+# # SODIR (Norwegian Continental Shelf) -- Quickstart
+#
+# Access Norwegian petroleum data from the SODIR (formerly NPD) public API.
+# SODIR provides wellbore, field, discovery, block, and production data for
+# the entire Norwegian Continental Shelf (NCS).
+#
+# ## Prerequisites
+# - Python 3.11+
+# - `requests` (for API calls)
+# - pandas, matplotlib
+# - No local data files required — data is fetched from the public API
+
+# %%
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+# %% [markdown]
+# ## 1. About the SODIR API
+#
+# SODIR exposes a REST API at `https://factmaps.sodir.no/` with endpoints
+# for wellbores, fields, discoveries, blocks, surveys, and production.
+# The `worldenergydata` package includes a client with rate limiting and
+# caching built in.
+
+# %% [markdown]
+# ## 2. Available endpoints
+#
+# The SODIR module covers these datasets:
+#
+# | Endpoint      | Table ID | Description                              |
+# |---------------|----------|------------------------------------------|
+# | blocks        | 1001     | NCS block information                    |
+# | wellbores     | 5000     | Wellbore drilling and completion data    |
+# | fields        | 2000     | Field-level production and reserves      |
+# | discoveries   | 3000     | Discovery details                        |
+# | surveys       | 4000     | Seismic survey metadata                  |
+
+# %% [markdown]
+# ## 3. Fetching data with the API client
+#
+# Below is a working example that fetches wellbore data.  If the SODIR API
+# is unreachable (corporate firewall, offline), the cell will print an
+# error message instead of failing.
+
+# %%
+try:
+    from worldenergydata.sodir.api_client import SodirAPIClient
+
+    client = SodirAPIClient(
+        base_url="https://factmaps.sodir.no",
+        rate_limit=5,
+        cache_ttl=86400,
+    )
+    print("SODIR API client initialized")
+    print(f"  Base URL: {client.base_url}")
+    print("  Ready to query wellbores, fields, discoveries, blocks")
+except ImportError as exc:
+    print(f"Could not import SODIR client: {exc}")
+    print("Install with: pip install worldenergydata")
+except Exception as exc:
+    print(f"Client init error: {exc}")
+
+# %% [markdown]
+# ## 4. Example: fetch NCS wellbores
+#
+# The snippet below shows how to fetch and explore wellbore data.  It is
+# wrapped in a try/except so the notebook does not fail when run offline.
+
+# %%
+try:
+    from worldenergydata.sodir.datasets import SodirDatasets
+
+    datasets = SodirDatasets(client)
+    wellbores_df = datasets.get_wellbores()
+
+    if wellbores_df is not None and not wellbores_df.empty:
+        print(f"Fetched {len(wellbores_df):,} NCS wellbores")
+        print("Columns:", list(wellbores_df.columns[:10]), "...")
+        display_df = wellbores_df.head()
+    else:
+        print("No wellbore data returned (API may be unreachable)")
+        display_df = pd.DataFrame({"note": ["Run when connected to internet"]})
+
+    display_df
+except Exception as exc:
+    print(f"Skipped live fetch: {exc}")
+    print("This is expected when running offline or without network access.")
+
+# %% [markdown]
+# ## 5. Working with cached / exported data
+#
+# After a successful fetch, SODIR data is cached under `data/sodir/cache/`.
+# You can also export to CSV for offline analysis:
+#
+# ```python
+# # Export to CSV
+# wellbores_df.to_csv("data/sodir/exports/wellbores.csv", index=False)
+#
+# # Reload later
+# df = pd.read_csv("data/sodir/exports/wellbores.csv")
+# ```
+
+# %% [markdown]
+# ## 6. NCS production analysis (when data is available)
+#
+# Once you have field production data, common analyses include:
+
+# %%
+# Synthetic example showing the kind of analysis you can do with NCS data
+ncs_example = pd.DataFrame({
+    "field": ["Johan Sverdrup", "Troll", "Ekofisk", "Snorre", "Gullfaks"],
+    "peak_oil_kbd": [755, 175, 370, 220, 250],
+    "start_year": [2019, 1995, 1971, 1992, 1986],
+    "water_depth_m": [115, 330, 75, 350, 220],
+})
+
+fig, ax = plt.subplots(figsize=(9, 5))
+ax.barh(ncs_example["field"], ncs_example["peak_oil_kbd"], color="steelblue")
+ax.set_xlabel("Peak Oil Production (kbd)")
+ax.set_title("Major NCS Fields — Peak Production Rates")
+ax.invert_yaxis()
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+# ## 7. Scheduler integration
+#
+# For automated data collection, use the worldenergydata scheduler:
+#
+# ```bash
+# # Fetch all SODIR datasets
+# uv run python -m worldenergydata.scheduler --module sodir --action fetch
+#
+# # Or use Make
+# make data-sodir
+# ```
+
+# %% [markdown]
+# ## Summary
+#
+# This notebook covered:
+# - SODIR API endpoints and available datasets
+# - Initializing the API client with rate limiting
+# - Fetching NCS wellbore data
+# - Caching and exporting for offline use
+# - Example NCS field production analysis
+# - Scheduler integration for automated data collection

--- a/notebooks/quickstart_sodir.py
+++ b/notebooks/quickstart_sodir.py
@@ -110,12 +110,14 @@ except Exception as exc:
 
 # %%
 # Synthetic example showing the kind of analysis you can do with NCS data
-ncs_example = pd.DataFrame({
-    "field": ["Johan Sverdrup", "Troll", "Ekofisk", "Snorre", "Gullfaks"],
-    "peak_oil_kbd": [755, 175, 370, 220, 250],
-    "start_year": [2019, 1995, 1971, 1992, 1986],
-    "water_depth_m": [115, 330, 75, 350, 220],
-})
+ncs_example = pd.DataFrame(
+    {
+        "field": ["Johan Sverdrup", "Troll", "Ekofisk", "Snorre", "Gullfaks"],
+        "peak_oil_kbd": [755, 175, 370, 220, 250],
+        "start_year": [2019, 1995, 1971, 1992, 1986],
+        "water_depth_m": [115, 330, 75, 350, 220],
+    }
+)
 
 fig, ax = plt.subplots(figsize=(9, 5))
 ax.barh(ncs_example["field"], ncs_example["peak_oil_kbd"], color="steelblue")


### PR DESCRIPTION
## Summary
5 quickstart notebooks in `# %%` percent format + README. Each runs in under 5 minutes and is under 50 cells.

### Notebooks

| Notebook | Data Source | Works Offline? |
|----------|-----------|----------------|
| `quickstart_bsee.py` | `well_data.csv` (57K rows, in repo) | Yes |
| `quickstart_fdas.py` | Pure computation (NPV/IRR/MIRR) | Yes |
| `quickstart_marine_safety.py` | 3 CSVs in `data/modules/marine_safety/input/` | Yes |
| `quickstart_sodir.py` | SODIR API (graceful offline fallback) | Partial |
| `quickstart_eia.py` | EIA API + `EIA_API_KEY` env var (graceful fallback) | Partial |

### What each demonstrates
- **BSEE**: Water depth distribution, top operators, spud timeline, deepwater classification
- **FDAS**: NPV sensitivity chart, 3-scenario comparison, cashflow waterfall
- **Marine Safety**: Fatality cause analysis, monthly timeline, hatch severity
- **SODIR**: Endpoint catalog, wellbore fetch, cache/export, synthetic NCS chart
- **EIA**: Weekly petroleum fetch, US crude production trend, top-producing states

### Format
- `# %%` percent format — opens in VS Code, JupyterLab, Jupytext
- matplotlib for all visualizations
- try/except wrappers for API calls — notebooks never crash

## Files: 6 new, +829 lines

## Test plan
- [ ] Open `notebooks/quickstart_fdas.py` in VS Code — runs all cells
- [ ] Open `notebooks/quickstart_bsee.py` — loads CSV and renders charts
- [ ] `notebooks/README.md` lists all notebooks with descriptions

Closes #293