### PR TITLE
chore(harness): link shared skills from workspace-hub + standardize Stop hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -106,19 +106,12 @@
     ],
     "Stop": [
       {
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow@alpha hooks session-end --generate-summary true --persist-state true --export-metrics true"
-          }
-        ]
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "statusMessage": "Post-task learning check",
-            "command": "bash -c 'SCRIPT=\"${WORKSPACE_HUB:-$(git rev-parse --show-superproject-working-tree 2>/dev/null | grep . || git rev-parse --show-toplevel)}/.claude/hooks/post-task-review.sh\"; [ -f \"$SCRIPT\" ] && bash \"$SCRIPT\" 2>/dev/null || true'"
+            "statusMessage": "Capturing session signals",
+            "command": "bash -c 'SCRIPT=\"${WORKSPACE_HUB:-$(git rev-parse --show-superproject-working-tree 2>/dev/null | grep . || git rev-parse --show-toplevel)}/.claude/hooks/consume-signals.sh\"; [ -f \"$SCRIPT\" ] && bash \"$SCRIPT\" 2>/dev/null || true'"
           }
         ]
       }

--- a/.claude/skills/.gitignore
+++ b/.claude/skills/.gitignore
@@ -2,3 +2,6 @@
 guidelines/
 meta/
 workflows/
+guidelines
+meta
+workflows

--- a/.claude/skills/meta
+++ b/.claude/skills/meta
@@ -1,1 +1,0 @@
-../../../.claude/skills/_internal/meta

--- a/.claude/skills/workflows
+++ b/.claude/skills/workflows
@@ -1,1 +1,0 @@
-../../../.claude/skills/_internal/workflows


### PR DESCRIPTION
## Summary
Part of the sibling single-source-of-truth harness flow ([#2775](https://github.com/vamseeachanta/workspace-hub/issues/2775)). Routes this repo's shared skill dirs (`meta`, `workflows`) to the canonical workspace-hub sources and standardizes the Stop hook.

- Replace tracked copies of `.claude/skills/{meta,workflows}` with symlinks into workspace-hub (untracked + gitignored)
- `.gitignore` patterns written without trailing slash so they match the symlinks
- `.claude/settings.json`: standardize Stop hook to `consume-signals.sh`

Direct push to `main` is blocked by the `protect_repo` ruleset (PR + status checks required), hence this PR.

## Test plan
- [ ] 13 required status checks pass
- [ ] `meta` / `workflows` resolve to `workspace-hub/.claude/skills/_internal/...`