### PR TITLE
test(bsee): repoint legacy NPV suite to FDAS path (#339, #341)

### DIFF
--- a/tests/integration/test_bsee_real_execution.py
+++ b/tests/integration/test_bsee_real_execution.py
@@ -241,26 +241,69 @@ class TestBSEERealExecution:
         assert "regular" in result.columns
         assert "col_x" not in result.columns
 
-    @pytest.mark.skip(
-        reason="generate_revenue_table moved to legacy/api12_economics module"
-    )
-    def test_generate_revenue_table(self):
-        """Test revenue calculation"""
-        pass
+    def test_generate_revenue_table(self, tmp_path):
+        """Revenue table builds from lower_tertiary WTI prices (FDAS forward path, #367)."""
+        analyzer = ProductionAPI12Analysis()
+        prices = pd.DataFrame(
+            {
+                "Month": pd.to_datetime(["2024-01-01", "2024-02-01"]),
+                "WTI_USD": [71.25, 73.50],
+                "source": ["test", "test"],
+            }
+        )
+        api12_df = pd.DataFrame(
+            {"PRODUCTION_DATE": [202401, 202402], "MON_O_PROD_VOL": [100.0, 200.0]}
+        )
+        cfg = {"Analysis": {"result_folder": str(tmp_path)}}
+        with patch(
+            "worldenergydata.bsee.analysis.production_api12.load_extended_wti_prices",
+            lambda **_: prices,
+        ):
+            revenue_df = analyzer.generate_revenue_table(cfg, api12_df)
+        for col in [
+            "Month",
+            "Monthly Oil Production",
+            "Avg Price (USD/bbl)",
+            "Revenue (USD)",
+        ]:
+            assert col in revenue_df.columns
 
-    @pytest.mark.skip(
-        reason="perform_npv_calculation moved to legacy/api12_economics module"
-    )
     def test_perform_npv_calculation(self):
-        """Test NPV calculation"""
-        pass
+        """perform_npv_calculation returns a finite NPV via the FDAS layer (#367)."""
+        analyzer = ProductionAPI12Analysis()
+        cfg = {
+            "economics": {
+                "cost": {"discount_rate_annual": 0.12, "CAPEX": 1000.0, "OPEX": 2.0}
+            }
+        }
+        revenue_df = pd.DataFrame(
+            {
+                "Month": [202401, 202402, ""],
+                "Monthly Oil Production": [100.0, 200.0, ""],
+                "Revenue (USD)": ["$1,000.00", "$3,000.00", "$4,000.00"],
+            }
+        )
+        npv = analyzer.perform_npv_calculation(cfg, revenue_df)
+        assert np.isfinite(npv)
 
-    @pytest.mark.skip(
-        reason="perform_excel_aligned_npv_calculation moved to legacy/api12_economics module"
-    )
     def test_perform_excel_aligned_npv(self):
-        """Test Excel-aligned NPV calculation"""
-        pass
+        """Excel-aligned wrapper delegates to the same FDAS path as perform_npv_calculation (#367)."""
+        analyzer = ProductionAPI12Analysis()
+        cfg = {
+            "economics": {
+                "cost": {"discount_rate_annual": 0.12, "CAPEX": 1000.0, "OPEX": 2.0}
+            }
+        }
+        revenue_df = pd.DataFrame(
+            {
+                "Month": [202401, 202402, ""],
+                "Monthly Oil Production": [100.0, 200.0, ""],
+                "Revenue (USD)": ["$1,000.00", "$3,000.00", "$4,000.00"],
+            }
+        )
+        assert analyzer.perform_excel_aligned_npv_calculation(
+            cfg, revenue_df
+        ) == pytest.approx(analyzer.perform_npv_calculation(cfg, revenue_df))
 
     def test_perform_decline_analysis(self, analyzer, real_config, real_production_df):
         """Test decline analysis"""

--- a/tests/integration/test_production_with_correct_format.py
+++ b/tests/integration/test_production_with_correct_format.py
@@ -151,19 +151,48 @@ class TestProductionWithCorrectFormat:
         # Should complete without error
         assert True
 
-    @pytest.mark.skip(
-        reason="generate_revenue_table moved to legacy/api12_economics module"
-    )
-    def test_generate_revenue_table(self, analyzer, valid_config, bsee_data):
-        """Test revenue generation"""
-        pass
+    def test_generate_revenue_table(self, analyzer, tmp_path):
+        """Revenue table builds from lower_tertiary WTI prices (FDAS forward path, #367)."""
+        prices = pd.DataFrame(
+            {
+                "Month": pd.to_datetime(["2024-01-01", "2024-02-01"]),
+                "WTI_USD": [71.25, 73.50],
+                "source": ["test", "test"],
+            }
+        )
+        api12_df = pd.DataFrame(
+            {"PRODUCTION_DATE": [202401, 202402], "MON_O_PROD_VOL": [100.0, 200.0]}
+        )
+        cfg = {"Analysis": {"result_folder": str(tmp_path)}}
+        with patch(
+            "worldenergydata.bsee.analysis.production_api12.load_extended_wti_prices",
+            lambda **_: prices,
+        ):
+            revenue_df = analyzer.generate_revenue_table(cfg, api12_df)
+        for col in [
+            "Month",
+            "Monthly Oil Production",
+            "Avg Price (USD/bbl)",
+            "Revenue (USD)",
+        ]:
+            assert col in revenue_df.columns
 
-    @pytest.mark.skip(
-        reason="perform_npv_calculation moved to legacy/api12_economics module"
-    )
-    def test_perform_npv_calculation(self, analyzer, valid_config):
-        """Test NPV calculation"""
-        pass
+    def test_perform_npv_calculation(self, analyzer):
+        """perform_npv_calculation returns a finite NPV via the FDAS layer (#367)."""
+        cfg = {
+            "economics": {
+                "cost": {"discount_rate_annual": 0.12, "CAPEX": 1000.0, "OPEX": 2.0}
+            }
+        }
+        revenue_df = pd.DataFrame(
+            {
+                "Month": [202401, 202402, ""],
+                "Monthly Oil Production": [100.0, 200.0, ""],
+                "Revenue (USD)": ["$1,000.00", "$3,000.00", "$4,000.00"],
+            }
+        )
+        npv = analyzer.perform_npv_calculation(cfg, revenue_df)
+        assert np.isfinite(npv)
 
     def test_full_analysis_pipeline(self, analyzer, valid_config, bsee_data, tmp_path):
         """Test complete analysis pipeline with correct data"""

--- a/tests/modules/bsee/analysis/npv-data-source-comparison/test_cash_flow_components.py
+++ b/tests/modules/bsee/analysis/npv-data-source-comparison/test_cash_flow_components.py
@@ -18,7 +18,7 @@ sys.path.insert(
 )
 
 try:
-    from worldenergydata.modules.bsee.analysis.production_api12 import (
+    from worldenergydata.bsee.analysis.production_api12 import (
         ProductionAPI12Analysis,
     )
 

--- a/tests/modules/bsee/analysis/npv-data-source-comparison/test_current_npv_implementation.py
+++ b/tests/modules/bsee/analysis/npv-data-source-comparison/test_current_npv_implementation.py
@@ -20,7 +20,7 @@ sys.path.insert(
     0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "src")
 )
 
-from worldenergydata.modules.bsee.analysis.production_api12 import (
+from worldenergydata.bsee.analysis.production_api12 import (
     ProductionAPI12Analysis,
 )
 

--- a/tests/modules/bsee/analysis/npv-data-source-comparison/test_npv_integration_workflow.py
+++ b/tests/modules/bsee/analysis/npv-data-source-comparison/test_npv_integration_workflow.py
@@ -20,10 +20,10 @@ sys.path.insert(
 )
 
 try:
-    from worldenergydata.engine import engine
-    from worldenergydata.modules.bsee.analysis.production_api12 import (
+    from worldenergydata.bsee.analysis.production_api12 import (
         ProductionAPI12Analysis,
     )
+    from worldenergydata.engine import engine
 
     ENGINE_AVAILABLE = True
 except ImportError as e:
@@ -135,7 +135,7 @@ class TestNPVIntegrationWorkflow:
         if not ENGINE_AVAILABLE:
             raise ImportError("ProductionAPI12Analysis not available")
 
-        from worldenergydata.modules.bsee.analysis.production_api12 import (
+        from worldenergydata.bsee.analysis.production_api12 import (
             ProductionAPI12Analysis,
         )
 
@@ -173,7 +173,7 @@ class TestNPVIntegrationWorkflow:
             print("Revenue table generation skipped - engine not available")
             return pd.DataFrame()
 
-        from worldenergydata.modules.bsee.analysis.production_api12 import (
+        from worldenergydata.bsee.analysis.production_api12 import (
             ProductionAPI12Analysis,
         )
 
@@ -219,7 +219,7 @@ class TestNPVIntegrationWorkflow:
             print("NPV calculation skipped - engine not available")
             return {}
 
-        from worldenergydata.modules.bsee.analysis.production_api12 import (
+        from worldenergydata.bsee.analysis.production_api12 import (
             ProductionAPI12Analysis,
         )
 


### PR DESCRIPTION
Closes #339, closes #341. Advances #367 (FDAS NPV migration close-out).

## What
Resolves the legacy NPV test drift by **repointing to the FDAS forward path** (keeping coverage), rather than deleting:

1. **Canonical imports** — `worldenergydata.modules.bsee.analysis.production_api12` → `worldenergydata.bsee.analysis.production_api12` across the `npv-data-source-comparison` suite. Drops the `modules.*` compat-shim dependency (#278) that #339 flagged as "the old import path namespace."
2. **Unskip stale stubs** — the empty `@pytest.mark.skip(reason="... moved to legacy/api12_economics module")` stubs in both integration files (`test_bsee_real_execution.py`, `test_production_with_correct_format.py`) were factually wrong — those methods are now FDAS-backed wrappers, not legacy. Replaced with real bodies:
   - `generate_revenue_table` — builds from `lower_tertiary` WTI prices (mocked source), asserts table structure.
   - `perform_npv_calculation` — returns a finite NPV through the **real** `fdas.core.financial.calculate_npv` (unmocked → genuine integration coverage).
   - `perform_excel_aligned_npv_calculation` — asserted to equal `perform_npv_calculation` (same forward path).
3. **Legitimate skips retained** — plotting (assetutilities YAML templates) and Excel-data-unavailable skips are unrelated and kept.

## Verification
Local standalone pytest (bypassing the known `uv run` hang on this repo): **54 passed / 5 skipped**, 0 failures, on the full affected set.

## Scope notes
- This is the `#339`/`#341` close-out item from #367. Remaining #367 AC (BSEE royalty 12.5% citation) stays blocked on the calc-citation-contract issue.