### PR TITLE
fix(bsee): define missing prepare_production_data method

### DIFF
--- a/src/worldenergydata/bsee/analysis/production_api10.py
+++ b/src/worldenergydata/bsee/analysis/production_api10.py
@@ -16,6 +16,20 @@ class ProductionAPI10Analysis:
     def router(self, cfg, api12_production_data):
         self.prepare_production_data(cfg, api12_production_data)
 
+        # api12_analysis.sort_values(by=['O_PROD_STATUS', 'WELL_LABEL'],
+        #                                     ascending=[False, True],
+        #                                     inplace=True)
+        # api12_analysis.reset_index(inplace=True, drop=True)
+
+    def prepare_production_data(self, cfg, api12_production_data):
+        # Guard: if DataFrame is empty or None, return early without iterating.
+        if api12_production_data is None or api12_production_data.empty:
+            return
+        if "COMPLETION_NAME" not in api12_production_data.columns:
+            raise ValueError(
+                "api12_production_data missing COMPLETION_NAME column"
+            )
+
         # Iterate over completions in the provided production data and build
         # per-completion field-production summaries. Mirrors the legacy
         # ong_fd_components.prepare_production_data loop: for each completion
@@ -27,11 +41,6 @@ class ProductionAPI10Analysis:
             ].copy()
             self.prepare_field_production_rate(df_temp, completion_name)
             self.prepare_field_production(df_temp, completion_name)
-
-        # api12_analysis.sort_values(by=['O_PROD_STATUS', 'WELL_LABEL'],
-        #                                     ascending=[False, True],
-        #                                     inplace=True)
-        # api12_analysis.reset_index(inplace=True, drop=True)
 
     def add_production_from_all_wells(self):
         # Third party imports

--- a/tests/unit/bsee/analysis/test_production_api10.py
+++ b/tests/unit/bsee/analysis/test_production_api10.py
@@ -1,0 +1,117 @@
+"""
+Tests for production_api10 module — covers the #326 bug fix.
+
+Verifies that ProductionAPI10Analysis.router() does not raise
+AttributeError because prepare_production_data is now defined on the
+class, and that prepare_production_data dispatches per completion to the
+existing aggregator methods.
+"""
+
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from worldenergydata.bsee.analysis.production_api10 import (
+    ProductionAPI10Analysis,
+)
+
+
+@pytest.fixture
+def analyzer():
+    """Create a ProductionAPI10Analysis instance for tests."""
+    return ProductionAPI10Analysis()
+
+
+@pytest.fixture
+def two_completion_df():
+    """Two distinct completions with the columns the aggregators read."""
+    return pd.DataFrame(
+        {
+            "COMPLETION_NAME": ["A", "A", "B", "B"],
+            "PRODUCTION_DATETIME": [
+                "2023-01-01",
+                "2023-02-01",
+                "2023-01-01",
+                "2023-02-01",
+            ],
+            "O_PROD_RATE_BOPD": [100.0, 110.0, 200.0, 210.0],
+            "MON_O_PROD_VOL": [3000.0, 3100.0, 6000.0, 6300.0],
+        }
+    )
+
+
+@pytest.fixture
+def single_completion_df():
+    return pd.DataFrame(
+        {
+            "COMPLETION_NAME": ["A", "A"],
+            "PRODUCTION_DATETIME": ["2023-01-01", "2023-02-01"],
+            "O_PROD_RATE_BOPD": [100.0, 110.0],
+            "MON_O_PROD_VOL": [3000.0, 3100.0],
+        }
+    )
+
+
+class TestProductionAPI10Analysis:
+
+    def test_router_no_attribute_error(self, analyzer, single_completion_df):
+        """router() must not raise AttributeError after the fix."""
+        analyzer.router({}, single_completion_df)
+
+    def test_prepare_production_data_calls_per_completion_delegates(
+        self, analyzer, two_completion_df
+    ):
+        """For 2 unique completions, each delegate is called twice."""
+        with patch.object(
+            analyzer, "prepare_field_production_rate"
+        ) as mock_rate, patch.object(
+            analyzer, "prepare_field_production"
+        ) as mock_prod:
+            analyzer.prepare_production_data({}, two_completion_df)
+            assert mock_rate.call_count == 2
+            assert mock_prod.call_count == 2
+
+    def test_prepare_production_data_single_completion(
+        self, analyzer, single_completion_df
+    ):
+        """For 1 unique completion, each delegate is called exactly once."""
+        with patch.object(
+            analyzer, "prepare_field_production_rate"
+        ) as mock_rate, patch.object(
+            analyzer, "prepare_field_production"
+        ) as mock_prod:
+            analyzer.prepare_production_data({}, single_completion_df)
+            assert mock_rate.call_count == 1
+            assert mock_prod.call_count == 1
+
+    def test_prepare_production_data_empty_dataframe(self, analyzer):
+        """Empty DataFrame must short-circuit without calling delegates."""
+        with patch.object(
+            analyzer, "prepare_field_production_rate"
+        ) as mock_rate, patch.object(
+            analyzer, "prepare_field_production"
+        ) as mock_prod:
+            analyzer.prepare_production_data({}, pd.DataFrame())
+            mock_rate.assert_not_called()
+            mock_prod.assert_not_called()
+
+    def test_prepare_production_data_missing_column(self, analyzer):
+        """DataFrame without COMPLETION_NAME must raise ValueError."""
+        df = pd.DataFrame({"OTHER_COL": [1, 2, 3]})
+        with pytest.raises(ValueError, match="COMPLETION_NAME"):
+            analyzer.prepare_production_data({}, df)
+
+    def test_router_invokes_prepare_production_data(
+        self, analyzer, single_completion_df
+    ):
+        """router() forwards (cfg, api12_production_data) to prepare_production_data."""
+        cfg = {"sentinel": True}
+        with patch.object(analyzer, "prepare_production_data") as mock_prep:
+            analyzer.router(cfg, single_completion_df)
+            mock_prep.assert_called_once_with(cfg, single_completion_df)
+
+    def test_prepare_production_data_defined_on_instance(self, analyzer):
+        """Sanity: method exists on the class (regression guard for #326)."""
+        assert hasattr(analyzer, "prepare_production_data")
+        assert callable(analyzer.prepare_production_data)


### PR DESCRIPTION
Closes #326.

## Problem
`ProductionAPI10Analysis.router()` called `self.prepare_production_data(cfg, api12_production_data)` on line 17, but the method was never defined on the class. Any call raised `AttributeError`.

## Verify gate (per execution prompt)
- Confirmed line 17 calls `prepare_production_data` and `grep "def prepare_production_data" production_api10.py` returns nothing.
- Confirmed orphaned loop at lines 23-29 iterates `api12_production_data.COMPLETION_NAME.unique()` and delegates to `prepare_field_production_rate` / `prepare_field_production` — variables match what the missing method's caller would expect, and the loop is a faithful mirror of the legacy `ong_fd_components.prepare_production_data` (line 226 of `common/legacy/ong_fd_components.py`).
- Confirmed sibling methods `prepare_field_production_rate` (line 85) and `prepare_field_production` (line 106) exist.
- Conclusion: orphan loop is the intended body of the missing method, not dead code. Plan diagnosis matches reality. Proceeded.

## Fix
- Added `prepare_production_data(self, cfg, api12_production_data)` containing the relocated loop, with empty-DataFrame guard and `COMPLETION_NAME`-missing `ValueError`.
- Removed the orphaned loop from `router()`; behavior preserved (loop now runs from inside `prepare_production_data`).
- Sibling methods `prepare_field_production_rate` / `prepare_field_production` are untouched.

## Tests added
`tests/unit/bsee/analysis/test_production_api10.py` — 7 cases:
- `test_router_no_attribute_error`
- `test_prepare_production_data_calls_per_completion_delegates`
- `test_prepare_production_data_single_completion`
- `test_prepare_production_data_empty_dataframe`
- `test_prepare_production_data_missing_column`
- `test_router_invokes_prepare_production_data`
- `test_prepare_production_data_defined_on_instance`

All 7 pass: `uv run pytest tests/unit/bsee/analysis/test_production_api10.py -v --no-cov` -> `7 passed`.

## Plan
`docs/plans/2026-05-04-issue-326-prepare-production-data-missing.md`