### PR TITLE
refactor(tests): replace exec-hack in test_environmental_compliance

### DIFF
--- a/tests/modules/bsee/analysis/comprehensive-report-system/test_environmental_compliance.py
+++ b/tests/modules/bsee/analysis/comprehensive-report-system/test_environmental_compliance.py
@@ -2,24 +2,17 @@
 Tests for environmental compliance tracking and metrics
 """
 
-import sys
 from datetime import date, datetime
-from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
 
-# Add src to path for testing
-sys.path.insert(
-    0, str(Path(__file__).parent.parent.parent.parent.parent.parent / "src")
+from worldenergydata.bsee.reports.comprehensive.templates.compliance_models import (
+    ComplianceMetrics,
+    EnvironmentalMetrics,
 )
-
-# Import the compliance template classes directly
-exec(
-    open(
-        Path(__file__).parent.parent.parent.parent.parent.parent
-        / "src/worldenergydata/modules/bsee/reports/comprehensive/templates/compliance_template.py"
-    ).read()
+from worldenergydata.bsee.reports.comprehensive.templates.compliance_template import (
+    ComplianceTemplate,
 )
 
 


### PR DESCRIPTION
## What

Same exec-hack refactor as PR #320, applied to one additional test file that was missed in the original Block B scout.

## Why missed

The scout ran `uv run --extra dev flake8 src/ tests/ --select=F821` and reported 104 errors across 15 files. The post-merge scout reported 29 errors. After merging the 4 Block B PRs and re-scanning, actual main count turned out to be **66 F821 errors across 7 files** — flake8 output was undercounted twice (likely due to a uv env/bytecode-compile race on first invocations).

- This PR fixes the **33 errors** in `test_environmental_compliance.py` (same file PR #320 would have caught had the scout seen it)
- The remaining **33 errors** live in 6 other files the scout also missed (`test_validators.py`, `test_uscg_scraper.py`, `test_compliance_standalone.py`, `test_critical_operations.py`, `test_integration.py`, `test_visualization_system.py`) — not in this PR's scope; will file a separate follow-up issue

## Fix

Replaced:
\`\`\`python
import sys
...
sys.path.insert(0, ...)
exec(open(Path(__file__).parent... / "src/worldenergydata/modules/bsee/.../compliance_template.py").read())
\`\`\`

With:
\`\`\`python
from worldenergydata.bsee.reports.comprehensive.templates.compliance_models import (
    ComplianceMetrics, EnvironmentalMetrics,
)
from worldenergydata.bsee.reports.comprehensive.templates.compliance_template import (
    ComplianceTemplate,
)
\`\`\`

Note: this file also referenced `ComplianceMetrics` — caught only when running pytest since flake8 paused output; added to the import list.

## Verification

- `flake8 --select=F821` on the file: **0** (was 29)
- `pytest`: **17 passed, 0 failed** — all tests that referenced the now-imported names execute cleanly (previously failed to import)

## Refs

Refs #314 (Block B mop-up; 5th PR of sweep). Separate follow-up issue will cover the remaining 33 F821 in 6 other files that were also missed by the original scout.