### PR TITLE
docs: plan source refresh acceptance contract

### DIFF
--- a/docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md
+++ b/docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md
@@ -1,0 +1,310 @@
+# Plan: Issue #462 — Source refresh acceptance criteria contract
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/462  
+**Status:** plan-review  
+**Tier:** T2 (contract document + machine-readable validation + skill update)  
+**Client:** N/A  
+**Project:** N/A
+
+## Resource Intelligence Summary
+
+### Execution mode
+
+Planning will use `parallel-readonly` evidence gathering. Implementation will be `single-lane` unless review requires separate worktrees for the documentation and validator changes.
+
+### Reproduction proofs
+
+N/A — this is a governance/data-contract issue. It does not allege a failing runtime path; it defines the acceptance contract that later runtime checks will use.
+
+### Evidence observed at planning time
+
+- `.claude/skills/worldenergydata-source-readiness/SKILL.md` already reports source readiness, data locations, scheduler output directories, latest-known dates, and blocker inputs.
+- `.claude/skills/worldenergydata-source-readiness/scripts/source_readiness_summary.py --format json` emits 31 module rows from `data/freshness-scorecard.json`, `data/modules/*/_metadata.json`, scheduler config, scheduler manifests, and `data/catalog.yaml`.
+- `scripts/audit/data_freshness_scorecard.py` currently derives `freshness_status` from scheduler manifests, catalog status, dataset count, and module metadata.
+- `tests/unit/audit/test_data_freshness_scorecard.py` covers a successful scheduler manifest, a non-success scheduler manifest, and output writing.
+- `scripts/cron/scheduler-health.sh` already treats missing, non-success, unparseable, or stale scheduler manifests as stale scheduler health.
+- `module-manifest.yaml` documents existing `catalog_status` values: `full`, `sample`, `empty`, `runtime_fetched`, `reference_data`, `not_applicable`, and `unknown`.
+- `config/scheduler/scheduler_config.yml` defines seven enabled scheduler jobs: `bsee_refresh`, `sodir_refresh`, `eia_us_refresh`, `metocean_refresh`, `brazil_anp_refresh`, `ukcs_refresh`, and `lng_terminals_refresh`.
+
+### Gaps this plan will close
+
+- There is no canonical contract that distinguishes `source_data_latest_date` from `last_successful_refresh`.
+- There is no machine-readable list of required source-readiness fields per high-value data group.
+- The current scorecard can report values such as `empty`, `sample`, and `full`, but the issue-level acceptance contract does not yet specify compatibility between catalog/completeness values and freshness values.
+- The readiness skill has a drafting pattern, but it does not point agents to a repo-level acceptance contract.
+- There is no validator that checks enum values, required data groups, scheduler-backed source mappings, or the "scheduler manifest required for green" rule without running downloads.
+
+## Artifact Map
+
+| Artifact | Path |
+|---|---|
+| Plan | `docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md` |
+| Plan index row | `docs/plans/README.md` |
+| Contract document | `docs/data/source-refresh-acceptance-criteria.md` |
+| Machine-readable contract | `data/source-refresh-acceptance-contract.json` |
+| Validator | `scripts/audit/validate_source_refresh_contract.py` |
+| Tests | `tests/unit/audit/test_source_refresh_contract.py` |
+| Skill update | `.claude/skills/worldenergydata-source-readiness/SKILL.md` |
+| Skill reference update | `.claude/skills/worldenergydata-source-readiness/references/readiness-fields.md` |
+| Plan review r1 — schema | `scripts/review/results/2026-06-09-plan-462-schema-r1.md` |
+| Plan review r1 — integration | `scripts/review/results/2026-06-09-plan-462-integration-r1.md` |
+| Plan review r2 — schema | `scripts/review/results/2026-06-09-plan-462-schema-r2.md` |
+| Plan review r2 — integration | `scripts/review/results/2026-06-09-plan-462-integration-r2.md` |
+| Plan review r3 — mapping | `scripts/review/results/2026-06-09-plan-462-mapping-r3.md` |
+| Plan review r3 — final readiness | `scripts/review/results/2026-06-09-plan-462-final-readiness-r3.md` |
+| Plan review r4 — mapping | `scripts/review/results/2026-06-09-plan-462-mapping-r4.md` |
+| Plan review r4 — final readiness | `scripts/review/results/2026-06-09-plan-462-final-readiness-r4.md` |
+
+## Deliverable
+
+The deliverable will define a source refresh acceptance contract that agents and humans can use to evaluate source readiness without running unbounded downloads. It will include a human-readable document, a JSON contract with required high-value data groups, a validator script, unit tests, and a skill update that routes agents to the contract.
+
+## Plan
+
+### Task 1 — Define the contract document
+
+Create `docs/data/source-refresh-acceptance-criteria.md`.
+
+The document will define:
+
+- required fields per data group
+- freshness status enum
+- completeness status enum
+- scorecard-to-contract mapping rules
+- scheduler-backed source rule
+- static/reference-data rule
+- blocked-source rule
+- distinction between source-data vintage and local refresh timestamp
+- acceptance checklist for source summaries and downstream workflow readiness
+
+The freshness enum will include `fresh`, `stale`, `missing`, `blocked`, `unknown`, `reference_data`, and `not_applicable`.
+
+The completeness enum will include `full`, `sample`, `empty`, `missing`, `runtime_fetched`, `reference_data`, `blocked`, `unknown`, and `not_applicable`.
+
+The contract will explicitly map current scorecard values into contract fields:
+
+| Scorecard `freshness_status` | Scorecard `catalog_status` | Contract `freshness_status` | Contract `completeness_status` |
+|---|---|---|---|
+| `empty` | `empty` | `missing` | `empty` |
+| `full` | `full` | `unknown` unless source vintage or scheduler success proves freshness | `full` |
+| `missing` | `not_applicable` | `not_applicable` | `not_applicable` |
+| `missing` | `runtime_fetched` | `missing` | `runtime_fetched` |
+| `not_applicable` | `not_applicable` | `not_applicable` | `not_applicable` |
+| `reference_data` | `reference_data` | `reference_data` | `reference_data` |
+| `sample` | `sample` | `stale` unless a successful scheduler manifest proves freshness | `sample` |
+| `unknown` | `unknown` | `unknown` | `unknown` |
+| `fresh` | any allowed value | `fresh` only if scheduler/source proof also passes | mapped from `catalog_status` |
+| `stale` | any allowed value | `stale` | mapped from `catalog_status` |
+
+`completeness_status` will be deterministically mapped from scorecard `catalog_status`; it will not use "unchanged" fallback language. `freshness_status` will be deterministically mapped from scorecard `freshness_status` plus scheduler/source proof, with `catalog_status` used only to classify completeness and special `runtime_fetched` handling.
+
+The implementation will include fixtures for each currently observed scorecard pair from `data/freshness-scorecard.json`: `empty|empty`, `full|full`, `missing|not_applicable`, `missing|runtime_fetched`, `not_applicable|not_applicable`, `reference_data|reference_data`, `sample|sample`, and `unknown|unknown`.
+
+### Task 2 — Add the machine-readable contract
+
+Create `data/source-refresh-acceptance-contract.json`.
+
+The JSON will include:
+
+- `schema_version`
+- enum definitions
+- required row fields
+- high-value source rows for BSEE, EIA US, SODIR, UKCS, Brazil ANP, LNG terminals, metocean, HSE, marine safety, vessel fleet, vessel hull models, oil price, and wind
+- scheduler job mapping for scheduler-backed sources
+- blocker issue mappings where already known
+- downstream consumer notes where known from issue context
+
+Each source row will require these fields:
+
+- `module_id`
+- `materialized_module_id`
+- `aliases`
+- `display_name`
+- `source_authority`
+- `source_url_or_api`
+- `source_data_latest_date`
+- `source_data_latest_date_basis`
+- `source_data_latest_date_unknown_reason`
+- `last_successful_refresh`
+- `last_successful_refresh_basis`
+- `data_location`
+- `external_data_root_required`
+- `scheduler_job`
+- `scheduler_output_dir`
+- `refresh_command`
+- `record_count`
+- `artifact_count`
+- `refresh_cadence`
+- `freshness_grace_days`
+- `freshness_status`
+- `completeness_status`
+- `credential_requirement`
+- `blocker_issue`
+- `downstream_consumers`
+
+Unknown `source_data_latest_date` will be represented as JSON `null`, not an empty string, and must be paired with `source_data_latest_date_basis: "unknown"` plus a non-empty `source_data_latest_date_unknown_reason`. Allowed non-null source date basis values will be `dataset_field`, `source_api_metadata`, `source_publication_date`, and `source_version`. Prohibited source date basis values will include `metadata_refresh`, `newest_file_modified`, `scheduler_success`, `manifest_timestamp`, and `unknown` when the date is non-null. The contract will prohibit metadata refresh dates, file modification timestamps, or scheduler success timestamps from being copied into `source_data_latest_date` unless the implementation actually inspects a business/date field inside the dataset.
+
+The EIA row will explicitly carry `module_id: "eia_us"`, `materialized_module_id: "eia"`, `aliases: ["eia"]`, `scheduler_job: "eia_us_refresh"`, `data_location: "data/modules/eia_us"`, and `scheduler_output_dir: "data/modules/eia"` so the existing scheduler output mismatch is visible instead of silently normalized away. Validator logic will require one of: existing `data_location`, `external_data_root_required: true`, or a declared `materialized_module_id`/`aliases` relationship whose scheduler output directory exists or is expected by scheduler config.
+
+### Task 3 — Implement validator
+
+Create `scripts/audit/validate_source_refresh_contract.py`.
+
+The validator will:
+
+- load `data/source-refresh-acceptance-contract.json`
+- verify all required top-level keys exist
+- verify every source row contains every field listed in `required_row_fields`
+- verify freshness and completeness values belong to their declared enums
+- verify the required high-value data groups are present
+- verify scorecard-to-contract mapping is deterministic from scorecard `freshness_status` plus `catalog_status`, including `missing|runtime_fetched` and `missing|not_applicable`
+- verify scheduler-backed sources name a job from `config/scheduler/scheduler_config.yml`
+- verify scheduler-backed source `scheduler_output_dir` exactly matches the configured job `output_dir`
+- verify scheduler-backed sources marked `fresh` have an existing `manifest.json` at the configured output directory, with `status: success`, parseable `last_success_ts`, and age within `freshness_grace_days`
+- verify scheduler-backed sources with known blockers, missing manifests, failed manifests, or stale manifests are not marked `fresh`
+- verify `source_data_latest_date` is either an ISO date/null and remains distinct from `last_successful_refresh`
+- verify null `source_data_latest_date` rows carry `source_data_latest_date_basis: "unknown"` and an explicit unknown reason
+- verify non-null `source_data_latest_date` rows use only allowed source-data basis values and reject prohibited basis values such as `metadata_refresh`, `newest_file_modified`, `scheduler_success`, and `manifest_timestamp`
+- verify each source row has an existing `data_location`, `external_data_root_required: true`, or explicit `materialized_module_id`/`aliases` mapping
+- verify every blocker issue value is either `none`, empty, or a GitHub issue URL / `#NNN` reference
+- verify `.claude/skills/worldenergydata-source-readiness/SKILL.md` references the contract document
+
+The validator will not download data or call external APIs.
+
+### Task 4 — Add tests first, then implementation
+
+Add `tests/unit/audit/test_source_refresh_contract.py`.
+
+Tests will cover:
+
+- valid minimal contract passes validation
+- source row missing any required row field fails validation
+- invalid freshness enum fails validation
+- invalid completeness enum fails validation
+- missing required high-value source fails validation
+- scheduler-backed source with an unknown job fails validation
+- scheduler-backed source with the wrong output directory fails validation
+- scheduler-backed source marked `fresh` without a successful in-cadence manifest fails validation
+- scorecard `freshness_status` plus `catalog_status` pairs `empty|empty`, `full|full`, `missing|not_applicable`, `missing|runtime_fetched`, `not_applicable|not_applicable`, `reference_data|reference_data`, `sample|sample`, and `unknown|unknown` map to contract freshness/completeness without leaking invalid values into the freshness enum
+- source rows keep `source_data_latest_date` and `last_successful_refresh` as distinct fields
+- null source-data latest dates require `source_data_latest_date_basis: "unknown"` and an unknown reason
+- non-null source-data latest dates reject prohibited basis values from metadata/file/scheduler clocks
+- EIA alias/materialization mapping validates `module_id: eia_us` to `materialized_module_id: eia`
+- fixtures cover one source in each lane: fresh, stale, missing, blocked, sample, and reference/static
+- skill file must reference the contract path
+
+### Task 5 — Update source-readiness skill
+
+Update `.claude/skills/worldenergydata-source-readiness/SKILL.md` and `references/readiness-fields.md` so agents:
+
+- run the readiness summary for current evidence
+- use the contract document for pass/fail acceptance decisions
+- avoid treating metadata refresh dates as source-data vintage
+- report data location and scheduler output location together when both exist
+
+### Task 6 — Verify
+
+Run focused verification:
+
+```bash
+set -euo pipefail
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/unit/audit/test_source_refresh_contract.py tests/unit/audit/test_data_freshness_scorecard.py -q
+python scripts/audit/validate_source_refresh_contract.py
+python .claude/skills/worldenergydata-source-readiness/scripts/source_readiness_summary.py --format json
+```
+
+Run the official workspace-hub legal/security scanner against the current worktree by passing a relative path from the workspace-hub checkout to this checkout:
+
+```bash
+set -euo pipefail
+export WORKSPACE_HUB="${WORKSPACE_HUB:?set path to workspace-hub checkout}"
+REL_FROM_HUB="$(python - <<'PY'
+import os
+from pathlib import Path
+print(os.path.relpath(Path.cwd().resolve(), Path(os.environ["WORKSPACE_HUB"]).resolve()))
+PY
+)"
+test -n "$REL_FROM_HUB"
+test "$REL_FROM_HUB" != "."
+(cd "$WORKSPACE_HUB" && bash scripts/legal/legal-sanity-scan.sh --repo="$REL_FROM_HUB" --diff-only)
+```
+
+Because `scripts/review/results/` is ignored by a broad `.gitignore` rule while historical review files are tracked, stage issue #462 review artifacts explicitly with `git add -f scripts/review/results/2026-06-09-plan-462-*.md`.
+
+## Files to Change
+
+| Action | Path | Reason |
+|---|---|---|
+| Create | `docs/data/source-refresh-acceptance-criteria.md` | Canonical human-readable source refresh contract |
+| Create | `data/source-refresh-acceptance-contract.json` | Machine-readable contract used by validator and agents |
+| Create | `scripts/audit/validate_source_refresh_contract.py` | No-download validator for enum, required source, scheduler mapping, and skill-reference checks |
+| Create | `tests/unit/audit/test_source_refresh_contract.py` | TDD coverage for contract validation |
+| Update | `.claude/skills/worldenergydata-source-readiness/SKILL.md` | Route agents from readiness summary to acceptance contract |
+| Update | `.claude/skills/worldenergydata-source-readiness/references/readiness-fields.md` | Document contract-backed interpretation rules |
+| Update | `docs/plans/README.md` | Index this plan |
+
+## TDD Test List
+
+| Test | What it verifies |
+|---|---|
+| `test_valid_minimal_contract_passes` | A valid fixture with required groups and enum values validates |
+| `test_source_row_missing_required_field_fails` | Every row must contain every `required_row_fields` entry |
+| `test_invalid_freshness_status_fails` | Unknown freshness values are rejected |
+| `test_invalid_completeness_status_fails` | Unknown completeness values are rejected |
+| `test_required_high_value_sources_present` | Required source rows cannot be omitted |
+| `test_scheduler_source_requires_known_job` | Scheduler-backed rows must name a configured job |
+| `test_scheduler_source_requires_exact_configured_output_dir` | Scheduler-backed rows must match the configured job output path exactly |
+| `test_fresh_scheduler_source_requires_success_manifest` | Scheduler-backed sources cannot be marked fresh without an in-cadence success manifest |
+| `test_observed_scorecard_pairs_map_to_contract_statuses` | Observed scorecard pairs, including `missing|runtime_fetched` and `missing|not_applicable`, map deterministically |
+| `test_source_date_and_refresh_date_are_distinct_fields` | Contract rows must keep source data vintage separate from local refresh timestamp |
+| `test_unknown_source_date_requires_basis_and_reason` | Null source-data latest dates require basis `unknown` and an explicit unknown reason |
+| `test_non_null_source_date_rejects_metadata_file_scheduler_basis` | Metadata refresh, file mtime, and scheduler success bases cannot populate source-data vintage |
+| `test_eia_us_alias_materialization_mapping_is_explicit` | EIA US row preserves `module_id` while declaring the existing `eia` materialization path |
+| `test_contract_fixture_covers_required_lanes` | Fixtures cover fresh, stale, missing, blocked, sample, and reference/static lanes |
+| `test_skill_references_contract` | Agent-facing skill routes to the canonical contract document |
+
+## Acceptance Criteria
+
+- [ ] `docs/data/source-refresh-acceptance-criteria.md` defines required fields, freshness enum, completeness enum, and pass/fail interpretation rules.
+- [ ] `data/source-refresh-acceptance-contract.json` includes initial rows for BSEE, EIA US, SODIR, UKCS, Brazil ANP, LNG terminals, metocean, HSE, marine safety, vessel fleet, vessel hull models, oil price, and wind.
+- [ ] Every source row contains every field listed in `required_row_fields`; the validator rejects missing row fields.
+- [ ] Scheduler-backed rows include configured scheduler job names and output directories.
+- [ ] Scheduler-backed row output directories exactly match scheduler config output directories, including the existing `eia_us_refresh` to `data/modules/eia` mapping.
+- [ ] The contract distinguishes `source_data_latest_date` from `last_successful_refresh`.
+- [ ] Unknown source-data latest dates use JSON `null` plus an explicit unknown reason.
+- [ ] Null source-data latest dates require `source_data_latest_date_basis: "unknown"`; non-null source-data latest dates reject metadata/file/scheduler clock bases.
+- [ ] Metadata refresh dates, file modification dates, and scheduler success dates are not allowed to populate `source_data_latest_date` unless a dataset business/date field is inspected.
+- [ ] The validator rejects invalid enum values and missing required high-value sources.
+- [ ] The validator rejects scheduler-backed rows that do not map to configured scheduler jobs.
+- [ ] The validator rejects scheduler-backed rows marked `fresh` when the success manifest is missing, failed, stale, or unparseable.
+- [ ] Observed scorecard pairs, including `missing|runtime_fetched` and `missing|not_applicable`, are explicitly mapped into contract freshness/completeness statuses.
+- [ ] EIA US explicitly records `materialized_module_id: eia` or equivalent alias metadata so `eia_us_refresh` output drift is visible and validated.
+- [ ] Tests cover fresh, stale, missing, blocked, sample, and reference/static lanes.
+- [ ] The source-readiness skill references the contract and tells agents to use it for acceptance decisions.
+- [ ] Focused tests pass.
+- [ ] The legal/security diff scan passes.
+
+## Risks and Open Questions
+
+- **Risk:** Existing scorecard `freshness_status` values include `empty`, `sample`, and `full` for current pipeline behavior. Implementation will preserve compatibility through an explicit scorecard-to-contract mapping layer unless a separate reviewed issue changes the scorecard schema.
+- **Risk:** Some high-value rows will initially have unknown source-data latest dates. Unknown is acceptable only as JSON `null` with `source_data_latest_date_basis: "unknown"` and a non-empty unknown reason; it must not be backfilled from metadata refresh timestamps.
+- **Risk:** The contract could become a static checklist that drifts from scheduler config. The validator must read scheduler config at runtime to reduce this drift.
+- **Risk:** The workspace-hub legal scanner cannot scan arbitrary worktrees by simple `--repo=worldenergydata` when this branch lives outside the workspace-hub root. Verification will use the relative-path command in Task 6 and must record the exact command in the PR body.
+- **Open:** Should `data/source-refresh-acceptance-contract.json` become the future source of truth for `module-manifest.yaml` `catalog_status`, or should it remain a validation overlay until source-specific issues close?
+
+## Adversarial Review Summary
+
+Rounds 1, 2, and 3 returned MAJOR findings. Round 4 returned APPROVE from both reviewers after the mapping, artifact, and status fixes. This plan is ready for user approval only after the committed/pushed artifacts are posted to the issue.
+
+| Reviewer | Verdict | Key findings addressed in this revision |
+|---|---|---|
+| Schema/contract r1 | MAJOR | Required row schema missing; scorecard enum compatibility underspecified; scheduler `fresh` not manifest-gated; source-data date semantics ambiguous; EIA identity/output drift not explicit; lane tests incomplete. |
+| Repo integration/testability r1 | MAJOR | Verification command used missing `.venv`; workspace-hub legal scan command was not reproducible for this worktree; scheduler output exact-match validation missing; scorecard enum mapping underspecified. |
+| Schema/contract r2 | MAJOR | Required row fields not validator-enforced; mapping not deterministic over scorecard `freshness_status` plus `catalog_status`; date-basis validation incomplete; EIA alias/materialization not contract-safe. |
+| Repo integration/testability r2 | MAJOR | Legal scan snippet still lacked exported `WORKSPACE_HUB` and non-empty relative path validation; ignored review artifacts needed force-add handling; `runtime_fetched` needed explicit mapping test coverage. |
+| Mapping r3 | MAJOR | Mapping still mishandled live `missing|runtime_fetched` rows. |
+| Final-readiness r3 | MAJOR | Mapping needed total observed-pair coverage; r3 review artifacts and plan status needed reconciliation. |
+| Mapping r4 | APPROVE | No findings; observed scorecard pairs and artifact hygiene verified. |
+| Final-readiness r4 | APPROVE | No findings; plan/index/review artifacts and verification command shape verified. |
+
+Implementation must not start until plan review is complete and the user applies `status:plan-approved`.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -72,6 +72,7 @@ This directory contains issue-plan artifacts created during the issue-planning-m
 | [#425](https://github.com/vamseeachanta/worldenergydata/issues/425) | [operator-hse-benchmarking](2026-05-18-issue-425-operator-hse-benchmarking.md) | plan-review | 2026-05-18 |
 | [#426](https://github.com/vamseeachanta/worldenergydata/issues/426) | [drilling-hse-patterns](2026-05-18-issue-426-drilling-hse-patterns.md) | plan-review | 2026-05-18 |
 | [#427](https://github.com/vamseeachanta/worldenergydata/issues/427) | [seasonal-intervention-risk](2026-05-18-issue-427-seasonal-intervention-risk.md) | plan-review | 2026-05-18 |
+| [#462](https://github.com/vamseeachanta/worldenergydata/issues/462) | [source-refresh-acceptance-contract](2026-06-09-issue-462-source-refresh-acceptance-contract.md) | plan-review | 2026-06-09 |
 
 ## Closed / superseded plans
 

--- a/scripts/review/results/2026-06-09-plan-462-final-readiness-r3.md
+++ b/scripts/review/results/2026-06-09-plan-462-final-readiness-r3.md
@@ -1,0 +1,18 @@
+# Plan #462 Review — Final Readiness r3
+
+Verdict: MAJOR
+
+## Findings
+
+- MAJOR — `docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md`: mapping is still contradictory. The table maps `freshness_status=missing` with any `catalog_status` to completeness `missing`, but the next paragraph says completeness is deterministically mapped from `catalog_status`. Current `data/freshness-scorecard.json` has `eia_us` as `catalog_status=runtime_fetched` and `freshness_status=missing`, and not-applicable modules as `catalog_status=not_applicable` plus `freshness_status=missing`. Fix: make the mapping total over observed pairs, especially `missing|runtime_fetched` and `missing|not_applicable`, and add explicit tests for those expected outputs.
+- MINOR — review-artifact coherence is stale for final approval. Artifact map and review summary include only r1/r2, while this is r3 final-readiness review. Fix: after r3 is persisted, add the r3 artifact row and update the review summary.
+- MINOR — plan status remains `draft`. Fix after the MAJOR is resolved and r3 is recorded: move both the plan and README row to `plan-review`, not `plan-approved`.
+
+## Checked
+
+- Plan, index, r1/r2 review artifacts, `.gitignore`, ignored artifact status.
+- Scheduler config: `eia_us_refresh -> data/modules/eia`.
+- Scorecard script and current `data/freshness-scorecard.json` status pairs.
+- Source-readiness skill/script/reference and JSON output.
+- Verification commands: Python/pytest available; workspace-hub legal scan command passed with `WORKSPACE_HUB` set to the workspace-hub checkout.
+- Force-add handling for ignored review artifacts.

--- a/scripts/review/results/2026-06-09-plan-462-final-readiness-r4.md
+++ b/scripts/review/results/2026-06-09-plan-462-final-readiness-r4.md
@@ -1,0 +1,17 @@
+# Plan #462 Review — Final Readiness r4
+
+Verdict: APPROVE
+
+## Findings
+
+None.
+
+## Checked
+
+- `docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md`: plan status, artifact map, verification section, and review summary.
+- `docs/plans/README.md`: issue #462 row matches plan file/status/date.
+- `scripts/review/results/2026-06-09-plan-462-*.md`: r1-r3 artifacts are present and listed coherently.
+- `.gitignore:299`: `results/` ignores review artifacts; `git add --dry-run -f ...` stages all review artifacts.
+- Absolute-path scan found no local path leaks in plan/index/review artifacts.
+- Verification shape checked: Python/pytest available; legal scan snippet runs with `WORKSPACE_HUB` set and passes; source readiness summary emits 31 rows; scorecard status pairs match the plan.
+- Live issue #462 is open with no `status:*` label. No plan defect blocks `status:plan-review`; artifacts still need commit/push and evidence post before label change.

--- a/scripts/review/results/2026-06-09-plan-462-integration-r1.md
+++ b/scripts/review/results/2026-06-09-plan-462-integration-r1.md
@@ -1,0 +1,19 @@
+# Plan #462 Review — Repo Integration/Testability r1
+
+Verdict: MAJOR
+
+## Findings
+
+- MAJOR — `docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md:136`: verification command uses `.venv/bin/python`, but this worktree has no `.venv/bin/python` or `.venv/bin/pytest`; focused verification will fail before tests run. Fix: use available `python -m pytest ...` or add an explicit environment bootstrap prerequisite.
+- MAJOR — `docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md:141` and `workspace-hub/scripts/legal/legal-sanity-scan.sh:263-268`: legal scan is not reproducible for this worktree. `worldenergydata` has no local `scripts/legal` scanner, and the workspace-hub scanner only scans `$WORKSPACE_ROOT/$TARGET_REPO`. Fix: use an exact command that targets the actual worktree, or add a repo-local wrapper/validated scanner path.
+- MINOR — `docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md:101-104` and `:163-164`: validator/test scope only requires a known scheduler job and some output dir. It does not require the contract output dir to equal the configured job `output_dir`. This permits drift, especially because `eia_us_refresh` maps to `data/modules/eia`, not `data/modules/eia_us`. Fix: validate exact job-to-output-dir pairs and add a negative test for wrong output dir.
+- MINOR — `docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md:71` and `:182`: enum compatibility is under-specified. Current scorecard emits freshness values omitted from the proposed freshness enum: `sample`, `full`, and `empty`. Fix: add an explicit scorecard-to-contract mapping rule and tests, or expand the freshness enum deliberately.
+
+## Checked
+
+- Plan file and plan index row
+- Scorecard script/tests
+- Scheduler config and scheduler-health script
+- Source-readiness skill/script/reference
+- Module manifest and freshness scorecard
+- Legal scanner availability/scope

--- a/scripts/review/results/2026-06-09-plan-462-integration-r2.md
+++ b/scripts/review/results/2026-06-09-plan-462-integration-r2.md
@@ -1,0 +1,16 @@
+# Plan #462 Review — Repo Integration/Testability r2
+
+Verdict: MAJOR
+
+## Findings
+
+- MAJOR — `docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md` Task 6 lines 196-207: legal scan recipe is still not reliably reproducible. The snippet reads `os.environ["WORKSPACE_HUB"]` but only assigns/checks a shell variable, not an exported environment variable. Fix: `export WORKSPACE_HUB=...`, add `set -euo pipefail` or explicit `REL_FROM_HUB` non-empty validation, then run the scanner.
+- MAJOR — plan Artifact Map plus `.gitignore:299`: review artifacts are local-only ignored files. `git status --ignored` reports both `scripts/review/results/2026-06-09-plan-462-*-r1.md` as ignored, and `git ls-files` has no entries for them. Fix: move them to a tracked path or force-add them.
+- MINOR — scorecard mapping test only covers `empty`, `sample`, and `full`, while the plan maps/requires `runtime_fetched` and current repo data has multiple `runtime_fetched` catalog rows. Fix: add `runtime_fetched` to the mapping test or add a dedicated regression test.
+
+## Checked
+
+- Plan file, plan index row, r1 review artifacts, git tracked/ignored state.
+- Scheduler config output dirs, including `eia_us_refresh -> data/modules/eia`.
+- Scorecard script/tests and current freshness scorecard/module manifest values.
+- Workspace-hub legal scanner path handling and revised command behavior.

--- a/scripts/review/results/2026-06-09-plan-462-mapping-r3.md
+++ b/scripts/review/results/2026-06-09-plan-462-mapping-r3.md
@@ -1,0 +1,15 @@
+# Plan #462 Review — Mapping r3
+
+Verdict: MAJOR
+
+## Findings
+
+- MAJOR — `docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md` Task 1 mapping table: scorecard mapping still mishandles `runtime_fetched`. The table maps `missing | any allowed value` to completeness `missing`, but live scorecard rows include `freshness_status: "missing"` with `catalog_status: "runtime_fetched"` for EIA and others. This contradicts the claim that completeness is deterministically mapped from `catalog_status`. Fix: add an explicit `missing | runtime_fetched -> freshness missing, completeness runtime_fetched` row, and make the test name/fixture cover the actual pair.
+
+## Checked
+
+- Required-row-field rejection.
+- Source-date basis/null rules.
+- EIA alias/materialization.
+- Legal scan recipe was runnable with `WORKSPACE_HUB` set to the workspace-hub checkout and scanner passed.
+- Ignored review artifact force-add handling.

--- a/scripts/review/results/2026-06-09-plan-462-mapping-r4.md
+++ b/scripts/review/results/2026-06-09-plan-462-mapping-r4.md
@@ -1,0 +1,16 @@
+# Plan #462 Review — Mapping r4
+
+Verdict: APPROVE
+
+## Findings
+
+None.
+
+## Checked
+
+- `docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md` header: `Status: plan-review`.
+- `docs/plans/README.md` issue #462 row: `plan-review`.
+- Live `data/freshness-scorecard.json` pairs: exactly `empty|empty`, `full|full`, `missing|not_applicable`, `missing|runtime_fetched`, `not_applicable|not_applicable`, `reference_data|reference_data`, `sample|sample`, `unknown|unknown`.
+- Plan mapping table and test/validator text cover all live pairs, including both `missing|runtime_fetched` and `missing|not_applicable`.
+- r3 artifacts exist and are listed/summarized in the plan.
+- Machine-specific absolute-path scan over the plan and `scripts/review/results/2026-06-09-plan-462-*.md` found no matches.

--- a/scripts/review/results/2026-06-09-plan-462-schema-r1.md
+++ b/scripts/review/results/2026-06-09-plan-462-schema-r1.md
@@ -1,0 +1,24 @@
+# Plan #462 Review — Schema/Contract r1
+
+Verdict: MAJOR
+
+## Findings
+
+- MAJOR — `docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md:79-104`: the JSON schema/validator does not enforce issue #462's required per-source fields. It can pass while omitting source authority/URL, local or external data location, refresh command, date basis, refresh timestamp, counts, cadence/grace, auth requirement, and downstream consumers. Fix: define a row schema with all required fields and add validator/tests for missing fields and allowed explicit-unknown values.
+- MAJOR — `docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md:71-73,182` and `scripts/audit/data_freshness_scorecard.py:73-81`: freshness enum compatibility is left as a risk, not a contract. The current scorecard emits `empty`, `sample`, and `full` as `freshness_status`, but the proposed freshness enum excludes them. Fix: define and validate a mapping from scorecard freshness/catalog values into contract `freshness_status` and `completeness_status`, or update the scorecard deliberately with regression tests.
+- MAJOR — `docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md:95-104,170-176`: the scheduler-backed-source rule is not machine-enforced. The plan validates job names/output dirs, but not the issue #462 requirement that scheduler-backed rows need a successful `manifest.json` before `fresh`. `scripts/cron/scheduler-health.sh:91-129` treats missing/non-success manifests as stale, and current `data/modules/*/manifest.json` files are absent. Fix: validator must read configured manifest paths, reject `fresh` for missing/non-success/stale manifests, and require blocked/missing classification for known blockers.
+- MAJOR — `docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md:89,119,165`: date semantics still allow ambiguity. "Rows may use empty strings" for unknown source latest dates does not satisfy "source data latest date, with evidence basis"; the readiness script explicitly distinguishes metadata refresh/newest file/scheduler success from source data vintage. Fix: use `null` plus required `source_data_latest_date_basis`/`unknown_reason`; prohibit metadata or file-modified clocks from populating source vintage.
+- MINOR — `config/scheduler/scheduler_config.yml:20-26` and `src/worldenergydata/scheduler/jobs/eia_us_refresh.py:25,68`: EIA has a module/source identity drift risk. The plan requires an "EIA US" row, while scheduler output is `data/modules/eia` and metadata writes module `eia`, not `eia_us`. Fix: require `module_id`, display name, scheduler job, data location, and scheduler output dir fields, with validator handling explicit aliases or rejecting mismatches.
+- MAJOR — `docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md:112-120,155-166`: tests do not cover issue #462's required lanes: fresh, stale, missing, blocked, sample, and reference/static. Fix: add contract fixtures/tests for at least one source in each lane and assert both freshness and completeness outcomes.
+
+## Checked
+
+- `docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md`
+- Issue #462 and blockers #266, #267, #458, #459, #460
+- `module-manifest.yaml`
+- `data/freshness-scorecard.json`
+- `scripts/audit/data_freshness_scorecard.py`
+- `scripts/cron/scheduler-health.sh`
+- `config/scheduler/scheduler_config.yml`
+- `.claude/skills/worldenergydata-source-readiness/`
+- `src/worldenergydata/scheduler/jobs/*refresh.py`

--- a/scripts/review/results/2026-06-09-plan-462-schema-r2.md
+++ b/scripts/review/results/2026-06-09-plan-462-schema-r2.md
@@ -1,0 +1,18 @@
+# Plan #462 Review — Schema/Contract r2
+
+Verdict: MAJOR
+
+## Findings
+
+- MAJOR — `docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md:107-131`, `:141-154`, `:162-175`: required row fields are listed, but validator/tests still do not explicitly reject a source row missing one of those fields. Fix: add a validator rule that checks every source row against `required_row_fields`, plus negative tests for missing required fields.
+- MAJOR — `docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md:80-88`, `:171`, `:232`, `:250`: scorecard mapping remains under-specified. The current scorecard has both `catalog_status` and `freshness_status`, but the plan maps from one "Current scorecard value" column and uses ambiguous completeness text like "unchanged or contract row value." Tests also omit `runtime_fetched`. Fix: define mapping as a deterministic function of scorecard `freshness_status` plus `catalog_status`, and test `runtime_fetched`.
+- MAJOR — `docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md:133`, `:151-152`, `:173`, `:234`: null source-date semantics are only partly enforced. Prose requires `source_data_latest_date_basis: "unknown"`, but validator/test bullets only require an unknown reason. Fix: validate basis values explicitly, require `basis == "unknown"` when date is null, and reject prohibited basis values for `source_data_latest_date`.
+- MINOR — `docs/plans/2026-06-09-issue-462-source-refresh-acceptance-contract.md:135`, `:148`, `:243`: EIA drift is visible but not contract-safe. The plan hardcodes `data_location: "data/modules/eia_us"` while scheduler config writes `eia_us_refresh` to `data/modules/eia` and the job writes metadata as `"eia"`. Fix: add explicit alias/materialization fields and validate either an existing data location, an external-root requirement, or a declared alias relationship.
+
+## Checked
+
+- Plan file lines for required schema, mapping, scheduler gating, date semantics, EIA row, and lane tests.
+- r1 artifacts.
+- Issue #462 body.
+- `scripts/audit/data_freshness_scorecard.py`, `config/scheduler/scheduler_config.yml`, `src/worldenergydata/scheduler/jobs/eia_us_refresh.py`.
+- `source_readiness_summary.py` basis/data-location behavior.


### PR DESCRIPTION
## Summary
- Add the reviewed plan for [#462](https://github.com/vamseeachanta/worldenergydata/issues/462), defining the source refresh acceptance contract implementation scope.
- Index the plan in `docs/plans/README.md`.
- Preserve adversarial review artifacts through r4, with both r4 reviewers returning APPROVE.

## Verification
- `python .claude/skills/worldenergydata-source-readiness/scripts/source_readiness_summary.py --format json` emits 31 rows, including `eia_us` and 8 `runtime_fetched` rows.
- Legal sanity scan passed via workspace-hub scanner against this worktree with `--diff-only`.
- Local absolute-path/secret/TODO scan over plan/index/review artifacts returned no matches.
- `git add --dry-run -f scripts/review/results/2026-06-09-plan-462-*.md` confirms ignored review artifacts are explicitly stageable.

## Gate
Implementation remains blocked until the user applies `status:plan-approved` to [#462](https://github.com/vamseeachanta/worldenergydata/issues/462).
