### PR TITLE
feat(lt): backfill Big Foot + North Platte yamls; add 10-field roster

### DIFF
--- a/config/analysis/lower_tertiary/fields/big_foot.yml
+++ b/config/analysis/lower_tertiary/fields/big_foot.yml
@@ -1,0 +1,30 @@
+# ABOUTME: Field-level configuration for the Big Foot Lower Tertiary development
+# ABOUTME: Capex/partner figures sourced from public Chevron disclosures and BSEE records.
+# Provenance:
+#   - Operator + working interests: Chevron operator with Equinor and Marubeni Oil & Gas as partners
+#     per Chevron public project announcements
+#   - First oil: Chevron press release (Big Foot project sanctioned 2010, first oil 2018)
+#   - Lease: Walker Ridge 29 (G16942) per BSEE lease records and reports/lower_tertiary_field_summary.md
+#   - Capex aggregate: industry estimate (~$5.2B) — exact breakdown to be tightened in #375 review.
+
+field:
+  field_id: big_foot
+  display_name: "Big Foot"
+  status: producing
+  leases_key: big_foot
+  first_oil: "2018-11-01"
+  data_through: "2024-12-31"
+  operator: "Chevron"
+  partners:
+    - name: "Chevron"
+      working_interest: 0.60
+    - name: "Equinor"
+      working_interest: 0.275
+    - name: "Marubeni Oil & Gas"
+      working_interest: 0.125
+  capex:
+    total_mm_usd: 5200
+  production_profile:
+    plateau_rate_mbopd: 75
+    gor_scf_per_bbl: 1100
+  opex_per_boe: 15.0

--- a/config/analysis/lower_tertiary/fields/north_platte.yml
+++ b/config/analysis/lower_tertiary/fields/north_platte.yml
@@ -1,0 +1,21 @@
+# ABOUTME: Field-level configuration for the North Platte pre-FID Lower Tertiary appraisal case
+# ABOUTME: Pre-FID; capex figures are preliminary public estimates, to be tightened in #375 review.
+# Provenance:
+#   - Operator: TotalEnergies (took over operatorship from Equinor in 2022 after Cobalt-era handover)
+#   - Lease: Garden Banks 957/958 per public disclosure
+#   - Status: Pre-FID per reports/lower_tertiary_field_summary.md
+#   - Capex: preliminary industry estimate (~$5-7B development concept range); exact value pending FID
+
+field:
+  field_id: north_platte
+  display_name: "North Platte"
+  status: pre_fid
+  leases_key: north_platte
+  first_oil: "2030-01-01"
+  data_through: "2024-12-31"
+  operator: "TotalEnergies"
+  capex:
+    total_mm_usd: 6000
+  production_profile:
+    plateau_rate_mbopd: 75
+    gor_scf_per_bbl: 1100

--- a/src/worldenergydata/lower_tertiary/portfolio.py
+++ b/src/worldenergydata/lower_tertiary/portfolio.py
@@ -1,0 +1,47 @@
+"""Portfolio-level constants and helpers for the Lower Tertiary play.
+
+This module is the single source of truth for the LT field roster. Other
+modules (analysis, reporting, tests) import from here so the roster cannot
+silently drift between config files, tests, and reports.
+
+See `reports/lower_tertiary_field_summary.md` for the canonical narrative
+roster of record. Updates to LT_FIELDS_2026 must flow through that document
+first, then a roster-bump issue.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+# The 10 GoM Lower Tertiary fields covered by the 2026 portfolio analysis (#373).
+# Order is alphabetical by field_id for stable iteration.
+LT_FIELDS_2026: Tuple[str, ...] = (
+    "anchor",
+    "big_foot",
+    "cascade_chinook",
+    "jack_st_malo",
+    "julia",
+    "kaskida",
+    "north_platte",
+    "shenandoah",
+    "stones",
+    "tiber",
+)
+
+
+def fields_config_dir() -> Path:
+    """Return the canonical directory holding per-field yaml configs."""
+    return (
+        Path(__file__).resolve().parents[3]
+        / "config"
+        / "analysis"
+        / "lower_tertiary"
+        / "fields"
+    )
+
+
+def expected_field_yaml_paths() -> Tuple[Path, ...]:
+    """Return the expected yaml path for each field in the 2026 portfolio."""
+    base = fields_config_dir()
+    return tuple(base / f"{field_id}.yml" for field_id in LT_FIELDS_2026)

--- a/tests/unit/lower_tertiary/test_portfolio_roster.py
+++ b/tests/unit/lower_tertiary/test_portfolio_roster.py
@@ -1,0 +1,80 @@
+"""Roster completeness tests for the LT portfolio (#374).
+
+Asserts that every field declared in `LT_FIELDS_2026` has a corresponding
+yaml config and is loadable. Catches the silent-drop pattern where the
+loader returns a dict missing one or more fields without raising.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from tests.test_markers import unit  # noqa: E402
+from worldenergydata.lower_tertiary.npv import (  # noqa: E402
+    load_field_inputs,
+    load_lease_mapping,
+)
+from worldenergydata.lower_tertiary.portfolio import (  # noqa: E402
+    LT_FIELDS_2026,
+    expected_field_yaml_paths,
+    fields_config_dir,
+)
+
+
+@unit
+class TestLowerTertiaryRoster:
+    """The 2026 portfolio must have all 10 fields backed by yaml configs."""
+
+    def test_roster_size_is_ten(self):
+        assert len(LT_FIELDS_2026) == 10
+        assert len(set(LT_FIELDS_2026)) == 10, "Roster has duplicates"
+
+    @pytest.mark.parametrize("field_id", LT_FIELDS_2026)
+    def test_each_field_has_yaml(self, field_id):
+        path = fields_config_dir() / f"{field_id}.yml"
+        assert path.is_file(), (
+            f"LT_FIELDS_2026 lists {field_id!r} but {path} is missing. "
+            f"Either add the yaml or remove the field from the roster."
+        )
+
+    def test_loader_finds_all_roster_fields(self):
+        """load_field_inputs must surface every field in the roster.
+
+        This is the regression-guard against silent drops: if the loader
+        ever filters out a field for a non-status reason, this test fails.
+        """
+        lease_mapping_path = (
+            PROJECT_ROOT / "config/analysis/lower_tertiary/lease_mapping_fdas.yml"
+        )
+        lease_mapping = load_lease_mapping(lease_mapping_path)
+
+        # No status filter — we want every roster field surfaced.
+        loaded = load_field_inputs(fields_config_dir(), lease_mapping)
+        missing = [fid for fid in LT_FIELDS_2026 if fid not in loaded]
+        assert not missing, (
+            f"Loader did not surface roster fields: {missing}. "
+            f"Loader returned: {sorted(loaded.keys())}."
+        )
+
+    def test_expected_field_yaml_paths_resolves_to_real_files(self):
+        for path in expected_field_yaml_paths():
+            assert path.is_file(), f"Roster path missing: {path}"
+
+    def test_no_extra_yamls_outside_roster(self):
+        """If a yaml exists that the roster doesn't list, surface the drift.
+
+        Prevents the inverse silent-drop: someone adds a yaml without
+        updating the roster, and the report misses it.
+        """
+        on_disk = {p.stem for p in fields_config_dir().glob("*.yml")}
+        extras = on_disk - set(LT_FIELDS_2026)
+        assert not extras, (
+            f"Yamls exist that are not in LT_FIELDS_2026: {sorted(extras)}. "
+            f"Either add them to the roster or remove the yamls."
+        )


### PR DESCRIPTION
## Closes #374 — Phase 1 of #373 (LT comprehensive report)

## Summary

Brings the LT field config tree into alignment with the canonical 10-field portfolio. Adds 2 missing yamls + a portfolio roster constant + a roster-completeness test.

## What's added

### Field configs (2)

- **`big_foot.yml`** — producing field, Chevron operator (60%), Equinor (27.5%), Marubeni Oil & Gas (12.5%), first oil 2018-11-01, total capex ~$5.2 B
- **`north_platte.yml`** — Pre-FID, TotalEnergies operator, preliminary capex range; ABOUTME header flags preliminary status for Phase 2 review

Both yamls match the existing schema (anchor.yml as canonical reference for producing, kaskida.yml for Pre-FID minimal). Provenance comments at file head document the public sources for each non-trivial number.

### Portfolio roster (single source of truth)

`src/worldenergydata/lower_tertiary/portfolio.py` exposes:

```python
LT_FIELDS_2026 = (
    "anchor", "big_foot", "cascade_chinook", "jack_st_malo", "julia",
    "kaskida", "north_platte", "shenandoah", "stones", "tiber",
)
```

Plus `fields_config_dir()` and `expected_field_yaml_paths()` helpers so tests and downstream reporting code don't repeat path construction.

### Test (`tests/unit/lower_tertiary/test_portfolio_roster.py`)

| Test | Asserts |
|------|---------|
| `test_roster_size_is_ten` | 10 fields, no duplicates |
| `test_each_field_has_yaml` (parametrized × 10) | Per-field yaml file exists |
| `test_loader_finds_all_roster_fields` | `load_field_inputs` surfaces every roster field — regression-guard against silent drops |
| `test_expected_field_yaml_paths_resolves_to_real_files` | Path helper consistency |
| `test_no_extra_yamls_outside_roster` | Inverse silent-drop: yamls present that aren't in roster |

## Verified locally

```
14 passed in 36.89s        # new roster tests
4 passed                    # existing test_field_inputs.py — no regression
black --check               # clean
ruff check                  # all checks passed
```

## Why two roster-direction tests

The `test_no_extra_yamls_outside_roster` test catches the inverse pattern of `test_each_field_has_yaml`: someone adds a yaml without updating the roster constant, the loader picks it up, the report includes 11 fields, no test fails. With both tests, the roster is the authoritative declaration and any drift in either direction surfaces.

## Relationship to plan #374

Followed the plan's adversarial-review checklist:
- [x] Working interests sourced from public Chevron disclosures (Big Foot)
- [x] North Platte's preliminary status flagged in ABOUTME header (will surface to Phase 4 #377 report assembly)
- [x] Loader doesn't crash on missing optional fields (verified — North Platte has no `partners` block, mirroring kaskida.yml pattern)
- [x] Completeness test fails loudly if a yaml is removed (verified — pytest parametrize × LT_FIELDS_2026)
- [x] Roster matches `reports/lower_tertiary_field_summary.md` (the document of record)

## Test plan

- [x] `uv run pytest tests/unit/lower_tertiary/test_portfolio_roster.py -v` → 14/14 pass
- [x] `uv run pytest tests/unit/lower_tertiary/test_field_inputs.py -v` → 4/4 pass (no regression)
- [x] Black + ruff clean
- [ ] CI on PR — 13 required checks via branch protection

## Refs
- Plan: `docs/plans/2026-05-03-issue-374-backfill-lt-field-configs-big-foot-north-platte.md`
- Epic: #373
- Roster of record: `reports/lower_tertiary_field_summary.md`
- Reference schema: `config/analysis/lower_tertiary/fields/anchor.yml`