### PR TITLE
fix(imports): missing-import sweep for 30 F821 errors

### DIFF
--- a/src/worldenergydata/bsee/analysis/cost/report.py
+++ b/src/worldenergydata/bsee/analysis/cost/report.py
@@ -21,9 +21,12 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import pandas as pd
+
+if TYPE_CHECKING:
+    import plotly.graph_objects as go
 
 logger = logging.getLogger(__name__)
 

--- a/src/worldenergydata/bsee/analysis/financial/cli_interface.py
+++ b/src/worldenergydata/bsee/analysis/financial/cli_interface.py
@@ -7,6 +7,7 @@ with comprehensive configuration options.
 
 import argparse
 import json
+import logging
 import sys
 from datetime import datetime
 from pathlib import Path

--- a/src/worldenergydata/bsee/analysis/well_data_verification/base.py
+++ b/src/worldenergydata/bsee/analysis/well_data_verification/base.py
@@ -8,12 +8,15 @@ import json
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from worldenergydata.common import get_logger
 from worldenergydata.validation.base import ValidationError, ValidationResult
 from worldenergydata.validation.schema import ValidationSchema
 from worldenergydata.validation.validators import DataValidator
+
+if TYPE_CHECKING:
+    from .config import VerificationConfig
 
 logger = get_logger(__name__)
 

--- a/src/worldenergydata/bsee/analysis/well_data_verification/cli.py
+++ b/src/worldenergydata/bsee/analysis/well_data_verification/cli.py
@@ -5,6 +5,7 @@ Provides CLI access to verification workflows, data quality checks, and report g
 """
 
 import argparse
+import logging
 import sys
 from datetime import datetime
 from pathlib import Path

--- a/src/worldenergydata/bsee/reports/comprehensive/aggregators/field_aggregator_enhanced.py
+++ b/src/worldenergydata/bsee/reports/comprehensive/aggregators/field_aggregator_enhanced.py
@@ -4,6 +4,7 @@ Aggregates lease-level data up to field level
 """
 
 import logging
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 import pandas as pd

--- a/src/worldenergydata/bsee/reports/comprehensive/cli.py
+++ b/src/worldenergydata/bsee/reports/comprehensive/cli.py
@@ -5,6 +5,7 @@ Provides easy access to hierarchical reporting functionality
 
 import argparse
 import json
+import logging
 import sys
 from datetime import datetime
 from pathlib import Path

--- a/src/worldenergydata/marine_safety/scrapers/uscg_scraper.py
+++ b/src/worldenergydata/marine_safety/scrapers/uscg_scraper.py
@@ -29,7 +29,7 @@ from urllib.parse import urljoin
 import pdfplumber
 import requests
 from bs4 import BeautifulSoup
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator
 from tenacity import (
     retry,
     retry_if_exception_type,

--- a/src/worldenergydata/metocean/extrapolation/visualization.py
+++ b/src/worldenergydata/metocean/extrapolation/visualization.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    pass
+    import plotly.graph_objects as go
 
 
 def plot_source_map(

--- a/src/worldenergydata/testing/cleanup/consolidate_tests.py
+++ b/src/worldenergydata/testing/cleanup/consolidate_tests.py
@@ -2,9 +2,12 @@
 Test consolidation utilities for reducing redundancy.
 """
 
+import logging
 import re
 from pathlib import Path
 from typing import Dict, List
+
+logger = logging.getLogger(__name__)
 
 
 class TestConsolidator:

--- a/src/worldenergydata/testing/data/bsee_data_converter.py
+++ b/src/worldenergydata/testing/data/bsee_data_converter.py
@@ -5,6 +5,7 @@ This module provides utilities to convert generic test data into BSEE-specific f
 required by the WorldEnergyData modules.
 """
 
+import logging
 import random
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -12,6 +13,8 @@ from typing import Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 
 class BSEEDataConverter:


### PR DESCRIPTION
Fixes 30 of 104 F821 errors in worldenergydata — trivial missing imports only.

- `import logging` x 3 files (cli_interface, well_data_verification/cli, comprehensive/cli) — 21 errors
- `import plotly.graph_objects as go` (TYPE_CHECKING) x 2 files — 3 errors
- `datetime` / `ValidationError` / `VerificationConfig` — 4 errors
- module-level `logger` in 2 testing utilities — 3 errors (includes `import logging`)

Total F821 fixed: 30.

Refs #314 (issue tracks the full 104-error sweep; this PR is 1 of 4).