### PR TITLE
fix(tests): restore broken imports in 5 CI-failing test files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,8 @@ dependencies = [
     "schedule>=1.2.0,<2.0",
     "pyarrow>=14.0.0,<20.0",
     "scikit-learn>=1.6.1,<2.0",
+    # Financial calculations (runtime dep for fdas/core/financial.py)
+    "numpy-financial>=1.0.0",
 ]
 
 [project.optional-dependencies]
@@ -222,7 +224,6 @@ dev = [
     "faker>=37.8.0",
     "hypothesis>=6.141.1",
     "mypy>=1.18.2",
-    "numpy-financial>=1.0.0",
     "pytest-asyncio>=1.2.0",
     "pytest-cov>=7.0.0",
     "pytest-timeout>=2.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,9 @@ disallow_untyped_defs = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]
-addopts = "--cov=src/worldenergydata --cov-report=term-missing --cov-report=html:reports/coverage/htmlcov --cov-report=xml:reports/coverage/coverage.xml --cov-report=json:reports/coverage/coverage.json"
+# Use importlib mode so duplicate test file names (e.g. multiple test_end_to_end.py)
+# in different dirs don't collide in sys.modules during collection.
+addopts = "--import-mode=importlib --cov=src/worldenergydata --cov-report=term-missing --cov-report=html:reports/coverage/htmlcov --cov-report=xml:reports/coverage/coverage.xml --cov-report=json:reports/coverage/coverage.json"
 
 [tool.coverage.run]
 source = ["src/worldenergydata"]

--- a/src/worldenergydata/modules/bsee/analysis/type_curves/blasingame.py
+++ b/src/worldenergydata/modules/bsee/analysis/type_curves/blasingame.py
@@ -1,0 +1,250 @@
+"""Blasingame type curve generation and matching.
+
+References:
+    Blasingame, T.A. & Lee, W.J. (1986). SPE 15028.
+    Palacio, J.C. & Blasingame, T.A. (1993). SPE 25909.
+"""
+
+import numpy as np
+from numpy.typing import NDArray
+from scipy.optimize import minimize
+
+from .models import MatchResult, ProductionData, ReservoirParams, TypeCurveSet
+
+
+def material_balance_time(
+    rate: NDArray[np.float64],
+    cumulative: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Compute material balance time tc = Np / q.
+
+    Returns tc array (same units as time in cumulative/rate).
+    """
+    with np.errstate(divide="ignore", invalid="ignore"):
+        tc = np.where(rate > 0, cumulative / rate, 0.0)
+    return tc
+
+
+def normalized_rate(
+    rate: NDArray[np.float64],
+    pressure_drawdown: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Compute q / (pi - pwf)."""
+    with np.errstate(divide="ignore", invalid="ignore"):
+        return np.where(pressure_drawdown > 0, rate / pressure_drawdown, 0.0)
+
+
+def rate_integral(
+    q_norm: NDArray[np.float64],
+    tc: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Rate integral: (1/tc) * integral(q_norm * dtc) via trapezoidal rule."""
+    n = len(tc)
+    if n == 0:
+        return np.array([])
+
+    cum = np.zeros(n)
+    cum[0] = q_norm[0] * tc[0] if tc[0] > 0 else 0.0
+    for i in range(1, n):
+        cum[i] = cum[i - 1] + 0.5 * (q_norm[i] + q_norm[i - 1]) * (tc[i] - tc[i - 1])
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        qDdi = np.where(tc > 0, cum / tc, q_norm)
+    return qDdi
+
+
+def rate_integral_derivative(
+    qDdi: NDArray[np.float64],
+    tc: NDArray[np.float64],
+    window: float = 0.2,
+) -> NDArray[np.float64]:
+    """Bourdet semi-log derivative of rate integral.
+
+    qDdid = -d(qDdi) / d(ln(tc))
+
+    Args:
+        window: smoothing window in log-cycles (not currently used for
+                simple 3-point derivative; kept for API compatibility).
+    """
+    n = len(tc)
+    if n < 3:
+        return np.zeros(n)
+
+    ln_tc = np.log(np.maximum(tc, 1e-30))
+    deriv = np.zeros(n)
+
+    for i in range(1, n - 1):
+        dxL = ln_tc[i] - ln_tc[i - 1]
+        dxR = ln_tc[i + 1] - ln_tc[i]
+        dyL = qDdi[i] - qDdi[i - 1]
+        dyR = qDdi[i + 1] - qDdi[i]
+        if dxL > 0 and dxR > 0:
+            deriv[i] = -((dyL / dxL) * dxR + (dyR / dxR) * dxL) / (dxL + dxR)
+
+    deriv[0] = deriv[1]
+    deriv[-1] = deriv[-2]
+    return np.maximum(deriv, 1e-30)
+
+
+def _bDpss_radial(reD: float) -> float:
+    """Pseudo-steady-state constant for radial model."""
+    return np.log(reD) - 0.5
+
+
+def _analytical_qDd(
+    tDd: NDArray[np.float64], reD: float
+) -> NDArray[np.float64]:
+    """Analytical boundary-dominated qDd for Blasingame (harmonic)."""
+    # During boundary-dominated flow, Blasingame collapses to 1/(1+tDd)
+    # weighted by bDpss. For the full solution including transient,
+    # use the exponential integral approximation.
+    return 1.0 / (1.0 + tDd)
+
+
+def _analytical_qDdi(
+    tDd: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Analytical rate integral for harmonic decline."""
+    with np.errstate(divide="ignore", invalid="ignore"):
+        return np.where(tDd > 0, np.log(1.0 + tDd) / tDd, 1.0)
+
+
+def _analytical_qDdid(
+    tDd: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Analytical rate integral derivative for harmonic decline."""
+    qDdi = _analytical_qDdi(tDd)
+    qDd = _analytical_qDd(tDd, reD=1.0)  # reD not needed for harmonic
+    return np.maximum(qDdi - qDd, 1e-30)
+
+
+def blasingame_typecurve(
+    reD_values: list[float] | None = None,
+    n_points: int = 300,
+) -> TypeCurveSet:
+    """Generate Blasingame type curves (qDd, qDdi, qDdid) for radial model.
+
+    Args:
+        reD_values: dimensionless drainage radii.
+        n_points: points per curve.
+
+    Returns:
+        TypeCurveSet with qDd, qDdi, qDdid for each reD.
+    """
+    if reD_values is None:
+        reD_values = [2, 5, 10, 20, 50, 100, 200, 1000]
+
+    tDd = np.logspace(-3, 3, n_points)
+    result = TypeCurveSet()
+
+    for reD in reD_values:
+        qDd = _analytical_qDd(tDd, reD)
+        qDdi = _analytical_qDdi(tDd)
+        qDdid = _analytical_qDdid(tDd)
+        result.tDd.append(tDd)
+        result.qDd.append(qDd)
+        result.qDdi.append(qDdi)
+        result.qDdid.append(qDdid)
+        result.labels.append(f"reD={reD}")
+
+    return result
+
+
+def match_blasingame(
+    data: ProductionData,
+    params: ReservoirParams,
+    reD_guesses: list[float] | None = None,
+    weights: tuple[float, float, float] = (0.2, 0.5, 0.3),
+) -> MatchResult:
+    """Automatic Blasingame type curve matching.
+
+    Multi-start optimization over (log_Ct, log_Cq, reD).
+    Matches qDd, qDdi, qDdid simultaneously with given weights.
+    """
+    if reD_guesses is None:
+        reD_guesses = [5.0, 20.0, 50.0, 100.0, 500.0]
+
+    dp = data.pressure_drawdown
+    if dp is None:
+        dp = np.full_like(data.rate, params.pi - params.pwf)
+
+    q_norm = normalized_rate(data.rate, dp)
+    tc = material_balance_time(data.rate, data.cumulative)
+    qDdi_data = rate_integral(q_norm, tc)
+    qDdid_data = rate_integral_derivative(qDdi_data, tc)
+
+    valid = (tc > 0) & (q_norm > 0) & (qDdi_data > 0) & (qDdid_data > 0)
+    tc_v = tc[valid]
+    qn_v = q_norm[valid]
+    qDdi_v = qDdi_data[valid]
+    qDdid_v = qDdid_data[valid]
+
+    if len(tc_v) < 3:
+        raise ValueError("Insufficient valid data points for matching")
+
+    w1, w2, w3 = weights
+
+    def objective(x):
+        log_Ct, log_Cq, reD = x
+        if reD <= 1.0:
+            return 1e12
+        Ct = 10**log_Ct
+        Cq = 10**log_Cq
+        tDd = Ct * tc_v
+
+        qDd_m = _analytical_qDd(tDd, reD)
+        qDdi_m = _analytical_qDdi(tDd)
+        qDdid_m = _analytical_qDdid(tDd)
+
+        qDd_d = Cq * qn_v
+        qDdi_d = Cq * qDdi_v
+        qDdid_d = Cq * qDdid_v
+
+        mask = (qDd_d > 0) & (qDd_m > 0) & (qDdi_m > 0) & (qDdid_m > 0)
+        if mask.sum() < 3:
+            return 1e12
+
+        res = (
+            w1 * np.sum((np.log(qDd_d[mask]) - np.log(qDd_m[mask])) ** 2)
+            + w2 * np.sum((np.log(qDdi_d[mask]) - np.log(qDdi_m[mask])) ** 2)
+            + w3 * np.sum((np.log(qDdid_d[mask]) - np.log(qDdid_m[mask])) ** 2)
+        )
+        return res
+
+    best = None
+    for reD_init in reD_guesses:
+        x0 = [0.0, -3.0, reD_init]
+        try:
+            res = minimize(
+                objective, x0, method="Nelder-Mead",
+                options={"maxiter": 10000, "xatol": 1e-8, "fatol": 1e-10},
+            )
+            if best is None or res.fun < best.fun:
+                best = res
+        except Exception:
+            continue
+
+    if best is None:
+        raise RuntimeError("Optimization failed to converge")
+
+    log_Ct, log_Cq, reD = best.x
+    Ct = 10**log_Ct
+    Cq = 10**log_Cq
+
+    bDpss = _bDpss_radial(max(reD, 1.01))
+    k = Cq * 141.2 * params.Bo * params.mu * bDpss / params.h
+    rwa = np.sqrt(
+        0.0002637 * k / (params.phi * params.mu * params.ct * Ct)
+    )
+    skin = np.log(params.rw / rwa) if rwa > 0 else 0.0
+    re = reD * rwa
+    ooip = np.pi * re**2 * params.h * params.phi * (1 - params.Sw) / (5.615 * params.Bo)
+
+    qi = q_norm[0] / Cq if Cq > 0 else 0.0
+    Di = Ct
+
+    return MatchResult(
+        k=k, skin=skin, re=re, rwa=rwa, ooip=ooip,
+        qi=qi, Di=Di, b=1.0, reD=reD, residual=best.fun,
+        Ct=Ct, Cq=Cq, model="blasingame",
+    )

--- a/src/worldenergydata/modules/bsee/analysis/type_curves/fetkovich.py
+++ b/src/worldenergydata/modules/bsee/analysis/type_curves/fetkovich.py
@@ -1,0 +1,209 @@
+"""Fetkovich type curve generation and matching.
+
+References:
+    Fetkovich, M.J. (1980). "Decline Rate Analysis Using Type Curves,"
+    JPT, SPE 4629-PA.
+"""
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .models import MatchResult, ProductionData, ReservoirParams, TypeCurveSet
+
+
+def _edwardson_wed(tD: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Cumulative dimensionless influx WeD(tD) via Edwardson polynomial.
+
+    Approximation for constant-pressure radial flow (infinite-acting).
+    Edwardson et al. (1962), also used by Fetkovich (1980).
+    """
+    weD = np.zeros_like(tD, dtype=np.float64)
+
+    small = tD < 0.01
+    mid = (tD >= 0.01) & (tD <= 200.0)
+    large = tD > 200.0
+
+    weD[small] = np.sqrt(tD[small] / np.pi)
+
+    t_mid = tD[mid]
+    sqrt_t = np.sqrt(t_mid)
+    num = 1.2838 * sqrt_t + 1.19328 * t_mid + 0.269872 * t_mid**1.5 + 0.00855294 * t_mid**2
+    den = 1.0 + 0.616599 * sqrt_t + 0.0413008 * t_mid
+    weD[mid] = num / den
+
+    t_large = tD[large]
+    weD[large] = -4.29881 + 2.02566 * t_large / np.log(t_large)
+
+    return weD
+
+
+def _constant_pressure_qD(tD: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Dimensionless rate qD = dWeD/dtD via finite differences."""
+    weD = _edwardson_wed(tD)
+    qD = np.gradient(weD, tD)
+    return np.maximum(qD, 1e-30)
+
+
+def fetkovich_transient(
+    tD: NDArray[np.float64], reD: float
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Generate Fetkovich transient stem for a given reD.
+
+    Rescales well-test (qD, tD) to decline (qDd, tDd).
+
+    Returns:
+        (tDd, qDd) arrays for the transient portion.
+    """
+    if reD <= 1.0:
+        raise ValueError(f"reD must be > 1, got {reD}")
+
+    ln_reD = np.log(reD)
+    qD = _constant_pressure_qD(tD)
+    qDd = qD * (ln_reD - 0.5)
+    scale_t = 0.5 * (reD**2 - 1.0) * (ln_reD - 0.5)
+    tDd = tD / scale_t
+    return tDd, qDd
+
+
+def fetkovich_boundary(
+    tDd: NDArray[np.float64], b: float
+) -> NDArray[np.float64]:
+    """Arps decline for boundary-dominated flow.
+
+    Args:
+        tDd: dimensionless decline time array.
+        b: Arps b-factor (0=exponential, 0<b<1=hyperbolic, 1=harmonic).
+
+    Returns:
+        qDd array.
+    """
+    if b < 0 or b > 1:
+        raise ValueError(f"b must be in [0, 1], got {b}")
+
+    if b == 0:
+        return np.exp(-tDd)
+
+    if b == 1:
+        return 1.0 / (1.0 + tDd)
+
+    return (1.0 + b * tDd) ** (-1.0 / b)
+
+
+def fetkovich_typecurve(
+    reD_values: list[float] | None = None,
+    b_values: list[float] | None = None,
+    n_points: int = 200,
+) -> TypeCurveSet:
+    """Generate complete Fetkovich type curve set.
+
+    Args:
+        reD_values: list of reD for transient stems.
+        b_values: list of b for boundary-dominated stems.
+        n_points: points per curve.
+
+    Returns:
+        TypeCurveSet with transient + boundary curves.
+    """
+    if reD_values is None:
+        reD_values = [2, 5, 10, 20, 50, 100, 200, 1000]
+    if b_values is None:
+        b_values = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]
+
+    tD = np.logspace(-2, 4, n_points)
+    tDd_bd = np.logspace(-2, 2, n_points)
+    result = TypeCurveSet()
+
+    for reD in reD_values:
+        tDd, qDd = fetkovich_transient(tD, reD)
+        mask = tDd > 0
+        result.tDd.append(tDd[mask])
+        result.qDd.append(qDd[mask])
+        result.labels.append(f"reD={reD}")
+
+    for b in b_values:
+        qDd = fetkovich_boundary(tDd_bd, b)
+        result.tDd.append(tDd_bd)
+        result.qDd.append(qDd)
+        result.labels.append(f"b={b}")
+
+    return result
+
+
+def match_fetkovich(
+    data: ProductionData,
+    params: ReservoirParams,
+    b_range: tuple[float, float] = (0.0, 1.0),
+    reD_guesses: list[float] | None = None,
+) -> MatchResult:
+    """Automatic Fetkovich type curve matching.
+
+    Uses multi-start optimization over (log_Ct, log_Cq, b, reD).
+    """
+    from scipy.optimize import minimize
+
+    if reD_guesses is None:
+        reD_guesses = [5.0, 20.0, 100.0, 500.0]
+
+    dp = data.pressure_drawdown
+    if dp is None:
+        dp = np.full_like(data.rate, params.pi - params.pwf)
+    q_norm = data.rate / dp
+
+    tDd_model = np.logspace(-2, 2, 300)
+
+    def objective(x):
+        log_Ct, log_Cq, b, reD = x
+        if reD <= 1.0 or b < 0 or b > 1:
+            return 1e12
+        Ct = 10**log_Ct
+        Cq = 10**log_Cq
+        tDd_data = Ct * data.time
+        qDd_data = Cq * q_norm
+        qDd_model = fetkovich_boundary(tDd_data, b)
+        mask = (qDd_data > 0) & (qDd_model > 0)
+        if mask.sum() < 3:
+            return 1e12
+        return np.sum(
+            (np.log(qDd_data[mask]) - np.log(qDd_model[mask])) ** 2
+        )
+
+    best = None
+    for reD_init in reD_guesses:
+        for b_init in [0.0, 0.3, 0.6, 1.0]:
+            x0 = [0.0, -3.0, b_init, reD_init]
+            try:
+                res = minimize(
+                    objective, x0, method="Nelder-Mead",
+                    options={"maxiter": 5000, "xatol": 1e-8, "fatol": 1e-10},
+                )
+                if best is None or res.fun < best.fun:
+                    best = res
+            except Exception:
+                continue
+
+    if best is None:
+        raise RuntimeError("Optimization failed to converge")
+
+    log_Ct, log_Cq, b, reD = best.x
+    Ct = 10**log_Ct
+    Cq = 10**log_Cq
+
+    ln_reD = np.log(max(reD, 1.01))
+    bDpss = ln_reD - 0.5
+    k = Cq * 141.2 * params.Bo * params.mu * bDpss / params.h
+    rwa = np.sqrt(
+        0.0002637 * k / (params.phi * params.mu * params.ct * Ct)
+    )
+    skin = np.log(params.rw / rwa) if rwa > 0 else 0.0
+    re = reD * rwa
+    area_ft2 = np.pi * re**2
+    ooip = area_ft2 * params.h * params.phi * (1 - params.Sw) / (5.615 * params.Bo)
+
+    qi = q_norm[0] / Cq if Cq > 0 else 0.0
+    Di = Ct
+
+    return MatchResult(
+        k=k, skin=skin, re=re, rwa=rwa, ooip=ooip,
+        qi=qi, Di=Di, b=b, reD=reD, residual=best.fun,
+        Ct=Ct, Cq=Cq, model="fetkovich",
+    )

--- a/src/worldenergydata/modules/bsee/analysis/type_curves/models.py
+++ b/src/worldenergydata/modules/bsee/analysis/type_curves/models.py
@@ -1,0 +1,73 @@
+"""Data models for type curve matching."""
+
+from dataclasses import dataclass, field
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+@dataclass
+class ReservoirParams:
+    """Reservoir and well parameters for type curve analysis."""
+
+    k: float  # permeability, md
+    h: float  # net pay thickness, ft
+    phi: float  # porosity, fraction
+    mu: float  # viscosity, cp
+    ct: float  # total compressibility, 1/psi
+    rw: float  # wellbore radius, ft
+    re: float  # drainage radius, ft
+    pi: float  # initial reservoir pressure, psi
+    pwf: float  # flowing bottomhole pressure, psi
+    Bo: float = 1.0  # oil formation volume factor, rb/STB
+    Sw: float = 0.0  # water saturation, fraction
+    skin: float = 0.0  # skin factor
+
+
+@dataclass
+class ProductionData:
+    """Time-series production data for matching."""
+
+    time: NDArray[np.float64]  # days
+    rate: NDArray[np.float64]  # STB/day (oil) or Mscf/day (gas)
+    cumulative: NDArray[np.float64]  # STB or Mscf
+    pressure_drawdown: NDArray[np.float64] | None = None  # pi - pwf, psi
+
+    def __post_init__(self):
+        if len(self.time) == 0:
+            raise ValueError("Production data arrays must not be empty")
+        if len(self.time) != len(self.rate):
+            raise ValueError("time and rate arrays must have same length")
+        if len(self.time) != len(self.cumulative):
+            raise ValueError("time and cumulative arrays must have same length")
+
+
+@dataclass
+class MatchResult:
+    """Result of type curve matching."""
+
+    k: float  # matched permeability, md
+    skin: float  # matched skin factor
+    re: float  # matched drainage radius, ft
+    rwa: float  # apparent wellbore radius, ft
+    ooip: float  # original oil in place, STB
+    qi: float  # initial rate from match, STB/day
+    Di: float  # initial decline rate, 1/day
+    b: float  # Arps b-factor (Fetkovich only)
+    reD: float  # matched dimensionless drainage radius
+    residual: float  # sum of squared residuals
+    Ct: float  # time shift factor
+    Cq: float  # rate shift factor
+    model: str = ""  # "fetkovich" or "blasingame"
+
+
+@dataclass
+class TypeCurveSet:
+    """Collection of type curves for plotting/matching."""
+
+    tDd: list[NDArray[np.float64]] = field(default_factory=list)
+    qDd: list[NDArray[np.float64]] = field(default_factory=list)
+    labels: list[str] = field(default_factory=list)
+    # Blasingame extras
+    qDdi: list[NDArray[np.float64]] = field(default_factory=list)
+    qDdid: list[NDArray[np.float64]] = field(default_factory=list)

--- a/tests/modules/bsee/analysis/test_type_curves.py
+++ b/tests/modules/bsee/analysis/test_type_curves.py
@@ -6,7 +6,7 @@ Covers: analytical curves, material balance time, auto-matching, edge cases.
 import numpy as np
 import pytest
 
-from worldenergydata.modules.bsee.analysis.type_curves import (
+from worldenergydata.bsee.analysis.type_curves import (
     ProductionData,
     ReservoirParams,
     blasingame_typecurve,

--- a/tests/modules/sodir-integration/performance/profile_api.py
+++ b/tests/modules/sodir-integration/performance/profile_api.py
@@ -23,11 +23,11 @@ from typing import Any, Dict, List, Optional, Tuple
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from sodir_module.api_client import SodirAPIClient
-from sodir_module.cache import SodirCache
-from sodir_module.processors.block_processor import BlockProcessor
-from sodir_module.processors.field_processor import FieldProcessor
-from sodir_module.processors.wellbore_processor import WellboreProcessor
+from worldenergydata.sodir.api_client import SodirAPIClient
+from worldenergydata.sodir.cache import SodirCache
+from worldenergydata.sodir.processors.block_processor import BlockProcessor
+from worldenergydata.sodir.processors.field_processor import FieldProcessor
+from worldenergydata.sodir.processors.wellbore_processor import WellboreProcessor
 
 
 @dataclass

--- a/tests/modules/sodir-integration/test_analysis.py
+++ b/tests/modules/sodir-integration/test_analysis.py
@@ -491,7 +491,7 @@ class TestVisualization:
         assert len(dashboard.charts) >= 3
         assert dashboard.layout is not None
 
-    @patch("sodir_module.visualization.plt")
+    @patch("worldenergydata.sodir.visualization.plt")
     def test_export_charts(self, mock_plt, visualizer, tmp_path):
         """Test chart export functionality"""
         # Create dummy chart

--- a/tests/modules/sodir-integration/test_api_client.py
+++ b/tests/modules/sodir-integration/test_api_client.py
@@ -21,9 +21,9 @@ import pytest
 # Add the module path for imports
 sys.path.insert(0, str(Path(__file__).parent))
 
-from sodir_module.api_client import SodirAPIClient
-from sodir_module.cache import CacheEntry, SodirCache
-from sodir_module.errors import (
+from worldenergydata.sodir.api_client import SodirAPIClient
+from worldenergydata.sodir.cache import CacheEntry, SodirCache
+from worldenergydata.sodir.errors import (
     SodirAPIError,
     SodirConfigurationError,
     SodirRateLimitError,
@@ -71,7 +71,7 @@ class TestSodirAPIClient:
 
         assert client.base_url == "https://factmaps.sodir.no/api/rest"
 
-    @patch("sodir_module.api_client.requests.get")
+    @patch("worldenergydata.sodir.api_client.requests.get")
     def test_get_request_basic(self, mock_get, api_client, mock_response):
         """Test basic GET request functionality."""
         mock_get.return_value = mock_response
@@ -86,7 +86,7 @@ class TestSodirAPIClient:
             timeout=api_client.timeout,
         )
 
-    @patch("sodir_module.api_client.requests.get")
+    @patch("worldenergydata.sodir.api_client.requests.get")
     def test_get_request_with_params(self, mock_get, api_client, mock_response):
         """Test GET request with query parameters."""
         mock_get.return_value = mock_response
@@ -131,7 +131,7 @@ class TestRateLimiting:
         client3 = SodirAPIClient("https://test.api", rate_limit=0)
         assert client3.min_interval == 0  # No rate limiting
 
-    @patch("sodir_module.api_client.requests.get")
+    @patch("worldenergydata.sodir.api_client.requests.get")
     def test_rate_limiting_enforced(self, mock_get, slow_client):
         """Test that rate limiting delays requests appropriately."""
         mock_response = Mock()
@@ -150,7 +150,7 @@ class TestRateLimiting:
         assert elapsed >= 0.4  # Allow some tolerance
         assert mock_get.call_count == 2
 
-    @patch("sodir_module.api_client.requests.get")
+    @patch("worldenergydata.sodir.api_client.requests.get")
     def test_no_rate_limiting_when_disabled(self, mock_get):
         """Test that rate limiting can be disabled."""
         mock_response = Mock()
@@ -183,7 +183,7 @@ class TestCaching:
         client.cache_enabled = True
         return client
 
-    @patch("sodir_module.api_client.requests.get")
+    @patch("worldenergydata.sodir.api_client.requests.get")
     def test_cache_hit(self, mock_get, client_with_cache):
         """Test that cached responses are returned without API call."""
         mock_response = Mock()
@@ -201,7 +201,7 @@ class TestCaching:
         assert result2 == {"data": ["first"]}
         assert mock_get.call_count == 1  # No additional API call
 
-    @patch("sodir_module.api_client.requests.get")
+    @patch("worldenergydata.sodir.api_client.requests.get")
     def test_cache_expiration(self, mock_get, client_with_cache):
         """Test that cache entries expire after TTL."""
         mock_response = Mock()
@@ -225,7 +225,7 @@ class TestCaching:
         assert result2 == {"data": ["second"]}
         assert mock_get.call_count == 2
 
-    @patch("sodir_module.api_client.requests.get")
+    @patch("worldenergydata.sodir.api_client.requests.get")
     def test_cache_key_includes_params(self, mock_get, client_with_cache):
         """Test that cache keys include query parameters."""
         mock_response = Mock()
@@ -269,7 +269,7 @@ class TestErrorHandling:
             retry_delay=0.1,  # Short delay for testing
         )
 
-    @patch("sodir_module.api_client.requests.get")
+    @patch("worldenergydata.sodir.api_client.requests.get")
     def test_retry_on_server_error(self, mock_get, client):
         """Test retry logic for 5xx server errors."""
         # Simulate server error then success
@@ -288,7 +288,7 @@ class TestErrorHandling:
         assert result == {"data": []}
         assert mock_get.call_count == 3
 
-    @patch("sodir_module.api_client.requests.get")
+    @patch("worldenergydata.sodir.api_client.requests.get")
     def test_retry_on_rate_limit(self, mock_get, client):
         """Test retry logic for rate limit errors."""
         # Simulate rate limit then success
@@ -308,7 +308,7 @@ class TestErrorHandling:
         assert result == {"data": []}
         assert mock_get.call_count == 2
 
-    @patch("sodir_module.api_client.requests.get")
+    @patch("worldenergydata.sodir.api_client.requests.get")
     def test_max_retries_exceeded(self, mock_get, client):
         """Test that retries stop after max attempts."""
         # Always return server error
@@ -323,7 +323,7 @@ class TestErrorHandling:
         assert exc_info.value.status_code == 500
         assert mock_get.call_count == 4  # Initial + 3 retries
 
-    @patch("sodir_module.api_client.requests.get")
+    @patch("worldenergydata.sodir.api_client.requests.get")
     def test_exponential_backoff(self, mock_get, client):
         """Test exponential backoff between retries."""
         # Always return server error
@@ -343,7 +343,7 @@ class TestErrorHandling:
         # Expected delays: 0.1, 0.2, 0.4 = 0.7 seconds minimum
         assert elapsed >= 0.6  # Allow some tolerance
 
-    @patch("sodir_module.api_client.requests.get")
+    @patch("worldenergydata.sodir.api_client.requests.get")
     def test_no_retry_on_client_error(self, mock_get, client):
         """Test that client errors (4xx) don't trigger retries."""
         error_response = Mock()
@@ -368,7 +368,7 @@ class TestSODIREndpoints:
             base_url="https://factmaps.sodir.no/api/rest", rate_limit=10
         )
 
-    @patch("sodir_module.api_client.requests.get")
+    @patch("worldenergydata.sodir.api_client.requests.get")
     def test_get_blocks(self, mock_get, client):
         """Test blocks endpoint method."""
         mock_response = Mock()
@@ -388,7 +388,7 @@ class TestSODIREndpoints:
             timeout=client.timeout,
         )
 
-    @patch("sodir_module.api_client.requests.get")
+    @patch("worldenergydata.sodir.api_client.requests.get")
     def test_get_wellbores(self, mock_get, client):
         """Test wellbores endpoint method."""
         mock_response = Mock()
@@ -408,7 +408,7 @@ class TestSODIREndpoints:
             timeout=client.timeout,
         )
 
-    @patch("sodir_module.api_client.requests.get")
+    @patch("worldenergydata.sodir.api_client.requests.get")
     def test_get_fields(self, mock_get, client):
         """Test fields endpoint method."""
         mock_response = Mock()
@@ -428,7 +428,7 @@ class TestSODIREndpoints:
             timeout=client.timeout,
         )
 
-    @patch("sodir_module.api_client.requests.get")
+    @patch("worldenergydata.sodir.api_client.requests.get")
     def test_get_discoveries(self, mock_get, client):
         """Test discoveries endpoint method."""
         mock_response = Mock()
@@ -448,7 +448,7 @@ class TestSODIREndpoints:
             timeout=client.timeout,
         )
 
-    @patch("sodir_module.api_client.requests.get")
+    @patch("worldenergydata.sodir.api_client.requests.get")
     def test_get_surveys(self, mock_get, client):
         """Test surveys endpoint method."""
         mock_response = Mock()
@@ -492,7 +492,7 @@ class TestRequestHeaders:
         assert client.headers["X-Custom-Header"] == "test-value"
         assert "User-Agent" in client.headers  # Default still present
 
-    @patch("sodir_module.api_client.requests.get")
+    @patch("worldenergydata.sodir.api_client.requests.get")
     def test_headers_sent_with_request(self, mock_get):
         """Test headers are included in requests."""
         mock_response = Mock()

--- a/tests/modules/sodir-integration/test_cross_regional_validation.py
+++ b/tests/modules/sodir-integration/test_cross_regional_validation.py
@@ -14,14 +14,14 @@ from unittest.mock import MagicMock, Mock, patch
 
 import numpy as np
 import pandas as pd
-from sodir_module.analysis import SodirAnalysis
+from worldenergydata.sodir.analysis import SodirAnalysis
 
 # Import SODIR components
-from sodir_module.cross_regional import CrossRegionalAnalyzer
-from sodir_module.datasets import DatasetGenerator
-from sodir_module.processors.block_processor import BlockProcessor
-from sodir_module.processors.field_processor import FieldProcessor
-from sodir_module.processors.wellbore_processor import WellboreProcessor
+from worldenergydata.sodir.cross_regional import CrossRegionalAnalyzer
+from worldenergydata.sodir.datasets import DatasetGenerator
+from worldenergydata.sodir.processors.block_processor import BlockProcessor
+from worldenergydata.sodir.processors.field_processor import FieldProcessor
+from worldenergydata.sodir.processors.wellbore_processor import WellboreProcessor
 
 
 class TestCrossRegionalValidation(unittest.TestCase):

--- a/tests/modules/sodir-integration/test_data_collection.py
+++ b/tests/modules/sodir-integration/test_data_collection.py
@@ -28,7 +28,7 @@ class TestSodirDataRouter(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        from sodir_module.data import SodirData
+        from worldenergydata.sodir.data import SodirData
 
         # Mock configuration
         self.config = {
@@ -214,7 +214,7 @@ class TestDataCollectionWorkflow(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        from sodir_module.workflows.collection import CollectionWorkflow
+        from worldenergydata.sodir.workflows.collection import CollectionWorkflow
 
         self.workflow_config = {
             "name": "daily_collection",
@@ -295,7 +295,7 @@ class TestDataStorage(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        from sodir_module.storage import DataStorage
+        from worldenergydata.sodir.storage import DataStorage
 
         self.storage_config = {
             "base_path": "tests/modules/sodir-integration/data",
@@ -400,7 +400,7 @@ class TestDatasetGeneration(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        from sodir_module.datasets import DatasetGenerator
+        from worldenergydata.sodir.datasets import DatasetGenerator
 
         self.generator = DatasetGenerator()
 
@@ -491,8 +491,8 @@ class TestDataValidationIntegration(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        from sodir_module.data import SodirData
-        from sodir_module.validators import DataValidator
+        from worldenergydata.sodir.data import SodirData
+        from worldenergydata.sodir.validators import DataValidator
 
         self.validator = DataValidator()
         config = {

--- a/tests/modules/sodir-integration/test_integration.py
+++ b/tests/modules/sodir-integration/test_integration.py
@@ -15,25 +15,25 @@ from pathlib import Path
 from typing import Any, Dict, List
 from unittest.mock import MagicMock, Mock, patch
 
-from sodir_module.analysis import SodirAnalysis
-from sodir_module.api_client import SodirAPIClient
-from sodir_module.batch import BatchConfig, SodirBatchProcessor
-from sodir_module.cache import SodirCache
-from sodir_module.cache_optimizer import SodirCacheOptimizer
-from sodir_module.cross_regional import CrossRegionalAnalyzer
-from sodir_module.data import SodirData
-from sodir_module.datasets import DatasetGenerator
-from sodir_module.parallel import SodirParallelProcessor
-from sodir_module.processors.block_processor import BlockProcessor
-from sodir_module.processors.discovery_processor import DiscoveryProcessor
-from sodir_module.processors.field_processor import FieldProcessor
-from sodir_module.processors.survey_processor import SurveyProcessor
-from sodir_module.processors.wellbore_processor import WellboreProcessor
+from worldenergydata.sodir.analysis import SodirAnalysis
+from worldenergydata.sodir.api_client import SodirAPIClient
+from worldenergydata.sodir.batch import BatchConfig, SodirBatchProcessor
+from worldenergydata.sodir.cache import SodirCache
+from worldenergydata.sodir.cache_optimizer import SodirCacheOptimizer
+from worldenergydata.sodir.cross_regional import CrossRegionalAnalyzer
+from worldenergydata.sodir.data import SodirData
+from worldenergydata.sodir.datasets import DatasetGenerator
+from worldenergydata.sodir.parallel import SodirParallelProcessor
+from worldenergydata.sodir.processors.block_processor import BlockProcessor
+from worldenergydata.sodir.processors.discovery_processor import DiscoveryProcessor
+from worldenergydata.sodir.processors.field_processor import FieldProcessor
+from worldenergydata.sodir.processors.survey_processor import SurveyProcessor
+from worldenergydata.sodir.processors.wellbore_processor import WellboreProcessor
 
 # Import all SODIR module components
-from sodir_module.sodir import Sodir
-from sodir_module.storage import DataStorage
-from sodir_module.workflows.collection import CollectionWorkflow
+from worldenergydata.sodir.sodir import Sodir
+from worldenergydata.sodir.storage import DataStorage
+from worldenergydata.sodir.workflows.collection import CollectionWorkflow
 
 
 class TestSodirIntegration(unittest.TestCase):
@@ -447,9 +447,9 @@ class TestSodirIntegration(unittest.TestCase):
 
     def test_performance_optimization_integration(self):
         """Test that performance optimizations work together."""
-        from sodir_module.batch import SodirBatchProcessor
-        from sodir_module.cache_optimizer import SodirCacheOptimizer
-        from sodir_module.parallel import SodirParallelProcessor
+        from worldenergydata.sodir.batch import SodirBatchProcessor
+        from worldenergydata.sodir.cache_optimizer import SodirCacheOptimizer
+        from worldenergydata.sodir.parallel import SodirParallelProcessor
 
         # Initialize optimized components
         cache = SodirCacheOptimizer(max_size_mb=50)

--- a/tests/modules/sodir-integration/test_performance.py
+++ b/tests/modules/sodir-integration/test_performance.py
@@ -21,18 +21,18 @@ import numpy as np
 
 # import memory_profiler  # Not installed in current environment
 import pandas as pd
-from sodir_module.analysis import SodirAnalysis
+from worldenergydata.sodir.analysis import SodirAnalysis
 
 # Import SODIR components
-from sodir_module.api_client import SodirAPIClient
-from sodir_module.batch import BatchConfig, SodirBatchProcessor
-from sodir_module.cache import SodirCache
-from sodir_module.cache_optimizer import SodirCacheOptimizer
-from sodir_module.parallel import SodirParallelProcessor
-from sodir_module.processors.block_processor import BlockProcessor
-from sodir_module.processors.field_processor import FieldProcessor
-from sodir_module.processors.wellbore_processor import WellboreProcessor
-from sodir_module.storage import DataStorage
+from worldenergydata.sodir.api_client import SodirAPIClient
+from worldenergydata.sodir.batch import BatchConfig, SodirBatchProcessor
+from worldenergydata.sodir.cache import SodirCache
+from worldenergydata.sodir.cache_optimizer import SodirCacheOptimizer
+from worldenergydata.sodir.parallel import SodirParallelProcessor
+from worldenergydata.sodir.processors.block_processor import BlockProcessor
+from worldenergydata.sodir.processors.field_processor import FieldProcessor
+from worldenergydata.sodir.processors.wellbore_processor import WellboreProcessor
+from worldenergydata.sodir.storage import DataStorage
 
 
 class TestPerformance(unittest.TestCase):

--- a/tests/modules/sodir-integration/test_processors.py
+++ b/tests/modules/sodir-integration/test_processors.py
@@ -30,7 +30,7 @@ class TestBlockProcessor(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        from sodir_module.processors.block_processor import BlockProcessor
+        from worldenergydata.sodir.processors.block_processor import BlockProcessor
 
         self.processor = BlockProcessor()
 
@@ -117,7 +117,7 @@ class TestWellboreProcessor(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        from sodir_module.processors.wellbore_processor import WellboreProcessor
+        from worldenergydata.sodir.processors.wellbore_processor import WellboreProcessor
 
         self.processor = WellboreProcessor()
 
@@ -200,7 +200,7 @@ class TestFieldProcessor(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        from sodir_module.processors.field_processor import FieldProcessor
+        from worldenergydata.sodir.processors.field_processor import FieldProcessor
 
         self.processor = FieldProcessor()
 
@@ -296,7 +296,7 @@ class TestDiscoveryProcessor(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        from sodir_module.processors.discovery_processor import DiscoveryProcessor
+        from worldenergydata.sodir.processors.discovery_processor import DiscoveryProcessor
 
         self.processor = DiscoveryProcessor()
 
@@ -344,7 +344,7 @@ class TestSurveyProcessor(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        from sodir_module.processors.survey_processor import SurveyProcessor
+        from worldenergydata.sodir.processors.survey_processor import SurveyProcessor
 
         self.processor = SurveyProcessor()
 
@@ -393,7 +393,7 @@ class TestCoordinateTransformation(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        from sodir_module.utils.coordinates import CoordinateTransformer
+        from worldenergydata.sodir.utils.coordinates import CoordinateTransformer
 
         self.transformer = CoordinateTransformer()
 
@@ -465,7 +465,7 @@ class TestDataValidation(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        from sodir_module.validators import DataValidator
+        from worldenergydata.sodir.validators import DataValidator
 
         self.validator = DataValidator()
 

--- a/tests/modules/sodir-integration/test_sodir_module.py
+++ b/tests/modules/sodir-integration/test_sodir_module.py
@@ -45,7 +45,7 @@ class TestSodirModuleStructure:
     def test_sodir_module_imports(self):
         """Test that SODIR module can be imported."""
         try:
-            from sodir_module import sodir
+            from worldenergydata.sodir import sodir
 
             assert hasattr(sodir, "Sodir"), "Sodir class should be available"
         except ImportError:
@@ -93,7 +93,7 @@ class TestSodirRouter:
     def test_sodir_router_initialization(self, mock_config):
         """Test SODIR router initialization."""
         try:
-            from sodir_module.sodir import Sodir
+            from worldenergydata.sodir.sodir import Sodir
 
             sodir_instance = Sodir()
             assert sodir_instance is not None
@@ -105,7 +105,7 @@ class TestSodirRouter:
     def test_router_method_signature(self, mock_config):
         """Test router method accepts configuration and returns results."""
         try:
-            from sodir_module.sodir import Sodir
+            from worldenergydata.sodir.sodir import Sodir
 
             sodir_instance = Sodir()
 
@@ -121,9 +121,9 @@ class TestSodirRouter:
     def test_router_delegates_to_data_collection(self, mock_config):
         """Test that router delegates data collection properly."""
         try:
-            from sodir_module.sodir import Sodir
+            from worldenergydata.sodir.sodir import Sodir
 
-            with patch("sodir_module.data.SodirData") as MockSodirData:
+            with patch("worldenergydata.sodir.data.SodirData") as MockSodirData:
                 mock_data_instance = MockSodirData.return_value
                 mock_data_instance.router.return_value = (mock_config, {"blocks": []})
 
@@ -139,8 +139,8 @@ class TestSodirRouter:
 
     def test_router_handles_errors(self, mock_config):
         """Test router error handling."""
-        from sodir_module.errors import SodirAPIError
-        from sodir_module.sodir import Sodir
+        from worldenergydata.sodir.errors import SodirAPIError
+        from worldenergydata.sodir.sodir import Sodir
 
         sodir_instance = Sodir()
 
@@ -194,7 +194,7 @@ class TestSodirConfiguration:
     def test_configuration_loading(self):
         """Test configuration can be loaded and used."""
         try:
-            from sodir_module.sodir import Sodir
+            from worldenergydata.sodir.sodir import Sodir
 
             sodir_instance = Sodir()
 
@@ -218,7 +218,7 @@ class TestSodirDataTypes:
     def test_blocks_endpoint(self):
         """Test blocks data endpoint configuration."""
         try:
-            from sodir_module.endpoints import SODIR_ENDPOINTS
+            from worldenergydata.sodir.endpoints import SODIR_ENDPOINTS
 
             assert "blocks" in SODIR_ENDPOINTS
             assert SODIR_ENDPOINTS["blocks"]["id"] == "1001"
@@ -230,7 +230,7 @@ class TestSodirDataTypes:
     def test_wellbores_endpoint(self):
         """Test wellbores data endpoint configuration."""
         try:
-            from sodir_module.endpoints import SODIR_ENDPOINTS
+            from worldenergydata.sodir.endpoints import SODIR_ENDPOINTS
 
             assert "wellbores" in SODIR_ENDPOINTS
             assert SODIR_ENDPOINTS["wellbores"]["id"] == "5000"
@@ -242,7 +242,7 @@ class TestSodirDataTypes:
     def test_fields_endpoint(self):
         """Test fields data endpoint configuration."""
         try:
-            from sodir_module.endpoints import SODIR_ENDPOINTS
+            from worldenergydata.sodir.endpoints import SODIR_ENDPOINTS
 
             assert "fields" in SODIR_ENDPOINTS
             assert SODIR_ENDPOINTS["fields"]["id"] == "7100"
@@ -254,7 +254,7 @@ class TestSodirDataTypes:
     def test_discoveries_endpoint(self):
         """Test discoveries data endpoint configuration."""
         try:
-            from sodir_module.endpoints import SODIR_ENDPOINTS
+            from worldenergydata.sodir.endpoints import SODIR_ENDPOINTS
 
             assert "discoveries" in SODIR_ENDPOINTS
             assert SODIR_ENDPOINTS["discoveries"]["id"] == "7000"
@@ -266,7 +266,7 @@ class TestSodirDataTypes:
     def test_surveys_endpoint(self):
         """Test surveys data endpoint configuration."""
         try:
-            from sodir_module.endpoints import SODIR_ENDPOINTS
+            from worldenergydata.sodir.endpoints import SODIR_ENDPOINTS
 
             assert "surveys" in SODIR_ENDPOINTS
             assert SODIR_ENDPOINTS["surveys"]["id"] == "4000"
@@ -282,7 +282,7 @@ class TestSodirIntegration:
     def test_follows_bsee_pattern(self):
         """Test that SODIR module follows BSEE architectural pattern."""
         try:
-            from sodir_module.sodir import Sodir
+            from worldenergydata.sodir.sodir import Sodir
 
             # Should have similar structure to BSEE module
             sodir_instance = Sodir()
@@ -303,7 +303,7 @@ class TestSodirIntegration:
     def test_compatible_with_existing_analysis(self):
         """Test that SODIR data is compatible with existing analysis tools."""
         try:
-            from sodir_module.sodir import Sodir
+            from worldenergydata.sodir.sodir import Sodir
 
             sodir_instance = Sodir()
 


### PR DESCRIPTION
## Summary
Resolves the 5 test collection errors that appear on every CI run (Test Python 3.10 / 3.11):

- `tests/modules/bsee/analysis/test_type_curves.py`
- `tests/modules/fdas/integration/test_end_to_end.py`
- `tests/modules/sodir-integration/test_api_client.py`
- `tests/modules/sodir-integration/test_cross_regional_validation.py`
- `tests/modules/sodir-integration/test_integration.py`

PR #2 of 4 in the main-CI cleanup sequence (after #308 stubs).

## Three root causes

**1. Missing `type_curves` submodules (restored)**
Commit `3c04803` ("refactor: consolidate modules to canonical locations") deleted `blasingame.py`, `fetkovich.py`, and `models.py` from `src/worldenergydata/modules/bsee/analysis/type_curves/` without relocating them. The `__init__.py` still imports them, so any import of the package fails. This PR restores the files at their **real path** — `src/worldenergydata/bsee/analysis/type_curves` is a symlink to the `modules/` location, so the canonical import path still works transparently.

**2. `numpy-financial` not installed in CI (moved to project.dependencies)**
`src/worldenergydata/fdas/core/financial.py` imports `numpy_financial` at module load time, so it's a runtime dep. It was listed only in `[dependency-groups].dev` (PEP 735) which CI doesn't install — CI runs `uv sync --all-extras` which only pulls PEP 621 `optional-dependencies`. Moved to `[project.dependencies]`.

**3. Stale `sodir_module` imports (retargeted to canonical)**
The sodir-integration tests import from `sodir_module.*` — a top-level package that doesn't exist on sys.path. A vendored copy lives under `tests/modules/sodir-integration/sodir_module/` but was never added to sys.path. Updated all 9 affected test files to import from `worldenergydata.sodir.*` — the canonical package.

## Expected CI impact

- Test Python 3.10/3.11 collection errors: **5 → 0**
- Lint: unchanged (separate PR)
- Type Check: unchanged (separate effort)
- Test Python 3.9: still fails (py3.9 union syntax — separate PR, planned to drop 3.9)

## Test plan
- [ ] CI Test Python 3.10 collects all tests without error (may still have runtime failures — in scope only to fix collection)
- [ ] CI Test Python 3.11 collects all tests without error
- [ ] No regression in other jobs