### PR TITLE
feat(cost): add disclosure-to-sanction linkage contract

### DIFF
--- a/.planning/plan-approved/335.md
+++ b/.planning/plan-approved/335.md
@@ -1,1 +1,0 @@
-Issue #335 plan approved via GitHub label by user on 2026-04-22.

--- a/.planning/plan-approved/335.md
+++ b/.planning/plan-approved/335.md
@@ -1,0 +1,1 @@
+Issue #335 plan approved via GitHub label by user on 2026-04-22.

--- a/src/worldenergydata/cost/data_collection/__init__.py
+++ b/src/worldenergydata/cost/data_collection/__init__.py
@@ -1,9 +1,23 @@
 """
-ABOUTME: Data collection sub-package — schema and public dataset for cost calibration.
-ABOUTME: Provides CostDataPoint schema and curated public sanctioned-project cost data.
+ABOUTME: Data collection sub-package — schema, public dataset, and linkage primitives.
+ABOUTME: Provides CostDataPoint schema, curated public sanctioned-project cost data,
+ABOUTME: and the derived-only disclosure-to-sanction linkage contract.
 """
 
 from worldenergydata.cost.data_collection.calibration_schema import CostDataPoint
+from worldenergydata.cost.data_collection.linkage import (
+    CostDataPointLinkResult,
+    LinkageStatus,
+    disclosure_row_is_linkable,
+    resolve_cost_datapoint_link,
+)
 from worldenergydata.cost.data_collection.public_dataset import load_public_dataset
 
-__all__ = ["CostDataPoint", "load_public_dataset"]
+__all__ = [
+    "CostDataPoint",
+    "CostDataPointLinkResult",
+    "LinkageStatus",
+    "disclosure_row_is_linkable",
+    "load_public_dataset",
+    "resolve_cost_datapoint_link",
+]

--- a/src/worldenergydata/cost/data_collection/linkage.py
+++ b/src/worldenergydata/cost/data_collection/linkage.py
@@ -1,0 +1,195 @@
+"""
+ABOUTME: Sanction-side linkage primitive (issue #335).
+ABOUTME: Derived-only exact (operator, project_name) resolution of disclosure
+ABOUTME: project rows against existing CostDataPoint sanction records.
+
+Design contract
+---------------
+This module is the **sanction-side primitive** for disclosure-to-sanction
+linkage.  It does one thing and one thing only: given an `(operator,
+project_name)` key, it returns one of three explicit outcomes — ``LINKED``,
+``UNLINKED``, or ``AMBIGUOUS`` — against a corpus of ``CostDataPoint``
+sanction records.
+
+Scope-gating (the parent #334 invariant that only *project-scope* disclosure
+rows participate in linkage, and *operator-scope* rows never do) is a
+**caller responsibility**.  The resolver deliberately has no scope knowledge;
+callers must pre-filter inputs via ``disclosure_row_is_linkable()``.
+
+No fuzzy matching, aliasing, trimming, or case normalization is performed.
+If a consumer needs stronger keys than exact `(operator, project_name)`, a
+later identifier/uniqueness issue will be required.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from worldenergydata.cost.data_collection.calibration_schema import CostDataPoint
+from worldenergydata.cost.data_collection.public_dataset import load_public_dataset
+
+__all__ = [
+    "LinkageStatus",
+    "CostDataPointLinkResult",
+    "resolve_cost_datapoint_link",
+    "disclosure_row_is_linkable",
+]
+
+
+# ---------------------------------------------------------------------------
+# Linkage outcome enum
+# ---------------------------------------------------------------------------
+
+
+class LinkageStatus(str, Enum):
+    """Canonical outcomes for a `(operator, project_name)` resolution."""
+
+    LINKED = "linked"
+    UNLINKED = "unlinked"
+    AMBIGUOUS = "ambiguous"
+
+
+# ---------------------------------------------------------------------------
+# Linkage result model
+# ---------------------------------------------------------------------------
+
+
+class CostDataPointLinkResult(BaseModel):
+    """Immutable outcome of a sanction-side linkage attempt.
+
+    Fields
+    ------
+    status
+        One of ``LinkageStatus.LINKED``, ``UNLINKED``, or ``AMBIGUOUS``.
+    match_key_operator
+        The operator string the caller supplied; echoed for debuggability.
+    match_key_project_name
+        The project_name string the caller supplied; echoed for debuggability.
+    matched_record
+        The single sanction record when ``status == LINKED``; ``None`` otherwise.
+    matched_count
+        Number of exact candidates found (0 for UNLINKED, 1 for LINKED, >=2 for
+        AMBIGUOUS).
+    candidates
+        Full list of exact-match candidates.  ``[]`` for UNLINKED, a single-
+        element list for LINKED, and the complete collision set for AMBIGUOUS.
+    """
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=False)
+
+    status: LinkageStatus
+    match_key_operator: Optional[str] = None
+    match_key_project_name: Optional[str] = None
+    matched_record: Optional[CostDataPoint] = None
+    matched_count: int = Field(ge=0)
+    candidates: list[CostDataPoint] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Sanction-side resolver
+# ---------------------------------------------------------------------------
+
+
+def resolve_cost_datapoint_link(
+    operator: Optional[str],
+    project_name: Optional[str],
+    sanctioned_records: Optional[list[CostDataPoint]] = None,
+) -> CostDataPointLinkResult:
+    """Resolve a disclosure `(operator, project_name)` key to sanction records.
+
+    Parameters
+    ----------
+    operator
+        Operator name exactly as it should match the sanction record.
+    project_name
+        Project name exactly as it should match the sanction record.
+    sanctioned_records
+        Sanction-record corpus to match against.  ``None`` (the default)
+        triggers a call to :func:`load_public_dataset`.  An explicitly-passed
+        empty list ``[]`` is honored as "no records to match" and will never
+        fall back to the default loader — this is the contract that lets
+        tests and callers inject empty corpora deterministically.
+
+    Returns
+    -------
+    CostDataPointLinkResult
+        Explicit linked / unlinked / ambiguous outcome.  Never raises on
+        missing-key inputs; ``None``/empty ``operator`` or ``project_name``
+        yields an UNLINKED result.
+    """
+    if not operator or not project_name:
+        return CostDataPointLinkResult(
+            status=LinkageStatus.UNLINKED,
+            match_key_operator=operator,
+            match_key_project_name=project_name,
+            matched_record=None,
+            matched_count=0,
+            candidates=[],
+        )
+
+    records = (
+        load_public_dataset() if sanctioned_records is None else sanctioned_records
+    )
+
+    exact_candidates = [
+        rec
+        for rec in records
+        if rec.operator == operator and rec.project_name == project_name
+    ]
+
+    count = len(exact_candidates)
+    if count == 0:
+        status = LinkageStatus.UNLINKED
+        matched_record: Optional[CostDataPoint] = None
+    elif count == 1:
+        status = LinkageStatus.LINKED
+        matched_record = exact_candidates[0]
+    else:
+        status = LinkageStatus.AMBIGUOUS
+        matched_record = None
+
+    return CostDataPointLinkResult(
+        status=status,
+        match_key_operator=operator,
+        match_key_project_name=project_name,
+        matched_record=matched_record,
+        matched_count=count,
+        candidates=exact_candidates,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Disclosure-side scope gate (parent #334 invariant)
+# ---------------------------------------------------------------------------
+
+# Once #334 lands a ``DisclosureScope(str, Enum)`` in
+# ``disclosure_ingest_contract.py``, consumers should pass the enum member's
+# string value here (``row.scope.value``).  We accept a plain string to avoid
+# importing an unmerged sibling module; the comparison is exact-string, in
+# keeping with the "no fuzzy matching" rule for the rest of the module.
+_LINKABLE_SCOPE_VALUE = "project"
+
+
+def disclosure_row_is_linkable(scope: str) -> bool:
+    """Return True iff a disclosure row's scope may be linked to a sanction record.
+
+    The parent #334 invariant is that only *project-scope* disclosure rows
+    participate in sanction-side linkage; *operator-scope* rows are company-
+    level and never linkable to a specific sanctioned project.
+
+    Parameters
+    ----------
+    scope
+        String scope value from the disclosure row (compatible with the
+        ``DisclosureScope(str, Enum).value`` that #334 will introduce).
+
+    Returns
+    -------
+    bool
+        ``True`` only if ``scope == "project"``.  Any other value, including
+        ``"operator"``, ``None``, or the empty string, yields ``False``.
+    """
+    return scope == _LINKABLE_SCOPE_VALUE

--- a/tests/unit/cost/test_linkage.py
+++ b/tests/unit/cost/test_linkage.py
@@ -1,0 +1,454 @@
+"""
+ABOUTME: Tests for the sanction-side linkage primitive (issue #335).
+ABOUTME: Verifies derived-only exact (operator, project_name) matching of
+ABOUTME: disclosure project rows to existing CostDataPoint sanction records.
+
+The resolver is intentionally scope-agnostic.  Disclosure-side scope gating
+(only project-scope rows may be linked, per #334) is expressed here via the
+`disclosure_row_is_linkable()` helper and must be called by consumers before
+invoking the resolver.  The resolver itself does no fuzzy matching, aliasing,
+case-folding, or whitespace trimming.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from worldenergydata.cost.data_collection.calibration_schema import (
+    ActivityType,
+    Confidence,
+    CostDataPoint,
+    CostType,
+    RigType,
+    SubseaType,
+    WaterDepthBand,
+    WellDepthBand,
+)
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_cost_point(
+    *,
+    operator: str = "BP",
+    project_name: str = "Mad Dog Phase 2",
+    region: str = "GOM",
+    cost_usd_mm: float = 145.0,
+) -> CostDataPoint:
+    """Build a minimal valid CostDataPoint for linkage testing.
+
+    Only the identity fields (operator, project_name) vary between most
+    tests; other fields are stable defaults matching the public dataset.
+    """
+    return CostDataPoint(
+        project_name=project_name,
+        region=region,
+        water_depth_m=1310.0,
+        water_depth_band=WaterDepthBand.DEEP,
+        well_depth_m=7620.0,
+        well_depth_band=WellDepthBand.DEEP,
+        operator=operator,
+        year_sanction=2017,
+        rig_type=RigType.SEMI_SUB,
+        activity_type=ActivityType.DRILLING,
+        hpht=False,
+        subsea=SubseaType.SUBSEA,
+        cost_usd_mm=cost_usd_mm,
+        cost_type=CostType.TOTAL_CAPEX,
+        source="Linkage test fixture",
+        confidence=Confidence.HIGH,
+    )
+
+
+# ---------------------------------------------------------------------------
+# LinkageStatus enum contract
+# ---------------------------------------------------------------------------
+
+
+class TestLinkageStatusEnum:
+    """The linkage contract exposes exactly three canonical states."""
+
+    def test_linkage_status_enum_exposes_linked_unlinked_ambiguous(self):
+        """LinkageStatus enum contains LINKED, UNLINKED, and AMBIGUOUS members."""
+        from worldenergydata.cost.data_collection.linkage import LinkageStatus
+
+        values = {member.value for member in LinkageStatus}
+        assert values == {"linked", "unlinked", "ambiguous"}
+
+
+# ---------------------------------------------------------------------------
+# resolve_cost_datapoint_link outcomes
+# ---------------------------------------------------------------------------
+
+
+class TestResolveOutcomes:
+    """resolve_cost_datapoint_link returns explicit linked/unlinked/ambiguous."""
+
+    def test_resolve_link_returns_linked_for_exact_single_match(self):
+        """A single exact (operator, project_name) hit yields LINKED."""
+        from worldenergydata.cost.data_collection.linkage import (
+            LinkageStatus,
+            resolve_cost_datapoint_link,
+        )
+
+        record = _make_cost_point(operator="BP", project_name="Mad Dog Phase 2")
+        result = resolve_cost_datapoint_link(
+            operator="BP",
+            project_name="Mad Dog Phase 2",
+            sanctioned_records=[record],
+        )
+
+        assert result.status == LinkageStatus.LINKED
+        assert result.matched_record is record
+        assert result.matched_count == 1
+        assert result.candidates == [record]
+
+    def test_resolve_link_returns_unlinked_for_no_exact_match(self):
+        """Zero exact hits yields UNLINKED with no matched record."""
+        from worldenergydata.cost.data_collection.linkage import (
+            LinkageStatus,
+            resolve_cost_datapoint_link,
+        )
+
+        record = _make_cost_point(operator="BP", project_name="Mad Dog Phase 2")
+        result = resolve_cost_datapoint_link(
+            operator="Shell",
+            project_name="Penguins",
+            sanctioned_records=[record],
+        )
+
+        assert result.status == LinkageStatus.UNLINKED
+        assert result.matched_record is None
+        assert result.matched_count == 0
+        assert result.candidates == []
+
+    def test_resolve_link_returns_ambiguous_for_multiple_exact_matches(self):
+        """Two or more exact hits yields AMBIGUOUS — no silent guessing."""
+        from worldenergydata.cost.data_collection.linkage import (
+            LinkageStatus,
+            resolve_cost_datapoint_link,
+        )
+
+        rec_a = _make_cost_point(
+            operator="BP", project_name="Mad Dog Phase 2", cost_usd_mm=145.0
+        )
+        rec_b = _make_cost_point(
+            operator="BP", project_name="Mad Dog Phase 2", cost_usd_mm=180.0
+        )
+        result = resolve_cost_datapoint_link(
+            operator="BP",
+            project_name="Mad Dog Phase 2",
+            sanctioned_records=[rec_a, rec_b],
+        )
+
+        assert result.status == LinkageStatus.AMBIGUOUS
+        assert result.matched_count == 2
+
+    def test_ambiguous_result_has_no_single_matched_record(self):
+        """AMBIGUOUS outcomes must not commit to a single record."""
+        from worldenergydata.cost.data_collection.linkage import (
+            resolve_cost_datapoint_link,
+        )
+
+        rec_a = _make_cost_point(operator="BP", project_name="Mad Dog Phase 2")
+        rec_b = _make_cost_point(
+            operator="BP", project_name="Mad Dog Phase 2", cost_usd_mm=200.0
+        )
+        result = resolve_cost_datapoint_link(
+            operator="BP",
+            project_name="Mad Dog Phase 2",
+            sanctioned_records=[rec_a, rec_b],
+        )
+
+        assert result.matched_record is None
+
+    def test_ambiguous_result_preserves_full_candidate_set(self):
+        """AMBIGUOUS must carry the full candidate list, not just a count."""
+        from worldenergydata.cost.data_collection.linkage import (
+            resolve_cost_datapoint_link,
+        )
+
+        rec_a = _make_cost_point(
+            operator="BP", project_name="Mad Dog Phase 2", cost_usd_mm=145.0
+        )
+        rec_b = _make_cost_point(
+            operator="BP", project_name="Mad Dog Phase 2", cost_usd_mm=180.0
+        )
+        rec_c = _make_cost_point(
+            operator="BP", project_name="Mad Dog Phase 2", cost_usd_mm=210.0
+        )
+        result = resolve_cost_datapoint_link(
+            operator="BP",
+            project_name="Mad Dog Phase 2",
+            sanctioned_records=[rec_a, rec_b, rec_c],
+        )
+
+        # CostDataPoint is not hashable (Pydantic v2 requires frozen=True);
+        # compare by membership rather than set equality.
+        assert len(result.candidates) == 3
+        assert rec_a in result.candidates
+        assert rec_b in result.candidates
+        assert rec_c in result.candidates
+
+
+# ---------------------------------------------------------------------------
+# Result shape
+# ---------------------------------------------------------------------------
+
+
+class TestLinkResultShape:
+    """CostDataPointLinkResult carries the debug/consumer payload."""
+
+    def test_link_result_preserves_match_key_and_match_count(self):
+        """The result echoes the lookup key and records the match count."""
+        from worldenergydata.cost.data_collection.linkage import (
+            resolve_cost_datapoint_link,
+        )
+
+        record = _make_cost_point(operator="BP", project_name="Mad Dog Phase 2")
+        result = resolve_cost_datapoint_link(
+            operator="BP",
+            project_name="Mad Dog Phase 2",
+            sanctioned_records=[record],
+        )
+
+        assert result.match_key_operator == "BP"
+        assert result.match_key_project_name == "Mad Dog Phase 2"
+        assert result.matched_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Dependency injection semantics
+# ---------------------------------------------------------------------------
+
+
+class TestRecordInjection:
+    """sanctioned_records argument distinguishes None (default) from [] (empty)."""
+
+    def test_helper_uses_load_public_dataset_by_default(self):
+        """sanctioned_records=None triggers load_public_dataset() fallback."""
+        from worldenergydata.cost.data_collection.linkage import (
+            resolve_cost_datapoint_link,
+        )
+        from worldenergydata.cost.data_collection.public_dataset import (
+            load_public_dataset,
+        )
+
+        # Pick any stable record from the real public dataset as a lookup key.
+        real = load_public_dataset()[0]
+        result = resolve_cost_datapoint_link(
+            operator=real.operator,
+            project_name=real.project_name,
+        )
+        # We only assert the resolver actually consulted the default loader;
+        # it must produce at least one candidate for a real dataset key.
+        assert result.matched_count >= 1
+
+    def test_helper_respects_injected_empty_record_list(self):
+        """sanctioned_records=[] must NOT fall back to load_public_dataset()."""
+        from worldenergydata.cost.data_collection.linkage import (
+            LinkageStatus,
+            resolve_cost_datapoint_link,
+        )
+
+        result = resolve_cost_datapoint_link(
+            operator="BP",
+            project_name="Mad Dog Phase 2",
+            sanctioned_records=[],
+        )
+
+        assert result.status == LinkageStatus.UNLINKED
+        assert result.matched_count == 0
+
+    def test_helper_accepts_injected_records_for_testing(self):
+        """Injected lists override the default loader for deterministic tests."""
+        from worldenergydata.cost.data_collection.linkage import (
+            LinkageStatus,
+            resolve_cost_datapoint_link,
+        )
+
+        injected = [
+            _make_cost_point(operator="Fictional Co", project_name="Nowhere Field"),
+        ]
+        result = resolve_cost_datapoint_link(
+            operator="Fictional Co",
+            project_name="Nowhere Field",
+            sanctioned_records=injected,
+        )
+
+        assert result.status == LinkageStatus.LINKED
+        assert result.matched_record is injected[0]
+
+
+# ---------------------------------------------------------------------------
+# No hidden normalization
+# ---------------------------------------------------------------------------
+
+
+class TestExactnessIsStrict:
+    """No trimming, case-folding, or alias handling is permitted."""
+
+    @pytest.mark.parametrize(
+        "operator,project_name",
+        [
+            ("bp", "Mad Dog Phase 2"),            # lowercased operator
+            ("BP", "mad dog phase 2"),            # lowercased project
+            ("  BP  ", "Mad Dog Phase 2"),        # padded operator
+            ("BP", "Mad Dog Phase 2 "),           # trailing space on project
+            ("BP", "Mad-Dog Phase 2"),            # punctuation variant
+        ],
+    )
+    def test_negative_exactness_case_changes_stay_unlinked(
+        self, operator, project_name
+    ):
+        """Any case/whitespace/punctuation variant yields UNLINKED."""
+        from worldenergydata.cost.data_collection.linkage import (
+            LinkageStatus,
+            resolve_cost_datapoint_link,
+        )
+
+        record = _make_cost_point(operator="BP", project_name="Mad Dog Phase 2")
+        result = resolve_cost_datapoint_link(
+            operator=operator,
+            project_name=project_name,
+            sanctioned_records=[record],
+        )
+
+        assert result.status == LinkageStatus.UNLINKED
+
+
+# ---------------------------------------------------------------------------
+# Operator-scope invariant (parent #334 invariant, enforced by caller gate)
+# ---------------------------------------------------------------------------
+
+
+class TestOperatorScopeNonLinkability:
+    """Operator-scope disclosure rows are never linkable; gate lives here."""
+
+    def test_operator_scope_rows_are_never_linkable(self):
+        """`disclosure_row_is_linkable('operator')` is False; project is True."""
+        from worldenergydata.cost.data_collection.linkage import (
+            disclosure_row_is_linkable,
+        )
+
+        assert disclosure_row_is_linkable("project") is True
+        assert disclosure_row_is_linkable("operator") is False
+
+    def test_operator_scope_bypass_attempt_does_not_link(self):
+        """Correct consumer flow filters operator rows out before the resolver.
+
+        The resolver itself has no scope knowledge; the contract is that
+        consumers call disclosure_row_is_linkable() first.  If a consumer
+        respects the gate, no operator-scope row can reach the resolver,
+        regardless of whether the operator name happens to match a sanction
+        record.
+        """
+        from worldenergydata.cost.data_collection.linkage import (
+            disclosure_row_is_linkable,
+            resolve_cost_datapoint_link,
+        )
+
+        # An operator-scope row only has operator, no project_name.
+        disclosure_scope = "operator"
+        disclosure_operator = "BP"
+        # Sanction record exists with the same operator — the bypass risk.
+        sanction_record = _make_cost_point(
+            operator="BP", project_name="Mad Dog Phase 2"
+        )
+
+        # Correct consumer gate: never invoke resolver for operator rows.
+        if disclosure_row_is_linkable(disclosure_scope):
+            pytest.fail(
+                "operator-scope row must be rejected before the resolver is called"
+            )
+
+        # Even if a consumer bypassed the gate and routed the operator name
+        # to the resolver with an empty/missing project_name, the result must
+        # not be LINKED, because the resolver demands an exact project match.
+        from worldenergydata.cost.data_collection.linkage import LinkageStatus
+
+        bypass_result = resolve_cost_datapoint_link(
+            operator=disclosure_operator,
+            project_name="",
+            sanctioned_records=[sanction_record],
+        )
+        assert bypass_result.status != LinkageStatus.LINKED
+
+
+# ---------------------------------------------------------------------------
+# Invalid/empty inputs
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidInputs:
+    """None or empty operator/project_name fail safely as UNLINKED."""
+
+    @pytest.mark.parametrize(
+        "operator,project_name",
+        [
+            (None, "Mad Dog Phase 2"),
+            ("BP", None),
+            ("", "Mad Dog Phase 2"),
+            ("BP", ""),
+            (None, None),
+        ],
+    )
+    def test_none_or_empty_operator_or_project_returns_unlinked(
+        self, operator, project_name
+    ):
+        """Missing key components yield UNLINKED, never an exception."""
+        from worldenergydata.cost.data_collection.linkage import (
+            LinkageStatus,
+            resolve_cost_datapoint_link,
+        )
+
+        record = _make_cost_point(operator="BP", project_name="Mad Dog Phase 2")
+        result = resolve_cost_datapoint_link(
+            operator=operator,
+            project_name=project_name,
+            sanctioned_records=[record],
+        )
+
+        assert result.status == LinkageStatus.UNLINKED
+        assert result.matched_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Public API surface
+# ---------------------------------------------------------------------------
+
+
+class TestDataCollectionExports:
+    """worldenergydata.cost.data_collection re-exports the linkage contract."""
+
+    def test_data_collection_exports_linkage_contract(self):
+        """Linkage primitives are reachable from the top-level package module."""
+        import worldenergydata.cost.data_collection as data_collection
+
+        assert hasattr(data_collection, "LinkageStatus")
+        assert hasattr(data_collection, "CostDataPointLinkResult")
+        assert hasattr(data_collection, "resolve_cost_datapoint_link")
+        assert hasattr(data_collection, "disclosure_row_is_linkable")
+
+
+# ---------------------------------------------------------------------------
+# Regression boundary — sanction dataset loader is unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPublicDatasetUnchanged:
+    """load_public_dataset() still returns its original shape/type."""
+
+    def test_load_public_dataset_shape_is_unchanged(self):
+        """Loader still returns list[CostDataPoint] with >=20 records."""
+        from worldenergydata.cost.data_collection.public_dataset import (
+            load_public_dataset,
+        )
+
+        records = load_public_dataset()
+        assert isinstance(records, list)
+        assert len(records) >= 20
+        for rec in records:
+            assert isinstance(rec, CostDataPoint)


### PR DESCRIPTION
## Summary
- add disclosure-to-sanction linkage contract for annual disclosure rows
- export linkage helpers from `worldenergydata.cost.data_collection`
- add targeted tests for exact-match linkage behavior and scope gating

## Validation
- `PYTHONPATH='src:../assetutilities/src' uv run python -m pytest --noconftest tests/unit/cost/test_linkage.py -v`

## Notes
- The broader proxy comparison regression boundary is currently broken on `main` for a pre-existing reason tracked in #342 (`worldenergydata.cost.calibration.proxy_comparison` missing).
- This PR does not modify that broken boundary.

Closes #335
