### PR TITLE
chore(ci): drop Python 3.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "worldenergydata"
 version = "0.1.0"
 description = "Standardized project configuration for worldenergydata"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "MIT"}
 authors = [
     {name = "Development Team", email = "dev@example.com"}
@@ -17,9 +17,9 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 dependencies = [
@@ -142,7 +142,7 @@ exclude = ["tests*", "docs*"]
 
 [tool.black]
 line-length = 88
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py310', 'py311', 'py312']
 include = '\.pyi?$'
 
 [tool.isort]

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -10,8 +10,8 @@ testpaths = tests
 # Ignore patterns
 norecursedirs = .git .venv __pycache__ *.egg-info .pytest_cache reports/coverage/htmlcov build dist legacy* _archived_tests _archive test_validators_data_validator.py unit/bsee modules/bsee/analysis unit/cost unit/hse unit/metocean unit/pipeline_ci_cd unit/sodir unit/ukcs well_production_dashboard brazil_anp comprehensive-report-system financial-analysis-sme-code well-data-verification fdas/integration marine_safety sodir-integration 2025-08-*
 
-# Minimum Python version
-minversion = 3.9
+# Minimum pytest version (not Python)
+minversion = 7.0
 
 # Command line options defaults
 addopts = 


### PR DESCRIPTION
## Summary
Removes the failing Test Python 3.9 CI job by dropping 3.9 from the supported Python matrix.

PR #4 of 4 in the main-CI cleanup sequence:
- ✅ #308 (type stubs) — merged
- ❌ #310 (test imports) — closed
- ✅ #311 (black + isort) — merged
- 🔄 **#THIS** (drop py3.9)

## Why drop 3.9
- The Test Python 3.9 job has been failing since 2026-04-14 due to new-style union syntax (\`str | None\`) used in integration CLI tests — this syntax requires python 3.10+.
- The codebase already uses 3.10+ syntax in many places (match statements, PEP 604 unions).
- Python 3.9 reaches end-of-life in October 2025; no reason to keep investing in it.

## Changes
- \`pyproject.toml\`:
  - \`requires-python = ">=3.10"\` (was \`>=3.9\`)
  - Classifiers: add 3.12, remove 3.9
  - \`[tool.black].target-version\`: remove \`py38\`/\`py39\`, add \`py312\`
- \`.github/workflows/ci.yml\`: test matrix \`["3.10", "3.11", "3.12"]\` (was \`["3.9", "3.10", "3.11"]\`)
- \`tests/pytest.ini\`: fix mis-labeled "Minimum Python version" comment — \`minversion=3.9\` was actually referring to pytest, not Python. Bumped to pytest 7.0.

## Expected CI impact
- **Test Python 3.9: removed** (job no longer exists)
- Test Python 3.10 / 3.11: unchanged from main's current state
- **Test Python 3.12: NEW job** — will likely fail initially (untested version) but worth seeing

## Caveat on 3.12
Adding 3.12 to the matrix is an optional bonus — I included it because py3.11 will reach EOL in 2027, and the repo should be exercising at least one "new" version. If 3.12 produces new failures, we can drop it back to just 3.10/3.11.

## Test plan
- [ ] Test Python 3.9 job no longer appears in CI
- [ ] No regression in Python 3.10/3.11 tests
- [ ] If Python 3.12 fails, evaluate whether it's acceptable to include or should be removed