### PR TITLE
docs(hse): route HSE acquirer/importer Usage examples through DataResolver

### DIFF
--- a/src/worldenergydata/hse/acquirers/bsee_acquirer.py
+++ b/src/worldenergydata/hse/acquirers/bsee_acquirer.py
@@ -12,15 +12,17 @@ Datasets:
     - INCs: Incidents of Non-Compliance (~51K operator-level records)
 
 Usage:
-    # As module
+    # As module — use DataResolver so the path resolves correctly whether
+    # data/ is in-repo or symlinked to /mnt/ace per #359.
+    from worldenergydata.common.data_resolver import get_module_data
     from worldenergydata.hse.acquirers.bsee_acquirer import BSEEAcquirer
 
     acquirer = BSEEAcquirer()
-    results = acquirer.download_all("data/modules/hse/raw/bsee")
+    results = acquirer.download_all(get_module_data("hse") / "raw/bsee")
 
     # CLI
     uv run python -m worldenergydata.hse.acquirers.bsee_acquirer \\
-        --output-dir data/modules/hse/raw/bsee --force
+        --output-dir "$(get_module_data hse)/raw/bsee" --force
 """
 
 import argparse

--- a/src/worldenergydata/hse/acquirers/osha_acquirer.py
+++ b/src/worldenergydata/hse/acquirers/osha_acquirer.py
@@ -14,15 +14,17 @@ Datasets:
     - Accident Injuries: Individual injury details from accidents
 
 Usage:
-    # As module
+    # As module — use DataResolver so the path resolves correctly whether
+    # data/ is in-repo or symlinked to /mnt/ace per #359.
+    from worldenergydata.common.data_resolver import get_module_data
     from worldenergydata.hse.acquirers.osha_acquirer import OSHAAcquirer
 
     acquirer = OSHAAcquirer()
-    results = acquirer.download_all("data/modules/hse/raw/osha")
+    results = acquirer.download_all(get_module_data("hse") / "raw/osha")
 
     # CLI
     uv run python -m worldenergydata.hse.acquirers.osha_acquirer \\
-        --output-dir data/modules/hse/raw/osha --force --filter-naics
+        --output-dir "$(get_module_data hse)/raw/osha" --force --filter-naics
 """
 
 import argparse

--- a/src/worldenergydata/hse/acquirers/osha_fatalities_acquirer.py
+++ b/src/worldenergydata/hse/acquirers/osha_fatalities_acquirer.py
@@ -13,16 +13,19 @@ Datasets:
     - Fatality Inspections: Extracted from main inspection dataset (type 'A')
 
 Usage:
+    # Use DataResolver so the path resolves correctly whether data/ is in-repo
+    # or symlinked to /mnt/ace per #359.
+    from worldenergydata.common.data_resolver import get_module_data
     from worldenergydata.hse.acquirers.osha_fatalities_acquirer import (
         OSHAFatalitiesAcquirer,
     )
 
     acquirer = OSHAFatalitiesAcquirer()
-    results = acquirer.download_all("data/modules/hse/raw/osha/fatalities")
+    results = acquirer.download_all(get_module_data("hse") / "raw/osha/fatalities")
 
     # CLI
     uv run python -m worldenergydata.hse.acquirers.osha_fatalities_acquirer \\
-        --output-dir data/modules/hse/raw/osha/fatalities --force
+        --output-dir "$(get_module_data hse)/raw/osha/fatalities" --force
 """
 
 import argparse

--- a/src/worldenergydata/hse/importers/bsee_incinv_importer.py
+++ b/src/worldenergydata/hse/importers/bsee_incinv_importer.py
@@ -12,16 +12,18 @@ a tab-delimited text file with columns:
 Maps records to the HSEIncident database model.
 
 Usage:
-    # As module
+    # As module — use DataResolver so the path resolves correctly whether
+    # data/ is in-repo or symlinked to /mnt/ace per #359.
+    from worldenergydata.common.data_resolver import get_module_data
     from worldenergydata.hse.importers.bsee_incinv_importer import BSEEIncInvImporter
 
-    importer = BSEEIncInvImporter(data_dir="data/modules/hse/raw/bsee")
+    importer = BSEEIncInvImporter(data_dir=get_module_data("hse") / "raw/bsee")
     records = importer.load()
     logger.info(f"Loaded {len(records)} incident investigation records")
 
     # CLI
     uv run python -m worldenergydata.hse.importers.bsee_incinv_importer \\
-        --data-dir data/modules/hse/raw/bsee
+        --data-dir "$(get_module_data hse)/raw/bsee"
 """
 
 import argparse

--- a/src/worldenergydata/hse/importers/bsee_incs_importer.py
+++ b/src/worldenergydata/hse/importers/bsee_incs_importer.py
@@ -13,16 +13,18 @@ Primary file columns (mv_incs_by_oper.txt):
     WARNING_INCS, COMP_SHUTIN_INCS, FAC_SHUTIN_INCS
 
 Usage:
-    # As module
+    # As module — use DataResolver so the path resolves correctly whether
+    # data/ is in-repo or symlinked to /mnt/ace per #359.
+    from worldenergydata.common.data_resolver import get_module_data
     from worldenergydata.hse.importers.bsee_incs_importer import BSEEINCSImporter
 
-    importer = BSEEINCSImporter(data_dir="data/modules/hse/raw/bsee")
+    importer = BSEEINCSImporter(data_dir=get_module_data("hse") / "raw/bsee")
     records = importer.load()
     logger.info(f"Loaded {len(records)} INC records")
 
     # CLI
     uv run python -m worldenergydata.hse.importers.bsee_incs_importer \\
-        --data-dir data/modules/hse/raw/bsee
+        --data-dir "$(get_module_data hse)/raw/bsee"
 """
 
 import argparse

--- a/src/worldenergydata/hse/importers/osha_importer.py
+++ b/src/worldenergydata/hse/importers/osha_importer.py
@@ -17,14 +17,20 @@ Column mappings:
     - Inspection type mapped to incident_type and severity
 
 Usage:
+    # Use DataResolver so the path resolves correctly whether data/ is in-repo
+    # or symlinked to /mnt/ace per #359.
+    from worldenergydata.common.data_resolver import get_module_data
     from worldenergydata.hse.importers.osha_importer import OSHAImporter
 
-    importer = OSHAImporter(db_session=session, data_dir="data/modules/hse/raw/osha")
+    importer = OSHAImporter(
+        db_session=session,
+        data_dir=get_module_data("hse") / "raw/osha",
+    )
     stats = importer.import_data()
 
     # CLI
     uv run python -m worldenergydata.hse.importers.osha_importer \\
-        --data-dir data/modules/hse/raw/osha
+        --data-dir "$(get_module_data hse)/raw/osha"
 """
 
 import argparse


### PR DESCRIPTION
## Summary

- 6 HSE module docstrings showed `Usage:` examples with hardcoded `\"data/modules/hse/raw/...\"` paths.
- After the 2026-03-24 relocation those paths resolve through the planned data symlink (#359), but the docstrings were teaching contributors to think of the repo-relative literal as canonical.
- Replaced each example with the canonical `get_module_data()` pattern from `worldenergydata.common.data_resolver`.

## Why

Docstrings are the first place a contributor learns a module's intended use. Showing them a path that's about to become a symlink target — and won't work without #359 wired — is a foot-gun for new contributors. After this PR every HSE acquirer/importer docstring teaches the right pattern.

## Files changed (6)

| File | Change |
|------|--------|
| `src/worldenergydata/hse/acquirers/osha_acquirer.py` | Usage example uses `get_module_data(\"hse\") / \"raw/osha\"` |
| `src/worldenergydata/hse/acquirers/osha_fatalities_acquirer.py` | …`/ \"raw/osha/fatalities\"` |
| `src/worldenergydata/hse/acquirers/bsee_acquirer.py` | …`/ \"raw/bsee\"` |
| `src/worldenergydata/hse/importers/bsee_incs_importer.py` | …`/ \"raw/bsee\"` |
| `src/worldenergydata/hse/importers/bsee_incinv_importer.py` | …`/ \"raw/bsee\"` |
| `src/worldenergydata/hse/importers/osha_importer.py` | …`/ \"raw/osha\"` |

## Scope intentionally limited

- **No code logic changes** — only docstring text
- **CLI parsers untouched** — making `--output-dir` default to `get_module_data()` is a separate, larger change (would need argparse default callable refactor); leaving that for a future PR if desired
- **eia_us_refresh.py NOT touched** — its `data/modules/eia` reference describes a default in prose, not a hardcoded literal

## Test plan

- [x] `git diff` confirms only docstring lines changed
- [x] `grep '\"data/modules/hse' src/` returns nothing in the changed files
- [ ] CI: 13/13 checks pass (will run via the new branch protection on main, validating gating works)

## Refs

- Closes the partial-drift comment on #285 from 2026-05-02 hygiene sweep (#368)
- Compatible with #359 — examples become *more* correct once symlink wiring lands