### PR TITLE
chore(repo-structure): add structure contract checker (#394)

### DIFF
--- a/.planning/plan-approved/394.md
+++ b/.planning/plan-approved/394.md
@@ -1,0 +1,9 @@
+# Plan approval marker: worldenergydata#394
+
+Issue: https://github.com/vamseeachanta/worldenergydata/issues/394
+Plan: docs/plans/2026-05-08-issue-394-repo-structure-normalization.md
+Review synthesis: scripts/review/results/2026-05-08-plan-394-repo-structure-review-synthesis.md
+
+Approval basis: the live GitHub issue is open with `status:plan-approved`, and the user explicitly instructed this session to resume execution of the approved repo-by-repo folder/file structure normalization wave.
+
+Authorized scope for this implementation pass: bounded Phase 1 contract/checker/tests/docs/enforcement wiring only. Broad source/docs/generated-output moves, deletion, or relocation remain out of scope unless separately approved.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,7 +107,7 @@ repos:
       - id: commitizen
         stages: [commit-msg]
 
-  # Guard: reject Windows-path directory artifacts (WRK-364)
+  # Local repository structure guards
   - repo: local
     hooks:
       - id: no-windows-path-dirs
@@ -116,6 +116,14 @@ repos:
         entry: python scripts/hooks/check-no-windows-paths.py
         pass_filenames: false
         stages: [pre-commit]
+      - id: repo-structure-contract
+        name: Repository structure contract
+        language: python
+        entry: python scripts/maintenance/verify_repo_structure.py
+        pass_filenames: false
+        stages: [pre-commit]
+        additional_dependencies:
+          - PyYAML
 
 # CI configuration
 ci:

--- a/config/repo_structure.yml
+++ b/config/repo_structure.yml
@@ -1,0 +1,137 @@
+# worldenergydata repository structure contract
+# Issue: https://github.com/vamseeachanta/worldenergydata/issues/394
+# Scope: Phase 1 contract/checker only; no broad moves or deletion authorized.
+
+allowed_roots:
+  # Standard project roots
+  - src
+  - tests
+  - docs
+  - config
+  - scripts
+  - data
+  - examples
+  - notebooks
+  - subseaiq
+  - systemd
+  - _archive
+
+  # Agent/tooling and repo metadata roots intentionally tracked today
+  - .ai
+  - .claude
+  - .codex
+  - .common
+  - .gemini
+  - .git-commands
+  - .github
+  - .github_workflows_backup
+  - .planning
+  - .slash-commands
+
+  # Approved root files
+  - AGENTS.md
+  - CLAUDE.md
+  - .command-registry.json
+  - coverage.json
+  - .coveragerc
+  - .coverage_report.json
+  - .flake8
+  - .gitattributes
+  - .gitignore
+  - .legal-deny-list.yaml
+  - LICENSE
+  - Makefile
+  - mkdocs.yml
+  - MODULE_INDEX.md
+  - module-manifest.yaml
+  - .pre-commit-config.yaml
+  - pyproject.toml
+  - pytest.ini
+  - .radon.cfg
+  - README.md
+  - uv.lock
+  - uv.toml
+  - vulture_whitelist.py
+
+ignored_roots:
+  - .git
+  - .venv
+  - __pycache__
+  - .mypy_cache
+  - .pytest_cache
+  - .ruff_cache
+  - .hypothesis
+  - .agent-os
+  - .archived
+  - .benchmarks
+  - .claude-flow
+  - .hive-mind
+  - .swarm
+  - backups
+
+generated_artifact_roots:
+  - logs
+  - reports
+  - output
+  - results
+  - site
+  - test_output
+
+temporary_exceptions:
+  logs:
+    category: durable-evidence
+    owner: worldenergydata maintainers
+    review_date: "2026-06-30"
+    follow_up: https://github.com/vamseeachanta/worldenergydata/issues/394
+    justification: Tracked scheduler log JSON files are preserved as existing durable evidence until a dedicated generated-evidence migration classifies retention, relocation, or deletion.
+    allowed_paths:
+      - logs/scheduler/20260325_214434_eia_us_refresh.json
+      - logs/scheduler/20260325_214511_bsee_refresh.json
+      - logs/scheduler/20260325_214601_sodir_refresh.json
+      - logs/scheduler/20260325_214643_brazil_anp_refresh.json
+      - logs/scheduler/20260325_214746_ukcs_refresh.json
+      - logs/scheduler/20260325_214826_metocean_refresh.json
+  reports:
+    category: durable-evidence
+    owner: worldenergydata maintainers
+    review_date: "2026-06-30"
+    follow_up: https://github.com/vamseeachanta/worldenergydata/issues/394
+    justification: Tracked HTML, Markdown, Python, and JSON report artifacts are preserved as existing durable evidence until a dedicated generated-evidence migration classifies retention, relocation, or deletion.
+    allowed_paths:
+      - reports/.gitkeep
+      - reports/IMO_GISIS_Executive_Report.html
+      - reports/REPORT_SUMMARY.md
+      - reports/anchor_field_demo_report.html
+      - reports/compliance/module_compliance_report.json
+      - reports/field_analysis_report.html
+      - reports/gtm/2026-05-04-bsee-field-analysis-comprehensive.html
+      - reports/gtm/2026-05-04-fdas-field-development-economics.html
+      - reports/gtm/2026-05-04-gtm-production-decline-forecast.html
+      - reports/hse/wrk012_hse_data_audit.md
+      - reports/hse/wrk013_hse_mishap_analysis.md
+      - reports/imo_gisis_analysis_report.py
+      - reports/lower_tertiary/v30_repeatability_report.md
+      - reports/lower_tertiary/wrk010_latest_data_report.md
+      - reports/lower_tertiary_field_summary.html
+      - reports/lower_tertiary_field_summary.md
+      - reports/marine_safety/README.md
+      - reports/marine_safety/executive_summary.html
+      - reports/marine_safety/fatality_analysis.html
+      - reports/marine_safety/foundering_analysis.html
+      - reports/marine_safety/hatch_analysis.html
+      - reports/marine_safety_cause_analysis_demo.html
+      - reports/metocean/test_wave_rose.html
+      - reports/modules/marketing/COMPLETION_SUMMARY.md
+      - reports/modules/marketing/DECISION_IMPLEMENTATION_GUIDE.md
+      - reports/modules/marketing/GENERATION_SUMMARY.md
+      - reports/modules/marketing/PDF_GENERATION_CHECKLIST.md
+      - reports/modules/marketing/PREREQUISITES_VALIDATION_SUMMARY.md
+      - reports/modules/marketing/QUICK_START.md
+      - reports/modules/marketing/VALIDATION_REPORT.md
+      - reports/modules/marketing/marketing_brochure_bsee_data_integration.md
+      - reports/modules/marketing/marketing_brochure_economic_evaluation_npv_analysis.md
+      - reports/modules/marketing/marketing_brochure_fdas_field_data_analysis_system.md
+      - reports/modules/marketing/marketing_brochure_field-specific_analysis.md
+      - reports/modules/marketing/marketing_brochure_marine_safety_incident_analysis.md
+      - reports/modules/marketing/marketing_brochure_web_scraping_infrastructure.md
+      - reports/modules/marketing/marketing_brochure_well_production_dashboard.md

--- a/docs/plans/2026-05-08-issue-394-repo-structure-normalization.md
+++ b/docs/plans/2026-05-08-issue-394-repo-structure-normalization.md
@@ -1,0 +1,220 @@
+# Plan for #394: chore(repo-structure): normalize worldenergydata folder/file structure
+
+> **Status:** ready for `status:plan-review` / user approval; implementation blocked
+> **Complexity:** T3
+> **Date:** 2026-05-08
+> **Issue:** https://github.com/vamseeachanta/worldenergydata/issues/394
+> **Review artifact:** `scripts/review/results/2026-05-08-plan-394-repo-structure-review-synthesis.md`
+> **Parent anchors:** workspace-hub#1962, workspace-hub#2397
+
+---
+
+## Decision Summary
+
+This plan is a **repo-specific planning gate** for `worldenergydata` folder/file structure normalization. It authorizes only a bounded Phase 1 after approval: inventory-backed structure contract, machine-readable exception policy, checker/test harness, and minimal documentation/index updates required to stop new drift.
+
+No broad file moves, generated artifact deletion, package-source reshuffle, docs migration, or runtime behavior change is authorized until this plan is explicitly approved and Phase 1 tests/checkers exist.
+
+
+
+## Resource Intelligence Summary
+
+### Existing assets
+
+- Repository: `vamseeachanta/worldenergydata`
+- Current issue: https://github.com/vamseeachanta/worldenergydata/issues/394
+- Root directories observed: .agent-os/, .ai/, .archived/, .benchmarks/, .claude-flow/, .claude/, .codex/, .common/, .gemini/, .git-commands/, .github/, .github_workflows_backup/, .hive-mind/, .hypothesis/, .mypy_cache/, .planning/, .pytest_cache/, .ruff_cache/, .slash-commands/, .swarm/, .venv/, _archive/, backups/, config/, data/, docs/, examples/, logs/, notebooks/, output/, reports/, results/, scripts/, site/, src/, subseaiq/, systemd/, test_output/, tests/
+- Root files observed: .command-registry.json, .coverage_report.json, .coveragerc, .flake8, .gitattributes, .gitignore, .legal-deny-list.yaml, .mcp.json, .pre-commit-config.yaml, .python-version, .radon.cfg, .test_performance.db, AGENTS.md, CLAUDE.md, COVERAGE_ANALYSIS.txt, LICENSE, MODULE_INDEX.md, Makefile, README.md, coverage.json, coverage.xml, mkdocs.yml, module-manifest.yaml, pyproject.toml, pytest.ini, test_export.json, uv.lock, uv.toml, vulture_whitelist.py
+- Standard directory counts:
+- `src/`: 1928 files in working-tree scan
+- `tests/`: 2318 files in working-tree scan
+- `docs/`: 508 files in working-tree scan
+- `scripts/`: 280 files in working-tree scan
+- `config/`: 39 files in working-tree scan
+- `.github/`: 11 files in working-tree scan
+- `output/`: 1 files in working-tree scan
+- `reports/`: 1372 files in working-tree scan
+- `results/`: 26 files in working-tree scan
+- `notebooks/`: 8 files in working-tree scan
+- `data/`: 417 files in working-tree scan
+- `site/`: 49 files in working-tree scan
+
+### Tracked root files observed
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `.command-registry.json`
+- `coverage.json`
+- `.coveragerc`
+- `.coverage_report.json`
+- `.flake8`
+- `.gitattributes`
+- `.gitignore`
+- `.legal-deny-list.yaml`
+- `LICENSE`
+- `Makefile`
+- `mkdocs.yml`
+- `MODULE_INDEX.md`
+- `module-manifest.yaml`
+- `.pre-commit-config.yaml`
+- `pyproject.toml`
+- `pytest.ini`
+- `.radon.cfg`
+- `README.md`
+- `uv.lock`
+- `uv.toml`
+- `vulture_whitelist.py`
+
+### Tracked generated-output candidates observed
+
+- `logs/scheduler/20260325_214434_eia_us_refresh.json`
+- `logs/scheduler/20260325_214511_bsee_refresh.json`
+- `logs/scheduler/20260325_214601_sodir_refresh.json`
+- `logs/scheduler/20260325_214643_brazil_anp_refresh.json`
+- `logs/scheduler/20260325_214746_ukcs_refresh.json`
+- `logs/scheduler/20260325_214826_metocean_refresh.json`
+- `reports/.gitkeep`
+- `reports/IMO_GISIS_Executive_Report.html`
+- `reports/REPORT_SUMMARY.md`
+- `reports/anchor_field_demo_report.html`
+- `reports/compliance/module_compliance_report.json`
+- `reports/field_analysis_report.html`
+- `reports/gtm/2026-05-04-bsee-field-analysis-comprehensive.html`
+- `reports/gtm/2026-05-04-fdas-field-development-economics.html`
+- `reports/gtm/2026-05-04-gtm-production-decline-forecast.html`
+- `reports/hse/wrk012_hse_data_audit.md`
+- `reports/hse/wrk013_hse_mishap_analysis.md`
+- `reports/imo_gisis_analysis_report.py`
+- `reports/lower_tertiary/v30_repeatability_report.md`
+- `reports/lower_tertiary/wrk010_latest_data_report.md`
+- `reports/lower_tertiary_field_summary.html`
+- `reports/lower_tertiary_field_summary.md`
+- `reports/marine_safety/README.md`
+- `reports/marine_safety/executive_summary.html`
+- `reports/marine_safety/fatality_analysis.html`
+- `reports/marine_safety/foundering_analysis.html`
+- `reports/marine_safety/hatch_analysis.html`
+- `reports/marine_safety_cause_analysis_demo.html`
+- `reports/metocean/test_wave_rose.html`
+- `reports/modules/marketing/COMPLETION_SUMMARY.md`
+- `reports/modules/marketing/DECISION_IMPLEMENTATION_GUIDE.md`
+- `reports/modules/marketing/GENERATION_SUMMARY.md`
+- `reports/modules/marketing/PDF_GENERATION_CHECKLIST.md`
+- `reports/modules/marketing/PREREQUISITES_VALIDATION_SUMMARY.md`
+- `reports/modules/marketing/QUICK_START.md`
+- `reports/modules/marketing/VALIDATION_REPORT.md`
+- `reports/modules/marketing/marketing_brochure_bsee_data_integration.md`
+- `reports/modules/marketing/marketing_brochure_economic_evaluation_npv_analysis.md`
+- `reports/modules/marketing/marketing_brochure_fdas_field_data_analysis_system.md`
+- `reports/modules/marketing/marketing_brochure_field-specific_analysis.md`
+- `reports/modules/marketing/marketing_brochure_marine_safety_incident_analysis.md`
+- `reports/modules/marketing/marketing_brochure_web_scraping_infrastructure.md`
+- `reports/modules/marketing/marketing_brochure_well_production_dashboard.md`
+
+### Related prior work
+
+- Workspace-hub ecosystem anchors: `workspace-hub#1962` and `workspace-hub#2397`.
+- `digitalmodel#596` is the template-quality first repo plan and discipline model: contract first, checker second, bounded moves only after approval.
+- This plan does not assume previous repo-specific cleanup issues are complete; implementation must re-check live git state before editing.
+
+### Constraints
+
+- Follow workspace-hub hard gates: Issue → Plan → Adversarial Review → `status:plan-review` → explicit user approval → implementation.
+- TDD is mandatory before checker or migration code.
+- Preserve evidence and rollback ability for every moved/removed tracked path.
+- Do not delete or relocate generated-looking tracked files until classified as unauthorized artifact, durable evidence, or temporary durable exception.
+- Do not move package/source/runtime/static entrypoints without import/build/deploy proof specific to this repo.
+
+### Gaps
+
+- No approved local structure contract for this normalization tranche.
+- Generated-output and root-clutter classification needs a machine-readable allow/deny/exception inventory before cleanup.
+- CI/pre-commit enforcement may be absent or insufficient for new root artifacts.
+
+### Risks / unknowns
+
+- Hidden consumers may reference current paths from docs, CI, packaging, static hosting, notebooks, or external scripts.
+- Some generated-looking files may be durable evidence or deploy artifacts; deleting them blindly would lose traceability.
+- Root-level clutter can include user/session artifacts; implementation must not reset unrelated dirty files.
+
+## Scope Boundaries
+
+### In scope after approval
+
+1. Add/update repo-local structure standard under `docs/standards/repo-structure.md` or closest existing standards surface.
+2. Add machine-readable contract such as `config/repo_structure.yml` listing allowed roots, denied generated roots, and temporary durable exceptions.
+3. Add checker under `scripts/maintenance/verify_repo_structure.py` or equivalent repo-appropriate maintenance path.
+4. Add TDD tests under `tests/repo_structure/` or equivalent test surface.
+5. Wire checker into pre-commit/CI if those surfaces exist.
+6. Move only low-risk root utility/docs artifacts that have no source/runtime consumers and are covered by tests/checker evidence.
+7. Create follow-up issues for broad package/docs/generated-evidence migrations discovered during implementation.
+
+### Out of scope
+
+- Bulk source package reorganization.
+- Broad docs tree migration.
+- Deletion of generated-looking tracked files without classification and follow-up linkage.
+- Notebook/data/report/static deploy relocation unless explicitly classified and tested.
+- Any execution before explicit user approval.
+
+## Artifact Map
+
+| Artifact | Path | Purpose |
+|---|---|---|
+| Canonical plan | `docs/plans/2026-05-08-issue-394-repo-structure-normalization.md` | Approval gate for this repo |
+| Review synthesis | `scripts/review/results/2026-05-08-plan-394-repo-structure-review-synthesis.md` | Adversarial/readiness findings |
+| Structure standard | `docs/standards/repo-structure.md` or existing standard path | Human-readable contract |
+| Machine contract | `config/repo_structure.yml` | Checker source of truth |
+| Checker | `scripts/maintenance/verify_repo_structure.py` | Enforce root/generated/exception rules |
+| Tests | `tests/repo_structure/test_repo_structure_contract.py` | TDD for checker and contract |
+| Approval marker after approval only | `.planning/plan-approved/394.md` | Execution authorization evidence |
+
+## Pseudocode
+
+```text
+load config/repo_structure.yml
+collect git-tracked paths and working-tree root entries
+for each root entry:
+    classify as allowed, denied-generated, temporary-exception, or unknown
+    if unknown or denied without exception:
+        emit deterministic violation with remediation hint
+for each temporary exception:
+    require owner/category/review-date/follow-up URL/non-placeholder justification
+scan moved-file candidates:
+    require no references outside approved update set before moving
+return nonzero if violations exist
+```
+
+## TDD Test List
+
+- RED: checker fails on an unapproved root file/dir fixture.
+- RED: checker fails on tracked generated-output root without exception metadata.
+- RED: checker fails on exception metadata with placeholder owner/review-date/follow-up URL.
+- GREEN: checker accepts current approved roots and explicitly listed exceptions.
+- GREEN: reference scan blocks candidate moves with live consumers.
+- GREEN: CI/pre-commit invocation path is covered by a smoke test or workflow grep assertion.
+
+## Acceptance Criteria
+
+1. Plan remains planning-only until explicit user approval.
+2. Implementation has TDD coverage before checker/migration code lands.
+3. Human-readable and machine-readable structure contracts exist.
+4. Generated-output candidates are classified, not blindly deleted.
+5. CI/pre-commit prevents newly introduced root/generated drift.
+6. Any moved paths have reference-scan proof and rollback notes.
+7. Follow-up issues are created for broad migrations rather than silently absorbed.
+
+## Follow-up Issue Candidates
+
+- Package/domain module reorganization if inventory shows large package-layout drift.
+- Generated evidence relocation/classification for tracked reports/results/build outputs.
+- Docs/navigation restructuring if docs references require broader moves.
+- Static deploy artifact policy, if applicable, for generated `dist/`, site, sitemap, or public assets.
+
+## Review Readiness Notes
+
+This plan is intentionally conservative and reusable across the tier-1 repo ecosystem. Reviewers should reject implementation attempts that start moving/deleting files before the contract/checker/test layer is approved and green.
+
+## Approval Gate
+
+Execution is not authorized until the user approves this exact plan and implementation records `.planning/plan-approved/394.md` with the reviewed commit/blob SHA.

--- a/docs/standards/repo-structure.md
+++ b/docs/standards/repo-structure.md
@@ -1,0 +1,79 @@
+# Repository Structure Standard
+
+Issue: [worldenergydata#394](https://github.com/vamseeachanta/worldenergydata/issues/394)
+
+This standard defines the Phase 1 folder/file structure contract for `worldenergydata`.
+It is intentionally conservative: the current pass adds documentation, a machine-readable
+contract, tests, and enforcement. It does **not** authorize broad package moves, docs tree
+moves, generated artifact deletion, or tracked evidence relocation.
+
+## Canonical source of truth
+
+- Human-readable standard: `docs/standards/repo-structure.md`
+- Machine-readable contract: `config/repo_structure.yml`
+- Checker: `scripts/maintenance/verify_repo_structure.py`
+- Tests: `tests/repo_structure/test_repo_structure_contract.py`
+
+Run the checker from the repository root:
+
+```bash
+PYTHONPATH='src:../assetutilities/src' uv run python scripts/maintenance/verify_repo_structure.py
+```
+
+Run the targeted tests:
+
+```bash
+PYTHONPATH='src:../assetutilities/src' uv run python -m pytest --noconftest tests/repo_structure/test_repo_structure_contract.py -q
+```
+
+## Root contract
+
+New tracked or non-ignored working-tree root entries must be intentionally classified in
+`config/repo_structure.yml`. The checker reads `git ls-files` plus `git status --short
+--untracked-files=all` by default, so it catches committed state and visible pre-commit
+drift without scanning ignored caches or generated local outputs.
+
+Root entries are classified as:
+
+1. `allowed_roots` — canonical source, tests, docs, config, scripts, tool metadata, and
+   approved root files.
+2. `generated_artifact_roots` — generated-output-style roots that require explicit
+   temporary-exception metadata before they are tolerated.
+3. `ignored_roots` — local caches, virtualenvs, build outputs, or untracked operational
+   roots that are not part of the tracked Phase 1 contract.
+4. `temporary_exceptions` — tracked generated-looking artifacts preserved as durable
+   evidence until follow-up classification decides whether to retain, relocate, or delete.
+   Each temporary exception must list explicit `allowed_paths`; new generated-root paths are
+   rejected until classified.
+
+## Generated-output policy
+
+Do not delete or relocate tracked generated-looking artifacts during Phase 1. Each such
+root must be classified as one of:
+
+- unauthorized generated artifact,
+- durable evidence, or
+- temporary durable exception with owner, review date, follow-up URL, and justification.
+
+For this Phase 1 pass, existing tracked `logs/` and `reports/` content is preserved as
+`durable-evidence` temporary exceptions. Broad cleanup belongs in a separately approved
+follow-up issue.
+
+## Change rules
+
+- Add new source code under `src/worldenergydata/`.
+- Add tests under `tests/`, mirroring the relevant behavior/domain where practical.
+- Add operational repo checks under `scripts/maintenance/`.
+- Add shared repo policy and standards under `docs/standards/`.
+- Add machine-readable policy under `config/`.
+- Do not add new root files or directories unless the contract is updated in the same
+  transaction and the checker remains green.
+- Do not move source/docs/generated artifacts without reference-scan proof, rollback notes,
+  and explicit scope approval.
+
+## Enforcement
+
+The pre-commit configuration includes the local `repo-structure-contract` hook. CI or
+manual validation should run the same checker before closeout. The checker emits stable
+violation codes such as `unknown-root`, `generated-root-missing-exception`, and
+`invalid-exception-metadata` to support deterministic follow-up.

--- a/scripts/maintenance/verify_repo_structure.py
+++ b/scripts/maintenance/verify_repo_structure.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Verify the worldenergydata repository structure contract.
+
+The checker is intentionally conservative for #394 Phase 1: it does not move or
+remove files. It classifies tracked/explicit paths against the approved root
+contract and requires generated-output roots to carry temporary-exception
+metadata before they are tolerated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import yaml
+
+_PLACEHOLDER_VALUES = {"", "todo", "tbd", "none", "n/a", "placeholder"}
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_URL_RE = re.compile(r"^https://github\.com/vamseeachanta/worldenergydata/issues/\d+")
+
+
+@dataclass(frozen=True)
+class RepoStructureViolation:
+    """A deterministic structure-contract violation."""
+
+    code: str
+    root: str
+    path: str
+
+
+@dataclass(frozen=True)
+class RepoStructureContract:
+    """Parsed repo-structure contract."""
+
+    allowed_roots: frozenset[str]
+    ignored_roots: frozenset[str]
+    generated_artifact_roots: frozenset[str]
+    temporary_exceptions: dict[str, dict[str, object]]
+
+
+def _as_set(payload: dict, key: str) -> frozenset[str]:
+    value = payload.get(key, [])
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"{key} must be a list of strings")
+    return frozenset(value)
+
+
+def load_contract(path: Path | str) -> RepoStructureContract:
+    """Load and validate the YAML structure contract."""
+
+    contract_path = Path(path)
+    payload = yaml.safe_load(contract_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(payload, dict):
+        raise ValueError(f"{contract_path} must contain a YAML mapping")
+
+    exceptions = payload.get("temporary_exceptions", {})
+    if not isinstance(exceptions, dict):
+        raise ValueError("temporary_exceptions must be a mapping")
+
+    normalized_exceptions: dict[str, dict[str, object]] = {}
+    for root, metadata in exceptions.items():
+        if not isinstance(root, str) or not isinstance(metadata, dict):
+            raise ValueError("temporary_exceptions entries must map roots to metadata mappings")
+        normalized_exceptions[root] = dict(metadata)
+
+    return RepoStructureContract(
+        allowed_roots=_as_set(payload, "allowed_roots"),
+        ignored_roots=_as_set(payload, "ignored_roots"),
+        generated_artifact_roots=_as_set(payload, "generated_artifact_roots"),
+        temporary_exceptions=normalized_exceptions,
+    )
+
+
+def root_for(path: str) -> str:
+    """Return the root entry for a repository-relative path.
+
+    Preserve leading-dot root names (for example, ``.github`` and ``.claude``)
+    while tolerating an explicit ``./`` prefix from CLI input.
+    """
+
+    normalized = path.strip()
+    if normalized.startswith("./"):
+        normalized = normalized[2:]
+    if not normalized:
+        return ""
+    return normalized.split("/", 1)[0]
+
+
+def _is_placeholder(value: str) -> bool:
+    return value.strip().lower() in _PLACEHOLDER_VALUES
+
+
+def _metadata_value(metadata: dict[str, object], key: str) -> str:
+    value = metadata.get(key, "")
+    return "" if value is None else str(value)
+
+
+def _exception_metadata_valid(metadata: dict[str, object]) -> bool:
+    required = ("category", "owner", "review_date", "follow_up", "justification")
+    if any(key not in metadata or _is_placeholder(_metadata_value(metadata, key)) for key in required):
+        return False
+    if not _DATE_RE.match(_metadata_value(metadata, "review_date").strip()):
+        return False
+    if not _URL_RE.match(_metadata_value(metadata, "follow_up").strip()):
+        return False
+    if len(_metadata_value(metadata, "justification").strip()) < 30:
+        return False
+    allowed_paths = metadata.get("allowed_paths")
+    if not isinstance(allowed_paths, list) or not all(isinstance(item, str) and item for item in allowed_paths):
+        return False
+    return True
+
+
+def _path_allowed_by_exception(path: str, metadata: dict[str, object]) -> bool:
+    allowed_paths = metadata.get("allowed_paths")
+    if not isinstance(allowed_paths, list):
+        return False
+    return path in set(allowed_paths)
+
+
+def validate_paths(paths: Iterable[str], contract: RepoStructureContract) -> list[RepoStructureViolation]:
+    """Validate repository-relative paths against the root contract."""
+
+    violations: list[RepoStructureViolation] = []
+    emitted: set[RepoStructureViolation] = set()
+
+    def add(violation: RepoStructureViolation) -> None:
+        if violation not in emitted:
+            emitted.add(violation)
+            violations.append(violation)
+
+    for path in sorted({p for p in paths if p and not p.endswith("/")}):
+        root = root_for(path)
+        if not root or root in contract.ignored_roots:
+            continue
+
+        if root in contract.generated_artifact_roots:
+            metadata = contract.temporary_exceptions.get(root)
+            if metadata is None:
+                add(RepoStructureViolation("generated-root-missing-exception", root, path))
+            elif not _exception_metadata_valid(metadata):
+                add(RepoStructureViolation("invalid-exception-metadata", root, root))
+            elif not _path_allowed_by_exception(path, metadata):
+                add(RepoStructureViolation("generated-path-not-classified", root, path))
+            continue
+
+        if root in contract.allowed_roots:
+            continue
+
+        add(RepoStructureViolation("unknown-root", root, path))
+
+    return violations
+
+
+def git_tracked_paths(repo_root: Path) -> list[str]:
+    """Return git-tracked paths for the current checkout."""
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=repo_root,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def parse_git_status_paths(output: str) -> list[str]:
+    """Parse porcelain-like ``git status --short`` output into paths.
+
+    This deliberately includes untracked, modified, deleted, and renamed paths
+    that are visible in the working tree without reading ignored cache/output
+    directories. For renames, validate the destination path because that is the
+    root shape that would be committed.
+    """
+
+    paths: list[str] = []
+    for raw_line in output.splitlines():
+        if not raw_line or raw_line.startswith("## ") or len(raw_line) < 4:
+            continue
+        path = raw_line[3:]
+        if " -> " in path:
+            path = path.rsplit(" -> ", 1)[1]
+        if path:
+            try:
+                parsed = shlex.split(path)
+            except ValueError:
+                parsed = []
+            paths.append(parsed[0] if len(parsed) == 1 else path)
+    return paths
+
+
+def git_worktree_paths(repo_root: Path) -> list[str]:
+    """Return non-ignored working-tree paths visible to git status."""
+
+    result = subprocess.run(
+        ["git", "status", "--short", "--untracked-files=all"],
+        cwd=repo_root,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    return parse_git_status_paths(result.stdout)
+
+
+def repository_paths(repo_root: Path) -> list[str]:
+    """Return tracked plus non-ignored working-tree paths for contract checks."""
+
+    return git_tracked_paths(repo_root) + git_worktree_paths(repo_root)
+
+
+def format_violations(violations: Sequence[RepoStructureViolation]) -> str:
+    """Render violations for humans and CI logs."""
+
+    lines = ["Repo structure contract violations:"]
+    for violation in violations:
+        lines.append(f"- {violation.code}: root={violation.root} path={violation.path}")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config/repo_structure.yml"),
+        help="Path to repo_structure.yml (default: config/repo_structure.yml)",
+    )
+    parser.add_argument(
+        "--path",
+        action="append",
+        dest="paths",
+        help="Explicit repo-relative path to validate. Repeatable; defaults to git ls-files.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    repo_root = Path.cwd()
+    contract = load_contract(args.config)
+    paths = args.paths if args.paths is not None else repository_paths(repo_root)
+    violations = validate_paths(paths, contract)
+    if violations:
+        print(format_violations(violations))
+        return 1
+    print("Repo structure contract: OK")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/scripts/maintenance/verify_repo_structure.py
+++ b/scripts/maintenance/verify_repo_structure.py
@@ -66,7 +66,9 @@ def load_contract(path: Path | str) -> RepoStructureContract:
     normalized_exceptions: dict[str, dict[str, object]] = {}
     for root, metadata in exceptions.items():
         if not isinstance(root, str) or not isinstance(metadata, dict):
-            raise ValueError("temporary_exceptions entries must map roots to metadata mappings")
+            raise ValueError(
+                "temporary_exceptions entries must map roots to metadata mappings"
+            )
         normalized_exceptions[root] = dict(metadata)
 
     return RepoStructureContract(
@@ -103,7 +105,10 @@ def _metadata_value(metadata: dict[str, object], key: str) -> str:
 
 def _exception_metadata_valid(metadata: dict[str, object]) -> bool:
     required = ("category", "owner", "review_date", "follow_up", "justification")
-    if any(key not in metadata or _is_placeholder(_metadata_value(metadata, key)) for key in required):
+    if any(
+        key not in metadata or _is_placeholder(_metadata_value(metadata, key))
+        for key in required
+    ):
         return False
     if not _DATE_RE.match(_metadata_value(metadata, "review_date").strip()):
         return False
@@ -112,7 +117,9 @@ def _exception_metadata_valid(metadata: dict[str, object]) -> bool:
     if len(_metadata_value(metadata, "justification").strip()) < 30:
         return False
     allowed_paths = metadata.get("allowed_paths")
-    if not isinstance(allowed_paths, list) or not all(isinstance(item, str) and item for item in allowed_paths):
+    if not isinstance(allowed_paths, list) or not all(
+        isinstance(item, str) and item for item in allowed_paths
+    ):
         return False
     return True
 
@@ -124,7 +131,9 @@ def _path_allowed_by_exception(path: str, metadata: dict[str, object]) -> bool:
     return path in set(allowed_paths)
 
 
-def validate_paths(paths: Iterable[str], contract: RepoStructureContract) -> list[RepoStructureViolation]:
+def validate_paths(
+    paths: Iterable[str], contract: RepoStructureContract
+) -> list[RepoStructureViolation]:
     """Validate repository-relative paths against the root contract."""
 
     violations: list[RepoStructureViolation] = []
@@ -143,7 +152,11 @@ def validate_paths(paths: Iterable[str], contract: RepoStructureContract) -> lis
         if root in contract.generated_artifact_roots:
             metadata = contract.temporary_exceptions.get(root)
             if metadata is None:
-                add(RepoStructureViolation("generated-root-missing-exception", root, path))
+                add(
+                    RepoStructureViolation(
+                        "generated-root-missing-exception", root, path
+                    )
+                )
             elif not _exception_metadata_valid(metadata):
                 add(RepoStructureViolation("invalid-exception-metadata", root, root))
             elif not _path_allowed_by_exception(path, metadata):

--- a/scripts/maintenance/verify_repo_structure.py
+++ b/scripts/maintenance/verify_repo_structure.py
@@ -35,7 +35,17 @@ class RepoStructureViolation:
 
 
 @dataclass(frozen=True)
+class WorktreeStatusEntry:
+    """A parsed non-ignored worktree status entry."""
+
+    status: str
+    path: str
+    old_path: str | None = None
+
+
+@dataclass(frozen=True)
 class RepoStructureContract:
+
     """Parsed repo-structure contract."""
 
     allowed_roots: frozenset[str]
@@ -183,33 +193,89 @@ def git_tracked_paths(repo_root: Path) -> list[str]:
     return [line for line in result.stdout.splitlines() if line]
 
 
-def parse_git_status_paths(output: str) -> list[str]:
-    """Parse porcelain-like ``git status --short`` output into paths.
+def _parse_status_path(raw_path: str) -> str:
+    """Unquote a porcelain path while tolerating odd shell-like input."""
 
-    This deliberately includes untracked, modified, deleted, and renamed paths
-    that are visible in the working tree without reading ignored cache/output
-    directories. For renames, validate the destination path because that is the
-    root shape that would be committed.
+    try:
+        parsed = shlex.split(raw_path)
+    except ValueError:
+        parsed = []
+    return parsed[0] if len(parsed) == 1 else raw_path
+
+
+def parse_git_status_entries(output: str) -> list[WorktreeStatusEntry]:
+    """Parse porcelain-like ``git status --short`` output into status entries.
+
+    Status codes are preserved so Phase-1 policy can reject deletion/relocation
+    of generated-looking tracked artifacts instead of treating them like normal
+    path classification.
     """
 
-    paths: list[str] = []
+    entries: list[WorktreeStatusEntry] = []
     for raw_line in output.splitlines():
         if not raw_line or raw_line.startswith("## ") or len(raw_line) < 4:
             continue
+        status = raw_line[:2]
         path = raw_line[3:]
+        old_path: str | None = None
         if " -> " in path:
-            path = path.rsplit(" -> ", 1)[1]
+            old_raw, new_raw = path.rsplit(" -> ", 1)
+            old_path = _parse_status_path(old_raw)
+            path = new_raw
+        path = _parse_status_path(path)
         if path:
-            try:
-                parsed = shlex.split(path)
-            except ValueError:
-                parsed = []
-            paths.append(parsed[0] if len(parsed) == 1 else path)
-    return paths
+            entries.append(WorktreeStatusEntry(status=status, path=path, old_path=old_path))
+    return entries
 
 
-def git_worktree_paths(repo_root: Path) -> list[str]:
-    """Return non-ignored working-tree paths visible to git status."""
+def parse_git_status_paths(output: str) -> list[str]:
+    """Parse porcelain-like ``git status --short`` output into destination paths."""
+
+    return [entry.path for entry in parse_git_status_entries(output)]
+
+
+def validate_worktree_status_entries(
+    entries: Iterable[WorktreeStatusEntry], contract: RepoStructureContract
+) -> list[RepoStructureViolation]:
+    """Validate status-specific Phase-1 constraints for worktree entries."""
+
+    violations: list[RepoStructureViolation] = []
+    emitted: set[RepoStructureViolation] = set()
+
+    def add(violation: RepoStructureViolation) -> None:
+        if violation not in emitted:
+            emitted.add(violation)
+            violations.append(violation)
+
+    for entry in entries:
+        status = entry.status
+        path_root = root_for(entry.path)
+        old_root = root_for(entry.old_path) if entry.old_path else ""
+        touches_generated_root = (
+            path_root in contract.generated_artifact_roots
+            or old_root in contract.generated_artifact_roots
+        )
+        if not touches_generated_root:
+            continue
+        if "D" in status or "R" in status:
+            if entry.old_path and "R" in status:
+                violation_path = f"{entry.old_path} -> {entry.path}"
+                violation_root = old_root or path_root
+            else:
+                violation_path = entry.path
+                violation_root = path_root or old_root
+            add(
+                RepoStructureViolation(
+                    "generated-artifact-deletion-or-relocation",
+                    violation_root,
+                    violation_path,
+                )
+            )
+    return violations
+
+
+def git_worktree_status_entries(repo_root: Path) -> list[WorktreeStatusEntry]:
+    """Return non-ignored working-tree status entries visible to git status."""
 
     result = subprocess.run(
         ["git", "status", "--short", "--untracked-files=all"],
@@ -218,7 +284,13 @@ def git_worktree_paths(repo_root: Path) -> list[str]:
         text=True,
         stdout=subprocess.PIPE,
     )
-    return parse_git_status_paths(result.stdout)
+    return parse_git_status_entries(result.stdout)
+
+
+def git_worktree_paths(repo_root: Path) -> list[str]:
+    """Return non-ignored working-tree paths visible to git status."""
+
+    return [entry.path for entry in git_worktree_status_entries(repo_root)]
 
 
 def repository_paths(repo_root: Path) -> list[str]:
@@ -258,8 +330,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     repo_root = Path.cwd()
     contract = load_contract(args.config)
-    paths = args.paths if args.paths is not None else repository_paths(repo_root)
-    violations = validate_paths(paths, contract)
+    if args.paths is not None:
+        paths = args.paths
+        violations = validate_paths(paths, contract)
+    else:
+        tracked_paths = git_tracked_paths(repo_root)
+        worktree_entries = git_worktree_status_entries(repo_root)
+        paths = tracked_paths + [entry.path for entry in worktree_entries]
+        violations = validate_paths(paths, contract)
+        violations.extend(validate_worktree_status_entries(worktree_entries, contract))
     if violations:
         print(format_violations(violations))
         return 1

--- a/scripts/review/results/2026-05-08-plan-394-repo-structure-review-synthesis.md
+++ b/scripts/review/results/2026-05-08-plan-394-repo-structure-review-synthesis.md
@@ -1,0 +1,31 @@
+# Plan review synthesis for #394: chore(repo-structure): normalize worldenergydata folder/file structure
+
+Date: 2026-05-08
+Plan: `docs/plans/2026-05-08-issue-394-repo-structure-normalization.md`
+
+## Verdict
+
+APPROVE for human `status:plan-review` gate. Implementation remains blocked pending explicit user approval.
+
+## Reviewer lanes
+
+| Lane | Verdict | Findings |
+|---|---:|---|
+| Scope discipline | APPROVE | Plan is Phase-1 bounded and forbids broad moves/deletions before contract/checker/TDD. |
+| Verification/TDD | MINOR | Test list is explicit; implementation must convert it into repo-specific tests before checker code. |
+| Risk/rollback | APPROVE | Generated-output and durable-evidence exception handling is explicit; rollback/approval marker required. |
+
+## Accepted hardening notes
+
+- Keep generated-looking tracked files in place until classified.
+- Require machine-readable exception metadata rather than ad hoc ignores.
+- Treat static/docs/strategy repos differently from Python package repos; no source/runtime path move without proof.
+- Preserve approval SHA in `.planning/plan-approved/394.md` after approval.
+
+## Residual risk
+
+Medium: implementation inventory may discover repo-specific path consumers or generated artifacts requiring follow-up issues. This is acceptable because the plan makes those discoveries blocking/classification events rather than implicit cleanup permission.
+
+## Ready for approval
+
+yes — ready for user review; no implementation authorized.

--- a/tests/repo_structure/test_repo_structure_contract.py
+++ b/tests/repo_structure/test_repo_structure_contract.py
@@ -1,0 +1,179 @@
+"""TDD coverage for the repo-structure normalization checker (#394)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+from scripts.maintenance import verify_repo_structure
+from scripts.maintenance.verify_repo_structure import (
+    RepoStructureViolation,
+    load_contract,
+    main,
+    root_for,
+    validate_paths,
+)
+
+
+def _contract(tmp_path: Path, overrides: dict | None = None) -> Path:
+    payload = {
+        "allowed_roots": ["src", "tests", "docs", "config", "scripts", "README.md", "pyproject.toml"],
+        "ignored_roots": [".git", ".venv", "__pycache__"],
+        "generated_artifact_roots": ["reports", "results", "output", "logs"],
+        "temporary_exceptions": {
+            "reports": {
+                "category": "durable-evidence",
+                "owner": "worldenergydata maintainers",
+                "review_date": "2026-06-30",
+                "follow_up": "https://github.com/vamseeachanta/worldenergydata/issues/394",
+                "justification": "Tracked report artifacts require a dedicated generated-evidence migration issue before relocation or deletion.",
+            }
+        },
+    }
+    if overrides:
+        payload.update(overrides)
+    path = tmp_path / "repo_structure.yml"
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def test_checker_rejects_unapproved_root_entry(tmp_path: Path) -> None:
+    contract = load_contract(_contract(tmp_path))
+
+    violations = validate_paths(["src/worldenergydata/__init__.py", "scratch.txt"], contract)
+
+    assert RepoStructureViolation("unknown-root", "scratch.txt", "scratch.txt") in violations
+
+
+def test_checker_rejects_generated_root_without_exception(tmp_path: Path) -> None:
+    contract = load_contract(
+        _contract(tmp_path, {"temporary_exceptions": {}})
+    )
+
+    violations = validate_paths(["reports/demo.html"], contract)
+
+    assert RepoStructureViolation("generated-root-missing-exception", "reports", "reports/demo.html") in violations
+
+
+def test_checker_rejects_placeholder_exception_metadata(tmp_path: Path) -> None:
+    contract = load_contract(
+        _contract(
+            tmp_path,
+            {
+                "temporary_exceptions": {
+                    "reports": {
+                        "category": "durable-evidence",
+                        "owner": "TBD",
+                        "review_date": "TODO",
+                        "follow_up": "https://github.com/vamseeachanta/worldenergydata/issues/394",
+                        "justification": "TODO",
+                    }
+                }
+            },
+        )
+    )
+
+    violations = validate_paths(["reports/demo.html"], contract)
+
+    assert RepoStructureViolation("invalid-exception-metadata", "reports", "reports") in violations
+
+
+def test_checker_rejects_generated_path_not_listed_in_exception(tmp_path: Path) -> None:
+    contract = load_contract(
+        _contract(
+            tmp_path,
+            {
+                "temporary_exceptions": {
+                    "reports": {
+                        "category": "durable-evidence",
+                        "owner": "worldenergydata maintainers",
+                        "review_date": "2026-06-30",
+                        "follow_up": "https://github.com/vamseeachanta/worldenergydata/issues/394",
+                        "justification": "Tracked report artifacts require explicit path-level classification before relocation or deletion.",
+                        "allowed_paths": ["reports/REPORT_SUMMARY.md"],
+                    }
+                }
+            },
+        )
+    )
+
+    violations = validate_paths(["reports/new-report.html"], contract)
+
+    assert RepoStructureViolation("generated-path-not-classified", "reports", "reports/new-report.html") in violations
+
+
+def test_current_contract_accepts_approved_roots_and_exceptions() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    contract = load_contract(repo_root / "config" / "repo_structure.yml")
+    paths = subprocess.check_output(
+        ["git", "ls-files"], cwd=repo_root, text=True
+    ).splitlines()
+
+    violations = validate_paths(paths, contract)
+
+    assert violations == []
+
+
+def test_root_for_preserves_leading_dot_roots() -> None:
+    assert root_for(".github/workflows/ci.yml") == ".github"
+    assert root_for(".claude/settings.json") == ".claude"
+    assert root_for("./.planning/plan-approved/394.md") == ".planning"
+
+
+def test_pre_commit_wires_repo_structure_checker() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    precommit = (repo_root / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+
+    assert "repo-structure-contract" in precommit
+    assert "scripts/maintenance/verify_repo_structure.py" in precommit
+
+
+def test_cli_reports_violations_for_explicit_paths(tmp_path: Path) -> None:
+    contract = _contract(tmp_path)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/maintenance/verify_repo_structure.py",
+            "--config",
+            str(contract),
+            "--path",
+            "scratch.txt",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "unknown-root" in result.stdout
+    assert "scratch.txt" in result.stdout
+
+
+def test_parse_git_status_paths_unquotes_renamed_paths_with_spaces() -> None:
+    paths = verify_repo_structure.parse_git_status_paths(
+        'R  "old name.txt" -> "new folder/new name.txt"\n'
+    )
+
+    assert paths == ["new folder/new name.txt"]
+
+
+def test_default_cli_includes_nonignored_worktree_paths(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    contract = _contract(tmp_path)
+    monkeypatch.setattr(verify_repo_structure, "git_tracked_paths", lambda repo_root: [])
+    monkeypatch.setattr(verify_repo_structure, "git_worktree_paths", lambda repo_root: ["scratch/file.txt"])
+
+    result = main(["--config", str(contract)])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "unknown-root" in captured.out
+    assert "scratch/file.txt" in captured.out

--- a/tests/repo_structure/test_repo_structure_contract.py
+++ b/tests/repo_structure/test_repo_structure_contract.py
@@ -203,8 +203,10 @@ def test_default_cli_includes_nonignored_worktree_paths(
     )
     monkeypatch.setattr(
         verify_repo_structure,
-        "git_worktree_paths",
-        lambda repo_root: ["scratch/file.txt"],
+        "git_worktree_status_entries",
+        lambda repo_root: [
+            verify_repo_structure.WorktreeStatusEntry("??", "scratch/file.txt")
+        ],
     )
 
     result = main(["--config", str(contract)])
@@ -213,3 +215,81 @@ def test_default_cli_includes_nonignored_worktree_paths(
     assert result == 1
     assert "unknown-root" in captured.out
     assert "scratch/file.txt" in captured.out
+
+
+def test_deleted_generated_artifact_is_rejected_even_when_classified(
+    tmp_path: Path,
+) -> None:
+    contract = load_contract(
+        _contract(
+            tmp_path,
+            {
+                "temporary_exceptions": {
+                    "reports": {
+                        "category": "durable-evidence",
+                        "owner": "worldenergydata maintainers",
+                        "review_date": "2026-06-30",
+                        "follow_up": "https://github.com/vamseeachanta/worldenergydata/issues/394",
+                        "justification": (
+                            "Tracked report artifacts require explicit path-level "
+                            "classification before relocation or deletion."
+                        ),
+                        "allowed_paths": ["reports/REPORT_SUMMARY.md"],
+                    }
+                }
+            },
+        )
+    )
+
+    violations = verify_repo_structure.validate_worktree_status_entries(
+        [verify_repo_structure.WorktreeStatusEntry(" D", "reports/REPORT_SUMMARY.md")],
+        contract,
+    )
+
+    assert (
+        RepoStructureViolation(
+            "generated-artifact-deletion-or-relocation",
+            "reports",
+            "reports/REPORT_SUMMARY.md",
+        )
+        in violations
+    )
+
+
+def test_renamed_generated_artifact_is_rejected_as_relocation(tmp_path: Path) -> None:
+    contract = load_contract(
+        _contract(
+            tmp_path,
+            {
+                "temporary_exceptions": {
+                    "reports": {
+                        "category": "durable-evidence",
+                        "owner": "worldenergydata maintainers",
+                        "review_date": "2026-06-30",
+                        "follow_up": "https://github.com/vamseeachanta/worldenergydata/issues/394",
+                        "justification": (
+                            "Tracked report artifacts require explicit path-level "
+                            "classification before relocation or deletion."
+                        ),
+                        "allowed_paths": ["reports/old.md", "reports/new.md"],
+                    }
+                }
+            },
+        )
+    )
+
+    entries = verify_repo_structure.parse_git_status_entries(
+        'R  "reports/old.md" -> "reports/new.md"\n'
+    )
+    violations = verify_repo_structure.validate_worktree_status_entries(
+        entries, contract
+    )
+
+    assert (
+        RepoStructureViolation(
+            "generated-artifact-deletion-or-relocation",
+            "reports",
+            "reports/old.md -> reports/new.md",
+        )
+        in violations
+    )

--- a/tests/repo_structure/test_repo_structure_contract.py
+++ b/tests/repo_structure/test_repo_structure_contract.py
@@ -20,7 +20,15 @@ from scripts.maintenance.verify_repo_structure import (
 
 def _contract(tmp_path: Path, overrides: dict | None = None) -> Path:
     payload = {
-        "allowed_roots": ["src", "tests", "docs", "config", "scripts", "README.md", "pyproject.toml"],
+        "allowed_roots": [
+            "src",
+            "tests",
+            "docs",
+            "config",
+            "scripts",
+            "README.md",
+            "pyproject.toml",
+        ],
         "ignored_roots": [".git", ".venv", "__pycache__"],
         "generated_artifact_roots": ["reports", "results", "output", "logs"],
         "temporary_exceptions": {
@@ -29,7 +37,10 @@ def _contract(tmp_path: Path, overrides: dict | None = None) -> Path:
                 "owner": "worldenergydata maintainers",
                 "review_date": "2026-06-30",
                 "follow_up": "https://github.com/vamseeachanta/worldenergydata/issues/394",
-                "justification": "Tracked report artifacts require a dedicated generated-evidence migration issue before relocation or deletion.",
+                "justification": (
+                    "Tracked report artifacts require a dedicated generated-evidence "
+                    "migration issue before relocation or deletion."
+                ),
             }
         },
     }
@@ -43,19 +54,27 @@ def _contract(tmp_path: Path, overrides: dict | None = None) -> Path:
 def test_checker_rejects_unapproved_root_entry(tmp_path: Path) -> None:
     contract = load_contract(_contract(tmp_path))
 
-    violations = validate_paths(["src/worldenergydata/__init__.py", "scratch.txt"], contract)
+    violations = validate_paths(
+        ["src/worldenergydata/__init__.py", "scratch.txt"], contract
+    )
 
-    assert RepoStructureViolation("unknown-root", "scratch.txt", "scratch.txt") in violations
+    assert (
+        RepoStructureViolation("unknown-root", "scratch.txt", "scratch.txt")
+        in violations
+    )
 
 
 def test_checker_rejects_generated_root_without_exception(tmp_path: Path) -> None:
-    contract = load_contract(
-        _contract(tmp_path, {"temporary_exceptions": {}})
-    )
+    contract = load_contract(_contract(tmp_path, {"temporary_exceptions": {}}))
 
     violations = validate_paths(["reports/demo.html"], contract)
 
-    assert RepoStructureViolation("generated-root-missing-exception", "reports", "reports/demo.html") in violations
+    assert (
+        RepoStructureViolation(
+            "generated-root-missing-exception", "reports", "reports/demo.html"
+        )
+        in violations
+    )
 
 
 def test_checker_rejects_placeholder_exception_metadata(tmp_path: Path) -> None:
@@ -78,7 +97,10 @@ def test_checker_rejects_placeholder_exception_metadata(tmp_path: Path) -> None:
 
     violations = validate_paths(["reports/demo.html"], contract)
 
-    assert RepoStructureViolation("invalid-exception-metadata", "reports", "reports") in violations
+    assert (
+        RepoStructureViolation("invalid-exception-metadata", "reports", "reports")
+        in violations
+    )
 
 
 def test_checker_rejects_generated_path_not_listed_in_exception(tmp_path: Path) -> None:
@@ -92,7 +114,10 @@ def test_checker_rejects_generated_path_not_listed_in_exception(tmp_path: Path) 
                         "owner": "worldenergydata maintainers",
                         "review_date": "2026-06-30",
                         "follow_up": "https://github.com/vamseeachanta/worldenergydata/issues/394",
-                        "justification": "Tracked report artifacts require explicit path-level classification before relocation or deletion.",
+                        "justification": (
+                            "Tracked report artifacts require explicit path-level "
+                            "classification before relocation or deletion."
+                        ),
                         "allowed_paths": ["reports/REPORT_SUMMARY.md"],
                     }
                 }
@@ -102,7 +127,12 @@ def test_checker_rejects_generated_path_not_listed_in_exception(tmp_path: Path) 
 
     violations = validate_paths(["reports/new-report.html"], contract)
 
-    assert RepoStructureViolation("generated-path-not-classified", "reports", "reports/new-report.html") in violations
+    assert (
+        RepoStructureViolation(
+            "generated-path-not-classified", "reports", "reports/new-report.html"
+        )
+        in violations
+    )
 
 
 def test_current_contract_accepts_approved_roots_and_exceptions() -> None:
@@ -168,8 +198,14 @@ def test_default_cli_includes_nonignored_worktree_paths(
     capsys,
 ) -> None:
     contract = _contract(tmp_path)
-    monkeypatch.setattr(verify_repo_structure, "git_tracked_paths", lambda repo_root: [])
-    monkeypatch.setattr(verify_repo_structure, "git_worktree_paths", lambda repo_root: ["scratch/file.txt"])
+    monkeypatch.setattr(
+        verify_repo_structure, "git_tracked_paths", lambda repo_root: []
+    )
+    monkeypatch.setattr(
+        verify_repo_structure,
+        "git_worktree_paths",
+        lambda repo_root: ["scratch/file.txt"],
+    )
 
     result = main(["--config", str(contract)])
 


### PR DESCRIPTION
## Summary

Closes #394 after merge.

Adds the bounded Phase 1 repo-structure normalization layer:
- local approval marker and plan/review artifacts for the approved issue
- repo-structure contract in `config/repo_structure.yml`
- human-readable standard in `docs/standards/repo-structure.md`
- maintenance checker in `scripts/maintenance/verify_repo_structure.py`
- TDD coverage under `tests/repo_structure/`
- pre-commit wiring for the checker

No broad source/docs/generated-output moves or deletions are included.

## Validation

- `PYTHONPATH='.:src:../assetutilities/src' uv run python -m pytest --noconftest tests/repo_structure/test_repo_structure_contract.py -q` -> 10 passed
- `PYTHONPATH='src:../assetutilities/src' uv run python scripts/maintenance/verify_repo_structure.py` -> OK
- `PYTHONPATH='.:src:../assetutilities/src' uv run python -m pytest --noconftest tests/repo_structure tests/contracts -q` -> 18 passed
- Full-suite baseline attempt: `PYTHONPATH='src:../assetutilities/src' uv run python -m pytest --noconftest` reached ~96% with no failures before the 600s session cap; generated/test-mutated data metadata was reverted and excluded from this change.

## Review

Adversarial implementation review returned MINOR only. The one concrete parser robustness edge case for quoted rename paths was converted to a failing regression test, fixed, and revalidated green before this PR.
