### PR TITLE
fix(tests): symlink E2E test must fail (not skip) when /mnt/ace mounted but symlink missing

### DIFF
--- a/tests/integration/test_data_symlink.py
+++ b/tests/integration/test_data_symlink.py
@@ -33,8 +33,28 @@ from worldenergydata.common.data_resolver import (
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DATA_DIR = PROJECT_ROOT / "data"
 SETUP_SCRIPT = PROJECT_ROOT / "scripts" / "setup-data-link.sh"
+ACE_MOUNT = Path("/mnt/ace/worldenergydata")
 
 _is_symlink = DATA_DIR.is_symlink()
+_ace_mount_exists = ACE_MOUNT.exists()
+
+
+def _require_symlink_or_skip():
+    """Distinguish legitimate skip from deployment drift.
+
+    Skip when /mnt/ace isn't mounted on this host (e.g., CI without the mount).
+    FAIL when /mnt/ace IS present but data/ isn't a symlink — that's the bug
+    pattern from #298/#359/#368: precondition-skipif silently masking a broken
+    deployment. /mnt/ace data exists, the catalog claims it's reachable, but
+    the symlink wiring was never done.
+    """
+    if not _ace_mount_exists:
+        pytest.skip("/mnt/ace mount not present on this host")
+    if not _is_symlink:
+        pytest.fail(
+            f"Drift detected: {ACE_MOUNT} exists but {DATA_DIR} is not a symlink. "
+            f"Run scripts/setup-data-link.sh. See #359 for context."
+        )
 
 
 @pytest.fixture(autouse=True)
@@ -62,10 +82,10 @@ def test_setup_data_link_script_exists():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(not _is_symlink, reason="requires data symlink to /mnt/ace")
 @pytest.mark.integration
 def test_data_resolver_follows_symlink():
     """When data/ is a symlink, DataResolver resolves through it."""
+    _require_symlink_or_skip()
     root = get_data_root()
     assert root.is_dir()
     # The resolved path should NOT be the symlink itself
@@ -90,10 +110,10 @@ def test_data_resolver_with_env_var_override(monkeypatch, tmp_path):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(not _is_symlink, reason="requires data symlink to /mnt/ace")
 @pytest.mark.integration
 def test_bsee_bin_accessible_via_symlink():
     """BSEE binary data is reachable through the symlink."""
+    _require_symlink_or_skip()
     bsee_path = get_module_data("bsee")
     assert bsee_path.is_dir(), f"BSEE module dir missing: {bsee_path}"
     # Sanity: directory should contain files
@@ -106,10 +126,10 @@ def test_bsee_bin_accessible_via_symlink():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(not _is_symlink, reason="requires data symlink to /mnt/ace")
 @pytest.mark.integration
 def test_hse_raw_accessible_via_symlink():
     """HSE OSHA CSVs are reachable through the symlink."""
+    _require_symlink_or_skip()
     hse_path = get_module_data("hse")
     assert hse_path.is_dir(), f"HSE module dir missing: {hse_path}"
     children = list(hse_path.iterdir())


### PR DESCRIPTION
## Summary

- Three tests in `tests/integration/test_data_symlink.py` used `@pytest.mark.skipif(not _is_symlink, ...)`, silently skipping the very condition #298 was supposed to assert. Result: the test stayed green-or-skipped through 37 days of broken catalog wiring.
- This PR distinguishes **\"environment can't run the test\"** (legitimate skip when `/mnt/ace` isn't mounted) from **\"the thing under test is broken\"** (deployment drift — `/mnt/ace` IS mounted but the symlink wasn't wired).
- New helper `_require_symlink_or_skip()` calls `pytest.skip` in the first case and `pytest.fail` in the second, with a message pointing at `scripts/setup-data-link.sh` and #359.

## Why this is safe to merge

CI environments do NOT mount `/mnt/ace`, so `_ace_mount_exists` evaluates `False` and the three tests skip cleanly — same observable behavior as before in CI. The new failure surface only triggers on hosts where `/mnt/ace` IS mounted (local dev, ace-linux-1) — which is exactly the population that should be alerted to fix #359.

## Verification (run locally with /mnt/ace mounted, no symlink)

```
$ uv run pytest tests/integration/test_data_symlink.py -v
...
FAILED test_data_resolver_follows_symlink — Drift detected: /mnt/ace/worldenergydata exists but .../data is not a symlink. Run scripts/setup-data-link.sh. See #359 for context.
FAILED test_bsee_bin_accessible_via_symlink — (same)
FAILED test_hse_raw_accessible_via_symlink — (same)
3 failed, 4 passed
```

The four other tests (script existence, env var override, graceful degradation, broken-symlink handling) are unaffected.

## Pattern worth promoting

> A test's `skipif` should answer **\"is this environment capable of running the test?\"** — not **\"is the thing under test still working?\"** When the precondition is itself the deployment requirement under test, use `pytest.fail` (not `skip`) so CI catches the drift.

## Test plan

- [x] `uv run pytest tests/integration/test_data_symlink.py -v` on host with `/mnt/ace` mounted but no symlink → 3 fail with drift message, 4 pass
- [ ] CI on default runner (no `/mnt/ace`) → 3 skip cleanly, 4 pass
- [ ] After #359 lands and symlink is wired → 7 pass

## Refs

- Closes the meta-drift on #299 (the test)
- Forces visibility of #359 (the underlying deployment drift)
- Implements the live-verification pattern proposed in #368