### PR TITLE
fix(.claude): resolve merge conflict in .claude/docs/agents.md (#414)

### DIFF
--- a/.claude/docs/agents.md
+++ b/.claude/docs/agents.md
@@ -3,7 +3,6 @@
 > Load on-demand when spawning agents
 
 ## Core Development (5)
-<<<<<<< HEAD
 
 | Agent | Purpose |
 |-------|---------|
@@ -96,33 +95,6 @@
 |-------|---------|
 | `migration-planner` | Migration strategy and execution |
 | `swarm-init` | Swarm initialization and topology setup |
-=======
-`coder`, `reviewer`, `tester`, `planner`, `researcher`
-
-## Swarm Coordination (5)
-`hierarchical-coordinator`, `mesh-coordinator`, `adaptive-coordinator`, `collective-intelligence-coordinator`, `swarm-memory-manager`
-
-## Consensus & Distributed (7)
-`byzantine-coordinator`, `raft-manager`, `gossip-coordinator`, `consensus-builder`, `crdt-synchronizer`, `quorum-manager`, `security-manager`
-
-## Performance & Optimization (5)
-`perf-analyzer`, `performance-benchmarker`, `task-orchestrator`, `memory-coordinator`, `smart-agent`
-
-## GitHub & Repository (9)
-`github-modes`, `pr-manager`, `code-review-swarm`, `issue-tracker`, `release-manager`, `workflow-automation`, `project-board-sync`, `repo-architect`, `multi-repo-swarm`
-
-## SPARC Methodology (6)
-`sparc-coord`, `sparc-coder`, `specification`, `pseudocode`, `architecture`, `refinement`
-
-## Specialized Development (8)
-`backend-dev`, `mobile-dev`, `ml-developer`, `cicd-engineer`, `api-docs`, `system-architect`, `code-analyzer`, `base-template-generator`
-
-## Testing & Validation (2)
-`tdd-london-swarm`, `production-validator`
-
-## Migration & Planning (2)
-`migration-planner`, `swarm-init`
->>>>>>> origin/main
 
 ---
 **Total: 54 agents**
@@ -133,7 +105,6 @@
 Task("Agent name", "Instructions", "agent-type")
 ```
 
-<<<<<<< HEAD
 ## Quick Selection Guide
 
 | Task Type | Recommended Agent |
@@ -148,15 +119,3 @@ Task("Agent name", "Instructions", "agent-type")
 | Performance issues | `perf-analyzer` |
 | TDD workflow | `sparc-coder` or `tdd-london-swarm` |
 | Cross-repo work | `multi-repo-swarm` |
-=======
-## Agent Selection Guide
-
-| Task Type | Recommended Agent |
-|-----------|-------------------|
-| Code implementation | `coder` |
-| Code review | `reviewer` |
-| Test writing | `tester` |
-| Research/analysis | `researcher` |
-| Architecture design | `system-architect` |
-| Multi-agent coordination | `hierarchical-coordinator` |
->>>>>>> origin/main

--- a/tests/test_agent_doc_clean.py
+++ b/tests/test_agent_doc_clean.py
@@ -1,0 +1,53 @@
+"""Asserts that .claude/docs/agents.md remains free of git merge-conflict markers
+and renders as valid Markdown.
+
+Filed as durable enforcement against a recurring failure mode. The conflict-
+introducing commit was 7493f543 ("chore: fresh repo after slimming") which left
+two unresolved conflict blocks in the file. Resolution landed via issue #414.
+
+Refs: worldenergydata#414, workspace-hub#2719 (audit that surfaced the bug).
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+AGENTS_DOC = REPO_ROOT / ".claude" / "docs" / "agents.md"
+
+CONFLICT_MARKER_PATTERN = re.compile(r"^(<<<<<<< |=======$|>>>>>>> )", re.MULTILINE)
+
+
+def test_agent_doc_exists():
+    """The agents.md reference doc must exist."""
+    assert AGENTS_DOC.exists(), f"{AGENTS_DOC} missing"
+
+
+def test_agent_doc_no_conflict_markers():
+    """The agents.md must not contain git merge-conflict markers."""
+    body = AGENTS_DOC.read_text(encoding="utf-8")
+    matches = CONFLICT_MARKER_PATTERN.findall(body)
+    assert not matches, (
+        f"{AGENTS_DOC.relative_to(REPO_ROOT)} contains {len(matches)} conflict marker(s); "
+        f"unresolved merge conflict regression"
+    )
+
+
+def test_agent_doc_starts_with_canonical_header():
+    """The agents.md must lead with the documented title — guards against accidental truncation."""
+    body = AGENTS_DOC.read_text(encoding="utf-8")
+    assert body.startswith("# Available Agents Reference"), (
+        f"{AGENTS_DOC.relative_to(REPO_ROOT)} missing canonical title — file may be corrupted"
+    )
+
+
+def test_agent_doc_has_no_empty_section_headers():
+    """No `## ...` line followed immediately by another `## ...` (sign of dropped content during conflict resolution)."""
+    body = AGENTS_DOC.read_text(encoding="utf-8")
+    lines = body.splitlines()
+    for i, line in enumerate(lines[:-1]):
+        if line.startswith("## ") and lines[i + 1].startswith("## "):
+            raise AssertionError(
+                f"{AGENTS_DOC.relative_to(REPO_ROOT)}:{i + 1} — section header '{line}' "
+                f"is followed immediately by another header; section body is missing"
+            )


### PR DESCRIPTION
## Summary

Resolves the unresolved git merge conflict markers in `.claude/docs/agents.md` (lines 6-125 and 136-162), introduced by [`7493f543`](https://github.com/vamseeachanta/worldenergydata/commit/7493f543) *"chore: fresh repo after slimming — relocated heavy data to /mnt/ace"*.

**Resolution**: keep HEAD version on both conflict blocks. HEAD preserves the rich `| Agent | Purpose |` table format with descriptions; origin/main version was a condensed comma-separated list that dropped the Purpose column.

## Discovery

Surfaced during workspace-hub#2719 ecosystem-wide adapter-pattern audit (Explore subagent over `worldenergydata/` flagged unresolved merge conflict markers in `.claude/docs/agents.md`).

## Changes

- `.claude/docs/agents.md`: 162 → 121 lines (-41 net deletion of conflict markers + dropped origin/main alternates). All 9 agent sections retained with Purpose column. 10-row Quick Selection Guide retained.
- `tests/test_agent_doc_clean.py`: NEW test file (53 lines) — 4 test cases asserting no conflict markers, canonical title, no empty section headers.

## Verification

```
$ grep -c "^<<<<<<<\|^=======$\|^>>>>>>>" .claude/docs/agents.md
0   # was 6 before fix

$ wc -l .claude/docs/agents.md
121 .claude/docs/agents.md

$ uv run python -m pytest tests/test_agent_doc_clean.py -o "addopts="
4 passed in 43.22s
```

TDD verified: test FAILED before fix (1 fail, 3 pass) → resolution applied → test PASSED (4 pass).

## Out of scope

- The `**Total: 54 agents**` line claims 54 but actual section count is 49 (5+5+7+5+9+6+8+2+2). Pre-existing data-inconsistency, shared by both HEAD and origin/main versions; not part of this fix.

## Test plan

- [x] Pytest `test_agent_doc_no_conflict_markers` passes after resolution (was failing before)
- [x] Pytest `test_agent_doc_exists` passes
- [x] Pytest `test_agent_doc_starts_with_canonical_header` passes
- [x] Pytest `test_agent_doc_has_no_empty_section_headers` passes
- [x] `grep` confirms zero conflict markers in resolved file

Closes #414. Plan + TDD-first execution per worldenergydata AGENTS.md gates and workspace-hub#2719 `status:plan-approved` gate.