### PR TITLE
test(ci): stabilize legacy NPV comparison failures

### DIFF
--- a/tests/modules/bsee/analysis/npv-data-source-comparison/test_cash_flow_components.py
+++ b/tests/modules/bsee/analysis/npv-data-source-comparison/test_cash_flow_components.py
@@ -447,6 +447,10 @@ class TestCashFlowComponents:
 class TestProductionAPI12CashFlowMethods:
     """Test ProductionAPI12Analysis class methods for cash flow calculations."""
 
+    pytestmark = pytest.mark.skip(
+        "legacy NPV API removed/refactored; deferred by workspace-hub#2451 and worldenergydata#339 pending re-enable/delete decision"
+    )
+
     @pytest.fixture
     def analyzer(self):
         """Create ProductionAPI12Analysis instance."""

--- a/tests/modules/bsee/analysis/npv-data-source-comparison/test_current_npv_implementation.py
+++ b/tests/modules/bsee/analysis/npv-data-source-comparison/test_current_npv_implementation.py
@@ -20,6 +20,11 @@ sys.path.insert(
     0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "src")
 )
 
+pytest.skip(
+    "legacy NPV API removed/refactored; deferred by workspace-hub#2451 and worldenergydata#339 pending re-enable/delete decision",
+    allow_module_level=True,
+)
+
 from worldenergydata.modules.bsee.analysis.production_api12 import (
     ProductionAPI12Analysis,
 )


### PR DESCRIPTION
## Summary
Stabilize the legacy NPV comparison failure surface identified in workspace-hub #2451 by:
- module-skipping `test_current_npv_implementation.py` with explicit tracking
- class-skipping the legacy-only `TestProductionAPI12CashFlowMethods` in `test_cash_flow_components.py`

## Why
Current main no longer reproduces the benchmark-fixture failure locally under `uv run --all-extras`, but still reproduces the fixture-scope/runtime failures tied to legacy NPV API drift. This PR removes those specific runtime failures from the active test surface while preserving the non-legacy cash-flow tests.

## Validation
- `uv run --all-extras pytest tests/benchmarks/test_eia_benchmarks.py --override-ini="addopts=" -q`
- `uv run pytest tests/modules/bsee/analysis/npv-data-source-comparison/test_current_npv_implementation.py --override-ini="addopts=" -q`
- `uv run pytest tests/modules/bsee/analysis/npv-data-source-comparison/test_cash_flow_components.py --override-ini="addopts=" -q`
- `uv run pytest tests/modules/bsee/analysis/npv-data-source-comparison/ --override-ini="addopts=" -q` (observational audit; many pre-existing failures remain in this directory)

## Tracking
- workspace-hub #2451
- worldenergydata #339
