### PR TITLE
fix(data): partial-symlink relocation wiring for /mnt/ace data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,12 @@ coordination/orchestration/*
 # Pipeline-regenerable data (see DATA_RESIDENCE_POLICY.md)
 # ============================================================
 
+# Per-host relocation symlinks created by scripts/setup-data-link.sh (#359).
+# These point to /mnt/ace bulk data and are host-specific — never commit.
+/data/modules/bsee/bin
+/data/modules/bsee/zip
+/data/modules/hse/raw
+
 # OSHA raw data (regenerate: osha_acquirer.py)
 data/modules/hse/raw/osha/*.csv
 data/modules/hse/raw/osha/*.csv.zip

--- a/scripts/setup-data-link.sh
+++ b/scripts/setup-data-link.sh
@@ -1,45 +1,137 @@
 #!/usr/bin/env bash
-# Setup data symlink for worldenergydata
-# Usage: ./scripts/setup-data-link.sh [/path/to/data]
+# Setup partial data symlinks for worldenergydata.
+#
+# Per the 2026-03-24 relocation (RELOCATION-LOG.md at /mnt/ace/worldenergydata),
+# bulk public data (~9.4 GB across HSE raw + BSEE bin/zip) lives outside the
+# git repo. Smaller modules (BSEE current, paleowells, marine_safety,
+# vessel_hull_models, etc.) stay in the repo. This script wires the three
+# relocated subtrees as per-path symlinks INTO the repo's data/ tree, leaving
+# everything else untouched.
+#
+# Usage:
+#   ./scripts/setup-data-link.sh                                 # use default /mnt/ace
+#   ./scripts/setup-data-link.sh /custom/path/worldenergydata/data
+#   ./scripts/setup-data-link.sh --check                         # verify-only, no changes
+#
+# Refs: #359 (this fix), #298/#299 (prior whole-tree approach that didn't fit
+# the actual relocation topology), #369 (test that catches drift live).
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 DEFAULT_TARGET="/mnt/ace/worldenergydata/data"
-TARGET="${1:-$DEFAULT_TARGET}"
+
+CHECK_ONLY=0
+TARGET=""
+for arg in "$@"; do
+    case "$arg" in
+        --check) CHECK_ONLY=1 ;;
+        -h|--help)
+            sed -n '2,16p' "$0"
+            exit 0
+            ;;
+        *) TARGET="$arg" ;;
+    esac
+done
+TARGET="${TARGET:-$DEFAULT_TARGET}"
+
+# Subtrees that were relocated. Each entry is "<repo-relative-path>:<target-relative-path>".
+# Paths are repo-relative under data/ and target-relative under TARGET/.
+RELOCATED_SUBTREES=(
+    "data/modules/bsee/bin:modules/bsee/bin"
+    "data/modules/bsee/zip:modules/bsee/zip"
+    "data/modules/hse/raw:modules/hse/raw"
+)
 
 if [ ! -d "$TARGET" ]; then
-    echo "ERROR: Data directory does not exist: $TARGET"
-    echo "Usage: $0 /path/to/worldenergydata/data"
+    echo "ERROR: Relocation root does not exist: $TARGET" >&2
+    echo "       (default is $DEFAULT_TARGET; pass a different path as the first arg)" >&2
     exit 1
 fi
 
-LINK="$PROJECT_ROOT/data"
+errors=0
+created=0
+verified=0
+repaired=0
 
-if [ -L "$LINK" ]; then
-    CURRENT=$(readlink -f "$LINK")
-    if [ "$CURRENT" = "$(readlink -f "$TARGET")" ]; then
-        echo "Symlink already correct: data -> $TARGET"
-    else
-        echo "Updating symlink: data -> $TARGET (was $CURRENT)"
-        rm "$LINK"
-        ln -s "$TARGET" "$LINK"
+for entry in "${RELOCATED_SUBTREES[@]}"; do
+    repo_rel="${entry%%:*}"
+    target_rel="${entry##*:}"
+    link="$PROJECT_ROOT/$repo_rel"
+    target="$TARGET/$target_rel"
+    parent="$(dirname "$link")"
+
+    if [ ! -d "$target" ]; then
+        echo "ERROR: Target missing for $repo_rel: $target" >&2
+        errors=$((errors + 1))
+        continue
     fi
-elif [ -d "$LINK" ]; then
-    echo "WARNING: data/ is a real directory, not a symlink."
-    echo "To use external data, remove it first: rm -rf $LINK"
-    exit 1
-else
-    ln -s "$TARGET" "$LINK"
-    echo "Created symlink: data -> $TARGET"
-fi
 
-for dir in modules/bsee modules/hse; do
-    if [ -d "$TARGET/$dir" ]; then
-        echo "  OK: $dir exists"
+    if [ ! -d "$parent" ]; then
+        echo "ERROR: Repo parent dir missing for $repo_rel: $parent" >&2
+        echo "       This script does not create parent directories — fix the repo layout first." >&2
+        errors=$((errors + 1))
+        continue
+    fi
+
+    # Refuse to clobber a real directory with content (data loss risk).
+    if [ -d "$link" ] && [ ! -L "$link" ]; then
+        if [ -n "$(ls -A "$link" 2>/dev/null)" ]; then
+            echo "ERROR: $repo_rel is a real directory with content; refusing to replace." >&2
+            echo "       If this content is safe to discard, remove it manually then re-run." >&2
+            errors=$((errors + 1))
+            continue
+        else
+            # Empty real dir — safe to remove and replace.
+            if [ "$CHECK_ONLY" = "1" ]; then
+                echo "  WOULD REPAIR (empty dir): $repo_rel -> $target"
+            else
+                rmdir "$link"
+                ln -s "$target" "$link"
+                echo "  REPAIRED (was empty dir): $repo_rel -> $target"
+                repaired=$((repaired + 1))
+            fi
+            continue
+        fi
+    fi
+
+    if [ -L "$link" ]; then
+        current="$(readlink -f "$link")"
+        if [ "$current" = "$(readlink -f "$target")" ]; then
+            echo "  OK: $repo_rel -> $target"
+            verified=$((verified + 1))
+        else
+            if [ "$CHECK_ONLY" = "1" ]; then
+                echo "  WOULD REPAIR (wrong target): $repo_rel -> $target (was $current)"
+            else
+                rm "$link"
+                ln -s "$target" "$link"
+                echo "  REPAIRED (wrong target): $repo_rel -> $target (was $current)"
+                repaired=$((repaired + 1))
+            fi
+        fi
+        continue
+    fi
+
+    if [ "$CHECK_ONLY" = "1" ]; then
+        echo "  WOULD CREATE: $repo_rel -> $target"
     else
-        echo "  WARN: $dir not found in $TARGET"
+        ln -s "$target" "$link"
+        echo "  CREATED: $repo_rel -> $target"
+        created=$((created + 1))
     fi
 done
 
-echo "Done. Data root: $TARGET"
+echo
+if [ "$errors" -gt 0 ]; then
+    echo "FAILED: $errors error(s); $created created, $repaired repaired, $verified verified." >&2
+    exit 1
+fi
+
+if [ "$CHECK_ONLY" = "1" ]; then
+    echo "Check complete. (use without --check to apply changes)"
+else
+    echo "Done. $created created, $repaired repaired, $verified already-correct."
+    echo "Verify: uv run pytest tests/integration/test_data_symlink.py -v"
+fi

--- a/tests/integration/test_data_symlink.py
+++ b/tests/integration/test_data_symlink.py
@@ -1,14 +1,19 @@
 """Integration tests for symlink-based data flow.
 
-These tests verify the two-tier data architecture:
-- Git repo holds small data files (~400 MB in data/modules/)
-- /mnt/ace/worldenergydata/data/ holds large files (BSEE bin, HSE raw)
-- A symlink connects them via scripts/setup-data-link.sh
+These tests verify the partial-symlink data architecture introduced by #359:
+- Git repo holds smaller modules in-tree (BSEE current, paleowells,
+  marine_safety, vessel_hull_models, schemas, catalogs — ~389 MB total)
+- /mnt/ace/worldenergydata/data/ holds the bulk relocated subtrees
+  (HSE raw 6.7 GB, BSEE bin 2.5 GB, BSEE zip 230 MB)
+- scripts/setup-data-link.sh wires the relocated subtrees as PER-PATH
+  symlinks INSIDE the repo's data/ tree (NOT a whole-tree symlink — that
+  would erase access to the in-tree modules)
 
 Resolution order tested (from data_resolver.py):
 1. WED_DATA_ROOT environment variable (explicit override)
-2. Symlink at <project_root>/data -> external mount
-3. Fallback to <project_root>/data/ directory (development)
+2. Repo's data/ directory (which contains per-subtree symlinks for the
+   relocated paths and real directories for everything else)
+3. DataNotFoundError if neither resolves
 """
 
 from __future__ import annotations
@@ -35,25 +40,36 @@ DATA_DIR = PROJECT_ROOT / "data"
 SETUP_SCRIPT = PROJECT_ROOT / "scripts" / "setup-data-link.sh"
 ACE_MOUNT = Path("/mnt/ace/worldenergydata")
 
-_is_symlink = DATA_DIR.is_symlink()
+# The three relocated subtrees per RELOCATION-LOG.md (2026-03-24).
+# Each (repo_path, ace_path) pair: repo_path is where the symlink lives,
+# ace_path is what it should point at.
+RELOCATED_SUBTREES = [
+    (DATA_DIR / "modules" / "bsee" / "bin", ACE_MOUNT / "data" / "modules" / "bsee" / "bin"),
+    (DATA_DIR / "modules" / "bsee" / "zip", ACE_MOUNT / "data" / "modules" / "bsee" / "zip"),
+    (DATA_DIR / "modules" / "hse" / "raw", ACE_MOUNT / "data" / "modules" / "hse" / "raw"),
+]
+
 _ace_mount_exists = ACE_MOUNT.exists()
+_all_relocated_links_present = all(p.is_symlink() for p, _ in RELOCATED_SUBTREES)
 
 
 def _require_symlink_or_skip():
     """Distinguish legitimate skip from deployment drift.
 
     Skip when /mnt/ace isn't mounted on this host (e.g., CI without the mount).
-    FAIL when /mnt/ace IS present but data/ isn't a symlink — that's the bug
-    pattern from #298/#359/#368: precondition-skipif silently masking a broken
-    deployment. /mnt/ace data exists, the catalog claims it's reachable, but
-    the symlink wiring was never done.
+    FAIL when /mnt/ace IS present but the per-subtree symlinks aren't wired —
+    that's the bug pattern from #298/#359/#368: precondition-skipif silently
+    masking a broken deployment. /mnt/ace data exists, the catalog claims it's
+    reachable, but the symlink wiring was never done.
     """
     if not _ace_mount_exists:
         pytest.skip("/mnt/ace mount not present on this host")
-    if not _is_symlink:
+    missing = [str(p) for p, _ in RELOCATED_SUBTREES if not p.is_symlink()]
+    if missing:
         pytest.fail(
-            f"Drift detected: {ACE_MOUNT} exists but {DATA_DIR} is not a symlink. "
-            f"Run scripts/setup-data-link.sh. See #359 for context."
+            f"Drift detected: {ACE_MOUNT} exists but per-subtree symlinks are "
+            f"missing at: {missing}. Run scripts/setup-data-link.sh. "
+            f"See #359 for context."
         )
 
 
@@ -78,18 +94,35 @@ def test_setup_data_link_script_exists():
 
 
 # ---------------------------------------------------------------------------
-# b) DataResolver follows symlink
+# b) Relocated subtrees resolve through per-path symlinks to /mnt/ace
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
-def test_data_resolver_follows_symlink():
-    """When data/ is a symlink, DataResolver resolves through it."""
+def test_relocated_subtrees_resolve_to_ace():
+    """Each per-subtree symlink resolves to its /mnt/ace counterpart."""
     _require_symlink_or_skip()
+    for link, expected_target in RELOCATED_SUBTREES:
+        assert link.is_symlink(), f"{link} is not a symlink"
+        assert link.resolve() == expected_target.resolve(), (
+            f"{link} resolves to {link.resolve()} (expected {expected_target})"
+        )
+        # The resolved path should be a real, populated directory.
+        assert link.is_dir(), f"{link} target is not a directory"
+        assert any(link.iterdir()), f"{link} target is empty"
+
+
+@pytest.mark.integration
+def test_data_root_is_repo_data_dir():
+    """data/ itself is a real directory (NOT a whole-tree symlink) under the partial-symlink topology."""
     root = get_data_root()
     assert root.is_dir()
-    # The resolved path should NOT be the symlink itself
-    assert root == DATA_DIR.resolve()
+    assert not DATA_DIR.is_symlink(), (
+        "data/ should be a real directory under the partial-symlink topology; "
+        "if it's a whole-tree symlink, that's the pre-#359 design that erases "
+        "access to in-repo modules. Run scripts/setup-data-link.sh after "
+        "removing the whole-tree symlink."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -106,34 +139,45 @@ def test_data_resolver_with_env_var_override(monkeypatch, tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# d) BSEE binary accessible via symlink
+# d) BSEE binary subtree is reachable specifically (not just bsee/ overall)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
 def test_bsee_bin_accessible_via_symlink():
-    """BSEE binary data is reachable through the symlink."""
+    """BSEE binary subtree (relocated) is reachable AND non-empty.
+
+    Targets data/modules/bsee/bin/ specifically — checking get_module_data('bsee')
+    alone would pass even with NO /mnt/ace mounted because bsee/ has in-repo
+    children (current/, paleowells/, schema.yaml, etc.). The point of this
+    test is that the RELOCATED subtree is wired correctly.
+    """
     _require_symlink_or_skip()
-    bsee_path = get_module_data("bsee")
-    assert bsee_path.is_dir(), f"BSEE module dir missing: {bsee_path}"
-    # Sanity: directory should contain files
-    children = list(bsee_path.iterdir())
-    assert len(children) > 0, "BSEE module dir is empty"
+    bin_path = get_module_data("bsee") / "bin"
+    assert bin_path.is_symlink(), f"{bin_path} is not a symlink"
+    assert bin_path.is_dir(), f"BSEE bin subtree missing: {bin_path}"
+    assert any(bin_path.iterdir()), f"BSEE bin subtree is empty: {bin_path}"
 
 
 # ---------------------------------------------------------------------------
-# e) HSE raw accessible via symlink
+# e) HSE raw subtree is reachable specifically
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
 def test_hse_raw_accessible_via_symlink():
-    """HSE OSHA CSVs are reachable through the symlink."""
+    """HSE raw subtree (relocated) is reachable AND non-empty.
+
+    Targets data/modules/hse/raw/ specifically. get_module_data('hse')
+    alone has the in-repo hse_incidents.db + schema.yaml siblings, so a
+    looser check would pass even when /mnt/ace isn't mounted. The relocated
+    subtree is what this test gates on.
+    """
     _require_symlink_or_skip()
-    hse_path = get_module_data("hse")
-    assert hse_path.is_dir(), f"HSE module dir missing: {hse_path}"
-    children = list(hse_path.iterdir())
-    assert len(children) > 0, "HSE module dir is empty"
+    raw_path = get_module_data("hse") / "raw"
+    assert raw_path.is_symlink(), f"{raw_path} is not a symlink"
+    assert raw_path.is_dir(), f"HSE raw subtree missing: {raw_path}"
+    assert any(raw_path.iterdir()), f"HSE raw subtree is empty: {raw_path}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_data_symlink.py
+++ b/tests/integration/test_data_symlink.py
@@ -44,9 +44,18 @@ ACE_MOUNT = Path("/mnt/ace/worldenergydata")
 # Each (repo_path, ace_path) pair: repo_path is where the symlink lives,
 # ace_path is what it should point at.
 RELOCATED_SUBTREES = [
-    (DATA_DIR / "modules" / "bsee" / "bin", ACE_MOUNT / "data" / "modules" / "bsee" / "bin"),
-    (DATA_DIR / "modules" / "bsee" / "zip", ACE_MOUNT / "data" / "modules" / "bsee" / "zip"),
-    (DATA_DIR / "modules" / "hse" / "raw", ACE_MOUNT / "data" / "modules" / "hse" / "raw"),
+    (
+        DATA_DIR / "modules" / "bsee" / "bin",
+        ACE_MOUNT / "data" / "modules" / "bsee" / "bin",
+    ),
+    (
+        DATA_DIR / "modules" / "bsee" / "zip",
+        ACE_MOUNT / "data" / "modules" / "bsee" / "zip",
+    ),
+    (
+        DATA_DIR / "modules" / "hse" / "raw",
+        ACE_MOUNT / "data" / "modules" / "hse" / "raw",
+    ),
 ]
 
 _ace_mount_exists = ACE_MOUNT.exists()
@@ -104,9 +113,9 @@ def test_relocated_subtrees_resolve_to_ace():
     _require_symlink_or_skip()
     for link, expected_target in RELOCATED_SUBTREES:
         assert link.is_symlink(), f"{link} is not a symlink"
-        assert link.resolve() == expected_target.resolve(), (
-            f"{link} resolves to {link.resolve()} (expected {expected_target})"
-        )
+        assert (
+            link.resolve() == expected_target.resolve()
+        ), f"{link} resolves to {link.resolve()} (expected {expected_target})"
         # The resolved path should be a real, populated directory.
         assert link.is_dir(), f"{link} target is not a directory"
         assert any(link.iterdir()), f"{link} target is empty"


### PR DESCRIPTION
## Closes #359

## Summary

Rewrites `scripts/setup-data-link.sh` from whole-tree symlink (`data/` → `/mnt/ace/.../data`) to **per-subtree symlinks** for the three relocated paths only:

| Subtree | Size | Source of truth |
|---------|------|-----------------|
| `data/modules/bsee/bin` → `/mnt/ace/.../bsee/bin` | 2.5 GB | BSEE bulk binary archives |
| `data/modules/bsee/zip` → `/mnt/ace/.../bsee/zip` | 230 MB | BSEE directional-survey zips |
| `data/modules/hse/raw` → `/mnt/ace/.../hse/raw` | 6.7 GB | HSE raw OSHA/EPA-TRI/BSEE incidents |

The whole-tree approach in the previous version would have replaced the repo's `data/` directory with a symlink, erasing access to ~389 MB of **in-repo** modules (`bsee/current` 57K wells, `bsee/paleowells`, `marine_safety`, `vessel_hull_models`, schemas, catalogs). Per-subtree symlinks preserve everything in-repo while routing only the three relocated paths to /mnt/ace.

## Why this is the right fix

- The 2026-03-24 RELOCATION-LOG explicitly states only HSE raw + BSEE bin/zip moved out
- Repo retains `bsee/current/` (the Tier-A production-ready foundation, 57K wells)
- The previous design implicitly assumed /mnt/ace mirrors the full tree — it doesn't
- See discussion on #359 for the design-constraint analysis that surfaced this

## Script behavior

```
$ scripts/setup-data-link.sh --check
  WOULD CREATE: data/modules/bsee/bin -> /mnt/ace/.../bsee/bin
  WOULD CREATE: data/modules/bsee/zip -> /mnt/ace/.../bsee/zip
  WOULD CREATE: data/modules/hse/raw  -> /mnt/ace/.../hse/raw
Check complete. (use without --check to apply changes)

$ scripts/setup-data-link.sh
  CREATED: data/modules/bsee/bin -> /mnt/ace/.../bsee/bin
  CREATED: data/modules/bsee/zip -> /mnt/ace/.../bsee/zip
  CREATED: data/modules/hse/raw  -> /mnt/ace/.../hse/raw
Done. 3 created, 0 repaired, 0 already-correct.

$ scripts/setup-data-link.sh   # idempotent re-run
  OK: data/modules/bsee/bin -> ...
  OK: data/modules/bsee/zip -> ...
  OK: data/modules/hse/raw  -> ...
Done. 0 created, 0 repaired, 3 already-correct.
```

Properties:
- **Idempotent** — safe to re-run; reports created vs. repaired vs. already-correct
- **Safe** — refuses to clobber real directories with content (data-loss guard)
- **Verifying** — `--check` flag for dry-run inspection
- **Override** — accepts a non-default ACE root as first positional arg
- **Fail-loud** — non-zero exit on any error

## Test refresh (tests/integration/test_data_symlink.py)

- `test_relocated_subtrees_resolve_to_ace` (NEW) — asserts all three links resolve to expected /mnt/ace targets and contain content
- `test_data_root_is_repo_data_dir` (NEW) — regression-guard ensuring `data/` itself is NOT a symlink (catches the pre-#359 design from re-emerging)
- `test_bsee_bin_accessible_via_symlink` / `test_hse_raw_accessible_via_symlink` — refined to check the relocated subtree specifically (the old version checked the parent module dir, which would pass even without /mnt/ace because of in-repo siblings)
- `_require_symlink_or_skip()` updated to enumerate which links are missing in the failure message
- Module docstring updated to describe the partial-symlink architecture

## Verified live

```
$ uv run pytest tests/integration/test_data_symlink.py -v
...
8 passed in 47.32s
```

(Host: ace-linux-1, /mnt/ace mounted, script applied. CI runners will skip cleanly via the existing `_require_symlink_or_skip` mechanism since they don't mount /mnt/ace.)

## .gitignore

The three per-host symlinks (`/data/modules/bsee/bin`, `/data/modules/bsee/zip`, `/data/modules/hse/raw`) are now ignored — they're host-specific outputs of the script and would be broken on any host without /mnt/ace.

## Test plan

- [x] `scripts/setup-data-link.sh --check` reports 3 WOULD CREATE actions on a host with /mnt/ace, no symlinks
- [x] `scripts/setup-data-link.sh` creates 3 symlinks correctly
- [x] Re-run is idempotent (3 already-correct)
- [x] `git status` shows no untracked symlinks after run
- [x] `uv run pytest tests/integration/test_data_symlink.py -v` → 8/8 pass
- [x] In-repo modules still accessible after symlink wiring (sanity-checked `bsee/current`, `marine_safety`)
- [ ] CI on PR (no /mnt/ace) → tests skip cleanly via `_require_symlink_or_skip`

## Follow-ups (separate issues)

- The catalog (`data/catalog/data-catalog.yml`) entries for relocated paths now resolve correctly via symlinks; no catalog changes needed for #359 itself
- HSE _metadata.json is still missing (#292 drift) — fold into #366 (HSE bulk dedup + ingest) since dedup informs row counts in the metadata
- Once this lands, the ProductionAPI12 / FDAS / disclosure analytics paths in #358 will have BSEE bulk reachable for downstream BSEE binary unpacking (#365) and HSE bulk dedup (#366)