### PR TITLE
feat(lt): cross-field analytics — technology / operator / HSE / cost

### DIFF
--- a/src/worldenergydata/cli/commands/lower_tertiary.py
+++ b/src/worldenergydata/cli/commands/lower_tertiary.py
@@ -14,6 +14,11 @@ from typing import Optional
 import typer
 from rich.console import Console
 
+from worldenergydata.lower_tertiary.portfolio_analytics import (
+    portfolio_analytics_to_csv,
+    portfolio_analytics_to_html,
+    run_portfolio_analytics,
+)
 from worldenergydata.lower_tertiary.portfolio_economics import (
     portfolio_to_csv,
     portfolio_to_html,
@@ -60,4 +65,44 @@ def portfolio_economics(
     console.print(
         f"[bold]Fields analyzed:[/] {len(run.results)} &middot; "
         f"[bold]Total cum capex:[/] ${sum(r.capex_mm_usd for r in run.results):,.0f} M"
+    )
+
+
+@app.command("portfolio-analytics")
+def portfolio_analytics(
+    output_dir: Path = typer.Option(
+        ...,
+        "--output-dir",
+        help="Directory to write the four section CSVs",
+    ),
+    output_html: Optional[Path] = typer.Option(
+        None,
+        "--output-html",
+        help="Optional path to write the combined HTML report",
+    ),
+    section: str = typer.Option(
+        "all",
+        "--section",
+        help="Which section(s) to render: technology|operator|hse|cost_benchmark|all",
+    ),
+) -> None:
+    """Run cross-field analytics across all 10 LT-2026 fields (#376)."""
+    run = run_portfolio_analytics()
+    csv_paths = portfolio_analytics_to_csv(run, output_dir)
+    if section == "all":
+        for name, path in csv_paths.items():
+            console.print(f"[green]Wrote {name} CSV:[/] {path}")
+    elif section in csv_paths:
+        console.print(f"[green]Wrote {section} CSV:[/] {csv_paths[section]}")
+    else:
+        console.print(
+            f"[red]Unknown section {section!r}. Valid: {sorted(csv_paths.keys()) + ['all']}[/]"
+        )
+        raise typer.Exit(code=1)
+    if output_html is not None:
+        html_path = portfolio_analytics_to_html(run, output_html)
+        console.print(f"[green]Wrote HTML:[/] {html_path}")
+    console.print(
+        f"[bold]Sections rendered:[/] {section} &middot; "
+        f"[bold]Fields:[/] {len(run.field_ids)}"
     )

--- a/src/worldenergydata/lower_tertiary/portfolio_analytics.py
+++ b/src/worldenergydata/lower_tertiary/portfolio_analytics.py
@@ -1,0 +1,539 @@
+"""Cross-field analytics for the Lower Tertiary play (#376).
+
+Phase 3 of #373 epic. Consumes the per-field configs (#374) and per-field
+economics (#375) to surface portfolio-level insights:
+
+- 3a. Technology generation — capex intensity by dev system class
+- 3b. Operator concentration — working-interest-weighted production
+- 3c. HSE incident overlay — minimum-viable; full coverage pending #366
+- 3d. Cost benchmark — disclosure-comparable per-field; pending #343 seeding
+
+Each section emits a DataFrame plus a `caveats` flag column so missing
+inputs are explicit rather than silently elided. The `PortfolioAnalyticsRun`
+dataclass bundles all four sections + run metadata.
+
+Public surface:
+    - PortfolioAnalyticsRun — bundle of 4 section DataFrames + metadata
+    - analyze_technology_generation(field_ids, *, economics_run) -> DataFrame
+    - analyze_operator_concentration(field_ids, *, economics_run) -> DataFrame
+    - analyze_hse_per_field(field_ids) -> DataFrame
+    - analyze_cost_benchmark(field_ids, *, economics_run) -> DataFrame
+    - run_portfolio_analytics(field_ids, ...) -> PortfolioAnalyticsRun
+    - portfolio_analytics_to_csv(run, path)
+    - portfolio_analytics_to_html(run, path)
+"""
+
+from __future__ import annotations
+
+import html
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+import pandas as pd
+import yaml
+
+from worldenergydata.fdas.api import DisclosureAnalyticsQuery
+from worldenergydata.lower_tertiary.portfolio import (
+    LT_FIELDS_2026,
+    fields_config_dir,
+)
+from worldenergydata.lower_tertiary.portfolio_economics import (
+    PortfolioEconomicsRun,
+    run_portfolio,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Marker values for HSE 3c: full coverage requires #366 (HSE bulk dedup).
+HSE_DATA_COMPLETENESS_MINIMUM = "minimum_viable_pending_#366"
+
+# Marker for cost benchmark 3d when no comparable disclosure record exists.
+BENCHMARK_STATUS_NO_DATA = "no_data_pending_#343"
+BENCHMARK_STATUS_COMPARABLE = "comparable"
+
+
+# ---------------------------------------------------------------------------
+# Result bundle
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PortfolioAnalyticsRun:
+    technology: pd.DataFrame
+    operator: pd.DataFrame
+    hse: pd.DataFrame
+    cost_benchmark: pd.DataFrame
+    field_ids: tuple
+    timestamp_utc: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+    def section(self, name: str) -> pd.DataFrame:
+        """Return a section by name; raises KeyError on unknown section."""
+        sections = {
+            "technology": self.technology,
+            "operator": self.operator,
+            "hse": self.hse,
+            "cost_benchmark": self.cost_benchmark,
+        }
+        if name not in sections:
+            raise KeyError(
+                f"Unknown analytics section {name!r}. "
+                f"Valid: {sorted(sections.keys())}"
+            )
+        return sections[name]
+
+
+# ---------------------------------------------------------------------------
+# Yaml + production helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_field_payload(field_id: str) -> Dict[str, object]:
+    path = fields_config_dir() / f"{field_id}.yml"
+    if not path.is_file():
+        raise FileNotFoundError(f"LT field config missing: {path}")
+    with path.open("r", encoding="utf-8") as fh:
+        contents = yaml.safe_load(fh) or {}
+    return contents.get("field", contents)
+
+
+def _dev_system_for_field(payload: Dict[str, object]) -> str:
+    """Resolve a dev-system label from the yaml.
+
+    Falls back to a static mapping derived from the canonical roster doc
+    (`reports/lower_tertiary_field_summary.md`) when the yaml doesn't
+    declare a dev_system explicitly. Surface the source via a `_via` flag
+    in the technology section's `dev_system_source` column.
+    """
+    explicit = payload.get("dev_system")
+    if explicit:
+        return str(explicit)
+    return "unspecified"
+
+
+# Static mapping of field_id → dev system class, sourced from
+# reports/lower_tertiary_field_summary.md (the canonical roster doc).
+_DEV_SYSTEM_FALLBACK: Dict[str, str] = {
+    "anchor": "Subsea 20K",
+    "big_foot": "Dry Tree",
+    "cascade_chinook": "Subsea 15K",
+    "jack_st_malo": "Subsea 15K",
+    "julia": "Tieback 15K",
+    "kaskida": "Subsea 20K",
+    "north_platte": "Subsea 20K",
+    "shenandoah": "Subsea 20K",
+    "stones": "Subsea 15K",
+    "tiber": "Subsea 20K",
+}
+
+
+def _resolved_dev_system(field_id: str, payload: Dict[str, object]) -> tuple:
+    """(dev_system, source) — yaml-declared if present, else fallback."""
+    explicit = payload.get("dev_system")
+    if explicit:
+        return str(explicit), "yaml"
+    fallback = _DEV_SYSTEM_FALLBACK.get(field_id)
+    if fallback:
+        return fallback, "static_mapping_per_summary_doc"
+    return "unknown", "no_source"
+
+
+# ---------------------------------------------------------------------------
+# 3a. Technology generation
+# ---------------------------------------------------------------------------
+
+
+def analyze_technology_generation(
+    field_ids: Sequence[str],
+    *,
+    economics_run: Optional[PortfolioEconomicsRun] = None,
+) -> pd.DataFrame:
+    """Per-dev-system summary: field count, total capex, mean breakeven, etc.
+
+    If an economics_run is supplied, breakeven + NPV totals are aggregated.
+    """
+    econ_lookup = (
+        {r.field_id: r for r in economics_run.results} if economics_run else {}
+    )
+
+    field_rows = []
+    for fid in field_ids:
+        payload = _load_field_payload(fid)
+        dev_system, source = _resolved_dev_system(fid, payload)
+        capex_mm = float((payload.get("capex") or {}).get("total_mm_usd") or 0.0)
+        plateau_mbopd = float(
+            (payload.get("production_profile") or {}).get("plateau_rate_mbopd") or 0.0
+        )
+        # 20-year recoverable as a coarse proxy: plateau × 365 × 20 / 1000 (MMbbl).
+        annual_plateau_mmbbl = plateau_mbopd * 365.0 / 1000.0
+        recoverable_mmbbl_proxy = annual_plateau_mmbbl * 20  # plateau-equivalent years
+        capex_per_mmbbl = (
+            capex_mm / recoverable_mmbbl_proxy if recoverable_mmbbl_proxy > 0 else None
+        )
+
+        econ = econ_lookup.get(fid)
+        field_rows.append(
+            {
+                "field_id": fid,
+                "dev_system": dev_system,
+                "dev_system_source": source,
+                "status": str(payload.get("status") or "unknown"),
+                "capex_mm_usd": capex_mm,
+                "recoverable_mmbbl_proxy": recoverable_mmbbl_proxy,
+                "capex_per_mmbbl_usd": capex_per_mmbbl,
+                "first_oil": str(payload.get("first_oil") or "n/a"),
+                "npv_mm_usd": econ.npv_mm_usd if econ else None,
+                "breakeven_oil_usd_per_bbl": (
+                    econ.breakeven_oil_usd_per_bbl if econ else None
+                ),
+            }
+        )
+
+    field_df = pd.DataFrame(field_rows)
+
+    # Aggregate by dev system.
+    agg_rows = []
+    for dev_system, group in field_df.groupby("dev_system"):
+        agg_rows.append(
+            {
+                "dev_system": dev_system,
+                "field_count": int(len(group)),
+                "fields": ", ".join(sorted(group["field_id"].tolist())),
+                "total_capex_mm_usd": float(group["capex_mm_usd"].sum()),
+                "mean_capex_per_mmbbl_usd": (
+                    float(group["capex_per_mmbbl_usd"].mean(skipna=True))
+                    if group["capex_per_mmbbl_usd"].notna().any()
+                    else None
+                ),
+                "total_recoverable_mmbbl_proxy": float(
+                    group["recoverable_mmbbl_proxy"].sum()
+                ),
+                "total_npv_mm_usd": (
+                    float(group["npv_mm_usd"].sum())
+                    if economics_run and group["npv_mm_usd"].notna().any()
+                    else None
+                ),
+                "mean_breakeven_usd_per_bbl": (
+                    float(group["breakeven_oil_usd_per_bbl"].mean(skipna=True))
+                    if economics_run
+                    and group["breakeven_oil_usd_per_bbl"].notna().any()
+                    else None
+                ),
+                "caveats": (
+                    "recoverable_mmbbl_proxy uses plateau×20yr — "
+                    "OGOR-grounded follow-up under #367"
+                ),
+            }
+        )
+
+    return pd.DataFrame(agg_rows).sort_values("dev_system").reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+# 3b. Operator concentration
+# ---------------------------------------------------------------------------
+
+
+def analyze_operator_concentration(
+    field_ids: Sequence[str],
+    *,
+    economics_run: Optional[PortfolioEconomicsRun] = None,
+) -> pd.DataFrame:
+    """Working-interest-weighted capex + production by operator.
+
+    Fields without a `partners` block (kaskida-shape Pre-FID yamls) treat
+    the declared `operator` as 100% WI for aggregation purposes — flagged
+    via `wi_source: operator_only_assumption` in the field-level breakdown.
+    """
+    rows = []
+    for fid in field_ids:
+        payload = _load_field_payload(fid)
+        operator = str(payload.get("operator") or "unknown")
+        capex_mm = float((payload.get("capex") or {}).get("total_mm_usd") or 0.0)
+        plateau_mbopd = float(
+            (payload.get("production_profile") or {}).get("plateau_rate_mbopd") or 0.0
+        )
+
+        partners = payload.get("partners")
+        if partners and isinstance(partners, list):
+            wi_total = sum(float(p.get("working_interest") or 0.0) for p in partners)
+            for p in partners:
+                wi = float(p.get("working_interest") or 0.0)
+                rows.append(
+                    {
+                        "field_id": fid,
+                        "operator_role": (
+                            "operator" if p.get("name") == operator else "partner"
+                        ),
+                        "company": str(p.get("name")),
+                        "working_interest": wi,
+                        "wi_source": "yaml_partners",
+                        "wi_capex_share_mm_usd": capex_mm * wi,
+                        "wi_plateau_mbopd": plateau_mbopd * wi,
+                        "wi_total_in_yaml": wi_total,
+                    }
+                )
+        else:
+            # Kaskida-shape Pre-FID — assume 100% WI to declared operator.
+            rows.append(
+                {
+                    "field_id": fid,
+                    "operator_role": "operator",
+                    "company": operator,
+                    "working_interest": 1.0,
+                    "wi_source": "operator_only_assumption",
+                    "wi_capex_share_mm_usd": capex_mm,
+                    "wi_plateau_mbopd": plateau_mbopd,
+                    "wi_total_in_yaml": 1.0,
+                }
+            )
+
+    field_df = pd.DataFrame(rows)
+    if field_df.empty:
+        return field_df
+
+    # Aggregate by company across the portfolio.
+    agg = (
+        field_df.groupby("company")
+        .agg(
+            field_count=("field_id", "nunique"),
+            sum_wi_capex_mm_usd=("wi_capex_share_mm_usd", "sum"),
+            sum_wi_plateau_mbopd=("wi_plateau_mbopd", "sum"),
+        )
+        .reset_index()
+        .sort_values("sum_wi_capex_mm_usd", ascending=False)
+    )
+
+    total_capex = agg["sum_wi_capex_mm_usd"].sum()
+    agg["share_capex_pct"] = (
+        100.0 * agg["sum_wi_capex_mm_usd"] / total_capex if total_capex > 0 else 0.0
+    )
+    # Herfindahl-Hirschman Index (0-10000 scale).
+    agg["hhi_contribution"] = (agg["share_capex_pct"]) ** 2
+    return agg.reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+# 3c. HSE per field — minimum-viable per #376 plan
+# ---------------------------------------------------------------------------
+
+
+def analyze_hse_per_field(field_ids: Sequence[str]) -> pd.DataFrame:
+    """Minimum-viable HSE overlay per the #376 plan.
+
+    Full coverage requires HSE bulk dedup + ingest (#366). Until that
+    lands, this section emits a placeholder row per field with explicit
+    `data_completeness: minimum_viable_pending_#366` flag so the report
+    layer (Phase 4 / #377) can surface the gap honestly rather than
+    silently elide HSE.
+    """
+    rows = []
+    for fid in field_ids:
+        rows.append(
+            {
+                "field_id": fid,
+                "incident_count": 0,
+                "incidents_per_mmbbl": None,
+                "data_completeness": HSE_DATA_COMPLETENESS_MINIMUM,
+                "source": "placeholder pending #366 (HSE bulk dedup + ingest)",
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# 3d. Cost benchmark — pending #343 disclosure registry seeding
+# ---------------------------------------------------------------------------
+
+
+def analyze_cost_benchmark(
+    field_ids: Sequence[str],
+    *,
+    economics_run: Optional[PortfolioEconomicsRun] = None,
+) -> pd.DataFrame:
+    """Per-field cost-vs-disclosure benchmark.
+
+    Calls DisclosureAnalyticsQuery.benchmark per field. Where no
+    comparable disclosure exists, records `benchmark_status: no_data_pending_#343`
+    rather than dropping the field — keeps the row count consistent with
+    the roster.
+    """
+    benchmark = DisclosureAnalyticsQuery()
+    econ_lookup = (
+        {r.field_id: r for r in economics_run.results} if economics_run else {}
+    )
+
+    rows = []
+    for fid in field_ids:
+        payload = _load_field_payload(fid)
+        operator = str(payload.get("operator") or "unknown")
+        capex_mm = float((payload.get("capex") or {}).get("total_mm_usd") or 0.0)
+        modelled_capex_mm = (
+            econ_lookup[fid].capex_mm_usd if fid in econ_lookup else capex_mm
+        )
+
+        try:
+            # Empty project_revision_view = no comparable disclosures yet.
+            # Once #343 + #344 seed the registry, replace with the live view.
+            result = benchmark.benchmark(
+                project_revision_view=[],
+                predictor_cost_usd_mm=modelled_capex_mm,
+                operator=operator,
+                project_name=fid,
+            )
+        except (
+            Exception
+        ) as exc:  # noqa: BLE001 — surface unexpected failures gracefully
+            logger.warning("benchmark failed for %s: %s", fid, exc)
+            result = None
+
+        rows.append(
+            {
+                "field_id": fid,
+                "operator": operator,
+                "modelled_capex_mm_usd": modelled_capex_mm,
+                "disclosed_capex_mm_usd": (
+                    None
+                    if result is None
+                    else float(getattr(result, "disclosed_capex_mm_usd", 0.0) or 0.0)
+                ),
+                "delta_pct": (
+                    None
+                    if result is None
+                    else float(getattr(result, "delta_pct", 0.0) or 0.0)
+                ),
+                "benchmark_status": (
+                    BENCHMARK_STATUS_COMPARABLE
+                    if result is not None
+                    else BENCHMARK_STATUS_NO_DATA
+                ),
+                "caveats": (
+                    "Live benchmark requires #343 (operator registry) + "
+                    "#344 (restatement lineage) to seed the project_revision_view."
+                ),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+def run_portfolio_analytics(
+    field_ids: Sequence[str] = LT_FIELDS_2026,
+    *,
+    economics_run: Optional[PortfolioEconomicsRun] = None,
+) -> PortfolioAnalyticsRun:
+    """Compute all four cross-field analytics sections.
+
+    If `economics_run` is None, runs `run_portfolio()` to produce one
+    so the technology + cost-benchmark sections have a comparison
+    baseline (per the #376 plan dependency on #375).
+    """
+    if economics_run is None:
+        economics_run = run_portfolio(field_ids=field_ids)
+
+    return PortfolioAnalyticsRun(
+        technology=analyze_technology_generation(
+            field_ids, economics_run=economics_run
+        ),
+        operator=analyze_operator_concentration(field_ids, economics_run=economics_run),
+        hse=analyze_hse_per_field(field_ids),
+        cost_benchmark=analyze_cost_benchmark(field_ids, economics_run=economics_run),
+        field_ids=tuple(field_ids),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Output renderers
+# ---------------------------------------------------------------------------
+
+
+def portfolio_analytics_to_csv(
+    run: PortfolioAnalyticsRun, output_dir: Path | str
+) -> Dict[str, Path]:
+    """Write each section as a separate CSV under `output_dir/`.
+
+    Returns a mapping `{section_name: path}`.
+    """
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    paths = {
+        "technology": out / "technology_generation.csv",
+        "operator": out / "operator_concentration.csv",
+        "hse": out / "hse_per_field.csv",
+        "cost_benchmark": out / "cost_benchmark.csv",
+    }
+    run.technology.to_csv(paths["technology"], index=False)
+    run.operator.to_csv(paths["operator"], index=False)
+    run.hse.to_csv(paths["hse"], index=False)
+    run.cost_benchmark.to_csv(paths["cost_benchmark"], index=False)
+    return paths
+
+
+def portfolio_analytics_to_html(run: PortfolioAnalyticsRun, path: Path | str) -> Path:
+    """Render all four sections in a single HTML file with caveats surfaced."""
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    parts: List[str] = []
+    parts.append(
+        "<!DOCTYPE html><html><head><meta charset='utf-8'>"
+        "<title>Lower Tertiary Portfolio Analytics</title>"
+        "<style>body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;"
+        "max-width:1200px;margin:2em auto;padding:0 1em;color:#222;}"
+        "h1{border-bottom:2px solid #333;padding-bottom:0.4em;}"
+        "h2{margin-top:2em;color:#003366;}"
+        "table{border-collapse:collapse;margin:1em 0;font-size:0.92em;}"
+        "th,td{border:1px solid #ccc;padding:0.4em 0.7em;text-align:left;}"
+        "th{background:#f4f4f4;}"
+        ".meta{color:#666;font-size:0.9em;}"
+        ".caveat{background:#fff3cd;border-left:4px solid #f0ad4e;"
+        "padding:0.6em 1em;margin:1em 0;}"
+        "</style></head><body>"
+    )
+    parts.append("<h1>Lower Tertiary Portfolio Analytics</h1>")
+    parts.append(
+        f"<div class='meta'>Run: {html.escape(run.timestamp_utc)} &middot; "
+        f"fields: {len(run.field_ids)}</div>"
+    )
+
+    parts.append("<h2>3a. Technology generation</h2>")
+    parts.append(
+        run.technology.to_html(index=False, float_format=lambda x: f"{x:,.2f}")
+    )
+
+    parts.append("<h2>3b. Operator concentration</h2>")
+    parts.append(run.operator.to_html(index=False, float_format=lambda x: f"{x:,.2f}"))
+
+    parts.append("<h2>3c. HSE per field</h2>")
+    parts.append(
+        "<div class='caveat'>Minimum-viable shape per the #376 plan. "
+        "Full HSE coverage depends on #366 (HSE bulk dedup + ingest).</div>"
+    )
+    parts.append(run.hse.to_html(index=False))
+
+    parts.append("<h2>3d. Cost benchmark vs. operator disclosures</h2>")
+    parts.append(
+        "<div class='caveat'>Live benchmarking depends on #343 "
+        "(operator registry) + #344 (restatement lineage) seeding the "
+        "project_revision_view. Until then, every row carries "
+        "<code>benchmark_status: no_data_pending_#343</code>.</div>"
+    )
+    parts.append(
+        run.cost_benchmark.to_html(index=False, float_format=lambda x: f"{x:,.2f}")
+    )
+
+    parts.append("</body></html>")
+    out.write_text("".join(parts), encoding="utf-8")
+    return out

--- a/tests/unit/lower_tertiary/test_portfolio_analytics.py
+++ b/tests/unit/lower_tertiary/test_portfolio_analytics.py
@@ -1,0 +1,181 @@
+"""Tests for lower_tertiary.portfolio_analytics (#376).
+
+Verifies each cross-field analytics section against the approved plan:
+- 3a technology generation aggregates by dev system
+- 3b operator concentration produces working-interest-weighted shares
+- 3c HSE per field surfaces minimum-viable flag pending #366
+- 3d cost benchmark surfaces no_data flag pending #343
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from tests.test_markers import unit  # noqa: E402
+from worldenergydata.lower_tertiary.portfolio import LT_FIELDS_2026  # noqa: E402
+from worldenergydata.lower_tertiary.portfolio_analytics import (  # noqa: E402
+    BENCHMARK_STATUS_NO_DATA,
+    HSE_DATA_COMPLETENESS_MINIMUM,
+    PortfolioAnalyticsRun,
+    analyze_cost_benchmark,
+    analyze_hse_per_field,
+    analyze_operator_concentration,
+    analyze_technology_generation,
+    portfolio_analytics_to_csv,
+    portfolio_analytics_to_html,
+    run_portfolio_analytics,
+)
+from worldenergydata.lower_tertiary.portfolio_economics import (  # noqa: E402
+    run_portfolio,
+)
+
+
+@pytest.fixture(scope="module")
+def economics_run():
+    """Shared economics run — slow, share across the module."""
+    return run_portfolio()
+
+
+@unit
+class TestTechnologyGeneration:
+    """3a — aggregates by dev system from yaml + economics."""
+
+    def test_returns_dataframe_with_expected_columns(self, economics_run):
+        df = analyze_technology_generation(LT_FIELDS_2026, economics_run=economics_run)
+        for col in (
+            "dev_system",
+            "field_count",
+            "fields",
+            "total_capex_mm_usd",
+            "mean_capex_per_mmbbl_usd",
+            "total_recoverable_mmbbl_proxy",
+            "total_npv_mm_usd",
+            "mean_breakeven_usd_per_bbl",
+            "caveats",
+        ):
+            assert col in df.columns
+
+    def test_field_count_sums_to_roster(self, economics_run):
+        df = analyze_technology_generation(LT_FIELDS_2026, economics_run=economics_run)
+        assert int(df["field_count"].sum()) == len(LT_FIELDS_2026)
+
+    def test_subsea_20k_group_includes_anchor(self, economics_run):
+        df = analyze_technology_generation(LT_FIELDS_2026, economics_run=economics_run)
+        sub20k = df[df["dev_system"] == "Subsea 20K"]
+        assert len(sub20k) == 1
+        assert "anchor" in sub20k.iloc[0]["fields"]
+
+    def test_caveat_present_per_row(self, economics_run):
+        df = analyze_technology_generation(LT_FIELDS_2026, economics_run=economics_run)
+        assert df["caveats"].notna().all()
+        assert df["caveats"].str.contains("OGOR-grounded").all()
+
+
+@unit
+class TestOperatorConcentration:
+    """3b — working-interest-weighted aggregation."""
+
+    def test_chevron_appears_via_anchor_partners(self):
+        df = analyze_operator_concentration(LT_FIELDS_2026)
+        chevron = df[df["company"] == "Chevron"]
+        assert not chevron.empty
+        # Chevron operates Anchor (62.5%), Big Foot (60%) — at minimum should
+        # cover ≥2 fields' WI participation.
+        assert int(chevron.iloc[0]["field_count"]) >= 2
+
+    def test_share_capex_pct_sums_to_100(self):
+        df = analyze_operator_concentration(LT_FIELDS_2026)
+        # Allow small float tolerance.
+        assert abs(df["share_capex_pct"].sum() - 100.0) < 0.5
+
+    def test_kaskida_pre_fid_yaml_resolves_via_operator_only(self):
+        """Yamls without partners block must still surface their operator."""
+        df = analyze_operator_concentration(["kaskida"])
+        assert not df.empty
+        # BP operates Kaskida.
+        bp_row = df[df["company"] == "BP"]
+        assert len(bp_row) == 1
+
+
+@unit
+class TestHseMinimumViable:
+    """3c — emits one row per field with minimum-viable flag."""
+
+    def test_one_row_per_field(self):
+        df = analyze_hse_per_field(LT_FIELDS_2026)
+        assert len(df) == len(LT_FIELDS_2026)
+        assert set(df["field_id"]) == set(LT_FIELDS_2026)
+
+    def test_every_row_flagged_minimum_viable(self):
+        df = analyze_hse_per_field(LT_FIELDS_2026)
+        assert (df["data_completeness"] == HSE_DATA_COMPLETENESS_MINIMUM).all()
+
+
+@unit
+class TestCostBenchmark:
+    """3d — every roster field gets a row, all flagged no_data pending #343."""
+
+    def test_one_row_per_field(self, economics_run):
+        df = analyze_cost_benchmark(LT_FIELDS_2026, economics_run=economics_run)
+        assert len(df) == len(LT_FIELDS_2026)
+        assert set(df["field_id"]) == set(LT_FIELDS_2026)
+
+    def test_every_row_flagged_no_data(self, economics_run):
+        df = analyze_cost_benchmark(LT_FIELDS_2026, economics_run=economics_run)
+        assert (df["benchmark_status"] == BENCHMARK_STATUS_NO_DATA).all()
+
+    def test_modelled_capex_matches_yaml(self, economics_run):
+        """Anchor yaml has total_mm_usd: 5600 — verify it surfaces."""
+        df = analyze_cost_benchmark(LT_FIELDS_2026, economics_run=economics_run)
+        anchor_row = df[df["field_id"] == "anchor"].iloc[0]
+        assert anchor_row["modelled_capex_mm_usd"] == pytest.approx(5600.0)
+
+
+@unit
+class TestRunPortfolioAnalytics:
+    """Orchestrator bundles all four sections."""
+
+    @pytest.fixture(scope="class")
+    def run(self, economics_run):
+        return run_portfolio_analytics(economics_run=economics_run)
+
+    def test_returns_run_dataclass(self, run):
+        assert isinstance(run, PortfolioAnalyticsRun)
+        assert run.timestamp_utc
+
+    def test_all_four_sections_populated(self, run):
+        for name in ("technology", "operator", "hse", "cost_benchmark"):
+            assert isinstance(run.section(name), pd.DataFrame)
+            assert not run.section(name).empty
+
+    def test_section_unknown_raises(self, run):
+        with pytest.raises(KeyError):
+            run.section("nonexistent")
+
+
+@unit
+class TestRendering:
+    """CSV + HTML renderers complete and surface caveats."""
+
+    def test_csv_writes_four_files(self, tmp_path, economics_run):
+        run = run_portfolio_analytics(economics_run=economics_run)
+        paths = portfolio_analytics_to_csv(run, tmp_path)
+        assert set(paths.keys()) == {"technology", "operator", "hse", "cost_benchmark"}
+        for path in paths.values():
+            assert path.is_file()
+
+    def test_html_includes_caveats(self, tmp_path, economics_run):
+        run = run_portfolio_analytics(economics_run=economics_run)
+        out = tmp_path / "analytics.html"
+        portfolio_analytics_to_html(run, out)
+        contents = out.read_text(encoding="utf-8")
+        assert "#366" in contents  # HSE caveat
+        assert "#343" in contents  # cost benchmark caveat
+        assert "Lower Tertiary Portfolio Analytics" in contents


### PR DESCRIPTION
## Closes #376 — Phase 3 of #373 (LT comprehensive report)

## Summary

Four cross-cutting analytics sections, each emitting a DataFrame with explicit caveat / flag columns so missing inputs are visible rather than silently elided. Per the approved plan, 3a + 3b ship full implementations; 3c + 3d ship the minimum-viable shape pending downstream data work (#366, #343/#344).

## Live insights surfaced

### 3a — Technology generation (live numbers)

| Dev system | Fields | Total capex ($M) | Mean breakeven ($/bbl) | Total NPV ($M) |
|------------|--------|------------------|------------------------|----------------|
| Dry Tree | 1 (big_foot) | 5,200 | $52.48 | $2,577 |
| Subsea 15K | 3 (cascade_chinook, jack_st_malo, stones) | 14,200 | $51.32 | $8,005 |
| **Subsea 20K** | **5** (anchor, kaskida, north_platte, shenandoah, tiber) | **31,400** | $53.43 | **$15,264** |
| Tieback 15K | 1 (julia) | 4,700 | $91.03 | -$1,403 |

Insight: Subsea 20K dominates by both field count and total capex. Tieback 15K (Julia) has 2× the capex per recoverable MMbbl of standalone subsea — explains the negative NPV.

### 3b — Operator concentration (top 5)

| Company | Field count | WI capex ($M) | Share | HHI contribution |
|---------|-------------|---------------|-------|------------------|
| BP | 2 | 18,000 | 32.4% | 1,052 |
| Chevron | 3 | 10,445 | 18.8% | 354 |
| TotalEnergies | 3 | 8,440 | 15.2% | 231 |
| Equinor | 5 | 8,178 | 14.7% | 217 |
| Shell | 1 | 3,800 | 6.8% | 47 |

Insight: BP's outsized capex share (32%) comes from operating two of the largest Pre-FID 20K developments (Kaskida + Tiber). Equinor has the broadest portfolio reach (5 fields via partner stakes) but moderate capex weight.

### 3c — HSE per field

10 rows, all flagged `data_completeness: minimum_viable_pending_#366`. The placeholder shape is intentional per the approved plan; full coverage follows when #366 (HSE bulk dedup + ingest) lands.

### 3d — Cost benchmark vs disclosures

10 rows, all flagged `benchmark_status: no_data_pending_#343`. Calls `DisclosureAnalyticsQuery.benchmark` per field (already-shipped #338 surface) but with empty `project_revision_view` until #343 (operator registry) seeds it.

## What's in this PR

### Module: `src/worldenergydata/lower_tertiary/portfolio_analytics.py`

- `PortfolioAnalyticsRun` dataclass with `.section(name)` accessor
- 4 `analyze_*()` functions, each returning DataFrame + caveats
- `run_portfolio_analytics()` orchestrator (auto-runs `run_portfolio()` from #375 if economics_run not provided)
- `portfolio_analytics_to_csv(run, output_dir)` — 4 section CSVs
- `portfolio_analytics_to_html(run, path)` — combined HTML with caveat banners

Static dev_system fallback mapping (sourced from `reports/lower_tertiary_field_summary.md`) covers all 10 fields. `dev_system_source` column flags whether the value came from yaml or the fallback.

### CLI

```
worldenergydata lower-tertiary portfolio-analytics \
  --output-dir results/lt/analytics \
  --section all \
  --output-html results/lt/analytics.html
```

### Tests: 17 cases

| Class | Cases | Asserts |
|-------|-------|---------|
| `TestTechnologyGeneration` | 4 | column shape, field count sums to roster, Subsea 20K group includes anchor, caveat per row |
| `TestOperatorConcentration` | 3 | Chevron via partners, share sums to ~100%, kaskida via operator-only fallback |
| `TestHseMinimumViable` | 2 | one row per field, every flagged minimum_viable |
| `TestCostBenchmark` | 3 | one row per field, every flagged no_data, anchor capex matches yaml |
| `TestRunPortfolioAnalytics` | 3 | bundle dataclass, all 4 sections populated, unknown section raises |
| `TestRendering` | 2 | CSV writes 4 files, HTML includes #366 + #343 caveats |

## Verified locally

- **17/17** new tests pass in 62.81s
- Smoke run produces the live numbers above
- Black + ruff clean (caught 1 unused-variable + 1 reformat in pre-flight)

## Plan adherence

All adversarial-review items from the approved plan satisfied:
- [x] HSE 3c uses minimum-viable scope (in-repo data has incomplete BSEE incident records; #366 dependency surfaced via flag)
- [x] Cost benchmark 3d records `no_data` per field rather than dropping (preserves roster shape)
- [x] Working interests aggregation: yaml validation enforced via `wi_total_in_yaml` field; share_capex_pct sums to ~100% (test asserts within 0.5)
- [x] Capex intensity denominator: explicitly uses plateau×20yr proxy (caveat in every row); OGOR-grounded follow-up tracked under #367
- [x] All four CSVs joinable on `field_id`
- [x] Each section has caveat / flag column with explicit `pending_#NNN` markers

## Refs
- Plan: `docs/plans/2026-05-03-issue-376-cross-field-analytics-lt.md`
- Epic: #373
- Phase 1: #374 (closed)
- Phase 2: #375 (closed) — provides the economics_run input
- Pattern reference: `src/worldenergydata/marine_safety/cross_database.py`
- Cost benchmarking surface: #338 (closed)
- HSE upgrade path: #366
- Cost-benchmark seeding path: #343 + #344