### PR TITLE
feat(cost): add disclosure ingest contract

### DIFF
--- a/.planning/plan-approved/337.md
+++ b/.planning/plan-approved/337.md
@@ -1,1 +1,0 @@
-Issue #337 plan approved via GitHub label by user on 2026-04-22.

--- a/.planning/plan-approved/337.md
+++ b/.planning/plan-approved/337.md
@@ -1,0 +1,1 @@
+Issue #337 plan approved via GitHub label by user on 2026-04-22.

--- a/src/worldenergydata/cost/data_collection/__init__.py
+++ b/src/worldenergydata/cost/data_collection/__init__.py
@@ -1,10 +1,30 @@
 """
-ABOUTME: Data collection sub-package — schema, public dataset, and linkage primitives.
+ABOUTME: Data collection sub-package — schema, public dataset, linkage primitives, and disclosure ingest contract.
 ABOUTME: Provides CostDataPoint schema, curated public sanctioned-project cost data,
-ABOUTME: and the derived-only disclosure-to-sanction linkage contract.
+ABOUTME: plus disclosure-layer linkage and ingest contracts for annual disclosure workflows.
 """
 
 from worldenergydata.cost.data_collection.calibration_schema import CostDataPoint
+from worldenergydata.cost.data_collection.disclosure_ingest_contract import (
+    AcceptedRecord,
+    CitationValidationResult,
+    ClassificationDecision,
+    ConflictReasonCode,
+    ConflictRecord,
+    DisclosureCitation,
+    DisclosureConfidence,
+    DisclosureIngestStatus,
+    DisclosureRow,
+    DisclosureScope,
+    DuplicateRecord,
+    IngestResult,
+    InvalidRecord,
+    SourcePriority,
+    classify_disclosure_row,
+    disclosure_business_key,
+    ingest_disclosure_rows,
+    validate_disclosure_citation,
+)
 from worldenergydata.cost.data_collection.linkage import (
     CostDataPointLinkResult,
     LinkageStatus,
@@ -14,10 +34,28 @@ from worldenergydata.cost.data_collection.linkage import (
 from worldenergydata.cost.data_collection.public_dataset import load_public_dataset
 
 __all__ = [
+    "AcceptedRecord",
+    "CitationValidationResult",
+    "ClassificationDecision",
+    "ConflictReasonCode",
+    "ConflictRecord",
     "CostDataPoint",
     "CostDataPointLinkResult",
+    "DisclosureCitation",
+    "DisclosureConfidence",
+    "DisclosureIngestStatus",
+    "DisclosureRow",
+    "DisclosureScope",
+    "DuplicateRecord",
+    "IngestResult",
+    "InvalidRecord",
     "LinkageStatus",
+    "SourcePriority",
+    "classify_disclosure_row",
+    "disclosure_business_key",
     "disclosure_row_is_linkable",
+    "ingest_disclosure_rows",
     "load_public_dataset",
     "resolve_cost_datapoint_link",
+    "validate_disclosure_citation",
 ]

--- a/src/worldenergydata/cost/data_collection/disclosure_ingest_contract.py
+++ b/src/worldenergydata/cost/data_collection/disclosure_ingest_contract.py
@@ -1,0 +1,442 @@
+"""
+ABOUTME: Disclosure-layer citation/provenance and ingest classification contract (issue #337).
+ABOUTME: Defines validation primitives + accepted/duplicate/conflict/invalid partitioning
+ABOUTME: with explicit conflict-reason codes for annual operator disclosure ingest.
+
+This module is the disclosure-layer contract surface. It is intentionally
+independent from the legacy sanction `CostDataPoint` schema in
+`calibration_schema.py`: the sanction surface keeps its single freeform
+`source` string + `confidence` enum, while annual disclosure rows must carry
+structured row-level provenance (`source_title`, `source_url`,
+`page_reference`, `quoted_text`, `confidence`, `source_priority`).
+
+Conflict reasoning uses explicit reason codes; source-priority differences
+are *annotated*, not silently resolved (the human/automation reviewing
+conflicts decides the winner). Duplicate/conflict classification considers
+both rows already in the dataset and rows already accepted earlier in the
+same incoming batch.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Iterable, Mapping, Optional, Sequence, Tuple
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class DisclosureConfidence(str, Enum):
+    """Confidence level for an annual-disclosure row.
+
+    Mirrors the sanction-layer Confidence enum by intent but is defined
+    independently so the disclosure layer can evolve its own quality rubric
+    without retrofitting the sanction schema.
+    """
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class DisclosureScope(str, Enum):
+    """Reporting scope for a disclosed metric."""
+
+    PROJECT = "project"
+    CORPORATE = "corporate"
+    SEGMENT = "segment"
+
+
+class SourcePriority(str, Enum):
+    """Ordered hierarchy of disclosure source types.
+
+    `rank` is monotonically increasing (lower number = stronger source).
+    The hierarchy is used to *annotate* conflicts, not to auto-pick winners.
+    """
+
+    OPERATOR_ANNUAL_REPORT = "operator_annual_report"
+    SEC_FILING = "sec_filing"
+    REGULATOR_DOCUMENT = "regulator_document"
+    INVESTOR_PRESENTATION = "investor_presentation"
+    PRESS_RELEASE = "press_release"
+    SECONDARY_OPERATOR_CONFIRMED = "secondary_operator_confirmed"
+
+    @property
+    def rank(self) -> int:
+        return _SOURCE_PRIORITY_RANK[self]
+
+
+_SOURCE_PRIORITY_RANK: dict[SourcePriority, int] = {
+    SourcePriority.OPERATOR_ANNUAL_REPORT: 0,
+    SourcePriority.SEC_FILING: 1,
+    SourcePriority.REGULATOR_DOCUMENT: 2,
+    SourcePriority.INVESTOR_PRESENTATION: 3,
+    SourcePriority.PRESS_RELEASE: 4,
+    SourcePriority.SECONDARY_OPERATOR_CONFIRMED: 5,
+}
+
+
+class DisclosureIngestStatus(str, Enum):
+    """Outcome partition for an ingested disclosure row."""
+
+    ACCEPTED = "accepted"
+    DUPLICATE = "duplicate"
+    CONFLICT = "conflict"
+    INVALID = "invalid"
+
+
+class ConflictReasonCode(str, Enum):
+    """Why two rows with the same business key disagree."""
+
+    VALUE_MISMATCH = "value_mismatch"
+    CITATION_MISMATCH = "citation_mismatch"
+    SOURCE_PRIORITY_CONFLICT = "source_priority_conflict"
+
+
+# ---------------------------------------------------------------------------
+# Citation + row models
+# ---------------------------------------------------------------------------
+
+
+class DisclosureCitation(BaseModel):
+    """Row-level provenance for a disclosed metric.
+
+    All five user-facing fields are mandatory and non-blank. `source_url`
+    must be an absolute http/https URL. `page_reference` is a general
+    locator (PDF page, section, table, or note identifier) so web-native
+    disclosures are supported without forcing a synthetic page number.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    source_title: str = Field(..., min_length=1)
+    source_url: str = Field(..., min_length=1)
+    page_reference: str = Field(..., min_length=1)
+    quoted_text: str = Field(..., min_length=1)
+    confidence: DisclosureConfidence
+    source_priority: SourcePriority
+
+    @field_validator("source_title", "source_url", "page_reference", "quoted_text")
+    @classmethod
+    def _reject_blank(cls, value: str) -> str:
+        if not value or not value.strip():
+            raise ValueError("must be a non-blank string")
+        return value
+
+    @field_validator("source_url")
+    @classmethod
+    def _require_absolute_http(cls, value: str) -> str:
+        if not (value.startswith("http://") or value.startswith("https://")):
+            raise ValueError("source_url must be an absolute http(s) URL")
+        return value
+
+
+class DisclosureRow(BaseModel):
+    """Minimum disclosure-layer row shape for the ingest contract.
+
+    Issue #334 owns the full disclosure schema/dataset. This row type is
+    deliberately the smallest shape that lets the contract be exercised
+    today; richer schemas can subclass or compose it once #334 lands.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    operator: str = Field(..., min_length=1)
+    fiscal_year: int = Field(..., ge=1970, le=2050)
+    scope_type: DisclosureScope
+    normalized_metric_name: str = Field(..., min_length=1)
+    metric_value: float
+    metric_unit: str = Field(..., min_length=1)
+    citation: DisclosureCitation
+    project_name: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class CitationValidationResult(BaseModel):
+    """Result of `validate_disclosure_citation`."""
+
+    model_config = ConfigDict(frozen=True)
+
+    is_valid: bool
+    errors: Tuple[str, ...] = ()
+
+
+def validate_disclosure_citation(row: DisclosureRow) -> CitationValidationResult:
+    """Validate the citation block of an already-constructed DisclosureRow.
+
+    Construction of `DisclosureRow`/`DisclosureCitation` already enforces
+    the structural rules; this function exists so callers operating on
+    pre-validated objects can re-check (or extend) them without rebuilding
+    the model.
+    """
+    errors: list[str] = []
+    citation = row.citation
+    for field_name in ("source_title", "source_url", "page_reference", "quoted_text"):
+        value = getattr(citation, field_name)
+        if not isinstance(value, str) or not value.strip():
+            errors.append(f"citation.{field_name} must be a non-blank string")
+    if not (
+        citation.source_url.startswith("http://")
+        or citation.source_url.startswith("https://")
+    ):
+        errors.append("citation.source_url must be an absolute http(s) URL")
+    if not isinstance(citation.confidence, DisclosureConfidence):
+        errors.append("citation.confidence must be a DisclosureConfidence")
+    if not isinstance(citation.source_priority, SourcePriority):
+        errors.append("citation.source_priority must be a SourcePriority")
+    return CitationValidationResult(is_valid=not errors, errors=tuple(errors))
+
+
+# ---------------------------------------------------------------------------
+# Business key + classification
+# ---------------------------------------------------------------------------
+
+
+BusinessKey = Tuple[str, int, DisclosureScope, str, Optional[str]]
+
+
+def disclosure_business_key(row: DisclosureRow) -> BusinessKey:
+    """Tuple key used for duplicate/conflict detection."""
+    return (
+        row.operator,
+        row.fiscal_year,
+        row.scope_type,
+        row.normalized_metric_name,
+        row.project_name,
+    )
+
+
+class ClassificationDecision(BaseModel):
+    """Outcome of comparing one new row against an existing/batch corpus."""
+
+    model_config = ConfigDict(frozen=True)
+
+    status: DisclosureIngestStatus
+    reason_code: Optional[ConflictReasonCode] = None
+    matched_row: Optional[DisclosureRow] = None
+    existing_priority: Optional[SourcePriority] = None
+    incoming_priority: Optional[SourcePriority] = None
+
+
+def _citation_payload_equal(a: DisclosureCitation, b: DisclosureCitation) -> bool:
+    """Two citations agree on every field *except* source_priority."""
+    return (
+        a.source_title == b.source_title
+        and a.source_url == b.source_url
+        and a.page_reference == b.page_reference
+        and a.quoted_text == b.quoted_text
+        and a.confidence == b.confidence
+    )
+
+
+def classify_disclosure_row(
+    *,
+    existing_rows: Sequence[DisclosureRow],
+    batch_seen_rows: Sequence[DisclosureRow],
+    new_row: DisclosureRow,
+) -> ClassificationDecision:
+    """Classify `new_row` against existing dataset rows + earlier batch rows.
+
+    Search order is: dataset rows first, then earlier rows in the same
+    batch. The first business-key collision determines the outcome — there
+    is no merging across multiple matches.
+    """
+    new_key = disclosure_business_key(new_row)
+    for candidate in list(existing_rows) + list(batch_seen_rows):
+        if disclosure_business_key(candidate) != new_key:
+            continue
+
+        value_match = candidate.metric_value == new_row.metric_value
+        unit_match = candidate.metric_unit == new_row.metric_unit
+        citation_payload_match = _citation_payload_equal(
+            candidate.citation, new_row.citation
+        )
+        priority_match = (
+            candidate.citation.source_priority == new_row.citation.source_priority
+        )
+
+        if value_match and unit_match and citation_payload_match and priority_match:
+            return ClassificationDecision(
+                status=DisclosureIngestStatus.DUPLICATE,
+                matched_row=candidate,
+            )
+
+        if not value_match or not unit_match:
+            return ClassificationDecision(
+                status=DisclosureIngestStatus.CONFLICT,
+                reason_code=ConflictReasonCode.VALUE_MISMATCH,
+                matched_row=candidate,
+                existing_priority=candidate.citation.source_priority,
+                incoming_priority=new_row.citation.source_priority,
+            )
+
+        if not citation_payload_match:
+            return ClassificationDecision(
+                status=DisclosureIngestStatus.CONFLICT,
+                reason_code=ConflictReasonCode.CITATION_MISMATCH,
+                matched_row=candidate,
+                existing_priority=candidate.citation.source_priority,
+                incoming_priority=new_row.citation.source_priority,
+            )
+
+        # Value, unit, and citation primitives all match — only source_priority differs.
+        return ClassificationDecision(
+            status=DisclosureIngestStatus.CONFLICT,
+            reason_code=ConflictReasonCode.SOURCE_PRIORITY_CONFLICT,
+            matched_row=candidate,
+            existing_priority=candidate.citation.source_priority,
+            incoming_priority=new_row.citation.source_priority,
+        )
+
+    return ClassificationDecision(status=DisclosureIngestStatus.ACCEPTED)
+
+
+# ---------------------------------------------------------------------------
+# Ingest contract (partitioned result)
+# ---------------------------------------------------------------------------
+
+
+class AcceptedRecord(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    index: int
+    row: DisclosureRow
+
+
+class DuplicateRecord(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    index: int
+    row: DisclosureRow
+    decision: ClassificationDecision
+
+
+class ConflictRecord(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    index: int
+    row: DisclosureRow
+    decision: ClassificationDecision
+
+
+class InvalidRecord(BaseModel):
+    """A raw input that failed citation/row construction or validation."""
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    index: int
+    raw: Any
+    errors: Tuple[str, ...]
+
+
+class IngestResult(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    accepted: Tuple[AcceptedRecord, ...] = ()
+    duplicates: Tuple[DuplicateRecord, ...] = ()
+    conflicts: Tuple[ConflictRecord, ...] = ()
+    invalid: Tuple[InvalidRecord, ...] = ()
+
+
+def _coerce_row(raw: Any) -> DisclosureRow:
+    """Coerce a dict / DisclosureRow into a DisclosureRow (raises ValidationError)."""
+    if isinstance(raw, DisclosureRow):
+        return raw
+    if isinstance(raw, Mapping):
+        payload = dict(raw)
+        citation = payload.get("citation")
+        if isinstance(citation, Mapping):
+            payload["citation"] = DisclosureCitation(**dict(citation))
+        return DisclosureRow(**payload)
+    raise TypeError(f"unsupported raw row type: {type(raw).__name__}")
+
+
+def ingest_disclosure_rows(
+    *,
+    raw_rows: Iterable[Any],
+    existing_rows: Sequence[DisclosureRow] = (),
+) -> IngestResult:
+    """Validate + classify a batch of raw disclosure rows.
+
+    Each raw row is parsed into a DisclosureRow. Failures land in `invalid`.
+    Successfully parsed rows are classified against `existing_rows` and
+    against rows already accepted earlier in the same batch, then
+    partitioned into accepted/duplicates/conflicts. Within each partition,
+    original input order is preserved.
+    """
+    accepted: list[AcceptedRecord] = []
+    duplicates: list[DuplicateRecord] = []
+    conflicts: list[ConflictRecord] = []
+    invalid: list[InvalidRecord] = []
+
+    accepted_rows: list[DisclosureRow] = []
+
+    for index, raw in enumerate(raw_rows):
+        try:
+            row = _coerce_row(raw)
+        except (ValidationError, TypeError, ValueError) as exc:
+            invalid.append(
+                InvalidRecord(index=index, raw=raw, errors=(str(exc),))
+            )
+            continue
+
+        citation_check = validate_disclosure_citation(row)
+        if not citation_check.is_valid:
+            invalid.append(
+                InvalidRecord(index=index, raw=raw, errors=citation_check.errors)
+            )
+            continue
+
+        decision = classify_disclosure_row(
+            existing_rows=existing_rows,
+            batch_seen_rows=accepted_rows,
+            new_row=row,
+        )
+        if decision.status == DisclosureIngestStatus.ACCEPTED:
+            accepted.append(AcceptedRecord(index=index, row=row))
+            accepted_rows.append(row)
+        elif decision.status == DisclosureIngestStatus.DUPLICATE:
+            duplicates.append(
+                DuplicateRecord(index=index, row=row, decision=decision)
+            )
+        else:
+            conflicts.append(
+                ConflictRecord(index=index, row=row, decision=decision)
+            )
+
+    return IngestResult(
+        accepted=tuple(accepted),
+        duplicates=tuple(duplicates),
+        conflicts=tuple(conflicts),
+        invalid=tuple(invalid),
+    )
+
+
+__all__ = [
+    "AcceptedRecord",
+    "CitationValidationResult",
+    "ClassificationDecision",
+    "ConflictReasonCode",
+    "ConflictRecord",
+    "DisclosureCitation",
+    "DisclosureConfidence",
+    "DisclosureIngestStatus",
+    "DisclosureRow",
+    "DisclosureScope",
+    "DuplicateRecord",
+    "IngestResult",
+    "InvalidRecord",
+    "SourcePriority",
+    "classify_disclosure_row",
+    "disclosure_business_key",
+    "ingest_disclosure_rows",
+    "validate_disclosure_citation",
+]

--- a/tests/unit/cost/test_disclosure_ingest_contract.py
+++ b/tests/unit/cost/test_disclosure_ingest_contract.py
@@ -1,0 +1,385 @@
+"""
+ABOUTME: Tests for the disclosure-layer citation/provenance and ingest classification contract.
+ABOUTME: Validates citation completeness, source-priority ordering, and accepted/duplicate/conflict/invalid partitioning.
+
+This contract sits on the disclosure-layer boundary (issue #337) and is intentionally
+independent from the legacy sanction CostDataPoint surface (issue #334 owns the
+disclosure schema; this module owns the validation/classification contract that
+will sit on top of it).
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+from pydantic import ValidationError
+
+from worldenergydata.cost.data_collection.disclosure_ingest_contract import (
+    ConflictReasonCode,
+    DisclosureCitation,
+    DisclosureConfidence,
+    DisclosureIngestStatus,
+    DisclosureRow,
+    DisclosureScope,
+    SourcePriority,
+    classify_disclosure_row,
+    disclosure_business_key,
+    ingest_disclosure_rows,
+    validate_disclosure_citation,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _valid_citation_kwargs() -> dict:
+    return {
+        "source_title": "BP 2024 Annual Report and Form 20-F",
+        "source_url": "https://www.bp.com/content/dam/bp/2024-annual-report.pdf",
+        "page_reference": "p. 142",
+        "quoted_text": "Mad Dog Phase 2 total project cost was $9.0 billion at completion.",
+        "confidence": DisclosureConfidence.HIGH,
+        "source_priority": SourcePriority.OPERATOR_ANNUAL_REPORT,
+    }
+
+
+def _valid_row_kwargs(**overrides) -> dict:
+    base = {
+        "operator": "BP",
+        "fiscal_year": 2024,
+        "scope_type": DisclosureScope.PROJECT,
+        "project_name": "Mad Dog Phase 2",
+        "normalized_metric_name": "total_project_cost_usd_mm",
+        "metric_value": 9000.0,
+        "metric_unit": "USD_MM",
+        "citation": DisclosureCitation(**_valid_citation_kwargs()),
+    }
+    base.update(overrides)
+    return base
+
+
+def _valid_row(**overrides) -> DisclosureRow:
+    return DisclosureRow(**_valid_row_kwargs(**overrides))
+
+
+# ---------------------------------------------------------------------------
+# Citation validation
+# ---------------------------------------------------------------------------
+
+
+def test_citation_contract_requires_title_url_page_quote_and_confidence():
+    """All five citation fields are mandatory at construction time."""
+    base = _valid_citation_kwargs()
+    for required_field in (
+        "source_title",
+        "source_url",
+        "page_reference",
+        "quoted_text",
+        "confidence",
+    ):
+        kwargs = dict(base)
+        kwargs.pop(required_field)
+        with pytest.raises(ValidationError):
+            DisclosureCitation(**kwargs)
+
+
+def test_citation_contract_rejects_blank_fields():
+    """Whitespace-only string citation fields fail validation."""
+    base = _valid_citation_kwargs()
+    for blank_field in ("source_title", "source_url", "page_reference", "quoted_text"):
+        kwargs = dict(base)
+        kwargs[blank_field] = "   "
+        with pytest.raises(ValidationError):
+            DisclosureCitation(**kwargs)
+
+
+def test_valid_disclosure_row_is_accepted():
+    """A fully populated disclosure row passes the citation validator."""
+    row = _valid_row()
+    result = validate_disclosure_citation(row)
+    assert result.is_valid is True
+    assert result.errors == ()
+
+
+def test_citation_contract_requires_absolute_http_source_url():
+    """Relative or non-http(s) source_urls fail validation."""
+    base = _valid_citation_kwargs()
+    for bad_url in ("/relative/path.pdf", "ftp://example.com/file.pdf", "example.com/file.pdf", ""):
+        kwargs = dict(base)
+        kwargs["source_url"] = bad_url
+        with pytest.raises(ValidationError):
+            DisclosureCitation(**kwargs)
+
+
+def test_confidence_must_use_declared_enum():
+    """confidence is enum-typed; arbitrary strings are rejected."""
+    base = _valid_citation_kwargs()
+    base["confidence"] = "very-high"
+    with pytest.raises(ValidationError):
+        DisclosureCitation(**base)
+
+
+def test_non_pdf_locators_are_accepted_in_page_reference():
+    """page_reference is a general locator — section/table identifiers are valid."""
+    base = _valid_citation_kwargs()
+    for locator in ("Section 4.2", "Table 12", "Note 7", "Item 1A — Risk Factors"):
+        kwargs = dict(base)
+        kwargs["page_reference"] = locator
+        citation = DisclosureCitation(**kwargs)
+        assert citation.page_reference == locator
+
+
+# ---------------------------------------------------------------------------
+# Source priority
+# ---------------------------------------------------------------------------
+
+
+def test_source_priority_values_are_explicit_and_ordered():
+    """SourcePriority is a deterministic, ordered hierarchy."""
+    expected_order = [
+        SourcePriority.OPERATOR_ANNUAL_REPORT,
+        SourcePriority.SEC_FILING,
+        SourcePriority.REGULATOR_DOCUMENT,
+        SourcePriority.INVESTOR_PRESENTATION,
+        SourcePriority.PRESS_RELEASE,
+        SourcePriority.SECONDARY_OPERATOR_CONFIRMED,
+    ]
+    sorted_by_rank = sorted(SourcePriority, key=lambda p: p.rank)
+    assert sorted_by_rank == expected_order
+    ranks = [p.rank for p in expected_order]
+    assert ranks == sorted(ranks), "ranks must be monotonically increasing"
+    assert len(set(ranks)) == len(ranks), "ranks must be unique"
+
+
+# ---------------------------------------------------------------------------
+# Business key
+# ---------------------------------------------------------------------------
+
+
+def test_disclosure_business_key_includes_required_dimensions():
+    """The business key disambiguates rows by operator + fiscal_year + scope + metric (+ optional project)."""
+    row = _valid_row()
+    key = disclosure_business_key(row)
+    assert key == (
+        "BP",
+        2024,
+        DisclosureScope.PROJECT,
+        "total_project_cost_usd_mm",
+        "Mad Dog Phase 2",
+    )
+
+
+def test_disclosure_business_key_omits_optional_project_for_corporate_scope():
+    """Corporate-scope rows omit project_name from the key."""
+    row = _valid_row(scope_type=DisclosureScope.CORPORATE, project_name=None)
+    key = disclosure_business_key(row)
+    assert key == (
+        "BP",
+        2024,
+        DisclosureScope.CORPORATE,
+        "total_project_cost_usd_mm",
+        None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Row-level classification
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_classification_for_identical_business_key_and_payload():
+    """Same business key + identical metric value and citation → DUPLICATE, no reason code."""
+    existing = _valid_row()
+    incoming = _valid_row()
+    decision = classify_disclosure_row(
+        existing_rows=[existing], batch_seen_rows=[], new_row=incoming
+    )
+    assert decision.status == DisclosureIngestStatus.DUPLICATE
+    assert decision.reason_code is None
+
+
+def test_conflict_classification_for_same_business_key_different_value():
+    """Same key, different metric_value → CONFLICT with VALUE_MISMATCH."""
+    existing = _valid_row()
+    incoming = _valid_row(metric_value=9500.0)
+    decision = classify_disclosure_row(
+        existing_rows=[existing], batch_seen_rows=[], new_row=incoming
+    )
+    assert decision.status == DisclosureIngestStatus.CONFLICT
+    assert decision.reason_code == ConflictReasonCode.VALUE_MISMATCH
+
+
+def test_conflict_classification_for_same_business_key_different_citation():
+    """Same key + same value, different citation (different source_url) → CITATION_MISMATCH."""
+    existing = _valid_row()
+    differing_citation = DisclosureCitation(
+        **{**_valid_citation_kwargs(), "source_url": "https://www.bp.com/another-2024.pdf"}
+    )
+    incoming = _valid_row(citation=differing_citation)
+    decision = classify_disclosure_row(
+        existing_rows=[existing], batch_seen_rows=[], new_row=incoming
+    )
+    assert decision.status == DisclosureIngestStatus.CONFLICT
+    assert decision.reason_code == ConflictReasonCode.CITATION_MISMATCH
+
+
+def test_source_priority_affects_conflict_reasoning():
+    """Same key + same value + same provenance fields but DIFFERENT source_priority → SOURCE_PRIORITY_CONFLICT."""
+    existing = _valid_row()
+    lower_priority_citation = DisclosureCitation(
+        **{
+            **_valid_citation_kwargs(),
+            "source_priority": SourcePriority.PRESS_RELEASE,
+        }
+    )
+    incoming = _valid_row(citation=lower_priority_citation)
+    decision = classify_disclosure_row(
+        existing_rows=[existing], batch_seen_rows=[], new_row=incoming
+    )
+    assert decision.status == DisclosureIngestStatus.CONFLICT
+    assert decision.reason_code == ConflictReasonCode.SOURCE_PRIORITY_CONFLICT
+    # Annotation must record both priorities so a reviewer can adjudicate later.
+    assert decision.existing_priority == SourcePriority.OPERATOR_ANNUAL_REPORT
+    assert decision.incoming_priority == SourcePriority.PRESS_RELEASE
+
+
+def test_source_priority_does_not_auto_select_winner():
+    """Source-priority differences are annotated, not silently resolved.
+
+    The plan is explicit: 'Source-priority affects conflict annotation, not
+    automatic winner selection.' Even when the incoming row carries a higher
+    priority than the existing row, the result must still be CONFLICT (not
+    ACCEPTED or DUPLICATE).
+    """
+    lower_priority_existing = _valid_row(
+        citation=DisclosureCitation(
+            **{**_valid_citation_kwargs(), "source_priority": SourcePriority.PRESS_RELEASE}
+        )
+    )
+    higher_priority_incoming = _valid_row()  # OPERATOR_ANNUAL_REPORT (rank 0)
+    decision = classify_disclosure_row(
+        existing_rows=[lower_priority_existing],
+        batch_seen_rows=[],
+        new_row=higher_priority_incoming,
+    )
+    assert decision.status == DisclosureIngestStatus.CONFLICT
+    assert decision.reason_code == ConflictReasonCode.SOURCE_PRIORITY_CONFLICT
+
+
+def test_classification_returns_accepted_for_unique_key():
+    """A row with a fresh business key against existing rows → ACCEPTED."""
+    existing = _valid_row()
+    incoming = _valid_row(fiscal_year=2023)
+    decision = classify_disclosure_row(
+        existing_rows=[existing], batch_seen_rows=[], new_row=incoming
+    )
+    assert decision.status == DisclosureIngestStatus.ACCEPTED
+    assert decision.reason_code is None
+
+
+# ---------------------------------------------------------------------------
+# Within-batch classification
+# ---------------------------------------------------------------------------
+
+
+def test_within_batch_duplicate_and_conflict_behavior_is_defined():
+    """Classification must consider rows already accepted earlier in the same batch."""
+    earlier = _valid_row()
+    duplicate_incoming = _valid_row()
+    decision_dup = classify_disclosure_row(
+        existing_rows=[], batch_seen_rows=[earlier], new_row=duplicate_incoming
+    )
+    assert decision_dup.status == DisclosureIngestStatus.DUPLICATE
+
+    conflicting_incoming = _valid_row(metric_value=9500.0)
+    decision_conf = classify_disclosure_row(
+        existing_rows=[], batch_seen_rows=[earlier], new_row=conflicting_incoming
+    )
+    assert decision_conf.status == DisclosureIngestStatus.CONFLICT
+    assert decision_conf.reason_code == ConflictReasonCode.VALUE_MISMATCH
+
+
+# ---------------------------------------------------------------------------
+# Ingest contract — partitioned result
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_contract_returns_partitioned_result_sets():
+    """ingest_disclosure_rows returns four explicit partitions with conflict annotations."""
+    existing = _valid_row()
+
+    # raw_rows: dict payloads (as a real ingest pipeline would deliver them)
+    accepted_raw = _valid_row_kwargs(fiscal_year=2023)  # fresh key → accepted
+    duplicate_raw = _valid_row_kwargs()  # exact match of existing → duplicate
+    conflict_raw = _valid_row_kwargs(metric_value=9500.0)  # value conflict
+
+    invalid_raw = _valid_row_kwargs(fiscal_year=2022)
+    # break citation: blank quoted_text → invalid
+    invalid_raw["citation"] = {**_valid_citation_kwargs(), "quoted_text": "   "}
+
+    result = ingest_disclosure_rows(
+        raw_rows=[accepted_raw, duplicate_raw, conflict_raw, invalid_raw],
+        existing_rows=[existing],
+    )
+
+    assert len(result.accepted) == 1
+    assert len(result.duplicates) == 1
+    assert len(result.conflicts) == 1
+    assert len(result.invalid) == 1
+
+    # Conflict annotation carries the reason code.
+    conflict_record = result.conflicts[0]
+    assert conflict_record.decision.status == DisclosureIngestStatus.CONFLICT
+    assert conflict_record.decision.reason_code == ConflictReasonCode.VALUE_MISMATCH
+
+    # Invalid record carries non-empty error messages.
+    invalid_record = result.invalid[0]
+    assert invalid_record.errors  # tuple of error strings, non-empty
+
+
+def test_ingest_contract_handles_within_batch_partitioning():
+    """Two identical raw rows in the same batch → first ACCEPTED, second DUPLICATE."""
+    raw_a = _valid_row_kwargs()
+    raw_b = deepcopy(raw_a)
+
+    result = ingest_disclosure_rows(raw_rows=[raw_a, raw_b], existing_rows=[])
+    assert len(result.accepted) == 1
+    assert len(result.duplicates) == 1
+    assert len(result.conflicts) == 0
+    assert len(result.invalid) == 0
+
+
+def test_ingest_contract_preserves_input_order_within_partitions():
+    """Partitioned output preserves the original ingest order so audit trails are reproducible."""
+    raw_first = _valid_row_kwargs(fiscal_year=2020)
+    raw_second = _valid_row_kwargs(fiscal_year=2021)
+    raw_third = _valid_row_kwargs(fiscal_year=2022)
+
+    result = ingest_disclosure_rows(
+        raw_rows=[raw_first, raw_second, raw_third], existing_rows=[]
+    )
+    accepted_years = [r.row.fiscal_year for r in result.accepted]
+    assert accepted_years == [2020, 2021, 2022]
+
+
+# ---------------------------------------------------------------------------
+# Boundary: legacy sanction schema is unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_sanction_schema_is_unchanged():
+    """#337 must not contaminate the legacy sanction CostDataPoint schema.
+
+    Specifically, CostDataPoint must NOT have grown disclosure-citation fields
+    (source_title, source_url, page_reference, quoted_text). The legacy `source`
+    string and `confidence` enum remain the only provenance surface there.
+    """
+    from worldenergydata.cost.data_collection.calibration_schema import CostDataPoint
+
+    field_names = set(CostDataPoint.model_fields.keys())
+    forbidden = {"source_title", "source_url", "page_reference", "quoted_text"}
+    leaked = field_names & forbidden
+    assert not leaked, f"sanction schema must not carry disclosure-citation fields: {leaked}"


### PR DESCRIPTION
## Summary
- add disclosure-layer ingest contract models, enums, classification, and partitioned ingest results
- export the disclosure ingest contract surface from `worldenergydata.cost.data_collection`
- add targeted tests for citation validation, conflict precedence, and batch ingest partitioning

## Validation
- `PYTHONPATH='src:../assetutilities/src' uv run python -m pytest --noconftest tests/unit/cost/test_disclosure_ingest_contract.py -v`
- `PYTHONPATH='src:../assetutilities/src' uv run python -m pytest --noconftest tests/unit/cost/test_calibration_schema.py -v`

## Notes
- `tests/unit/cost/test_proxy_comparison.py` is still blocked by the pre-existing missing-module issue tracked in #342.
- `tests/unit/cost/test_operator_disclosures.py` is still absent, so the conditional regression check remains a no-op until #334 lands.

Closes #337
