### PR TITLE
fix: 5 scope-level F821 bugs in production_api10 + executive_charts

### DIFF
--- a/src/worldenergydata/bsee/analysis/production_api10.py
+++ b/src/worldenergydata/bsee/analysis/production_api10.py
@@ -18,8 +18,17 @@ class ProductionAPI10Analysis:
     def router(self, cfg, api12_production_data):
         self.prepare_production_data(cfg, api12_production_data)
 
-        self.prepare_field_production_rate(df_temp, completion_name)
-        self.prepare_field_production(df_temp, completion_name)
+        # Iterate over completions in the provided production data and build
+        # per-completion field-production summaries. Mirrors the legacy
+        # ong_fd_components.prepare_production_data loop: for each completion
+        # name, slice the DataFrame and feed it to the per-field aggregators.
+        completion_name_list = api12_production_data.COMPLETION_NAME.unique()
+        for completion_name in completion_name_list:
+            df_temp = api12_production_data[
+                api12_production_data.COMPLETION_NAME == completion_name
+            ].copy()
+            self.prepare_field_production_rate(df_temp, completion_name)
+            self.prepare_field_production(df_temp, completion_name)
 
         # api12_analysis.sort_values(by=['O_PROD_STATUS', 'WELL_LABEL'],
         #                                     ascending=[False, True],

--- a/src/worldenergydata/bsee/reports/comprehensive/templates/executive_charts.py
+++ b/src/worldenergydata/bsee/reports/comprehensive/templates/executive_charts.py
@@ -353,7 +353,7 @@ def create_multi_panel_dashboard(panels: List[Dict], data: Dict) -> Optional[Any
         rows=max_row,
         cols=max_col,
         subplot_titles=[p.get("title", "") for p in panels],
-        specs=[[{"type": p.get("type", "scatter")}] * max_col for _ in range(max_row)],
+        specs=[[{"type": "scatter"}] * max_col for _ in range(max_row)],
     )
 
     # Add panels


### PR DESCRIPTION
Fixes 5 of 104 F821 errors — real logic bugs (not missing imports).

## Scope
- `src/worldenergydata/bsee/analysis/production_api10.py` (4 F821 → 0): the `router` method referenced `df_temp` and `completion_name` as if they were in-scope, but neither was defined there — they are loop variables from the legacy `ong_fd_components.prepare_production_data` pattern (lines 226-248 of that file). Restored the `for completion_name in completion_name_list` loop that slices `api12_production_data` by `COMPLETION_NAME` before calling `prepare_field_production_rate` / `prepare_field_production`, matching the legacy reference implementation exactly.
- `src/worldenergydata/bsee/reports/comprehensive/templates/executive_charts.py` (1 F821 → 0): in `create_multi_panel_dashboard`, the `specs=` argument to `make_subplots` contained a bare `p.get(...)` outside any comprehension binding. Replaced with the canonical `{"type": "scatter"}` spec used by the sibling `create_traffic_light_grid` function (same file). `scatter` specs accept both Bar and Scatter traces, which are the only trace types this function actually adds, so runtime behavior is preserved.

## Verification
```
uv run --extra dev flake8 --select=F821 \
  src/worldenergydata/bsee/analysis/production_api10.py \
  src/worldenergydata/bsee/reports/comprehensive/templates/executive_charts.py
```
Result: empty (0 F821 errors on both files).

AST parse clean on both files.

## Notes
- `ProductionAPI10Analysis.router` is never called in-tree (no `prod_api10_analysis.router(...)` references found). `self.prepare_production_data` is referenced but not defined on this class — those are latent bugs outside the F821 sweep, intentionally not addressed here to keep this PR minimal.

Refs #314 (issue tracks the full 104-error sweep; this PR is 4 of 4).