### PR TITLE
fix: wire ukcs scheduler refresh

### DIFF
--- a/src/worldenergydata/scheduler/jobs/ukcs_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/ukcs_refresh.py
@@ -1,54 +1,94 @@
-"""UK Continental Shelf (UKCS) data refresh job -- Tier 2 (scaffolding only).
-
-TODO: Implement data fetching for UKCS production data.
-- Identify NSTA (North Sea Transition Authority) data endpoints
-- Add HTTP client for production/well data retrieval
-- Write Parquet output to data/ukcs/ directory
-- Add tests in tests/unit/scheduler/test_ukcs_adapter.py
-"""
+"""UK Continental Shelf (UKCS) data refresh job."""
 
 import logging
 from datetime import datetime
 from pathlib import Path
 
 from worldenergydata.common.data_resolver import get_module_data_safe
-from worldenergydata.scheduler.jobs.base import AbstractJob, JobResult
+from worldenergydata.scheduler.jobs.base import (
+    AbstractJob,
+    JobResult,
+    write_refresh_metadata,
+)
+from worldenergydata.scheduler.parquet_output import write_parquet
+from worldenergydata.ukcs.production.field_production import UKCSFieldProductionLoader
+from worldenergydata.ukcs.production.nsta_client import NSTAClient
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_OUTPUT_DIR = get_module_data_safe("ukcs")
+_DEFAULT_DATASET = "monthly"
 
 
 class UkcsRefreshJob(AbstractJob):
-    """Refresh UK Continental Shelf production data -- Tier 2 stub.
-
-    This adapter follows the standard pattern (D-17) but data
-    fetching is not yet implemented. Returns a skipped result
-    until implementation is complete.
-    """
+    """Refresh one NSTA UKCS production dataset into raw and normalized snapshots."""
 
     name = "ukcs_refresh"
     default_output_dir = _DEFAULT_OUTPUT_DIR
 
     def run(self, config: dict) -> JobResult:
-        """Return skipped result until UKCS fetching is implemented.
-
-        Args:
-            config: Reserved for future use (e.g., nsta_api_url, output_dir).
-
-        Returns:
-            JobResult with status="skipped".
-        """
+        """Download a configured NSTA production year/dataset."""
         start = datetime.now()
-        output_dir = Path(config.get("output_dir", self.default_output_dir))
-        # Scaffolded for future adapter implementation; path is intentionally resolved now.
-        logger.info("%s: Tier 2 stub -- not yet implemented.", self.name)
-        logger.debug("%s output directory: %s", self.name, output_dir)
-        return JobResult(
-            job_name=self.name,
-            start_time=start,
-            end_time=datetime.now(),
-            status="skipped",
-            records_updated=0,
-            error_msg=None,
-        )
+        if "output_dir" not in config:
+            return JobResult(
+                job_name=self.name,
+                start_time=start,
+                end_time=datetime.now(),
+                status="skipped",
+                records_updated=0,
+                error_msg="UKCS live refresh requires an explicit output_dir",
+            )
+
+        output_dir = Path(config["output_dir"])
+        year = int(config.get("year", datetime.now().year))
+        dataset = str(config.get("dataset", _DEFAULT_DATASET))
+        force_refresh = bool(config.get("force_refresh", False))
+
+        try:
+            client_kwargs = {"cache_dir": str(output_dir / "raw")}
+            download_url = config.get("download_url") or config.get("base_url")
+            if download_url:
+                client_kwargs["base_url"] = str(download_url)
+            client = NSTAClient(**client_kwargs)
+            raw_df = client.download(
+                year=year,
+                dataset=dataset,
+                force_refresh=force_refresh,
+            )
+            if "max_records" in config:
+                raw_df = raw_df.head(int(config["max_records"]))
+            raw_records = len(raw_df)
+            raw_dir = output_dir / "raw"
+            raw_dir.mkdir(parents=True, exist_ok=True)
+            raw_df.to_parquet(
+                raw_dir / f"nsta_production_{year}_{dataset}.parquet",
+                engine="pyarrow",
+                index=False,
+                compression="snappy",
+            )
+
+            normalized = UKCSFieldProductionLoader().load(raw_df)
+            write_parquet(
+                normalized,
+                output_dir,
+                f"ukcs_production_{year}_{dataset}.parquet",
+            )
+            write_refresh_metadata("ukcs", output_dir, raw_records)
+            return JobResult(
+                job_name=self.name,
+                start_time=start,
+                end_time=datetime.now(),
+                status="success",
+                records_updated=raw_records,
+                error_msg=None,
+            )
+        except Exception as exc:
+            logger.warning("UKCS refresh failed: %s", exc)
+            return JobResult(
+                job_name=self.name,
+                start_time=start,
+                end_time=datetime.now(),
+                status="failure",
+                records_updated=0,
+                error_msg=str(exc),
+            )

--- a/src/worldenergydata/scheduler/jobs/ukcs_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/ukcs_refresh.py
@@ -43,6 +43,7 @@ class UkcsRefreshJob(AbstractJob):
         year = int(config.get("year", datetime.now().year))
         dataset = str(config.get("dataset", _DEFAULT_DATASET))
         force_refresh = bool(config.get("force_refresh", False))
+        max_records = int(config["max_records"]) if "max_records" in config else None
 
         try:
             client_kwargs = {"cache_dir": str(output_dir / "raw")}
@@ -54,9 +55,10 @@ class UkcsRefreshJob(AbstractJob):
                 year=year,
                 dataset=dataset,
                 force_refresh=force_refresh,
+                max_records=max_records,
             )
-            if "max_records" in config:
-                raw_df = raw_df.head(int(config["max_records"]))
+            if max_records is not None:
+                raw_df = raw_df.head(max_records)
             raw_records = len(raw_df)
             raw_dir = output_dir / "raw"
             raw_dir.mkdir(parents=True, exist_ok=True)

--- a/src/worldenergydata/ukcs/production/field_production.py
+++ b/src/worldenergydata/ukcs/production/field_production.py
@@ -15,7 +15,7 @@ import logging
 
 import pandas as pd
 
-from worldenergydata.common.units import GasUnits, OilUnits
+from worldenergydata.common.units import GasUnits, OilUnits, WaterUnits
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +31,14 @@ _RAW_WATER_COL = "WaterProduction (Thousand Tonnes)"
 _RAW_FIELD_COL = "FieldName"
 _RAW_YEAR_COL = "Year"
 _RAW_MONTH_COL = "Month"
+
+_PPRS_FIELD_COL = "FIELDNAME"
+_PPRS_YEAR_COL = "PERIODYR"
+_PPRS_MONTH_COL = "PERIODMNTH"
+_PPRS_OIL_TONNES_COL = "OILPRODMAS"
+_PPRS_ASSOC_GAS_KSM3_COL = "AGASPROKSM"
+_PPRS_DRY_GAS_KSM3_COL = "DGASPROKSM"
+_PPRS_WATER_M3_COL = "WATPRODVOL"
 
 
 class UKCSFieldProductionLoader:
@@ -56,16 +64,38 @@ class UKCSFieldProductionLoader:
             )
 
         result = pd.DataFrame()
-        result["field"] = raw[_RAW_FIELD_COL].str.upper().str.strip()
-        result["year"] = raw[_RAW_YEAR_COL].astype(int)
-        result["month"] = raw[_RAW_MONTH_COL].astype(int)
+        result["field"] = (
+            _column(raw, _RAW_FIELD_COL, _PPRS_FIELD_COL).str.upper().str.strip()
+        )
+        result["year"] = _column(raw, _RAW_YEAR_COL, _PPRS_YEAR_COL).astype(int)
+        result["month"] = _column(raw, _RAW_MONTH_COL, _PPRS_MONTH_COL).astype(int)
 
-        # Thousand tonnes → bbl
-        result["oil_bbl"] = raw[_RAW_OIL_COL].fillna(0.0) * 1000.0 * TONNES_TO_BBL
-        # MMscf → Mcf
-        result["gas_mcf"] = raw[_RAW_GAS_COL].fillna(0.0) * MMSCF_TO_MCF
-        # Thousand tonnes → bbl
-        result["water_bbl"] = raw[_RAW_WATER_COL].fillna(0.0) * 1000.0 * TONNES_TO_BBL
+        if _RAW_OIL_COL in raw.columns:
+            # Legacy fixture: thousand tonnes → bbl
+            result["oil_bbl"] = raw[_RAW_OIL_COL].fillna(0.0) * 1000.0 * TONNES_TO_BBL
+        else:
+            # Current PPRS schema: tonnes → bbl
+            result["oil_bbl"] = raw[_PPRS_OIL_TONNES_COL].fillna(0.0) * TONNES_TO_BBL
+
+        if _RAW_GAS_COL in raw.columns:
+            # Legacy fixture: MMscf → Mcf
+            result["gas_mcf"] = raw[_RAW_GAS_COL].fillna(0.0) * MMSCF_TO_MCF
+        else:
+            # Current PPRS schema: associated + dry gas KSm3 → Mcf
+            gas_ksm3 = raw.get(_PPRS_ASSOC_GAS_KSM3_COL, 0.0).fillna(0.0)
+            gas_ksm3 += raw.get(_PPRS_DRY_GAS_KSM3_COL, 0.0).fillna(0.0)
+            result["gas_mcf"] = gas_ksm3 * GasUnits.SM3_TO_SCF
+
+        if _RAW_WATER_COL in raw.columns:
+            # Legacy fixture: thousand tonnes → bbl
+            result["water_bbl"] = (
+                raw[_RAW_WATER_COL].fillna(0.0) * 1000.0 * TONNES_TO_BBL
+            )
+        else:
+            # Current PPRS schema: m3 → bbl
+            result["water_bbl"] = (
+                raw[_PPRS_WATER_M3_COL].fillna(0.0) * WaterUnits.M3_TO_BBL
+            )
 
         return result.reset_index(drop=True)
 
@@ -93,3 +123,10 @@ class UKCSFieldProductionLoader:
         numeric = ["oil_bbl", "gas_mcf", "water_bbl"]
         annual = df.groupby(["field", "year"])[numeric].sum().reset_index()
         return annual
+
+
+def _column(raw: pd.DataFrame, *names: str) -> pd.Series:
+    for name in names:
+        if name in raw.columns:
+            return raw[name]
+    raise KeyError(names[0])

--- a/src/worldenergydata/ukcs/production/nsta_client.py
+++ b/src/worldenergydata/ukcs/production/nsta_client.py
@@ -1,7 +1,7 @@
 """NSTA CSV downloader with local cache and year/field parameters.
 
-Data source: NSTA Open Data Centre
-  https://www.nstauthority.co.uk/data-centre/
+Data source: NSTA Open Data / data.gov.uk
+  https://opendata-nstauthority.hub.arcgis.com/datasets/NSTAUTHORITY::nsta-field-production-pprs-wgs84
 
 Field production CSVs are freely downloadable with no authentication.
 CSV format: FieldName, Year, Month, OilProduction (Thousand Tonnes),
@@ -22,7 +22,10 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_BASE_URL = "https://www.nstauthority.co.uk/data-centre/nsta-open-data/"
+DEFAULT_BASE_URL = (
+    "https://opendata-nstauthority.hub.arcgis.com/api/download/v1/"
+    "items/ba8b7b78d3a74edc88293011981ce2d7/csv?layers=0"
+)
 
 
 class NSTAClient:
@@ -84,4 +87,4 @@ class NSTAClient:
         return pd.read_csv(io.BytesIO(response.content), encoding=encoding)
 
     def _build_url(self, year: int, dataset: str) -> str:
-        return f"{self.base_url}?year={year}&type={dataset}"
+        return self.base_url.format(year=year, dataset=dataset)

--- a/src/worldenergydata/ukcs/production/nsta_client.py
+++ b/src/worldenergydata/ukcs/production/nsta_client.py
@@ -1,11 +1,10 @@
-"""NSTA CSV downloader with local cache and year/field parameters.
+"""NSTA production downloader with local cache and year/field parameters.
 
-Data source: NSTA Open Data / data.gov.uk
-  https://opendata-nstauthority.hub.arcgis.com/datasets/NSTAUTHORITY::nsta-field-production-pprs-wgs84
+Data source: official UKCS Transition ArcGIS PPRS production points service
+  https://services-eu1.arcgis.com/OZMfUznmLTnWccBc/arcgis/rest/services/UKCS_hydrocarbon_field_production_reports_PPRS_points_(WGS84)/FeatureServer/0
 
-Field production CSVs are freely downloadable with no authentication.
-CSV format: FieldName, Year, Month, OilProduction (Thousand Tonnes),
-            GasProduction (MMscf), WaterProduction (Thousand Tonnes)
+The NSTA Hub CSV download redirects to this FeatureServer export. The default
+uses the pageable FeatureServer query endpoint and caches rows as CSV locally.
 """
 
 import io
@@ -23,8 +22,9 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 DEFAULT_BASE_URL = (
-    "https://opendata-nstauthority.hub.arcgis.com/api/download/v1/"
-    "items/ba8b7b78d3a74edc88293011981ce2d7/csv?layers=0"
+    "https://services-eu1.arcgis.com/OZMfUznmLTnWccBc/arcgis/rest/services/"
+    "UKCS_hydrocarbon_field_production_reports_PPRS_points_(WGS84)/"
+    "FeatureServer/0/query"
 )
 
 
@@ -63,8 +63,9 @@ class NSTAClient:
         dataset: str = "monthly",
         force_refresh: bool = False,
         encoding: str = "utf-8",
+        max_records: int | None = None,
     ) -> pd.DataFrame:
-        """Download NSTA CSV for a given year/dataset, using cache when available."""
+        """Download NSTA production data for a given year/dataset."""
         if not force_refresh and self.is_cached(year, dataset):
             logger.info("Using cached NSTA data for %d (%s)", year, dataset)
             return self.load_cached(year, dataset, encoding=encoding)
@@ -78,6 +79,14 @@ class NSTAClient:
         url = self._build_url(year, dataset)
         logger.info("Downloading NSTA data from %s", url)
 
+        if _is_arcgis_query_url(url):
+            return self._download_arcgis_query(
+                url=url,
+                year=year,
+                dataset=dataset,
+                max_records=max_records,
+            )
+
         response = requests.get(url, timeout=60)
         response.raise_for_status()
 
@@ -88,3 +97,51 @@ class NSTAClient:
 
     def _build_url(self, year: int, dataset: str) -> str:
         return self.base_url.format(year=year, dataset=dataset)
+
+    def _download_arcgis_query(
+        self,
+        url: str,
+        year: int,
+        dataset: str,
+        max_records: int | None,
+    ) -> pd.DataFrame:
+        rows = []
+        offset = 0
+        page_size = min(max_records or 2000, 2000)
+        while True:
+            remaining = None if max_records is None else max_records - len(rows)
+            if remaining is not None and remaining <= 0:
+                break
+            record_count = page_size if remaining is None else min(page_size, remaining)
+            response = requests.get(
+                url,
+                params={
+                    "where": f"PERIODYR = '{year}'",
+                    "outFields": "*",
+                    "returnGeometry": "false",
+                    "resultOffset": offset,
+                    "resultRecordCount": record_count,
+                    "f": "json",
+                },
+                timeout=60,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            page_rows = [
+                feature["attributes"]
+                for feature in payload.get("features", [])
+                if isinstance(feature, dict)
+                and isinstance(feature.get("attributes"), dict)
+            ]
+            rows.extend(page_rows)
+            if not payload.get("exceededTransferLimit") or not page_rows:
+                break
+            offset += record_count
+        df = pd.DataFrame(rows)
+        cache_path = self.cache_dir / self._cache_key(year, dataset)
+        df.to_csv(cache_path, index=False)
+        return df
+
+
+def _is_arcgis_query_url(url: str) -> bool:
+    return "/query" in url and "arcgis/rest/services" in url

--- a/tests/unit/safety_analysis/test_bert_pipeline.py
+++ b/tests/unit/safety_analysis/test_bert_pipeline.py
@@ -1,7 +1,9 @@
 # ABOUTME: Tests for BERT embedding extraction and classification pipeline.
 """Tests for BERT-based embedding and classification in safety analysis."""
 
+import hashlib
 import random
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import numpy as np
@@ -71,6 +73,54 @@ _ATRISK_PHRASES = [
 ]
 
 
+class _FakeTokenizer:
+    """Deterministic tokenizer stub for BERT unit tests."""
+
+    def __call__(
+        self,
+        texts,
+        return_tensors,
+        truncation,
+        max_length,
+        padding,
+    ):
+        del return_tensors, truncation, max_length, padding
+        token_rows = []
+        for text in texts:
+            tokens = text.split()[:8] or [""]
+            token_rows.append([_stable_token_id(token) for token in tokens])
+        width = max(len(row) for row in token_rows)
+        padded = [row + [0] * (width - len(row)) for row in token_rows]
+        mask = [[1] * len(row) + [0] * (width - len(row)) for row in token_rows]
+        return {
+            "input_ids": torch.tensor(padded, dtype=torch.long),
+            "attention_mask": torch.tensor(mask, dtype=torch.long),
+        }
+
+
+class _FakeModel:
+    """Deterministic transformer stub with a BERT-sized hidden state."""
+
+    config = SimpleNamespace(hidden_size=768)
+
+    def eval(self):
+        return self
+
+    def cuda(self):
+        return self
+
+    def __call__(self, **inputs):
+        input_ids = inputs["input_ids"].float()
+        dims = torch.arange(self.config.hidden_size, dtype=torch.float32)
+        hidden = ((input_ids.unsqueeze(-1) + dims) % 97) / 97.0
+        return SimpleNamespace(last_hidden_state=hidden)
+
+
+def _stable_token_id(token: str) -> int:
+    digest = hashlib.sha1(token.encode("utf-8")).hexdigest()
+    return int(digest[:8], 16) % 1000 + 1
+
+
 @pytest.fixture
 def bert_config():
     """BertConfig with small max_length for faster testing."""
@@ -80,6 +130,22 @@ def bert_config():
         batch_size=4,
         device="cpu",
         pooling_strategy="cls",
+    )
+
+
+@pytest.fixture(autouse=True)
+def fake_huggingface_model(monkeypatch):
+    """Keep BERT unit tests deterministic and offline-safe."""
+    if not _HAS_BERT:
+        return
+    monkeypatch.setattr(
+        "worldenergydata.safety_analysis.nlp.bert_pipeline."
+        "AutoTokenizer.from_pretrained",
+        lambda model_name: _FakeTokenizer(),
+    )
+    monkeypatch.setattr(
+        "worldenergydata.safety_analysis.nlp.bert_pipeline.AutoModel.from_pretrained",
+        lambda model_name: _FakeModel(),
     )
 
 

--- a/tests/unit/scheduler/test_ukcs_adapter.py
+++ b/tests/unit/scheduler/test_ukcs_adapter.py
@@ -58,6 +58,7 @@ def test_ukcs_downloads_configured_year_and_writes_outputs(tmp_path: Path):
         year=2026,
         dataset="monthly",
         force_refresh=True,
+        max_records=None,
     )
     assert (tmp_path / "raw" / "nsta_production_2026_monthly.parquet").exists()
     normalized_path = tmp_path / "ukcs_production_2026_monthly.parquet"
@@ -85,6 +86,12 @@ def test_ukcs_max_records_bounds_written_outputs(tmp_path: Path):
 
     assert result.status == "success"
     assert result.records_updated == 1
+    client.download.assert_called_once_with(
+        year=2026,
+        dataset="monthly",
+        force_refresh=False,
+        max_records=1,
+    )
     normalized = pd.read_parquet(tmp_path / "ukcs_production_2026_monthly.parquet")
     assert normalized["field"].tolist() == ["FORTIES"]
 

--- a/tests/unit/scheduler/test_ukcs_adapter.py
+++ b/tests/unit/scheduler/test_ukcs_adapter.py
@@ -1,0 +1,136 @@
+"""Tests for the UKCS scheduler adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from worldenergydata.scheduler.jobs.ukcs_refresh import UkcsRefreshJob
+
+
+def _raw_ukcs_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "FieldName": "Forties",
+                "Year": 2026,
+                "Month": 1,
+                "OilProduction (Thousand Tonnes)": 450.3,
+                "GasProduction (MMscf)": 12.5,
+                "WaterProduction (Thousand Tonnes)": 310.2,
+            }
+        ]
+    )
+
+
+def _two_row_raw_ukcs_df() -> pd.DataFrame:
+    first = _raw_ukcs_df().iloc[0].to_dict()
+    second = {
+        **first,
+        "FieldName": "Buzzard",
+        "OilProduction (Thousand Tonnes)": 780.1,
+    }
+    return pd.DataFrame([first, second])
+
+
+def test_ukcs_downloads_configured_year_and_writes_outputs(tmp_path: Path):
+    client = MagicMock()
+    client.download.return_value = _raw_ukcs_df()
+
+    with patch(
+        "worldenergydata.scheduler.jobs.ukcs_refresh.NSTAClient",
+        return_value=client,
+    ):
+        result = UkcsRefreshJob().run(
+            {
+                "output_dir": str(tmp_path),
+                "year": 2026,
+                "dataset": "monthly",
+                "force_refresh": True,
+            }
+        )
+
+    assert result.status == "success"
+    assert result.records_updated == 1
+    client.download.assert_called_once_with(
+        year=2026,
+        dataset="monthly",
+        force_refresh=True,
+    )
+    assert (tmp_path / "raw" / "nsta_production_2026_monthly.parquet").exists()
+    normalized_path = tmp_path / "ukcs_production_2026_monthly.parquet"
+    assert normalized_path.exists()
+    normalized = pd.read_parquet(normalized_path)
+    assert normalized.loc[0, "field"] == "FORTIES"
+    assert normalized.loc[0, "oil_bbl"] > 0
+
+
+def test_ukcs_max_records_bounds_written_outputs(tmp_path: Path):
+    client = MagicMock()
+    client.download.return_value = _two_row_raw_ukcs_df()
+
+    with patch(
+        "worldenergydata.scheduler.jobs.ukcs_refresh.NSTAClient",
+        return_value=client,
+    ):
+        result = UkcsRefreshJob().run(
+            {
+                "output_dir": str(tmp_path),
+                "year": 2026,
+                "max_records": 1,
+            }
+        )
+
+    assert result.status == "success"
+    assert result.records_updated == 1
+    normalized = pd.read_parquet(tmp_path / "ukcs_production_2026_monthly.parquet")
+    assert normalized["field"].tolist() == ["FORTIES"]
+
+
+def test_ukcs_missing_output_dir_skips_without_network():
+    with patch("worldenergydata.scheduler.jobs.ukcs_refresh.NSTAClient") as client:
+        result = UkcsRefreshJob().run({"year": 2026})
+
+    assert result.status == "skipped"
+    assert result.records_updated == 0
+    client.assert_not_called()
+
+
+def test_ukcs_client_failure_returns_failure(tmp_path: Path):
+    client = MagicMock()
+    client.download.side_effect = RuntimeError("NSTA offline")
+
+    with patch(
+        "worldenergydata.scheduler.jobs.ukcs_refresh.NSTAClient",
+        return_value=client,
+    ):
+        result = UkcsRefreshJob().run({"output_dir": str(tmp_path), "year": 2026})
+
+    assert result.status == "failure"
+    assert result.records_updated == 0
+    assert "NSTA offline" in (result.error_msg or "")
+
+
+def test_ukcs_passes_configured_download_url_to_client(tmp_path: Path):
+    client = MagicMock()
+    client.download.return_value = _raw_ukcs_df()
+    download_url = "https://example.test/nsta/{year}/{dataset}.csv"
+
+    with patch(
+        "worldenergydata.scheduler.jobs.ukcs_refresh.NSTAClient",
+        return_value=client,
+    ) as client_cls:
+        UkcsRefreshJob().run(
+            {
+                "output_dir": str(tmp_path),
+                "year": 2026,
+                "download_url": download_url,
+            }
+        )
+
+    client_cls.assert_called_once_with(
+        cache_dir=str(tmp_path / "raw"),
+        base_url=download_url,
+    )

--- a/tests/unit/ukcs/test_field_production.py
+++ b/tests/unit/ukcs/test_field_production.py
@@ -95,6 +95,30 @@ class TestUKCSFieldProductionLoaderLoad:
         result = loader.load(raw)
         assert len(result) == len(raw)
 
+    def test_load_accepts_current_pprs_schema_columns(self, loader):
+        raw = pd.DataFrame(
+            [
+                {
+                    "FIELDNAME": "Forties",
+                    "PERIODYR": 2026,
+                    "PERIODMNTH": 1,
+                    "OILPRODMAS": 450.3,
+                    "AGASPROKSM": 12.5,
+                    "DGASPROKSM": 1.5,
+                    "WATPRODVOL": 310.2,
+                }
+            ]
+        )
+
+        result = loader.load(raw)
+
+        assert result.loc[0, "field"] == "FORTIES"
+        assert result.loc[0, "year"] == 2026
+        assert result.loc[0, "month"] == 1
+        assert result.loc[0, "oil_bbl"] == pytest.approx(450.3 * TONNES_TO_BBL)
+        assert result.loc[0, "gas_mcf"] == pytest.approx((12.5 + 1.5) * 35.3147)
+        assert result.loc[0, "water_bbl"] == pytest.approx(310.2 * 6.2898)
+
 
 class TestUKCSFieldProductionLoaderFilter:
     @pytest.fixture

--- a/tests/unit/ukcs/test_nsta_client.py
+++ b/tests/unit/ukcs/test_nsta_client.py
@@ -54,6 +54,16 @@ class TestNSTAClientCacheKey:
         assert k1 != k2
 
 
+class TestNSTAClientUrl:
+    def test_build_url_uses_current_hub_csv_download(self, tmp_path):
+        client = NSTAClient(cache_dir=str(tmp_path))
+        url = client._build_url(year=2026, dataset="monthly")
+        assert (
+            url == "https://opendata-nstauthority.hub.arcgis.com/api/download/v1/"
+            "items/ba8b7b78d3a74edc88293011981ce2d7/csv?layers=0"
+        )
+
+
 class TestNSTAClientCache:
     def test_is_cached_false_when_missing(self, tmp_path):
         client = NSTAClient(cache_dir=str(tmp_path))

--- a/tests/unit/ukcs/test_nsta_client.py
+++ b/tests/unit/ukcs/test_nsta_client.py
@@ -16,6 +16,34 @@ MOCK_PRODUCTION_CSV = (
     "FORTIES,2022,2,430.0,11.0,295.7\n"
 )
 
+MOCK_PPRS_JSON = {
+    "features": [
+        {
+            "attributes": {
+                "FIELDNAME": "ABIGAIL",
+                "PERIODYR": "2022",
+                "PERIODMNTH": "10",
+                "OILPRODMAS": 6948.1176,
+                "AGASPROKSM": 2787.0,
+                "DGASPROKSM": 0.0,
+                "WATPRODVOL": 1393.0,
+            }
+        },
+        {
+            "attributes": {
+                "FIELDNAME": "ABIGAIL",
+                "PERIODYR": "2022",
+                "PERIODMNTH": "11",
+                "OILPRODMAS": 16983.0378,
+                "AGASPROKSM": 6390.0,
+                "DGASPROKSM": 0.0,
+                "WATPRODVOL": 2599.0,
+            }
+        },
+    ],
+    "exceededTransferLimit": False,
+}
+
 
 class TestNSTAClientInit:
     def test_default_cache_dir_created(self, tmp_path):
@@ -27,9 +55,9 @@ class TestNSTAClientInit:
         NSTAClient(cache_dir=str(cache))
         assert cache.exists()
 
-    def test_default_base_url_contains_nsta(self, tmp_path):
+    def test_default_base_url_contains_ukcs_service(self, tmp_path):
         client = NSTAClient(cache_dir=str(tmp_path))
-        assert "nstauthority" in client.base_url or "nsta" in client.base_url.lower()
+        assert "UKCS_hydrocarbon_field_production_reports" in client.base_url
 
 
 class TestNSTAClientCacheKey:
@@ -55,12 +83,13 @@ class TestNSTAClientCacheKey:
 
 
 class TestNSTAClientUrl:
-    def test_build_url_uses_current_hub_csv_download(self, tmp_path):
+    def test_build_url_uses_official_arcgis_query_endpoint(self, tmp_path):
         client = NSTAClient(cache_dir=str(tmp_path))
         url = client._build_url(year=2026, dataset="monthly")
         assert (
-            url == "https://opendata-nstauthority.hub.arcgis.com/api/download/v1/"
-            "items/ba8b7b78d3a74edc88293011981ce2d7/csv?layers=0"
+            url == "https://services-eu1.arcgis.com/OZMfUznmLTnWccBc/arcgis/rest/"
+            "services/UKCS_hydrocarbon_field_production_reports_PPRS_points_(WGS84)/"
+            "FeatureServer/0/query"
         )
 
 
@@ -93,8 +122,70 @@ class TestNSTAClientCache:
 
 class TestNSTAClientDownload:
     @patch("worldenergydata.ukcs.production.nsta_client.requests")
-    def test_download_saves_to_cache(self, mock_requests, tmp_path):
+    def test_download_queries_official_arcgis_endpoint(self, mock_requests, tmp_path):
         client = NSTAClient(cache_dir=str(tmp_path))
+        mock_response = MagicMock()
+        mock_response.json.return_value = MOCK_PPRS_JSON
+        mock_response.raise_for_status = MagicMock()
+        mock_requests.get.return_value = mock_response
+
+        df = client.download(year=2022, max_records=2, force_refresh=True)
+
+        assert df.to_dict("records") == [
+            feature["attributes"] for feature in MOCK_PPRS_JSON["features"]
+        ]
+        mock_requests.get.assert_called_once_with(
+            client._build_url(2022, "monthly"),
+            params={
+                "where": "PERIODYR = '2022'",
+                "outFields": "*",
+                "returnGeometry": "false",
+                "resultOffset": 0,
+                "resultRecordCount": 2,
+                "f": "json",
+            },
+            timeout=60,
+        )
+
+    @patch("worldenergydata.ukcs.production.nsta_client.requests")
+    def test_download_paginates_official_arcgis_endpoint(self, mock_requests, tmp_path):
+        client = NSTAClient(cache_dir=str(tmp_path))
+        first_response = MagicMock()
+        first_response.json.return_value = {
+            "features": [MOCK_PPRS_JSON["features"][0]],
+            "exceededTransferLimit": True,
+        }
+        first_response.raise_for_status = MagicMock()
+        second_response = MagicMock()
+        second_response.json.return_value = {
+            "features": [MOCK_PPRS_JSON["features"][1]],
+            "exceededTransferLimit": False,
+        }
+        second_response.raise_for_status = MagicMock()
+        mock_requests.get.side_effect = [first_response, second_response]
+
+        df = client.download(year=2022, force_refresh=True)
+
+        assert len(df) == 2
+        assert mock_requests.get.call_args_list[0].kwargs["params"]["resultOffset"] == 0
+        assert (
+            mock_requests.get.call_args_list[0].kwargs["params"]["resultRecordCount"]
+            == 2000
+        )
+        assert (
+            mock_requests.get.call_args_list[1].kwargs["params"]["resultOffset"] == 2000
+        )
+        assert (
+            mock_requests.get.call_args_list[1].kwargs["params"]["resultRecordCount"]
+            == 2000
+        )
+
+    @patch("worldenergydata.ukcs.production.nsta_client.requests")
+    def test_download_saves_to_cache(self, mock_requests, tmp_path):
+        client = NSTAClient(
+            cache_dir=str(tmp_path),
+            base_url="https://example.test/nsta_{year}_{dataset}.csv",
+        )
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.content = MOCK_PRODUCTION_CSV.encode("utf-8")
@@ -117,7 +208,10 @@ class TestNSTAClientDownload:
 
     @patch("worldenergydata.ukcs.production.nsta_client.requests")
     def test_download_force_refresh_ignores_cache(self, mock_requests, tmp_path):
-        client = NSTAClient(cache_dir=str(tmp_path))
+        client = NSTAClient(
+            cache_dir=str(tmp_path),
+            base_url="https://example.test/nsta_{year}_{dataset}.csv",
+        )
         cache_path = tmp_path / client._cache_key(year=2022)
         cache_path.write_text("old,data\n1,2\n")
 


### PR DESCRIPTION
## Summary
- Replaces the `ukcs_refresh` scheduler stub with an NSTA-backed refresh that writes raw and normalized Parquet snapshots plus refresh metadata.
- Updates `NSTAClient` to default to the official UKCS Transition ArcGIS PPRS production points FeatureServer query endpoint, with pagination and cache support.
- Passes scheduler `max_records` through to the client so bounded refreshes limit ArcGIS query size, while full refreshes page through all available rows.
- Extends `UKCSFieldProductionLoader` to normalize current PPRS schema columns (`FIELDNAME`, `PERIODYR`, `OILPRODMAS`, etc.) while preserving legacy fixture support.
- Makes BERT pipeline unit tests deterministic/offline-safe by stubbing HuggingFace tokenizer/model loading in tests; production BERT code is unchanged.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /mnt/local-analysis/worldenergydata/.venv/bin/python -m pytest tests/unit/ukcs tests/unit/scheduler -q` -> 331 passed, 1 warning.
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /mnt/local-analysis/worldenergydata/.venv/bin/python -m pytest tests/unit/safety_analysis/test_bert_pipeline.py tests/unit/ukcs/test_nsta_client.py tests/unit/scheduler/test_ukcs_adapter.py -q` -> 23 passed, 15 skipped locally because optional BERT deps are not installed in this venv.
- `black --check` on changed Python files -> pass.
- `git diff --check` -> pass.
- `scripts/legal/legal-sanity-scan.sh --repo=../../../home/vamsee/.config/superpowers/worktrees/worldenergydata/fix-issue-269-ukcs-adapter --diff-only` -> pass.

## Live Source Note
The original data.gov.uk / old NSTA Hub item links currently return permission or token-required errors. Parallel source probes found the current official UKCS Transition ArcGIS service instead:

- FeatureServer query endpoint: `https://services-eu1.arcgis.com/OZMfUznmLTnWccBc/arcgis/rest/services/UKCS_hydrocarbon_field_production_reports_PPRS_points_(WGS84)/FeatureServer/0/query`
- Hub CSV download: `https://hub.arcgis.com/api/download/v1/items/dd38204275a04618ab7ddd00f87224e3/csv?layers=0`

Verified from this branch:
- Anonymous query count returns `133384` rows.
- Hub CSV redirects to a services-eu1 export blob with `x-ms-meta-recordCount: 133384`.
- Bounded scheduler live smoke for `year=2022`, `max_records=2`, `force_refresh=True` completed successfully and wrote raw CSV, raw Parquet, normalized Parquet, and `_metadata.json`.

Related: #269
