### PR TITLE
chore(types): add types-requests and types-PyYAML stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,9 @@ dev = [
     "flake8>=6.0",
     "mypy>=1.0",
     "pre-commit>=3.0",
+    "types-requests>=2.31",
+    "types-PyYAML>=6.0",
+    "types-python-dateutil>=2.9",
 ]
 test = [
     "pytest>=8.4.2",
@@ -146,7 +149,7 @@ profile = "black"
 line_length = 88
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true


### PR DESCRIPTION
## Summary
Progress on Type Check CI — but does **not** make it green. The stub additions + mypy target bump reveal pre-existing untyped-code debt that was previously hidden.

**Changes:**
- Add `types-requests>=2.31`, `types-PyYAML>=6.0`, `types-python-dateutil>=2.9` to `[project.optional-dependencies].dev`
- Bump `[tool.mypy].python_version` from `3.8` → `3.10` (matches runtime target; eliminates false-positive crash on torch's `match` syntax)

## Why Type Check still fails
Before this PR, mypy crashed early on `.venv/lib/python3.11/site-packages/torch/_inductor/kernel/mm.py:813` because `match` statements aren't valid in python 3.8 (the old mypy target). That crash masked the rest of the type errors in the repo.

Post-fix, mypy runs to completion and reports **2918 pre-existing type errors** across `src/worldenergydata/`:

| Error code | Count |
|------------|------:|
| `[no-untyped-def]` | 978 |
| `[assignment]` | 329 |
| `[attr-defined]` | 318 |
| `[no-any-return]` | 260 |
| `[arg-type]` | 223 |
| 17 other codes | 810 |

These are all pre-existing — not introduced by this PR. Getting Type Check to pass requires either adding pervasive type annotations (weeks of work) or relaxing mypy rules via per-module overrides.

## What this PR still accomplishes
- ✅ Makes mypy's python target honest (3.10 matches runtime)
- ✅ Adds stubs for `requests`, `yaml`, `dateutil.parser` so those 65 errors disappear
- ❌ Does not flip Type Check to green — that's deferred to a separate effort

## Expected CI impact
- Type Check: FAIL (65 stub errors, mypy crash) → FAIL (2918 real errors, but mypy no longer crashing). Net "quality of failure" is better; raw pass/fail unchanged.
- Lint, Tests: unchanged.

## Follow-up recommendation
Open a separate tracking issue for "mypy clean-up" that either (a) adds annotations incrementally per-module or (b) relaxes the mypy config via `disallow_untyped_defs = false` + per-module overrides. Out of scope for this cleanup sweep.

## Test plan
- [ ] Confirm mypy reaches completion (no torch-syntax crash)
- [ ] Confirm error count drops from stubs (61→0) even though other errors appear
- [ ] No regression in other CI jobs