### PR TITLE
feat(cost): add disclosure analytics views and FDAS surface

### DIFF
--- a/.planning/plan-approved/338.md
+++ b/.planning/plan-approved/338.md
@@ -1,1 +1,0 @@
-Issue #338 plan approved via GitHub label by user on 2026-04-22.

--- a/.planning/plan-approved/338.md
+++ b/.planning/plan-approved/338.md
@@ -1,0 +1,1 @@
+Issue #338 plan approved via GitHub label by user on 2026-04-22.

--- a/src/worldenergydata/cost/__init__.py
+++ b/src/worldenergydata/cost/__init__.py
@@ -1,6 +1,6 @@
 """
 ABOUTME: Cost calibration module — sanctioned project benchmarking and multivariate prediction.
-ABOUTME: Entry point for the cost sub-package (data collection + calibration).
+ABOUTME: Entry point for the cost sub-package (data collection + calibration + disclosure analytics).
 """
 
 from worldenergydata.cost.calibration.cost_predictor import (
@@ -9,10 +9,33 @@ from worldenergydata.cost.calibration.cost_predictor import (
 )
 from worldenergydata.cost.data_collection.calibration_schema import CostDataPoint
 from worldenergydata.cost.data_collection.public_dataset import load_public_dataset
+from worldenergydata.cost.disclosure_analytics import (
+    COMPARABILITY_COMPARABLE,
+    SCOPE_OPERATOR,
+    SCOPE_PROJECT,
+    DisclosureBenchmarkResult,
+    DisclosureRecord,
+    OperatorCapexRow,
+    ProjectRevisionRow,
+    build_cost_disclosure_benchmark,
+    load_operator_annual_capex_view,
+    load_project_cost_revision_view,
+)
 
 __all__ = [
     "CostDataPoint",
     "load_public_dataset",
     "CostPredictor",
     "PredictionResult",
+    # Disclosure analytics (issue #338)
+    "DisclosureRecord",
+    "ProjectRevisionRow",
+    "OperatorCapexRow",
+    "DisclosureBenchmarkResult",
+    "load_project_cost_revision_view",
+    "load_operator_annual_capex_view",
+    "build_cost_disclosure_benchmark",
+    "COMPARABILITY_COMPARABLE",
+    "SCOPE_PROJECT",
+    "SCOPE_OPERATOR",
 ]

--- a/src/worldenergydata/cost/disclosure_analytics.py
+++ b/src/worldenergydata/cost/disclosure_analytics.py
@@ -1,0 +1,270 @@
+# ABOUTME: Derived annual disclosure analytics views (issue #338).
+# ABOUTME: Project revision view, operator capex series, and gated cost-benchmark hook.
+
+"""Derived annual disclosure analytics.
+
+This module takes raw annual-disclosure records and emits *derived* views:
+
+  - :func:`load_project_cost_revision_view` — per-project annual capex with YoY deltas.
+  - :func:`load_operator_annual_capex_view` — per-operator annual capex with YoY deltas.
+  - :func:`build_cost_disclosure_benchmark` — thin cost-side consumer hook that only
+    compares rows already flagged same-basis/comparable under #336 outputs.
+
+Design invariants (per issue #338 plan):
+
+  * Raw-vs-derived separation. The raw input list is never mutated; each derived
+    row carries its own copy of provenance metadata.
+  * Scope separation. Project-scope rows never leak into the operator view, and
+    vice versa.
+  * YoY math is only emitted when a prior-year row exists within the same group;
+    no forward-fill or interpolation.
+  * Comparability policy is owned by #336. This module only accepts rows whose
+    ``comparability_status`` is exactly :data:`COMPARABILITY_COMPARABLE`, and
+    refuses all other inputs for the benchmark hook (including ``None``).
+  * No lower-tertiary consumption. Lower-tertiary field/project mapping is
+    deferred to a separate contract issue.
+
+The :class:`DisclosureRecord` shape defined here is a minimal local contract so
+#338 can ship ahead of the #334 raw foundation. Once #334 lands, this module can
+depend on the canonical type without changing its public API.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Optional, Sequence
+
+__all__ = [
+    "DisclosureRecord",
+    "ProjectRevisionRow",
+    "OperatorCapexRow",
+    "DisclosureBenchmarkResult",
+    "load_project_cost_revision_view",
+    "load_operator_annual_capex_view",
+    "build_cost_disclosure_benchmark",
+    "COMPARABILITY_COMPARABLE",
+    "SCOPE_PROJECT",
+    "SCOPE_OPERATOR",
+]
+
+
+SCOPE_PROJECT = "project"
+SCOPE_OPERATOR = "operator"
+
+COMPARABILITY_COMPARABLE = "comparable"
+
+
+@dataclass(frozen=True)
+class DisclosureRecord:
+    """Raw annual-disclosure row consumed by the derived views.
+
+    This is a local contract for #338; once #334's canonical foundation lands,
+    this module can accept that type interchangeably.
+    """
+
+    operator: str
+    fiscal_year: int
+    reported_capex_usd_mm: float
+    scope: str
+    project_name: Optional[str] = None
+    provenance: Mapping[str, Any] = field(default_factory=dict)
+    comparability_status: Optional[str] = None
+    comparability_basis: Optional[str] = None
+    currency: Optional[str] = None
+
+
+@dataclass
+class ProjectRevisionRow:
+    """Derived per-project annual capex + YoY revision."""
+
+    operator: str
+    project_name: str
+    fiscal_year: int
+    reported_capex_usd_mm: float
+    yoy_delta_usd_mm: Optional[float]
+    yoy_delta_pct: Optional[float]
+    provenance: dict
+    comparability_status: Optional[str]
+
+
+@dataclass
+class OperatorCapexRow:
+    """Derived per-operator annual capex + YoY delta."""
+
+    operator: str
+    fiscal_year: int
+    reported_capex_usd_mm: float
+    yoy_delta_usd_mm: Optional[float]
+    yoy_delta_pct: Optional[float]
+    provenance: dict
+    comparability_status: Optional[str]
+
+
+@dataclass(frozen=True)
+class DisclosureBenchmarkResult:
+    """Outcome of the gated cost-vs-disclosure comparison."""
+
+    operator: str
+    project_name: str
+    fiscal_year: int
+    disclosed_capex_usd_mm: float
+    predicted_capex_usd_mm: float
+    absolute_delta_usd_mm: float
+    pct_delta: float
+    comparability_status: str
+
+
+def _copy_provenance(src: Mapping[str, Any]) -> dict:
+    return deepcopy(dict(src))
+
+
+def _yoy(
+    current: float, prior: Optional[float]
+) -> tuple[Optional[float], Optional[float]]:
+    if prior is None:
+        return None, None
+    delta = current - prior
+    pct = delta / prior if prior != 0 else None
+    return delta, pct
+
+
+def load_project_cost_revision_view(
+    records: Iterable[DisclosureRecord],
+) -> list[ProjectRevisionRow]:
+    """Build the project annual cost revision view.
+
+    Groups by ``(operator, project_name)``, sorts by ``fiscal_year``, and emits
+    a derived row per raw row with YoY delta and YoY percent when a prior-year
+    row exists in the same group.
+
+    Operator-scope rows and rows missing ``project_name`` are excluded — they
+    belong to the operator view, never this one.
+    """
+    project_rows = [
+        r
+        for r in records
+        if r.scope == SCOPE_PROJECT and r.project_name
+    ]
+    groups: dict[tuple[str, str], list[DisclosureRecord]] = {}
+    for r in project_rows:
+        groups.setdefault((r.operator, r.project_name), []).append(r)
+
+    result: list[ProjectRevisionRow] = []
+    for rows in groups.values():
+        rows_sorted = sorted(rows, key=lambda x: x.fiscal_year)
+        prior_capex: Optional[float] = None
+        for r in rows_sorted:
+            delta, pct = _yoy(r.reported_capex_usd_mm, prior_capex)
+            result.append(
+                ProjectRevisionRow(
+                    operator=r.operator,
+                    project_name=r.project_name,
+                    fiscal_year=r.fiscal_year,
+                    reported_capex_usd_mm=r.reported_capex_usd_mm,
+                    yoy_delta_usd_mm=delta,
+                    yoy_delta_pct=pct,
+                    provenance=_copy_provenance(r.provenance),
+                    comparability_status=r.comparability_status,
+                )
+            )
+            prior_capex = r.reported_capex_usd_mm
+    return result
+
+
+def load_operator_annual_capex_view(
+    records: Iterable[DisclosureRecord],
+) -> list[OperatorCapexRow]:
+    """Build the operator annual capex view.
+
+    Groups by ``operator``, sorts by ``fiscal_year``, and emits a derived row
+    per raw row with YoY deltas computed within-group only.
+
+    Project-scope rows are excluded.
+    """
+    operator_rows = [r for r in records if r.scope == SCOPE_OPERATOR]
+    groups: dict[str, list[DisclosureRecord]] = {}
+    for r in operator_rows:
+        groups.setdefault(r.operator, []).append(r)
+
+    result: list[OperatorCapexRow] = []
+    for rows in groups.values():
+        rows_sorted = sorted(rows, key=lambda x: x.fiscal_year)
+        prior_capex: Optional[float] = None
+        for r in rows_sorted:
+            delta, pct = _yoy(r.reported_capex_usd_mm, prior_capex)
+            result.append(
+                OperatorCapexRow(
+                    operator=r.operator,
+                    fiscal_year=r.fiscal_year,
+                    reported_capex_usd_mm=r.reported_capex_usd_mm,
+                    yoy_delta_usd_mm=delta,
+                    yoy_delta_pct=pct,
+                    provenance=_copy_provenance(r.provenance),
+                    comparability_status=r.comparability_status,
+                )
+            )
+            prior_capex = r.reported_capex_usd_mm
+    return result
+
+
+def build_cost_disclosure_benchmark(
+    project_revision_view: Iterable[ProjectRevisionRow],
+    predictor_cost_usd_mm: float,
+    *,
+    operator: str,
+    project_name: str,
+    fiscal_year: Optional[int] = None,
+) -> Optional[DisclosureBenchmarkResult]:
+    """Compare a predictor output against the latest comparable disclosed capex.
+
+    Parameters
+    ----------
+    project_revision_view
+        Output of :func:`load_project_cost_revision_view`.
+    predictor_cost_usd_mm
+        Cost point estimate from an upstream predictor (e.g. ``CostPredictor``).
+        This function does not call the predictor — it only accepts its scalar
+        output, keeping the hook thin and non-intrusive on predictor semantics.
+    operator, project_name
+        Scope filter for the comparison.
+    fiscal_year
+        Optional — if provided, compare against the exact fiscal year rather
+        than the latest available.
+
+    Returns
+    -------
+    DisclosureBenchmarkResult | None
+        ``None`` if no row matches the scope *or* no matching row has been
+        flagged :data:`COMPARABILITY_COMPARABLE` under #336's outputs. Refusing
+        rather than inferring keeps comparability policy owned by #336.
+    """
+    candidates = [
+        r
+        for r in project_revision_view
+        if r.operator == operator
+        and r.project_name == project_name
+        and r.comparability_status == COMPARABILITY_COMPARABLE
+    ]
+    if fiscal_year is not None:
+        candidates = [r for r in candidates if r.fiscal_year == fiscal_year]
+    if not candidates:
+        return None
+
+    latest = max(candidates, key=lambda r: r.fiscal_year)
+    abs_delta = predictor_cost_usd_mm - latest.reported_capex_usd_mm
+    pct_delta = (
+        abs_delta / latest.reported_capex_usd_mm
+        if latest.reported_capex_usd_mm
+        else 0.0
+    )
+    return DisclosureBenchmarkResult(
+        operator=operator,
+        project_name=project_name,
+        fiscal_year=latest.fiscal_year,
+        disclosed_capex_usd_mm=latest.reported_capex_usd_mm,
+        predicted_capex_usd_mm=predictor_cost_usd_mm,
+        absolute_delta_usd_mm=abs_delta,
+        pct_delta=pct_delta,
+        comparability_status=latest.comparability_status,
+    )

--- a/src/worldenergydata/fdas/__init__.py
+++ b/src/worldenergydata/fdas/__init__.py
@@ -110,15 +110,21 @@ __all__ = [
     "AdapterError",
     # Query API (issue #288)
     "economics",
+    # Disclosure analytics (issue #338)
+    "disclosure_analytics",
     # Metadata
     "__version__",
 ]
 
 
 def __getattr__(name: str):
-    """Lazy import of query API singletons (issue #288)."""
+    """Lazy import of query API singletons (issue #288, #338)."""
     if name == "economics":
         from worldenergydata.fdas.api import economics
 
         return economics
+    if name == "disclosure_analytics":
+        from worldenergydata.fdas.api import disclosure_analytics
+
+        return disclosure_analytics
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/worldenergydata/fdas/api.py
+++ b/src/worldenergydata/fdas/api.py
@@ -272,3 +272,76 @@ class EconomicsQuery:
 
 # Module-level singleton instance for convenience attribute access
 economics = EconomicsQuery()
+
+
+# --------------------------------------------------------------------------
+# Disclosure analytics (issue #338)
+# --------------------------------------------------------------------------
+
+
+class DisclosureAnalyticsQuery:
+    """FDAS consumer-facing surface for annual disclosure analytics.
+
+    Thin delegator over :mod:`worldenergydata.cost.disclosure_analytics`. All
+    semantics (scope separation, YoY math, comparability gating) live in the
+    cost-side module — this class is the explicit FDAS API seam called for
+    by issue #338.
+
+    Examples
+    --------
+    >>> from worldenergydata.fdas.api import disclosure_analytics
+    >>> view = disclosure_analytics.project_revision(raw_records)
+    >>> op_view = disclosure_analytics.operator_capex(raw_records)
+    >>> benchmark = disclosure_analytics.benchmark(
+    ...     view, predictor_cost_usd_mm=1100.0,
+    ...     operator="AcmeCorp", project_name="Mariner-A",
+    ... )
+    """
+
+    @staticmethod
+    def project_revision(records: Sequence[Any]) -> List[Any]:
+        """Return the project annual cost revision view."""
+        from worldenergydata.cost.disclosure_analytics import (
+            load_project_cost_revision_view,
+        )
+
+        return load_project_cost_revision_view(records)
+
+    @staticmethod
+    def operator_capex(records: Sequence[Any]) -> List[Any]:
+        """Return the operator annual capex series view."""
+        from worldenergydata.cost.disclosure_analytics import (
+            load_operator_annual_capex_view,
+        )
+
+        return load_operator_annual_capex_view(records)
+
+    @staticmethod
+    def benchmark(
+        project_revision_view: Sequence[Any],
+        predictor_cost_usd_mm: float,
+        *,
+        operator: str,
+        project_name: str,
+        fiscal_year: Optional[int] = None,
+    ) -> Optional[Any]:
+        """Compare a predictor output to the latest comparable disclosed capex.
+
+        Returns ``None`` unless at least one matching row is flagged
+        same-basis/comparable under #336 outputs. See
+        :func:`worldenergydata.cost.disclosure_analytics.build_cost_disclosure_benchmark`.
+        """
+        from worldenergydata.cost.disclosure_analytics import (
+            build_cost_disclosure_benchmark,
+        )
+
+        return build_cost_disclosure_benchmark(
+            project_revision_view,
+            predictor_cost_usd_mm,
+            operator=operator,
+            project_name=project_name,
+            fiscal_year=fiscal_year,
+        )
+
+
+disclosure_analytics = DisclosureAnalyticsQuery()

--- a/tests/test_query_api.py
+++ b/tests/test_query_api.py
@@ -402,6 +402,98 @@ class TestFDASEconomicsQuery:
 
 
 # ==========================================================================
+# FDAS Disclosure Analytics Query API Tests (issue #338)
+# ==========================================================================
+
+
+class TestFDASDisclosureAnalyticsQuery:
+    """Tests for worldenergydata.fdas.api.DisclosureAnalyticsQuery (issue #338)."""
+
+    def test_import_disclosure_analytics_query(self):
+        """DisclosureAnalyticsQuery is importable from fdas.api."""
+        from worldenergydata.fdas.api import DisclosureAnalyticsQuery
+
+        assert DisclosureAnalyticsQuery is not None
+
+    def test_project_revision_method_signature(self):
+        """DisclosureAnalyticsQuery.project_revision accepts a records iterable."""
+        from worldenergydata.fdas.api import DisclosureAnalyticsQuery
+
+        sig = inspect.signature(DisclosureAnalyticsQuery.project_revision)
+        params = list(sig.parameters.keys())
+        assert "records" in params
+
+    def test_operator_capex_method_signature(self):
+        from worldenergydata.fdas.api import DisclosureAnalyticsQuery
+
+        sig = inspect.signature(DisclosureAnalyticsQuery.operator_capex)
+        params = list(sig.parameters.keys())
+        assert "records" in params
+
+    def test_benchmark_method_signature(self):
+        from worldenergydata.fdas.api import DisclosureAnalyticsQuery
+
+        sig = inspect.signature(DisclosureAnalyticsQuery.benchmark)
+        params = list(sig.parameters.keys())
+        assert "project_revision_view" in params
+        assert "predictor_cost_usd_mm" in params
+        assert "operator" in params
+        assert "project_name" in params
+
+    def test_project_revision_returns_derived_rows(self):
+        """End-to-end: FDAS seam delegates to cost.disclosure_analytics."""
+        from worldenergydata.cost.disclosure_analytics import (
+            DisclosureRecord,
+            ProjectRevisionRow,
+            SCOPE_PROJECT,
+        )
+        from worldenergydata.fdas.api import DisclosureAnalyticsQuery
+
+        records = [
+            DisclosureRecord(
+                operator="AcmeCorp",
+                fiscal_year=2022,
+                reported_capex_usd_mm=900.0,
+                scope=SCOPE_PROJECT,
+                project_name="Mariner-A",
+                provenance={"source": "10-K"},
+            ),
+        ]
+        view = DisclosureAnalyticsQuery.project_revision(records)
+        assert len(view) == 1
+        assert isinstance(view[0], ProjectRevisionRow)
+        assert view[0].yoy_delta_usd_mm is None
+
+    def test_benchmark_refuses_non_comparable_rows(self):
+        """Comparability gating is enforced at the FDAS seam too."""
+        from worldenergydata.cost.disclosure_analytics import (
+            DisclosureRecord,
+            SCOPE_PROJECT,
+        )
+        from worldenergydata.fdas.api import DisclosureAnalyticsQuery
+
+        records = [
+            DisclosureRecord(
+                operator="AcmeCorp",
+                fiscal_year=2022,
+                reported_capex_usd_mm=900.0,
+                scope=SCOPE_PROJECT,
+                project_name="Mariner-A",
+                provenance={"source": "10-K"},
+                comparability_status=None,  # missing -> must refuse
+            ),
+        ]
+        view = DisclosureAnalyticsQuery.project_revision(records)
+        result = DisclosureAnalyticsQuery.benchmark(
+            view,
+            predictor_cost_usd_mm=1000.0,
+            operator="AcmeCorp",
+            project_name="Mariner-A",
+        )
+        assert result is None
+
+
+# ==========================================================================
 # Marine Safety Query API Tests
 # ==========================================================================
 
@@ -546,6 +638,18 @@ class TestPackageLevelImports:
         # Lazy-loaded via fdas/__init__.py __getattr__
         assert fdas_mod.economics is not None
 
+    def test_fdas_disclosure_analytics_accessible(self):
+        """wed.fdas.disclosure_analytics should be accessible (issue #338)."""
+        import worldenergydata as wed
+
+        fdas_mod = wed.fdas
+        # Lazy-loaded via fdas/__init__.py __getattr__
+        assert fdas_mod.disclosure_analytics is not None
+        # Must be the same class as defined in fdas.api — no divergent surface.
+        from worldenergydata.fdas.api import DisclosureAnalyticsQuery
+
+        assert isinstance(fdas_mod.disclosure_analytics, DisclosureAnalyticsQuery)
+
     def test_marine_safety_api_accessible(self):
         """wed.marine_safety_api should resolve to marine_safety.api module."""
         import worldenergydata as wed
@@ -564,6 +668,15 @@ class TestPackageLevelImports:
         import worldenergydata as wed
 
         assert callable(wed.fdas.economics.npv)
+
+    def test_fdas_disclosure_analytics_callables(self):
+        """wed.fdas.disclosure_analytics exposes project_revision/operator_capex/benchmark."""
+        import worldenergydata as wed
+
+        ns = wed.fdas.disclosure_analytics
+        assert callable(ns.project_revision)
+        assert callable(ns.operator_capex)
+        assert callable(ns.benchmark)
 
     def test_marine_safety_incidents_query_callable(self):
         """wed.marine_safety_api.incidents.query is callable."""

--- a/tests/unit/cost/test_disclosure_analytics.py
+++ b/tests/unit/cost/test_disclosure_analytics.py
@@ -1,0 +1,429 @@
+# ABOUTME: Unit tests for derived annual disclosure analytics views (issue #338).
+# ABOUTME: Proves project/operator scope separation, raw-vs-derived isolation, and #336 comparability gating.
+
+"""Tests for ``worldenergydata.cost.disclosure_analytics``.
+
+Covers #338 scope:
+  - Project annual cost revision view.
+  - Operator annual capex series view.
+  - Cost-side consumer hook bounded by #336 comparability metadata.
+  - Raw-vs-derived separation + lower-tertiary deferral invariants.
+
+These tests deliberately avoid importing from ``worldenergydata.cost.data_collection``:
+the raw disclosure foundation lands in #334, and #338 must work against its own
+minimal record shape until then.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib
+import inspect
+
+import pytest
+
+
+# --------------------------------------------------------------------------
+# Fixtures
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def analytics_module():
+    return importlib.import_module("worldenergydata.cost.disclosure_analytics")
+
+
+@pytest.fixture
+def make_record(analytics_module):
+    """Factory for ``DisclosureRecord`` instances with sensible defaults."""
+
+    def _factory(**overrides):
+        defaults = dict(
+            operator="AcmeCorp",
+            fiscal_year=2022,
+            reported_capex_usd_mm=1000.0,
+            scope=analytics_module.SCOPE_PROJECT,
+            project_name="Mariner-A",
+            provenance={"source": "10-K", "filing_id": "acme-2022-10k"},
+            comparability_status=None,
+            comparability_basis=None,
+            currency="USD",
+        )
+        defaults.update(overrides)
+        return analytics_module.DisclosureRecord(**defaults)
+
+    return _factory
+
+
+@pytest.fixture
+def project_dataset(analytics_module, make_record):
+    """Two operator/project groups across three fiscal years each, plus stray operator rows."""
+    return [
+        make_record(
+            operator="AcmeCorp",
+            project_name="Mariner-A",
+            fiscal_year=2020,
+            reported_capex_usd_mm=800.0,
+        ),
+        make_record(
+            operator="AcmeCorp",
+            project_name="Mariner-A",
+            fiscal_year=2021,
+            reported_capex_usd_mm=900.0,
+        ),
+        make_record(
+            operator="AcmeCorp",
+            project_name="Mariner-A",
+            fiscal_year=2022,
+            reported_capex_usd_mm=950.0,
+            comparability_status=analytics_module.COMPARABILITY_COMPARABLE,
+        ),
+        make_record(
+            operator="BetaOil",
+            project_name="Horizon-East",
+            fiscal_year=2021,
+            reported_capex_usd_mm=500.0,
+        ),
+        make_record(
+            operator="BetaOil",
+            project_name="Horizon-East",
+            fiscal_year=2022,
+            reported_capex_usd_mm=525.0,
+        ),
+        # Operator-scope row that must NEVER appear in the project view.
+        make_record(
+            operator="AcmeCorp",
+            scope=analytics_module.SCOPE_OPERATOR,
+            project_name=None,
+            fiscal_year=2022,
+            reported_capex_usd_mm=5000.0,
+        ),
+    ]
+
+
+@pytest.fixture
+def operator_dataset(analytics_module, make_record):
+    return [
+        make_record(
+            operator="AcmeCorp",
+            scope=analytics_module.SCOPE_OPERATOR,
+            project_name=None,
+            fiscal_year=2020,
+            reported_capex_usd_mm=3800.0,
+        ),
+        make_record(
+            operator="AcmeCorp",
+            scope=analytics_module.SCOPE_OPERATOR,
+            project_name=None,
+            fiscal_year=2021,
+            reported_capex_usd_mm=4200.0,
+        ),
+        make_record(
+            operator="AcmeCorp",
+            scope=analytics_module.SCOPE_OPERATOR,
+            project_name=None,
+            fiscal_year=2022,
+            reported_capex_usd_mm=5000.0,
+        ),
+        # Project-scope row that must not leak into operator view.
+        make_record(
+            operator="AcmeCorp",
+            project_name="Mariner-A",
+            fiscal_year=2022,
+            reported_capex_usd_mm=950.0,
+        ),
+    ]
+
+
+# --------------------------------------------------------------------------
+# Project revision view
+# --------------------------------------------------------------------------
+
+
+class TestProjectRevisionView:
+    def test_project_scope_records_produce_project_revision_view(
+        self, analytics_module, project_dataset
+    ):
+        """Project rows create a derived revision view with YoY deltas."""
+        view = analytics_module.load_project_cost_revision_view(project_dataset)
+        mariner = [
+            r for r in view if r.operator == "AcmeCorp" and r.project_name == "Mariner-A"
+        ]
+        assert len(mariner) == 3
+        mariner_sorted = sorted(mariner, key=lambda r: r.fiscal_year)
+        assert mariner_sorted[0].yoy_delta_usd_mm is None
+        assert mariner_sorted[0].yoy_delta_pct is None
+        assert mariner_sorted[1].yoy_delta_usd_mm == pytest.approx(100.0)
+        assert mariner_sorted[1].yoy_delta_pct == pytest.approx(0.125)
+        assert mariner_sorted[2].yoy_delta_usd_mm == pytest.approx(50.0)
+        assert mariner_sorted[2].yoy_delta_pct == pytest.approx(50.0 / 900.0)
+
+    def test_operator_rows_never_appear_in_linkable_project_view(
+        self, analytics_module, project_dataset
+    ):
+        view = analytics_module.load_project_cost_revision_view(project_dataset)
+        for row in view:
+            assert row.project_name is not None
+            assert row.project_name != ""
+
+    def test_derived_rows_preserve_provenance_fields(
+        self, analytics_module, project_dataset
+    ):
+        view = analytics_module.load_project_cost_revision_view(project_dataset)
+        for row in view:
+            assert "source" in row.provenance
+            assert row.provenance["source"] == "10-K"
+            assert "filing_id" in row.provenance
+
+    def test_yoy_delta_only_computed_with_valid_prior_year(
+        self, analytics_module, make_record
+    ):
+        # Isolated single year: no prior -> no delta.
+        records = [
+            make_record(
+                operator="SoloCorp",
+                project_name="OnlyProject",
+                fiscal_year=2022,
+                reported_capex_usd_mm=700.0,
+            ),
+        ]
+        view = analytics_module.load_project_cost_revision_view(records)
+        assert len(view) == 1
+        assert view[0].yoy_delta_usd_mm is None
+        assert view[0].yoy_delta_pct is None
+
+    def test_yoy_delta_not_computed_across_non_contiguous_operators(
+        self, analytics_module, make_record
+    ):
+        """Prior-year comparison must be per (operator, project) group, not cross-group."""
+        records = [
+            make_record(
+                operator="Op1",
+                project_name="P",
+                fiscal_year=2020,
+                reported_capex_usd_mm=100.0,
+            ),
+            make_record(
+                operator="Op2",
+                project_name="P",
+                fiscal_year=2021,
+                reported_capex_usd_mm=300.0,
+            ),
+        ]
+        view = analytics_module.load_project_cost_revision_view(records)
+        op2 = [r for r in view if r.operator == "Op2"][0]
+        assert op2.yoy_delta_usd_mm is None
+
+
+# --------------------------------------------------------------------------
+# Operator annual capex view
+# --------------------------------------------------------------------------
+
+
+class TestOperatorCapexView:
+    def test_operator_scope_records_produce_operator_capex_view(
+        self, analytics_module, operator_dataset
+    ):
+        view = analytics_module.load_operator_annual_capex_view(operator_dataset)
+        acme = sorted(
+            [r for r in view if r.operator == "AcmeCorp"], key=lambda r: r.fiscal_year
+        )
+        assert len(acme) == 3
+        assert acme[0].yoy_delta_usd_mm is None
+        assert acme[1].yoy_delta_usd_mm == pytest.approx(400.0)
+        assert acme[2].yoy_delta_usd_mm == pytest.approx(800.0)
+        assert acme[1].yoy_delta_pct == pytest.approx(400.0 / 3800.0)
+
+    def test_project_rows_never_appear_in_operator_view(
+        self, analytics_module, operator_dataset
+    ):
+        view = analytics_module.load_operator_annual_capex_view(operator_dataset)
+        # Operator view rows must not carry project-scope residue.
+        for row in view:
+            # The derived row schema has no project_name field at all -> attribute error is OK,
+            # but if present (future schema evolution), it must be falsy.
+            project_attr = getattr(row, "project_name", None)
+            assert not project_attr
+
+
+# --------------------------------------------------------------------------
+# Raw-vs-derived separation
+# --------------------------------------------------------------------------
+
+
+class TestRawVsDerivedSeparation:
+    def test_raw_records_are_not_mutated_by_view_generation(
+        self, analytics_module, project_dataset
+    ):
+        snapshot = copy.deepcopy(project_dataset)
+        analytics_module.load_project_cost_revision_view(project_dataset)
+        analytics_module.load_operator_annual_capex_view(project_dataset)
+        assert project_dataset == snapshot
+
+    def test_derived_provenance_is_isolated_from_raw(
+        self, analytics_module, project_dataset
+    ):
+        view = analytics_module.load_project_cost_revision_view(project_dataset)
+        # Mutating a derived row's provenance must not bleed back into raw.
+        first = view[0]
+        first.provenance["injected"] = True
+        for raw in project_dataset:
+            assert "injected" not in raw.provenance
+
+
+# --------------------------------------------------------------------------
+# Cost-side consumer hook (benchmark)
+# --------------------------------------------------------------------------
+
+
+class TestCostDisclosureBenchmark:
+    def test_cost_consumer_can_compare_predictor_output_to_latest_disclosed_capex_when_rows_are_comparable(
+        self, analytics_module, make_record
+    ):
+        records = [
+            make_record(
+                operator="AcmeCorp",
+                project_name="Mariner-A",
+                fiscal_year=2022,
+                reported_capex_usd_mm=950.0,
+                comparability_status=analytics_module.COMPARABILITY_COMPARABLE,
+                comparability_basis="USD-2020-real",
+            ),
+        ]
+        view = analytics_module.load_project_cost_revision_view(records)
+        result = analytics_module.build_cost_disclosure_benchmark(
+            view,
+            predictor_cost_usd_mm=1100.0,
+            operator="AcmeCorp",
+            project_name="Mariner-A",
+        )
+        assert result is not None
+        assert result.disclosed_capex_usd_mm == pytest.approx(950.0)
+        assert result.predicted_capex_usd_mm == pytest.approx(1100.0)
+        assert result.absolute_delta_usd_mm == pytest.approx(150.0)
+        assert result.pct_delta == pytest.approx(150.0 / 950.0)
+        assert result.comparability_status == analytics_module.COMPARABILITY_COMPARABLE
+
+    def test_cost_consumer_refuses_mixed_basis_or_non_comparable_rows(
+        self, analytics_module, make_record
+    ):
+        records = [
+            make_record(
+                operator="AcmeCorp",
+                project_name="Mariner-A",
+                fiscal_year=2022,
+                reported_capex_usd_mm=950.0,
+                comparability_status="mixed_basis",
+            ),
+        ]
+        view = analytics_module.load_project_cost_revision_view(records)
+        result = analytics_module.build_cost_disclosure_benchmark(
+            view,
+            predictor_cost_usd_mm=1100.0,
+            operator="AcmeCorp",
+            project_name="Mariner-A",
+        )
+        assert result is None
+
+    def test_cost_consumer_refuses_rows_with_missing_comparability_metadata(
+        self, analytics_module, make_record
+    ):
+        # comparability_status defaults to None — must be rejected rather than assumed comparable.
+        records = [
+            make_record(
+                operator="AcmeCorp",
+                project_name="Mariner-A",
+                fiscal_year=2022,
+                reported_capex_usd_mm=950.0,
+            ),
+        ]
+        view = analytics_module.load_project_cost_revision_view(records)
+        result = analytics_module.build_cost_disclosure_benchmark(
+            view,
+            predictor_cost_usd_mm=1100.0,
+            operator="AcmeCorp",
+            project_name="Mariner-A",
+        )
+        assert result is None
+
+    def test_cost_consumer_returns_none_when_no_matching_project(
+        self, analytics_module, make_record
+    ):
+        records = [
+            make_record(
+                operator="AcmeCorp",
+                project_name="Mariner-A",
+                fiscal_year=2022,
+                reported_capex_usd_mm=950.0,
+                comparability_status=analytics_module.COMPARABILITY_COMPARABLE,
+            ),
+        ]
+        view = analytics_module.load_project_cost_revision_view(records)
+        result = analytics_module.build_cost_disclosure_benchmark(
+            view,
+            predictor_cost_usd_mm=1100.0,
+            operator="Unknown",
+            project_name="Mariner-A",
+        )
+        assert result is None
+
+
+# --------------------------------------------------------------------------
+# Deferral invariant: lower_tertiary untouched by #338
+# --------------------------------------------------------------------------
+
+
+class TestLowerTertiaryDeferralInvariant:
+    def test_no_lower_tertiary_behavior_changes_are_introduced(self):
+        """#338 must not import or mutate anything in ``lower_tertiary``.
+
+        This is a static guard — the analytics module's source must not
+        reference the lower-tertiary namespace at all.
+        """
+        import worldenergydata.cost.disclosure_analytics as analytics
+
+        source = inspect.getsource(analytics)
+        assert "lower_tertiary" not in source, (
+            "disclosure_analytics must not reference lower_tertiary until a "
+            "dedicated mapping contract exists (see issue #338 plan)."
+        )
+
+    def test_lower_tertiary_npv_module_remains_importable_unchanged(self):
+        """Basic smoke — lower_tertiary.npv must still import without side effects from #338."""
+        module = importlib.import_module("worldenergydata.lower_tertiary.npv")
+        # Confirm module loaded — we do not make assertions on internal behavior
+        # because #338 is not in the business of lower-tertiary economics.
+        assert module is not None
+
+
+# --------------------------------------------------------------------------
+# Public export surface
+# --------------------------------------------------------------------------
+
+
+class TestCostPackageExports:
+    def test_cost_package_exposes_disclosure_analytics_surface(self):
+        from worldenergydata import cost
+
+        for name in (
+            "DisclosureRecord",
+            "ProjectRevisionRow",
+            "OperatorCapexRow",
+            "DisclosureBenchmarkResult",
+            "load_project_cost_revision_view",
+            "load_operator_annual_capex_view",
+            "build_cost_disclosure_benchmark",
+            "COMPARABILITY_COMPARABLE",
+            "SCOPE_PROJECT",
+            "SCOPE_OPERATOR",
+        ):
+            assert hasattr(cost, name), f"cost module missing export: {name}"
+
+    def test_cost_predictor_exports_remain_intact(self):
+        from worldenergydata import cost
+
+        # #338 must not regress the existing cost public API.
+        assert hasattr(cost, "CostPredictor")
+        assert hasattr(cost, "PredictionResult")
+        assert hasattr(cost, "CostDataPoint")
+        assert hasattr(cost, "load_public_dataset")

--- a/tests/unit/fdas/test_disclosure_api.py
+++ b/tests/unit/fdas/test_disclosure_api.py
@@ -1,0 +1,191 @@
+# ABOUTME: Tests for the FDAS disclosure analytics namespace/query seam (issue #338).
+# ABOUTME: Verifies explicit grounding in fdas/api.py + lazy export via fdas/__init__.py.
+
+"""Tests for ``worldenergydata.fdas.api.DisclosureAnalyticsQuery``.
+
+The FDAS consumer-facing surface for annual disclosure analytics lives in
+``fdas/api.py``. It must:
+
+  - be explicitly named and importable from that module,
+  - be reachable via the lazy attribute pattern on the ``fdas`` package,
+  - delegate to ``cost.disclosure_analytics`` (no duplicated logic),
+  - not regress the existing ``economics`` namespace.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import pytest
+
+
+@pytest.fixture
+def analytics_module():
+    return importlib.import_module("worldenergydata.cost.disclosure_analytics")
+
+
+@pytest.fixture
+def sample_records(analytics_module):
+    DR = analytics_module.DisclosureRecord
+    return [
+        DR(
+            operator="AcmeCorp",
+            fiscal_year=2021,
+            reported_capex_usd_mm=800.0,
+            scope=analytics_module.SCOPE_PROJECT,
+            project_name="Mariner-A",
+            provenance={"source": "10-K"},
+        ),
+        DR(
+            operator="AcmeCorp",
+            fiscal_year=2022,
+            reported_capex_usd_mm=900.0,
+            scope=analytics_module.SCOPE_PROJECT,
+            project_name="Mariner-A",
+            provenance={"source": "10-K"},
+        ),
+        DR(
+            operator="AcmeCorp",
+            fiscal_year=2021,
+            reported_capex_usd_mm=4200.0,
+            scope=analytics_module.SCOPE_OPERATOR,
+            provenance={"source": "10-K"},
+        ),
+        DR(
+            operator="AcmeCorp",
+            fiscal_year=2022,
+            reported_capex_usd_mm=5000.0,
+            scope=analytics_module.SCOPE_OPERATOR,
+            provenance={"source": "10-K"},
+        ),
+    ]
+
+
+# --------------------------------------------------------------------------
+# API seam grounding — the plan requires the surface be hosted explicitly
+# in fdas/api.py, not as a loose package attribute.
+# --------------------------------------------------------------------------
+
+
+class TestDisclosureAnalyticsAPISeam:
+    def test_fdas_api_module_defines_disclosure_analytics_query_class(self):
+        api = importlib.import_module("worldenergydata.fdas.api")
+        assert hasattr(api, "DisclosureAnalyticsQuery")
+        assert inspect.isclass(api.DisclosureAnalyticsQuery)
+
+    def test_fdas_api_module_exposes_disclosure_analytics_singleton(self):
+        api = importlib.import_module("worldenergydata.fdas.api")
+        assert hasattr(api, "disclosure_analytics")
+        assert isinstance(api.disclosure_analytics, api.DisclosureAnalyticsQuery)
+
+    def test_disclosure_query_has_project_and_operator_methods(self):
+        api = importlib.import_module("worldenergydata.fdas.api")
+        cls = api.DisclosureAnalyticsQuery
+        assert callable(getattr(cls, "project_revision", None))
+        assert callable(getattr(cls, "operator_capex", None))
+        assert callable(getattr(cls, "benchmark", None))
+
+
+# --------------------------------------------------------------------------
+# Lazy export via fdas/__init__.py
+# --------------------------------------------------------------------------
+
+
+class TestFDASPackageLazyExport:
+    def test_fdas_exposes_disclosure_analytics_namespace(self):
+        fdas = importlib.import_module("worldenergydata.fdas")
+        ns = fdas.disclosure_analytics
+        assert ns is not None
+
+    def test_fdas_package_still_exposes_economics_namespace(self):
+        """Regression guard — #338 must not break the #288 query API seam."""
+        fdas = importlib.import_module("worldenergydata.fdas")
+        assert fdas.economics is not None
+
+    def test_fdas_package_unknown_attribute_still_raises(self):
+        fdas = importlib.import_module("worldenergydata.fdas")
+        with pytest.raises(AttributeError):
+            _ = fdas.nonexistent_attribute_xyz
+
+
+# --------------------------------------------------------------------------
+# Query behavior — project + operator views returned via FDAS seam
+# --------------------------------------------------------------------------
+
+
+class TestFDASDisclosureQueryBehavior:
+    def test_fdas_query_object_returns_project_revision_view(
+        self, sample_records, analytics_module
+    ):
+        from worldenergydata.fdas.api import disclosure_analytics
+
+        view = disclosure_analytics.project_revision(sample_records)
+        assert all(
+            isinstance(row, analytics_module.ProjectRevisionRow) for row in view
+        )
+        mariner = sorted(
+            [r for r in view if r.project_name == "Mariner-A"],
+            key=lambda r: r.fiscal_year,
+        )
+        assert len(mariner) == 2
+        assert mariner[0].yoy_delta_usd_mm is None
+        assert mariner[1].yoy_delta_usd_mm == pytest.approx(100.0)
+
+    def test_fdas_query_object_returns_operator_capex_view(
+        self, sample_records, analytics_module
+    ):
+        from worldenergydata.fdas.api import disclosure_analytics
+
+        view = disclosure_analytics.operator_capex(sample_records)
+        assert all(
+            isinstance(row, analytics_module.OperatorCapexRow) for row in view
+        )
+        acme = sorted(
+            [r for r in view if r.operator == "AcmeCorp"], key=lambda r: r.fiscal_year
+        )
+        assert len(acme) == 2
+        assert acme[1].yoy_delta_usd_mm == pytest.approx(800.0)
+
+    def test_fdas_benchmark_refuses_non_comparable_rows(
+        self, sample_records, analytics_module
+    ):
+        """FDAS benchmark is the same gated hook — non-comparable rows must refuse."""
+        from worldenergydata.fdas.api import disclosure_analytics
+
+        view = disclosure_analytics.project_revision(sample_records)
+        result = disclosure_analytics.benchmark(
+            view,
+            predictor_cost_usd_mm=1000.0,
+            operator="AcmeCorp",
+            project_name="Mariner-A",
+        )
+        # None of the sample records are flagged COMPARABILITY_COMPARABLE.
+        assert result is None
+
+    def test_fdas_benchmark_accepts_comparable_rows(self, analytics_module):
+        from worldenergydata.fdas.api import disclosure_analytics
+
+        DR = analytics_module.DisclosureRecord
+        records = [
+            DR(
+                operator="AcmeCorp",
+                fiscal_year=2022,
+                reported_capex_usd_mm=950.0,
+                scope=analytics_module.SCOPE_PROJECT,
+                project_name="Mariner-A",
+                provenance={"source": "10-K"},
+                comparability_status=analytics_module.COMPARABILITY_COMPARABLE,
+                comparability_basis="USD-2020-real",
+            ),
+        ]
+        view = disclosure_analytics.project_revision(records)
+        result = disclosure_analytics.benchmark(
+            view,
+            predictor_cost_usd_mm=1100.0,
+            operator="AcmeCorp",
+            project_name="Mariner-A",
+        )
+        assert result is not None
+        assert result.disclosed_capex_usd_mm == pytest.approx(950.0)
+        assert result.absolute_delta_usd_mm == pytest.approx(150.0)


### PR DESCRIPTION
## Summary
- add annual disclosure analytics views in the cost package
- expose the analytics surface through FDAS integration points
- add targeted analytics, FDAS, and query-surface regression tests

## Validation
- `PYTHONPATH='src:../assetutilities/src' uv run python -m pytest --noconftest tests/unit/cost/test_disclosure_analytics.py tests/unit/fdas/test_disclosure_api.py tests/test_query_api.py --no-cov -v`

Closes #338
