### PR TITLE
fix(bsee/well): restore SQL column constants

### DIFF
--- a/src/worldenergydata/bsee/data/loaders/api/well.py
+++ b/src/worldenergydata/bsee/data/loaders/api/well.py
@@ -416,21 +416,21 @@ class WellData:
     def get_eWellAPMRawData_from_zip(self, cfg):
 
         columns = [
-            MMS_COMPANY_NUM,
-            API_WELL_NUMBER,
-            WATER_DEPTH,
-            WELL_NM_BP_SFIX,
-            WELL_NM_ST_SFIX,
-            SURF_AREA_CODE,
-            SURF_BLOCK_NUM,
-            SURF_LEASE_NUM,
-            BOTM_AREA_CODE,
-            BOTM_BLOCK_NUM,
-            BOTM_LEASE_NUM,
-            RIG_ID_NUM,
-            BOREHOLE_STAT_CD,
-            WELL_TYPE_CODE,
-            BUS_ASC_NAME,
+            "MMS_COMPANY_NUM",
+            "API_WELL_NUMBER",
+            "WATER_DEPTH",
+            "WELL_NM_BP_SFIX",
+            "WELL_NM_ST_SFIX",
+            "SURF_AREA_CODE",
+            "SURF_BLOCK_NUM",
+            "SURF_LEASE_NUM",
+            "BOTM_AREA_CODE",
+            "BOTM_BLOCK_NUM",
+            "BOTM_LEASE_NUM",
+            "RIG_ID_NUM",
+            "BOREHOLE_STAT_CD",
+            "WELL_TYPE_CODE",
+            "BUS_ASC_NAME",
         ]
 
         # TODO


### PR DESCRIPTION
Fixes 15 of 104 F821 errors in `src/worldenergydata/bsee/data/loaders/api/well.py`.

## What was broken
`WellData.get_eWellAPMRawData_from_zip` had a `columns = [...]` list referencing 15 bare identifiers (`MMS_COMPANY_NUM`, `API_WELL_NUMBER`, `WATER_DEPTH`, `WELL_NM_BP_SFIX`, `WELL_NM_ST_SFIX`, `SURF_AREA_CODE`, `SURF_BLOCK_NUM`, `SURF_LEASE_NUM`, `BOTM_AREA_CODE`, `BOTM_BLOCK_NUM`, `BOTM_LEASE_NUM`, `RIG_ID_NUM`, `BOREHOLE_STAT_CD`, `WELL_TYPE_CODE`, `BUS_ASC_NAME`) that were never defined at module scope or imported — flake8 flagged each as F821.

## Archeology
- `git log -S "MMS_COMPANY_NUM" --all` shows these bare names entered the repo already undefined in the 7493f543 "fresh repo after slimming" import. No commit in any branch ever assigned `MMS_COMPANY_NUM = ...`.
- The sibling file `src/worldenergydata/bsee/data/sources/zip/well_data.py` has the **identical** 15-element column list in its own `get_eWellAPMRawData_from_zip` method, but written as **string literals**. That sibling is the canonical form; the api/well.py version is a stub (body after the columns list is just `# TODO`) that was copied with the quotes stripped somewhere along the way.
- The names are real BSEE database column names (confirmed by hits in `data/catalog.yaml`, the bsee schema files, and docs).

## Fix
Convert each bare name to a string literal to match the sibling module and the BSEE schema. No behavior change — the method is an unfinished stub (returns nothing) that only builds a column name list.

## Verification
- `flake8 --select=F821` on the file: empty (was 15 errors).
- `ast.parse` on the file: OK.

Refs #314 (issue tracks the full 104-error sweep; this PR is 2 of 4).