### PR TITLE
docs: add worldenergydata source readiness skill

### DIFF
--- a/.claude/skills/worldenergydata-source-readiness/SKILL.md
+++ b/.claude/skills/worldenergydata-source-readiness/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: worldenergydata-source-readiness
+description: Summarize worldenergydata source readiness, freshness, data locations, and scheduler blockers from repo metadata. Use when asked for worldenergydata data completeness, latest data dates, data locations, refresh status, scheduler source health, or acceptance-criteria inputs for data-source freshness.
+---
+
+# WorldEnergyData Source Readiness
+
+## Quick Start
+
+From the worldenergydata repo root, run:
+
+```bash
+python .claude/skills/worldenergydata-source-readiness/scripts/source_readiness_summary.py
+```
+
+For JSON output:
+
+```bash
+python .claude/skills/worldenergydata-source-readiness/scripts/source_readiness_summary.py --format json
+```
+
+## What To Report
+
+Use this skill to answer, in one pass:
+
+- data group / module name
+- catalog status and freshness status
+- latest known date
+- repo-local data location
+- external data location, if metadata records one
+- scheduler output location, if configured
+- scheduler success manifest timestamp, if present
+- dataset count, record count, file count, and data size
+- blocker issue or operational gap, when known from current GitHub issue state
+
+## Source Of Truth Order
+
+1. `data/freshness-scorecard.json` for module-level status.
+2. `data/modules/<module>/_metadata.json` for file counts, sizes, external roots, and newest file modified date.
+3. `data/modules/<module>/manifest.json` for successful scheduler refresh timestamp.
+4. `config/scheduler/scheduler_config.yml` for scheduler job names and output directories.
+5. `data/catalog.yaml` for dataset paths and row counts.
+
+If these disagree, state the disagreement instead of collapsing it. In particular, distinguish:
+
+- **metadata refresh date**: when the module inventory was generated
+- **newest file modified date**: newest known local file timestamp
+- **scheduler success date**: when a scheduler job last completed successfully
+- **source data vintage**: the newest business/date field inside the dataset; do not claim this unless inspected directly
+
+## Acceptance Criteria Drafting Pattern
+
+For Tier-A data-source readiness, require each source to expose:
+
+- `source_data_latest_date`
+- `last_successful_refresh`
+- `data_location`
+- `record_count`
+- `freshness_status`
+- `refresh_cadence`
+- `blocker_issue` or `none`
+
+Treat a source as green only when it has a successful scheduler manifest or another documented refresh proof within its cadence.
+
+## Details
+
+See [references/readiness-fields.md](references/readiness-fields.md) for field definitions and interpretation rules.

--- a/.claude/skills/worldenergydata-source-readiness/references/readiness-fields.md
+++ b/.claude/skills/worldenergydata-source-readiness/references/readiness-fields.md
@@ -1,0 +1,35 @@
+# Readiness Fields
+
+## Table Columns
+
+| Field | Meaning |
+|---|---|
+| `module` | worldenergydata module / data group key. |
+| `catalog_status` | Declared module status from the freshness scorecard. |
+| `freshness_status` | Derived freshness class from scorecard and scheduler manifest. |
+| `latest_known_date` | Best available timestamp from scheduler success, metadata refresh, or newest file modified date. |
+| `latest_date_basis` | Which clock produced `latest_known_date`. |
+| `data_location` | Repo-local `data/modules/<module>` path. |
+| `external_data_root` | External storage path from module metadata, when present. |
+| `scheduler_output_dir` | Configured scheduler output directory, when present. |
+| `datasets` | Dataset count from scorecard/catalog. |
+| `records` | Record count from scorecard or module metadata. |
+| `files` | File count from module metadata. |
+| `size` | Human-readable module size from metadata. |
+| `scheduler_last_success` | Last successful scheduler manifest timestamp. |
+
+## Interpretation
+
+- `runtime_fetched` plus `missing` usually means the source is configured or planned but lacks a repo-visible success manifest.
+- `sample` means local data exists but should not be represented as full production coverage.
+- `full` means catalog declares full coverage, but still verify data vintage before making buyer-facing freshness claims.
+- `unknown` needs classification before acceptance criteria can be closed.
+- `not_applicable` modules are infrastructure or analytical modules unless the issue explicitly scopes them as data products.
+
+## Fast Commands
+
+```bash
+python .claude/skills/worldenergydata-source-readiness/scripts/source_readiness_summary.py
+python scripts/audit/data_freshness_scorecard.py --project-root . --check --max-unknown 999
+bash scripts/cron/scheduler-health.sh
+```

--- a/.claude/skills/worldenergydata-source-readiness/scripts/source_readiness_summary.py
+++ b/.claude/skills/worldenergydata-source-readiness/scripts/source_readiness_summary.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Print worldenergydata source readiness and data-location summary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text())
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    return yaml.safe_load(path.read_text()) or {}
+
+
+def repo_root_from_script() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def newest_modified(metadata: dict[str, Any]) -> str:
+    values = [
+        item.get("modified")
+        for item in metadata.get("files", [])
+        if isinstance(item, dict) and item.get("modified")
+    ]
+    return max(values) if values else ""
+
+
+def scheduler_outputs(config: dict[str, Any]) -> dict[str, str]:
+    outputs: dict[str, str] = {}
+    for job in config.get("jobs", []) or []:
+        output_dir = job.get("output_dir")
+        name = job.get("name", "")
+        if not output_dir or not name.endswith("_refresh"):
+            continue
+        module = name[: -len("_refresh")]
+        outputs[module] = output_dir
+    return outputs
+
+
+def latest_known_date(entry: dict[str, Any], metadata: dict[str, Any]) -> tuple[str, str]:
+    scheduler_success = entry.get("scheduler_last_success_ts") or ""
+    if scheduler_success:
+        return scheduler_success, "scheduler_success"
+    last_refresh = entry.get("last_refresh") or metadata.get("last_refresh") or ""
+    if last_refresh:
+        return last_refresh, "metadata_refresh"
+    newest = newest_modified(metadata)
+    if newest:
+        return newest, "newest_file_modified"
+    return "", ""
+
+
+def build_rows(repo_root: Path) -> list[dict[str, Any]]:
+    scorecard = load_json(repo_root / "data" / "freshness-scorecard.json")
+    modules = scorecard.get("modules", {})
+    scheduler_map = scheduler_outputs(
+        load_yaml(repo_root / "config" / "scheduler" / "scheduler_config.yml")
+    )
+
+    rows: list[dict[str, Any]] = []
+    for module, entry in sorted(modules.items()):
+        module_dir = repo_root / "data" / "modules" / module
+        metadata = load_json(module_dir / "_metadata.json")
+        manifest = load_json(module_dir / "manifest.json")
+        entry = dict(entry)
+        if manifest and not entry.get("scheduler_last_success_ts"):
+            entry["scheduler_last_success_ts"] = manifest.get("last_success_ts")
+        latest, basis = latest_known_date(entry, metadata)
+        rows.append(
+            {
+                "module": module,
+                "catalog_status": entry.get("catalog_status", ""),
+                "freshness_status": entry.get("freshness_status", ""),
+                "latest_known_date": latest,
+                "latest_date_basis": basis,
+                "data_location": str(Path("data") / "modules" / module),
+                "external_data_root": metadata.get("external_data_root") or "",
+                "scheduler_output_dir": scheduler_map.get(module, ""),
+                "datasets": entry.get("dataset_count", 0),
+                "records": entry.get("record_count", metadata.get("record_count", 0)),
+                "files": metadata.get("file_count", ""),
+                "size": metadata.get("total_size_human", ""),
+                "scheduler_last_success": entry.get("scheduler_last_success_ts") or "",
+            }
+        )
+    return rows
+
+
+def markdown(rows: list[dict[str, Any]]) -> str:
+    headers = [
+        "Module",
+        "Status",
+        "Freshness",
+        "Latest Known Date",
+        "Basis",
+        "Data Location",
+        "External Location",
+        "Scheduler Output",
+        "Datasets",
+        "Records",
+        "Files",
+        "Size",
+    ]
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "|---|---|---|---|---|---|---|---|---:|---:|---:|---|",
+    ]
+    for row in rows:
+        values = [
+            row["module"],
+            row["catalog_status"],
+            row["freshness_status"],
+            row["latest_known_date"],
+            row["latest_date_basis"],
+            row["data_location"],
+            row["external_data_root"],
+            row["scheduler_output_dir"],
+            str(row["datasets"]),
+            str(row["records"]),
+            str(row["files"]),
+            row["size"],
+        ]
+        lines.append("| " + " | ".join(values) + " |")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=repo_root_from_script())
+    parser.add_argument("--format", choices=("markdown", "json"), default="markdown")
+    args = parser.parse_args()
+
+    rows = build_rows(args.repo_root.resolve())
+    if args.format == "json":
+        print(json.dumps(rows, indent=2))
+    else:
+        print(markdown(rows))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a repo-local agent skill for fast worldenergydata data-source readiness lookup. The skill covers completeness, freshness, latest known dates, repo/external data locations, scheduler output directories, and acceptance-criteria inputs.

Files added:
- `.claude/skills/worldenergydata-source-readiness/SKILL.md`
- `.claude/skills/worldenergydata-source-readiness/references/readiness-fields.md`
- `.claude/skills/worldenergydata-source-readiness/scripts/source_readiness_summary.py`

## Verification

- `python .claude/skills/worldenergydata-source-readiness/scripts/source_readiness_summary.py`
  - emitted Markdown table with 31 module rows
- `python .claude/skills/worldenergydata-source-readiness/scripts/source_readiness_summary.py --format json | python -m json.tool`
  - valid JSON
- `/mnt/local-analysis/worldenergydata/.venv/bin/python -m py_compile .claude/skills/worldenergydata-source-readiness/scripts/source_readiness_summary.py`
  - passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /mnt/local-analysis/worldenergydata/.venv/bin/python -m pytest tests/unit/audit/test_data_freshness_scorecard.py -q`
  - 3 passed
- `bash /mnt/local-analysis/workspace-hub/scripts/legal/legal-sanity-scan.sh --repo=../../../home/vamsee/.config/superpowers/worktrees/worldenergydata/skill-source-readiness --diff-only`
  - PASS

## Notes

The skill intentionally does not hard-code today’s volatile source status. Agents should run the bundled script to read current repo metadata each time.