### PR TITLE
fix: update sodir scheduler endpoint contract

### DIFF
--- a/src/worldenergydata/scheduler/jobs/sodir_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/sodir_refresh.py
@@ -27,6 +27,23 @@ SODIR_DATASETS: Dict[str, str] = {
 }
 
 _DEFAULT_OUTPUT_DIR = get_module_data_safe("sodir")
+_DEFAULT_RECORD_LIMIT = 1000
+
+
+def _rows_from_response(response: dict) -> list[dict]:
+    """Extract tabular rows from current and legacy SODIR responses."""
+    if not response:
+        return []
+    if isinstance(response.get("data"), list):
+        return response["data"]
+    features = response.get("features")
+    if isinstance(features, list):
+        return [
+            feature.get("attributes", feature)
+            for feature in features
+            if isinstance(feature, dict)
+        ]
+    return []
 
 
 class SodirRefreshJob(AbstractJob):
@@ -74,12 +91,19 @@ class SodirRefreshJob(AbstractJob):
 
         for dataset_key, output_file in SODIR_DATASETS.items():
             try:
-                endpoint_cfg = SODIR_ENDPOINTS[dataset_key]
-                endpoint_path = endpoint_cfg["endpoint"]
-                table_id = endpoint_cfg["table_id"]
-
-                response = client.get(endpoint_path, params={"table": table_id})
-                rows = response.get("data", [])
+                endpoint_path = SODIR_ENDPOINTS[dataset_key]["endpoint"]
+                max_records = int(config.get("max_records", _DEFAULT_RECORD_LIMIT))
+                response = client.get(
+                    endpoint_path,
+                    params={
+                        "where": "1=1",
+                        "outFields": "*",
+                        "returnGeometry": "false",
+                        "resultRecordCount": max_records,
+                        "f": "json",
+                    },
+                )
+                rows = _rows_from_response(response)
 
                 if rows:
                     df = pd.DataFrame(rows)

--- a/src/worldenergydata/sodir/endpoints.py
+++ b/src/worldenergydata/sodir/endpoints.py
@@ -6,12 +6,12 @@ Migrated from factpages.sodir.no to factmaps.sodir.no (May 2025).
 """
 
 # SODIR dataset endpoint definitions
-# New API uses /api/rest/services/DataService/data with table ID as query parameter
+# Current API uses ArcGIS FeatureServer layer query endpoints.
 SODIR_ENDPOINTS = {
     "blocks": {
         "id": "1001",
         "table_id": "1001",
-        "endpoint": "/api/rest/services/DataService/data",
+        "endpoint": "/api/rest/services/DataService/Data/FeatureServer/1001/query",
         "description": "Norwegian Continental Shelf block information",
         "fields": [
             "npdidBlock",
@@ -26,7 +26,7 @@ SODIR_ENDPOINTS = {
     "wellbores": {
         "id": "5000",
         "table_id": "5000",
-        "endpoint": "/api/rest/services/DataService/data",
+        "endpoint": "/api/rest/services/DataService/Data/FeatureServer/5000/query",
         "description": "Wellbore drilling and completion data",
         "fields": [
             "npdidWellbore",
@@ -46,7 +46,7 @@ SODIR_ENDPOINTS = {
     "fields": {
         "id": "7100",
         "table_id": "7100",
-        "endpoint": "/api/rest/services/DataService/data",
+        "endpoint": "/api/rest/services/DataService/Data/FeatureServer/7100/query",
         "description": "Field information including reserves and production",
         "fields": [
             "npdidField",
@@ -64,7 +64,7 @@ SODIR_ENDPOINTS = {
     "discoveries": {
         "id": "7000",
         "table_id": "7000",
-        "endpoint": "/api/rest/services/DataService/data",
+        "endpoint": "/api/rest/services/DataService/Data/FeatureServer/7000/query",
         "description": "Discovery information and reserve classifications",
         "fields": [
             "npdidDiscovery",
@@ -80,7 +80,7 @@ SODIR_ENDPOINTS = {
     "surveys": {
         "id": "4000",
         "table_id": "4000",
-        "endpoint": "/api/rest/services/DataService/data",
+        "endpoint": "/api/rest/services/DataService/Data/FeatureServer/4000/query",
         "description": "Seismic surveys and geological studies",
         "fields": [
             "npdidSurvey",
@@ -95,7 +95,7 @@ SODIR_ENDPOINTS = {
     "facilities": {
         "id": "3000",
         "table_id": "3000",
-        "endpoint": "/api/rest/services/DataService/data",
+        "endpoint": "/api/rest/services/DataService/Data/FeatureServer/3000/query",
         "description": "Offshore facilities and infrastructure",
         "fields": [
             "npdidFacility",

--- a/tests/unit/scheduler/test_sodir_adapter.py
+++ b/tests/unit/scheduler/test_sodir_adapter.py
@@ -34,8 +34,10 @@ FAKE_FIELDS = [
 
 
 def _mock_client_get(endpoint, params=None):
-    """Return fake data based on table_id query parameter."""
+    """Return fake data based on FeatureServer layer or legacy table_id parameter."""
     table = params.get("table") if params else None
+    if table is None:
+        table = endpoint.rstrip("/").split("/")[-2]
     data_map = {
         "1001": FAKE_BLOCKS,
         "5000": FAKE_WELLBORES,
@@ -78,6 +80,54 @@ def test_creates_client_and_fetches_endpoints(mock_cls, job, config):
     assert mock_instance.get.call_count == len(SODIR_DATASETS)
 
 
+@patch("worldenergydata.scheduler.jobs.sodir_refresh.SodirAPIClient")
+def test_fetches_current_sodir_featureserver_contract(mock_cls, job, config):
+    """SodirRefreshJob.run() uses current FeatureServer query endpoints."""
+    mock_instance = MagicMock()
+    mock_instance.get.side_effect = _mock_client_get
+    mock_cls.return_value = mock_instance
+
+    job.run(config)
+
+    mock_instance.get.assert_any_call(
+        "/api/rest/services/DataService/Data/FeatureServer/1001/query",
+        params={
+            "where": "1=1",
+            "outFields": "*",
+            "returnGeometry": "false",
+            "resultRecordCount": 1000,
+            "f": "json",
+        },
+    )
+
+
+@patch("worldenergydata.scheduler.jobs.sodir_refresh.SodirAPIClient")
+def test_parses_current_sodir_featureserver_attributes(mock_cls, job, config, tmp_path):
+    """SodirRefreshJob.run() writes FeatureServer attributes as rows."""
+
+    def _featureserver_response(endpoint, params=None):
+        return {
+            "features": [
+                {"attributes": {"blcName": "1/2", "blcNpdidBlock": 3382}},
+                {"attributes": {"blcName": "1/3", "blcNpdidBlock": 3383}},
+            ]
+        }
+
+    mock_instance = MagicMock()
+    mock_instance.get.side_effect = _featureserver_response
+    mock_cls.return_value = mock_instance
+
+    result = job.run(config)
+
+    assert result.status == "success"
+    assert result.records_updated == len(SODIR_DATASETS) * 2
+    df = pd.read_parquet(tmp_path / "sodir_blocks.parquet")
+    assert df.to_dict("records") == [
+        {"blcName": "1/2", "blcNpdidBlock": 3382},
+        {"blcName": "1/3", "blcNpdidBlock": 3383},
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Test 2: Converts fetched data to DataFrames and writes Parquet files
 # ---------------------------------------------------------------------------
@@ -110,6 +160,8 @@ def test_partial_failure_continues(mock_cls, job, config, tmp_path):
 
     def _partial_fail(endpoint, params=None):
         table = params.get("table") if params else None
+        if table is None:
+            table = endpoint.rstrip("/").split("/")[-2]
         if table == "5000":
             raise SodirAPIError("Connection timeout for wellbores")
         return _mock_client_get(endpoint, params)


### PR DESCRIPTION
## Summary
- Update SODIR scheduler endpoints to the current Factmaps ArcGIS FeatureServer query URLs.
- Parse current `features[].attributes` responses while keeping legacy `data` response compatibility.
- Add scheduler adapter regression coverage for the current endpoint contract and parser.

## Why
Issue #273 tracks live `sodir_refresh` failures caused by stale endpoint paths returning SODIR/ArcGIS `Invalid URL` errors. The current API exposes the scheduled datasets as DataService FeatureServer layers under `https://factmaps.sodir.no/api/rest`.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /mnt/local-analysis/worldenergydata/.venv/bin/python -m pytest tests/unit/scheduler/test_sodir_adapter.py -q` => 7 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /mnt/local-analysis/worldenergydata/.venv/bin/python -m pytest tests/unit/scheduler -q` => 210 passed, 1 warning
- Live job verification with `PYTHONPATH=src` and temp output dir, `max_records=2` => `status='success'`, `records_updated=6`, wrote blocks/wellbores/fields Parquet plus `_metadata.json`
- Live `DataScheduler.run_once('sodir_refresh')` verification with temp scheduler config/output dir, `max_records=2` => `status='success'`, `records_updated=6`, wrote Parquet, `_metadata.json`, and scheduler `manifest.json`
- `git diff --check` => PASS
- `scripts/legal/legal-sanity-scan.sh --diff-only` => PASS

## Issue
- #273