### PR TITLE
fix(bsee): rebuild BSEE refresh adapters from closed-thread knowledge (#267, epic #423)

### DIFF
--- a/config/bsee.yml
+++ b/config/bsee.yml
@@ -1,0 +1,83 @@
+# BSEE Module Configuration — scheduler refresh source catalog
+# ---------------------------------------------------------------
+# Re-encodes the BSEE data-source knowledge from closed issues #9
+# (master data-source catalog), #11 (scraping-method hierarchy), and
+# #12 (additional platform/pipeline/lease datasets) as reviewable
+# config. Serves the bsee_refresh scheduler job (#267, epic #423).
+#
+# Authoritative upstream index of every bulk zip download:
+#   https://www.data.bsee.gov/Main/RawData.aspx
+# The FULL raw-data catalog (29 regular datasets + OGOR-A yearly
+# files, with expected archive members) lives in
+#   src/worldenergydata/bsee/data/refresh/url_registry.py
+# This file selects and parameterizes the subset refreshed by the
+# scheduler. A unit test cross-checks URLs here against the registry
+# and BSEEWebScraper so they cannot drift apart silently.
+#
+# Scraping-method hierarchy (issue #11), preferred first:
+#   1. Plain HTTP request/POST downloads (this file: bulk zip files)
+#   2. Background Selenium  3. Foreground Selenium (last resort)
+#
+# Gotchas (issue #267 runtime findings, live-verified 2026-06-10):
+#   - Stale dataset URLs return HTTP 200 + an HTML page (~28 KB), not
+#     a 404. Payloads must be content-classified before zip parsing.
+#   - Archive members are quoted CSV with CRLF line endings but a
+#     .txt extension, behind a leading directory entry.
+#   - Healthy responses use Content-Type: application/x-zip-compressed
+#     and carry Last-Modified (BSEE regenerates files daily ~09:45 UTC).
+
+module: bsee
+version: 1.0.0
+description: BSEE Gulf of Mexico bulk raw-data refresh catalog
+
+portal:
+  raw_data_index: https://www.data.bsee.gov/Main/RawData.aspx
+  tutorials: https://www.data.bsee.gov/Main/Tutorials/Default.aspx
+
+# Datasets refreshed by the bsee_refresh scheduler job.
+# url_key must exist in BSEEWebScraper.URLS; registry_dir must match a
+# DatasetSpec.bin_dir in url_registry.py (drift-guarded by tests).
+scheduler_datasets:
+  platform:
+    url: https://www.data.bsee.gov/Platform/Files/PlatStrucRawData.zip
+    url_key: platform
+    registry_dir: platstruc
+    output_file: bsee_platform_structures.parquet
+    primary_member_patterns:
+      - mv_platstruc_structures.txt
+    timeout_s: 600
+    approx_size_mb: 2
+
+  pipeline_permit:
+    url: https://www.data.bsee.gov/Pipeline/Files/PipePermRawData.zip
+    url_key: pipeline_permit
+    registry_dir: ~  # not in url_registry.py regular specs
+    output_file: bsee_pipeline_permits.parquet
+    primary_member_patterns:
+      - mv_pipeperm_applications.txt
+    timeout_s: 600
+    approx_size_mb: 9
+
+  pipeline_location:
+    # Corrected 2026-06-10: PipeLocAllRawData.zip went stale (serves
+    # HTML); the live file is PipeLocRawData.zip per Main/RawData.aspx.
+    url: https://www.data.bsee.gov/Pipeline/Files/PipeLocRawData.zip
+    url_key: pipeline_location
+    registry_dir: pipeloc
+    output_file: bsee_pipeline_locations.parquet
+    primary_member_patterns:
+      - mv_pipelinelocation*.txt
+    timeout_s: 900
+    approx_size_mb: 28
+
+  deepwater_structure:
+    # Corrected 2026-06-10: moved from /Platform/Files/ to
+    # /Other/Files/ upstream; old path serves HTML.
+    url: https://www.data.bsee.gov/Other/Files/PermStrucRawData.zip
+    url_key: deepwater_structure
+    registry_dir: permstruc
+    output_file: bsee_deepwater_structures.parquet
+    primary_member_patterns:
+      - mv_perm_platforms.txt
+    timeout_s: 600
+    approx_size_mb: 0.01  # 8.5 KB zip, live-measured 2026-06-10

--- a/docs/data/bsee-source-catalog.md
+++ b/docs/data/bsee-source-catalog.md
@@ -1,0 +1,69 @@
+# BSEE Source Catalog — Closed-Thread Knowledge → Code
+
+This page maps the BSEE data-ingest domain knowledge accumulated in
+closed issues #9, #11, #12, and #49 to its current, tested home in
+code. It exists so the knowledge survives as adapters and tests rather
+than as issue prose. Part of epic #423; the runtime fixes address #267.
+
+## Where the knowledge lives now
+
+| Closed-thread knowledge | Source thread | Code home |
+|---|---|---|
+| `https://www.data.bsee.gov/Main/RawData.aspx` is the authoritative index of all bulk zip downloads | #9, #12 | `config/bsee.yml` (`portal.raw_data_index`); full per-dataset registry in `src/worldenergydata/bsee/data/refresh/url_registry.py` |
+| Scheduler dataset catalog (URLs, primary tables, timeouts) externalized as reviewable config | #9 | `config/bsee.yml` (`scheduler_datasets`), loaded by `src/worldenergydata/scheduler/jobs/bsee_refresh.py:load_dataset_catalog` with built-in fallback |
+| Scraping-method hierarchy: plain request/POST first, Selenium background, Selenium foreground last | #11 | Bulk path uses plain requests only (`src/worldenergydata/bsee/data/scrapers/bsee_web.py`); hierarchy documented in `config/bsee.yml` and `payload.py` module docstring |
+| Downloaded data goes stale easily; prefer re-download over cached archives (refresh cadence) | #9 | Scheduler `bsee_refresh` weekly job (`config/scheduler/scheduler_config.yml`); BSEE regenerates files daily ~09:45 UTC (live-verified 2026-06-10) |
+| Read zips live from URL into memory without temp extraction (for files ~10 MB) | #12 | `BSEEWebScraper.download_zip_to_memory` + `worldenergydata.bsee.data.refresh.payload.extract_primary_table` |
+| Platform-structure / pipeline-segment / lease-area datasets enumerated | #12 | `url_registry.py` (`platstruc`, `pipeloc`, `lab` = LeaseAreaBlock, `serialreg`, `leaseowner`, ...); scheduler subset in `config/bsee.yml` |
+| Well/borehole by-API12 query workflow (download → load → query; online query preferred) | #9 | `src/worldenergydata/bsee/analysis/well_api12.py` and `bsee/data/sources/` (pre-existing; not reworked here) |
+
+## Runtime contract gotchas (issue #267, live-verified 2026-06-10)
+
+These are encoded as code + tests in
+`src/worldenergydata/bsee/data/refresh/payload.py` and
+`tests/unit/bsee/test_bsee_payload.py` /
+`tests/unit/scheduler/test_bsee_adapter.py`:
+
+1. **Stale URLs return HTTP 200 + HTML, not 404.** When BSEE moves a
+   file, the old URL serves a ~28 KB HTML page with status 200.
+   `classify_payload()` checks zip magic / HTML markers before any
+   `zipfile` call, and the refresh job classifies the failure
+   `deterministic` (issue #460) instead of crashing with
+   `BadZipFile`.
+2. **Two URLs had moved** (the #267 root cause):
+   - `deepwater_structure`: `/Platform/Files/PermStrucRawData.zip` →
+     `/Other/Files/PermStrucRawData.zip`
+   - `pipeline_location`: `PipeLocAllRawData.zip` →
+     `PipeLocRawData.zip`
+   A drift-guard test asserts `config/bsee.yml`,
+   `BSEEWebScraper.URLS`, and `url_registry.py` agree.
+3. **Archives contain no `.csv`.** Each zip holds a leading directory
+   entry plus quoted-CSV **`.txt`** members with CRLF endings (e.g.
+   `PlatStrucRawData/mv_platstruc_structures.txt`). Extraction skips
+   directory entries, selects the primary member by configured glob
+   (fallback: largest member), and tolerates latin-1 bytes in operator
+   names.
+4. **Healthy responses** use `Content-Type:
+   application/x-zip-compressed` and carry `Last-Modified` (files are
+   regenerated daily). The optional live smoke test
+   (`BSEE_LIVE_SMOKE=1`) HEAD-checks every catalog URL.
+
+## Failure classification (issue #460 interface)
+
+`DatasetFailure` carries `FailureClass.DETERMINISTIC` (stale-URL HTML,
+empty body, archive without data members, zero-row parse) vs
+`FailureClass.TRANSIENT` (timeouts, connection errors, corrupt
+payload). When *all* datasets fail deterministically, the job's
+`error_msg` is prefixed `[deterministic]` so the scheduler retry layer
+can skip backoff.
+
+## Deliberately out of scope
+
+- **#49 KeyError `'Total Depth Date'`** lives in the analysis path
+  (`src/worldenergydata/bsee/analysis/well_api12.py:511`,
+  `get_api12_analysis`), not the refresh path reworked here. Left for
+  a dedicated rework of the directional-survey/well-path module.
+- Writing *all* archive members (not just the primary table) to
+  Parquet, and lease-area (`lab`) / serial-register datasets in the
+  scheduler job — the catalog structure supports adding them as new
+  `scheduler_datasets` entries.

--- a/src/worldenergydata/bsee/data/refresh/payload.py
+++ b/src/worldenergydata/bsee/data/refresh/payload.py
@@ -1,0 +1,187 @@
+"""BSEE download payload classification and archive extraction.
+
+Hardened helpers for the BSEE refresh path (issue #267, epic #423).
+
+Knowledge re-encoded from closed threads #9 / #11 / #12:
+
+* ``https://www.data.bsee.gov/Main/RawData.aspx`` is the authoritative
+  index of all bulk "Raw Data" zip downloads (issue #9, #12).  When a
+  dataset URL goes stale, BSEE serves an HTTP 200 **HTML** page (~28 KB)
+  instead of a 404 -- payloads must therefore be classified by content,
+  never trusted by status code alone (issue #267 runtime findings,
+  live-verified 2026-06-10).
+* Healthy archives are served with ``Content-Type:
+  application/x-zip-compressed`` and contain a leading directory entry
+  plus one or more ``mv_*.txt`` members.  Members are comma-delimited,
+  double-quoted CSV with CRLF line endings despite the ``.txt``
+  extension (live-verified against ``PlatStrucRawData.zip`` and
+  ``PermStrucRawData.zip``, 2026-06-10).  Legacy fixtures use ``.csv``
+  members; both extensions are accepted.
+* Plain request/response downloading is the preferred scraping method
+  -- request/POST first, Selenium only as a last resort (issue #11
+  method hierarchy).
+
+Failure classification follows issue #460: deterministic failures
+(stale-URL HTML payloads, empty bodies, archives without data members)
+cannot succeed on retry within the same process, while transient
+failures (timeouts, connection resets, 5xx) may.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from dataclasses import dataclass
+from enum import Enum
+from fnmatch import fnmatch
+from typing import Optional
+
+import pandas as pd
+
+#: Zip local-file-header magic. Also matches empty (``PK\x05\x06``) and
+#: spanned (``PK\x07\x08``) archives via the shared ``PK`` prefix check.
+_ZIP_MAGIC_PREFIXES = (b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08")
+
+#: Leading byte sequences that identify an HTML/error payload.  BSEE
+#: stale-URL responses start with a doctype or ``<html`` tag.
+_HTML_MARKERS = (b"<!doctype", b"<html", b"<head", b"<?xml")
+
+#: Member extensions that may hold tabular data.  BSEE raw-data zips
+#: ship ``.txt`` (quoted CSV); legacy fixtures and other agencies ship
+#: ``.csv``.
+DATA_MEMBER_EXTENSIONS = (".txt", ".csv")
+
+
+class PayloadKind(Enum):
+    """Coarse classification of a downloaded payload body."""
+
+    ZIP = "zip"
+    HTML = "html"
+    EMPTY = "empty"
+    UNKNOWN = "unknown"
+
+
+class FailureClass(Enum):
+    """Retry semantics of a dataset failure (issue #460).
+
+    DETERMINISTIC failures will fail identically on immediate retry
+    (stale URL serving HTML, no data members in archive). TRANSIENT
+    failures (network errors, timeouts) may succeed on retry.
+    """
+
+    DETERMINISTIC = "deterministic"
+    TRANSIENT = "transient"
+
+
+@dataclass(frozen=True)
+class DatasetFailure:
+    """A classified per-dataset refresh failure."""
+
+    dataset: str
+    reason: str
+    failure_class: FailureClass
+    detail: str = ""
+
+    def summary(self) -> str:
+        """One-line summary for job error messages and logs."""
+        return f"{self.dataset}: {self.reason} ({self.failure_class.value})"
+
+
+def classify_payload(data: Optional[bytes]) -> PayloadKind:
+    """Classify a downloaded body before any zip parsing (issue #267).
+
+    BSEE answers stale dataset URLs with HTTP 200 + an HTML page, which
+    previously surfaced as ``zipfile.BadZipFile: File is not a zip
+    file``.  Classifying the payload first lets callers fail with a
+    deterministic, actionable reason instead.
+    """
+    if not data:
+        return PayloadKind.EMPTY
+    head = data[:4]
+    if any(head.startswith(p) for p in _ZIP_MAGIC_PREFIXES):
+        return PayloadKind.ZIP
+    sniff = data[:256].lstrip().lower()
+    if any(sniff.startswith(m) for m in _HTML_MARKERS):
+        return PayloadKind.HTML
+    return PayloadKind.UNKNOWN
+
+
+def list_data_members(zf: zipfile.ZipFile) -> list[zipfile.ZipInfo]:
+    """Return non-directory members that can hold tabular data.
+
+    BSEE archives lead with a zero-byte directory entry (e.g.
+    ``PlatStrucRawData/``) -- naive ``namelist()[0]`` reads fail on it.
+    """
+    members = []
+    for info in zf.infolist():
+        if info.is_dir():
+            continue
+        name = info.filename.lower()
+        if name.endswith(DATA_MEMBER_EXTENSIONS):
+            members.append(info)
+    return members
+
+
+def select_primary_member(
+    members: list[zipfile.ZipInfo],
+    patterns: Optional[list[str]] = None,
+) -> Optional[zipfile.ZipInfo]:
+    """Pick the member holding the dataset's primary table.
+
+    Tries each glob pattern in priority order against the member
+    basename (e.g. ``mv_platstruc_structures.txt``); falls back to the
+    largest data member, which for BSEE archives is the main entity
+    table in all observed datasets.
+    """
+    if not members:
+        return None
+    for pattern in patterns or []:
+        for info in members:
+            basename = info.filename.rsplit("/", 1)[-1].lower()
+            if fnmatch(basename, pattern.lower()):
+                return info
+    return max(members, key=lambda info: info.file_size)
+
+
+def read_member_table(zf: zipfile.ZipFile, member: zipfile.ZipInfo) -> pd.DataFrame:
+    """Read one archive member as a DataFrame.
+
+    Members are quoted CSV with CRLF endings regardless of extension.
+    BSEE exports occasionally contain non-UTF-8 bytes (operator names),
+    so decoding falls back to latin-1.
+    """
+    raw = zf.read(member)
+    try:
+        return pd.read_csv(io.BytesIO(raw), low_memory=False)
+    except UnicodeDecodeError:
+        return pd.read_csv(io.BytesIO(raw), low_memory=False, encoding="latin-1")
+
+
+def extract_primary_table(
+    zip_bytes: bytes,
+    member_patterns: Optional[list[str]] = None,
+) -> tuple[pd.DataFrame, str]:
+    """Extract the primary data table from a verified zip payload.
+
+    Args:
+        zip_bytes: Payload already classified as ``PayloadKind.ZIP``.
+        member_patterns: Optional glob priority list for the primary
+            member (e.g. ``["mv_platstruc_structures.txt"]``).
+
+    Returns:
+        ``(dataframe, member_name)``.
+
+    Raises:
+        zipfile.BadZipFile: If the bytes are not a readable archive.
+        LookupError: If the archive holds no data members
+            (deterministic failure -- the upstream contract changed).
+    """
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+        members = list_data_members(zf)
+        primary = select_primary_member(members, member_patterns)
+        if primary is None:
+            raise LookupError(
+                "archive contains no .txt/.csv data members: "
+                f"{[i.filename for i in zf.infolist()][:10]}"
+            )
+        return read_member_table(zf, primary), primary.filename

--- a/src/worldenergydata/bsee/data/scrapers/bsee_web.py
+++ b/src/worldenergydata/bsee/data/scrapers/bsee_web.py
@@ -20,7 +20,17 @@ class BSEEWebScraper:
     storing them on disk, solving the GitHub file size limit issue.
     """
 
-    # BSEE data source URLs
+    # BSEE data source URLs.
+    #
+    # The authoritative index of every bulk download is the "portal"
+    # page (issue #9 / #12); when BSEE relocates a file the old URL
+    # returns HTTP 200 with an HTML page instead of a 404, so callers
+    # must classify payload content before zip parsing (issue #267,
+    # see worldenergydata.bsee.data.refresh.payload).
+    #
+    # 2026-06-10 live-verified corrections (issue #267):
+    #   deepwater_structure moved /Platform/Files/ -> /Other/Files/
+    #   pipeline_location:  PipeLocAllRawData.zip -> PipeLocRawData.zip
     URLS = {
         "well": "https://www.data.bsee.gov/Well/Files/APDRawData.zip",
         "production": "https://www.data.bsee.gov/Production/Files/ProductionRawData.zip",
@@ -28,8 +38,8 @@ class BSEEWebScraper:
         "portal": "https://www.data.bsee.gov/Main/RawData.aspx",
         "platform": "https://www.data.bsee.gov/Platform/Files/PlatStrucRawData.zip",
         "pipeline_permit": "https://www.data.bsee.gov/Pipeline/Files/PipePermRawData.zip",
-        "deepwater_structure": "https://www.data.bsee.gov/Platform/Files/PermStrucRawData.zip",
-        "pipeline_location": "https://www.data.bsee.gov/Pipeline/Files/PipeLocAllRawData.zip",
+        "deepwater_structure": "https://www.data.bsee.gov/Other/Files/PermStrucRawData.zip",
+        "pipeline_location": "https://www.data.bsee.gov/Pipeline/Files/PipeLocRawData.zip",
     }
 
     # Request configuration

--- a/src/worldenergydata/scheduler/jobs/bsee_refresh.py
+++ b/src/worldenergydata/scheduler/jobs/bsee_refresh.py
@@ -1,18 +1,37 @@
 """BSEE (Bureau of Safety and Environmental Enforcement) data refresh job.
 
 Downloads platform structures, pipeline permits/locations, and deepwater
-structures via BSEEWebScraper, extracting CSVs from zips and writing Parquet.
+structures via BSEEWebScraper, extracting the primary table from each
+raw-data archive and writing Parquet.
+
+The dataset catalog is externalized to ``config/bsee.yml`` (knowledge
+from closed issues #9 / #11 / #12); built-in defaults below mirror it
+so the job still runs from an installed package without the repo
+checkout.  Payload classification and archive extraction live in
+``worldenergydata.bsee.data.refresh.payload`` (issue #267): BSEE serves
+HTTP 200 + HTML for stale URLs, and healthy archives contain quoted-CSV
+``.txt`` members behind a directory entry rather than a ``.csv`` in the
+first slot.
+
+Per-dataset failures are classified deterministic vs transient (issue
+#460) so the scheduler's retry layer can skip pointless backoff.
 """
 
-import io
 import logging
 import zipfile
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-import pandas as pd
+import yaml
 
+from worldenergydata.bsee.data.refresh.payload import (
+    DatasetFailure,
+    FailureClass,
+    PayloadKind,
+    classify_payload,
+    extract_primary_table,
+)
 from worldenergydata.bsee.data.scrapers.bsee_web import BSEEWebScraper
 from worldenergydata.common.data_resolver import get_module_data_safe
 from worldenergydata.scheduler.jobs.base import (
@@ -23,26 +42,56 @@ from worldenergydata.scheduler.jobs.base import (
 
 logger = logging.getLogger(__name__)
 
+#: Built-in defaults mirroring config/bsee.yml ``scheduler_datasets``.
+#: Keep in sync with the YAML catalog (drift-guarded by unit tests).
 BSEE_DATASETS = {
     "platform": {
         "url_key": "platform",
         "output_file": "bsee_platform_structures.parquet",
+        "primary_member_patterns": ["mv_platstruc_structures.txt"],
     },
     "pipeline_permit": {
         "url_key": "pipeline_permit",
         "output_file": "bsee_pipeline_permits.parquet",
+        "primary_member_patterns": ["mv_pipeperm_applications.txt"],
     },
     "pipeline_location": {
         "url_key": "pipeline_location",
         "output_file": "bsee_pipeline_locations.parquet",
+        "primary_member_patterns": ["mv_pipelinelocation*.txt"],
     },
     "deepwater_structure": {
         "url_key": "deepwater_structure",
         "output_file": "bsee_deepwater_structures.parquet",
+        "primary_member_patterns": ["mv_perm_platforms.txt"],
     },
 }
 
+#: Repo-level YAML catalog (issue #9 knowledge as reviewable config).
+DEFAULT_CATALOG_PATH = Path(__file__).resolve().parents[4] / "config" / "bsee.yml"
+
 _DEFAULT_OUTPUT_DIR = get_module_data_safe("bsee")
+
+
+def load_dataset_catalog(catalog_path: Optional[Path] = None) -> dict:
+    """Load the scheduler dataset catalog from ``config/bsee.yml``.
+
+    Falls back to the built-in ``BSEE_DATASETS`` defaults when the YAML
+    catalog is absent (e.g. installed package without repo checkout) or
+    unreadable -- the refresh must not hard-fail on missing config.
+    """
+    path = catalog_path or DEFAULT_CATALOG_PATH
+    try:
+        raw = yaml.safe_load(path.read_text())
+        datasets = raw["scheduler_datasets"]
+        if not isinstance(datasets, dict) or not datasets:
+            raise ValueError("scheduler_datasets empty or not a mapping")
+        return datasets
+    except Exception as exc:
+        logger.warning(
+            "BSEE catalog %s unusable (%s); using built-in defaults", path, exc
+        )
+        return BSEE_DATASETS
 
 
 class BseeRefreshJob(AbstractJob):
@@ -52,13 +101,16 @@ class BseeRefreshJob(AbstractJob):
     default_output_dir = _DEFAULT_OUTPUT_DIR
 
     def run(self, config: dict) -> JobResult:
-        """Execute BSEE data refresh across all dataset types.
+        """Execute BSEE data refresh across all cataloged dataset types.
 
         Downloads each BSEE dataset independently. Partial failures are
-        tolerated -- only a complete failure of all datasets returns failure.
+        tolerated -- only a complete failure of all datasets returns
+        failure, with each dataset's failure classified deterministic
+        vs transient (issue #460).
 
         Args:
-            config: May contain "output_dir" for Parquet output location.
+            config: Must contain "output_dir"; may contain
+                "catalog_path" to override the YAML dataset catalog.
 
         Returns:
             JobResult with total records across all successful datasets.
@@ -77,27 +129,35 @@ class BseeRefreshJob(AbstractJob):
         output_dir = Path(config["output_dir"])
         output_dir.mkdir(parents=True, exist_ok=True)
 
+        catalog_path = config.get("catalog_path")
+        datasets = load_dataset_catalog(Path(catalog_path) if catalog_path else None)
+
         scraper = BSEEWebScraper()
         total_records = 0
-        failed_datasets: list[str] = []
+        failures: list[DatasetFailure] = []
 
-        for dataset_name, info in BSEE_DATASETS.items():
+        for dataset_name, info in datasets.items():
             try:
-                records = self._process_dataset(scraper, dataset_name, info, output_dir)
-                if records is not None:
-                    total_records += records
-                else:
-                    failed_datasets.append(dataset_name)
-            except Exception as exc:
-                logger.warning("BSEE %s processing error: %s", dataset_name, exc)
-                failed_datasets.append(dataset_name)
+                outcome = self._process_dataset(scraper, dataset_name, info, output_dir)
+            except Exception as exc:  # e.g. parquet write / disk errors
+                outcome = DatasetFailure(
+                    dataset_name,
+                    f"unexpected error: {exc}",
+                    FailureClass.TRANSIENT,
+                )
+            if isinstance(outcome, DatasetFailure):
+                logger.warning("BSEE %s", outcome.summary())
+                failures.append(outcome)
+            else:
+                total_records += outcome
 
         if total_records > 0:
-            if failed_datasets:
-                logger.warning(
-                    "BSEE refresh partial: failed datasets=%s",
-                    failed_datasets,
+            error_msg = None
+            if failures:
+                error_msg = "Partial BSEE refresh; failed: " + "; ".join(
+                    f.summary() for f in failures
                 )
+                logger.warning(error_msg)
             write_refresh_metadata("bsee", output_dir, total_records)
             return JobResult(
                 job_name=self.name,
@@ -105,10 +165,16 @@ class BseeRefreshJob(AbstractJob):
                 end_time=datetime.now(),
                 status="success",
                 records_updated=total_records,
-                error_msg=None,
+                error_msg=error_msg,
             )
 
-        error_msg = f"All BSEE downloads failed: {', '.join(failed_datasets)}"
+        error_msg = "All BSEE downloads failed: " + "; ".join(
+            f.summary() for f in failures
+        )
+        if failures and all(
+            f.failure_class is FailureClass.DETERMINISTIC for f in failures
+        ):
+            error_msg = "[deterministic] " + error_msg
         logger.error(error_msg)
         return JobResult(
             job_name=self.name,
@@ -125,35 +191,76 @@ class BseeRefreshJob(AbstractJob):
         dataset_name: str,
         info: dict,
         output_dir: Path,
-    ) -> Optional[int]:
-        """Download, extract, and write a single BSEE dataset to Parquet.
+    ):
+        """Download, validate, extract, and write one BSEE dataset.
 
         Returns:
-            Number of rows written, or None if download failed.
+            Number of rows written (int) on success, or a classified
+            ``DatasetFailure`` describing why the dataset was skipped.
         """
-        url = BSEEWebScraper.URLS[info["url_key"]]
+        url_key = info["url_key"]
+        url = info.get("url") or BSEEWebScraper.URLS[url_key]
         logger.info("BSEE downloading %s from %s", dataset_name, url)
 
-        zip_bytes = scraper.download_zip_to_memory(url, data_type=info["url_key"])
-        if zip_bytes is None:
-            logger.warning("BSEE %s download returned None", dataset_name)
-            return None
+        try:
+            payload = scraper.download_zip_to_memory(url, data_type=url_key)
+        except Exception as exc:
+            return DatasetFailure(
+                dataset_name, f"download error: {exc}", FailureClass.TRANSIENT
+            )
+        if payload is None:
+            # Scraper exhausted its own retries (timeouts / HTTP errors).
+            return DatasetFailure(
+                dataset_name,
+                "download failed after retries",
+                FailureClass.TRANSIENT,
+            )
 
-        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
-            csv_names = [n for n in zf.namelist() if n.lower().endswith(".csv")]
-            if not csv_names:
-                logger.warning("BSEE %s zip contains no CSV files", dataset_name)
-                return None
-            csv_name = csv_names[0]
-            logger.info("BSEE %s extracting %s", dataset_name, csv_name)
-            df = pd.read_csv(zf.open(csv_name))
+        kind = classify_payload(payload)
+        if kind is not PayloadKind.ZIP:
+            # HTTP 200 + HTML means the URL went stale upstream; retrying
+            # in-process cannot succeed (issues #267 / #460).
+            return DatasetFailure(
+                dataset_name,
+                f"expected zip, got {kind.value} payload "
+                f"({len(payload)} bytes) -- URL likely stale, check "
+                "https://www.data.bsee.gov/Main/RawData.aspx",
+                FailureClass.DETERMINISTIC,
+            )
+
+        try:
+            df, member_name = extract_primary_table(
+                bytes(payload), info.get("primary_member_patterns")
+            )
+        except LookupError as exc:
+            return DatasetFailure(dataset_name, str(exc), FailureClass.DETERMINISTIC)
+        except zipfile.BadZipFile as exc:
+            return DatasetFailure(
+                dataset_name,
+                f"corrupt zip payload: {exc}",
+                FailureClass.TRANSIENT,
+            )
+        except Exception as exc:
+            return DatasetFailure(
+                dataset_name,
+                f"extraction error: {exc}",
+                FailureClass.DETERMINISTIC,
+            )
+
+        if df.empty:
+            return DatasetFailure(
+                dataset_name,
+                f"primary member {member_name} parsed to 0 rows",
+                FailureClass.DETERMINISTIC,
+            )
 
         out_path = output_dir / info["output_file"]
         df.to_parquet(out_path, engine="pyarrow", index=False, compression="snappy")
         logger.info(
-            "BSEE %s wrote %d rows to %s",
+            "BSEE %s wrote %d rows from %s to %s",
             dataset_name,
             len(df),
+            member_name,
             out_path,
         )
         return len(df)

--- a/tests/unit/bsee/test_bsee_payload.py
+++ b/tests/unit/bsee/test_bsee_payload.py
@@ -1,0 +1,140 @@
+"""Tests for BSEE payload classification and archive extraction.
+
+Encodes the live-verified BSEE raw-data archive shape from issue #267
+(2026-06-10): a leading directory entry, quoted-CSV ``.txt`` members
+with CRLF line endings, and HTTP-200 HTML bodies for stale URLs.
+"""
+
+import io
+import zipfile
+
+import pytest
+
+from worldenergydata.bsee.data.refresh.payload import (
+    DatasetFailure,
+    FailureClass,
+    PayloadKind,
+    classify_payload,
+    extract_primary_table,
+    list_data_members,
+    select_primary_member,
+)
+
+# Mimics live PlatStrucRawData member content (quoted CSV, CRLF, .txt).
+BSEE_TXT_CONTENT = (
+    '"AREA_CODE","BLOCK_NUMBER","STRUCTURE_NAME"\r\n'
+    '"MP","   20","3"\r\n'
+    '"MI","  686","C-CMP"\r\n'
+)
+
+
+def _bsee_style_zip(members: dict, dir_name: str = "PlatStrucRawData") -> bytes:
+    """Build a zip shaped like a live BSEE archive (leading dir entry)."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(f"{dir_name}/", "")
+        for name, content in members.items():
+            zf.writestr(f"{dir_name}/{name}", content)
+    return buf.getvalue()
+
+
+class TestClassifyPayload:
+    def test_zip_magic_is_zip(self):
+        data = _bsee_style_zip({"mv_x.txt": BSEE_TXT_CONTENT})
+        assert classify_payload(data) is PayloadKind.ZIP
+
+    def test_html_error_page_detected(self):
+        # BSEE serves HTTP 200 + HTML for stale URLs (issue #267).
+        html = b"\r\n<!DOCTYPE html>\r\n<html><head>..."
+        assert classify_payload(html) is PayloadKind.HTML
+
+    def test_html_lowercase_tag_detected(self):
+        assert classify_payload(b"  <html lang='en'>") is PayloadKind.HTML
+
+    def test_none_and_empty_are_empty(self):
+        assert classify_payload(None) is PayloadKind.EMPTY
+        assert classify_payload(b"") is PayloadKind.EMPTY
+
+    def test_garbage_is_unknown(self):
+        assert classify_payload(b"\x00\x01\x02 not anything") is PayloadKind.UNKNOWN
+
+
+class TestListDataMembers:
+    def test_skips_directory_entry_and_keeps_txt(self):
+        data = _bsee_style_zip({"mv_a.txt": "x", "readme.pdf": "y", "mv_b.csv": "z"})
+        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            names = [m.filename for m in list_data_members(zf)]
+        assert "PlatStrucRawData/" not in names
+        assert "PlatStrucRawData/readme.pdf" not in names
+        assert set(names) == {
+            "PlatStrucRawData/mv_a.txt",
+            "PlatStrucRawData/mv_b.csv",
+        }
+
+
+class TestSelectPrimaryMember:
+    def _members(self, data):
+        zf = zipfile.ZipFile(io.BytesIO(data))
+        return list_data_members(zf)
+
+    def test_pattern_match_wins_over_size(self):
+        data = _bsee_style_zip(
+            {
+                "mv_platstruc_platformincs.txt": "h\n" + "x\n" * 5000,
+                "mv_platstruc_structures.txt": BSEE_TXT_CONTENT,
+            }
+        )
+        chosen = select_primary_member(
+            self._members(data), ["mv_platstruc_structures.txt"]
+        )
+        assert chosen.filename.endswith("mv_platstruc_structures.txt")
+
+    def test_falls_back_to_largest_member(self):
+        data = _bsee_style_zip(
+            {"mv_small.txt": "a,b\n1,2\n", "mv_big.txt": "a,b\n" + "1,2\n" * 1000}
+        )
+        chosen = select_primary_member(self._members(data), ["no_match_*.txt"])
+        assert chosen.filename.endswith("mv_big.txt")
+
+    def test_empty_members_returns_none(self):
+        assert select_primary_member([], ["x"]) is None
+
+
+class TestExtractPrimaryTable:
+    def test_extracts_bsee_style_txt_member(self):
+        data = _bsee_style_zip({"mv_platstruc_structures.txt": BSEE_TXT_CONTENT})
+        df, member = extract_primary_table(data, ["mv_platstruc_structures.txt"])
+        assert member == "PlatStrucRawData/mv_platstruc_structures.txt"
+        assert list(df.columns) == ["AREA_CODE", "BLOCK_NUMBER", "STRUCTURE_NAME"]
+        assert len(df) == 2
+
+    def test_legacy_csv_member_still_supported(self):
+        data = _bsee_style_zip({"data.csv": "col_a,col_b\n1,hello\n"})
+        df, member = extract_primary_table(data)
+        assert len(df) == 1
+
+    def test_latin1_fallback_for_non_utf8_operator_names(self):
+        content = b'"NAME"\r\n"Petr\xf3leo"\r\n'  # latin-1 accented byte
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("X/mv_ops.txt", content)
+        df, _ = extract_primary_table(buf.getvalue())
+        assert df.iloc[0, 0] == "Petróleo"
+
+    def test_no_data_members_raises_lookup_error(self):
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("X/", "")
+            zf.writestr("X/readme.pdf", "no tables here")
+        with pytest.raises(LookupError):
+            extract_primary_table(buf.getvalue())
+
+    def test_non_zip_bytes_raise_bad_zip_file(self):
+        with pytest.raises(zipfile.BadZipFile):
+            extract_primary_table(b"<html>error page</html>")
+
+
+class TestDatasetFailure:
+    def test_summary_includes_class(self):
+        f = DatasetFailure("platform", "boom", FailureClass.DETERMINISTIC)
+        assert f.summary() == "platform: boom (deterministic)"

--- a/tests/unit/scheduler/test_bsee_adapter.py
+++ b/tests/unit/scheduler/test_bsee_adapter.py
@@ -1,16 +1,27 @@
-"""Tests for BSEE adapter: download, extract, write Parquet per dataset type."""
+"""Tests for BSEE adapter: download, extract, write Parquet per dataset type.
+
+Includes issue #267 hardening coverage: payload classification,
+BSEE-shaped archives, the YAML catalog, and URL drift guards
+(knowledge re-encoded from closed #9/#11/#12).
+"""
 
 import io
+import os
 import zipfile
-from datetime import datetime
-from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pandas as pd
 import pytest
+import yaml
 
-from worldenergydata.scheduler.jobs.base import JobResult
-from worldenergydata.scheduler.jobs.bsee_refresh import BSEE_DATASETS, BseeRefreshJob
+from worldenergydata.bsee.data.refresh.url_registry import get_regular_specs
+from worldenergydata.bsee.data.scrapers.bsee_web import BSEEWebScraper
+from worldenergydata.scheduler.jobs.bsee_refresh import (
+    BSEE_DATASETS,
+    DEFAULT_CATALOG_PATH,
+    BseeRefreshJob,
+    load_dataset_catalog,
+)
 
 
 def _make_zip_bytes(csv_content: str, csv_filename: str = "data.csv") -> bytes:
@@ -131,3 +142,174 @@ class TestBseeAdapterRecordCount:
         # 4 datasets x 3 rows each = 12
         assert result.records_updated == 12
         assert result.status == "success"
+
+
+# ---------------------------------------------------------------------------
+# Issue #267 hardening: payload classification, BSEE-shaped archives,
+# YAML catalog, and URL drift guards (knowledge from closed #9/#11/#12).
+# ---------------------------------------------------------------------------
+
+HTML_ERROR_PAGE = (
+    b"\r\n<!DOCTYPE html>\r\n<html><head><title>BSEE</title></head>"
+    b"<body>moved</body></html>"
+)
+
+# Live BSEE archive shape: leading directory entry + quoted-CSV .txt
+# members (verified against PlatStrucRawData.zip, 2026-06-10).
+BSEE_TXT_CSV = (
+    '"AREA_CODE","BLOCK_NUMBER","STRUCTURE_NAME"\r\n'
+    '"MP","   20","3"\r\n'
+    '"MI","  686","C-CMP"\r\n'
+)
+
+
+def _bsee_real_shape_zip() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("PlatStrucRawData/", "")
+        zf.writestr("PlatStrucRawData/mv_platstruc_cgrefcodes.txt", '"A"\r\n"x"\r\n')
+        zf.writestr("PlatStrucRawData/mv_platstruc_structures.txt", BSEE_TXT_CSV)
+    return buf.getvalue()
+
+
+class TestBseeAdapterHtmlPayload:
+    """HTTP 200 + HTML (stale URL) must classify, not crash (issue #267)."""
+
+    @patch("worldenergydata.scheduler.jobs.bsee_refresh.BSEEWebScraper")
+    def test_html_payload_is_deterministic_failure_not_crash(
+        self, MockScraper, tmp_path
+    ):
+        scraper = MockScraper.return_value
+        scraper.download_zip_to_memory.return_value = HTML_ERROR_PAGE
+
+        job = BseeRefreshJob()
+        result = job.run({"output_dir": str(tmp_path)})
+
+        assert result.status == "failure"
+        assert "html" in result.error_msg.lower()
+        assert "deterministic" in result.error_msg
+        # All failures deterministic => prefixed for the retry layer (#460).
+        assert result.error_msg.startswith("[deterministic]")
+
+    @patch("worldenergydata.scheduler.jobs.bsee_refresh.BSEEWebScraper")
+    def test_mixed_html_and_zip_is_partial_success(self, MockScraper, tmp_path):
+        scraper = MockScraper.return_value
+
+        def selective(url, data_type="default", **kwargs):
+            if data_type in ("pipeline_location", "deepwater_structure"):
+                return HTML_ERROR_PAGE  # the observed #267 runtime failure
+            return _bsee_real_shape_zip()
+
+        scraper.download_zip_to_memory.side_effect = selective
+
+        job = BseeRefreshJob()
+        result = job.run({"output_dir": str(tmp_path)})
+
+        assert result.status == "success"
+        assert (tmp_path / "bsee_platform_structures.parquet").exists()
+        assert not (tmp_path / "bsee_pipeline_locations.parquet").exists()
+        assert "pipeline_location" in result.error_msg
+        assert "deterministic" in result.error_msg
+
+
+class TestBseeAdapterRealArchiveShape:
+    """Live archives hold .txt quoted-CSV members behind a dir entry."""
+
+    @patch("worldenergydata.scheduler.jobs.bsee_refresh.BSEEWebScraper")
+    def test_txt_members_extracted_via_primary_pattern(self, MockScraper, tmp_path):
+        scraper = MockScraper.return_value
+        scraper.download_zip_to_memory.return_value = _bsee_real_shape_zip()
+
+        job = BseeRefreshJob()
+        result = job.run({"output_dir": str(tmp_path)})
+
+        assert result.status == "success"
+        df = pd.read_parquet(tmp_path / "bsee_platform_structures.parquet")
+        assert list(df.columns) == ["AREA_CODE", "BLOCK_NUMBER", "STRUCTURE_NAME"]
+        assert len(df) == 2
+
+    @patch("worldenergydata.scheduler.jobs.bsee_refresh.BSEEWebScraper")
+    def test_zip_without_data_members_is_deterministic_failure(
+        self, MockScraper, tmp_path
+    ):
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("X/", "")
+            zf.writestr("X/readme.pdf", "nope")
+        scraper = MockScraper.return_value
+        scraper.download_zip_to_memory.return_value = buf.getvalue()
+
+        job = BseeRefreshJob()
+        result = job.run({"output_dir": str(tmp_path)})
+
+        assert result.status == "failure"
+        assert "no .txt/.csv data members" in result.error_msg
+
+
+class TestBseeCatalogConfig:
+    """config/bsee.yml is the externalized catalog (issue #9 knowledge)."""
+
+    def test_default_catalog_loads_four_scheduler_datasets(self):
+        datasets = load_dataset_catalog()
+        assert set(datasets) == set(BSEE_DATASETS)
+        for name, info in datasets.items():
+            assert info["url_key"] == BSEE_DATASETS[name]["url_key"]
+            assert info["output_file"] == BSEE_DATASETS[name]["output_file"]
+
+    def test_missing_catalog_falls_back_to_builtin(self, tmp_path):
+        datasets = load_dataset_catalog(tmp_path / "absent.yml")
+        assert datasets is BSEE_DATASETS
+
+    def test_malformed_catalog_falls_back_to_builtin(self, tmp_path):
+        bad = tmp_path / "bad.yml"
+        bad.write_text("scheduler_datasets: []\n")
+        assert load_dataset_catalog(bad) is BSEE_DATASETS
+
+    def test_catalog_urls_match_scraper_registry(self):
+        """Drift guard: YAML catalog, BSEEWebScraper.URLS, and the
+        url_registry must agree on every dataset URL (issue #267 root
+        cause was exactly this kind of silent drift)."""
+        raw = yaml.safe_load(DEFAULT_CATALOG_PATH.read_text())
+        registry = {s.bin_dir: s.zip_url for s in get_regular_specs()}
+        for name, info in raw["scheduler_datasets"].items():
+            assert info["url"] == BSEEWebScraper.URLS[info["url_key"]], name
+            if info.get("registry_dir"):
+                assert info["url"] == registry[info["registry_dir"]], name
+
+    def test_stale_urls_are_gone(self):
+        """The two URLs that caused #267's HTML payloads must not return."""
+        urls = set(BSEEWebScraper.URLS.values())
+        assert (
+            "https://www.data.bsee.gov/Pipeline/Files/PipeLocAllRawData.zip" not in urls
+        )
+        assert (
+            "https://www.data.bsee.gov/Platform/Files/PermStrucRawData.zip" not in urls
+        )
+
+
+@pytest.mark.network
+@pytest.mark.smoke
+@pytest.mark.skipif(
+    os.environ.get("BSEE_LIVE_SMOKE") != "1",
+    reason="live BSEE smoke test; set BSEE_LIVE_SMOKE=1 to run",
+)
+class TestBseeLiveSmoke:
+    """Optional live probe: catalog URLs must serve zip content.
+
+    HEAD-only (no payload download); BSEE regenerates these files daily
+    around 09:45 UTC, so Last-Modified should also be present.
+    """
+
+    def test_catalog_urls_serve_zip_content_type(self):
+        import requests
+
+        raw = yaml.safe_load(DEFAULT_CATALOG_PATH.read_text())
+        session = requests.Session()
+        session.headers["User-Agent"] = "WorldEnergyData/1.0 (BSEE smoke test)"
+        for name, info in raw["scheduler_datasets"].items():
+            resp = session.head(info["url"], timeout=45)
+            assert resp.status_code == 200, name
+            ctype = resp.headers.get("Content-Type", "")
+            assert (
+                "zip" in ctype or "octet-stream" in ctype
+            ), f"{name}: stale URL serves {ctype}"


### PR DESCRIPTION
> *This was generated by AI during triage-driven rework.*

Rebuilds the BSEE data-ingest knowledge from closed threads #9 / #11 / #12 into hardened, tested adapter code. Addresses #267; part of epic #423.

## What changed

- **`src/worldenergydata/bsee/data/refresh/payload.py`** (new): payload classification (zip/html/empty) before any `zipfile` call, BSEE-shaped archive extraction (leading directory entry + quoted-CSV `.txt` members, glob-selected primary table, largest-member + latin-1 fallbacks), and `DatasetFailure` with deterministic/transient classes (#460 interface).
- **`config/bsee.yml`** (new): scheduler dataset catalog as reviewable YAML (issue #9 knowledge), drift-guarded by tests against `BSEEWebScraper.URLS` and `url_registry.py`.
- **`bsee_web.py`**: fixed the two stale URLs that were #267's root cause (`deepwater_structure` moved `/Platform/Files/` → `/Other/Files/`; `pipeline_location` `PipeLocAllRawData.zip` → `PipeLocRawData.zip`). Old URLs return HTTP 200 + ~28 KB HTML, not 404 (live-verified 2026-06-10).
- **`bsee_refresh.py`**: loads the YAML catalog (built-in fallback), classifies payloads before extraction, no longer assumes zip-with-CSV-in-first-entry, reports per-dataset classified failures; all-deterministic total failure is prefixed `[deterministic]` for the retry layer (#460).
- **`docs/data/bsee-source-catalog.md`** (new): maps the closed-thread knowledge (#9/#11/#12/#49) to its code/test homes.

## Verification evidence

- `uv run pytest tests/unit/bsee/test_bsee_payload.py tests/unit/scheduler/test_bsee_adapter.py` → **32 passed** (incl. the opt-in live smoke with `BSEE_LIVE_SMOKE=1`: all 4 catalog URLs HEAD-verified `application/x-zip-compressed`).
- Live probes 2026-06-10: 4 corrected URLs serve zips regenerated daily ~09:45 UTC; both old URLs serve HTTP 200 + HTML (the exact #267 failure mode).
- Archive shape live-verified (PlatStruc/PermStruc/PipePerm downloads to /tmp, not committed): `.txt` quoted-CSV members behind a directory entry; no `.csv` anywhere — the old `endswith(".csv")` + `namelist()[0]` logic could never succeed. Platform's primary table (`mv_platstruc_structures.txt`, 1.5 MB) is *not* the largest member (`mv_platstruc_platformincs.txt`, 9 MB), hence configured member patterns.
- **Live end-to-end `BseeRefreshJob.run`** (reduced 2-dataset catalog, output to /tmp): `status=success`, `records_updated=7150` — platform 7,091 rows + deepwater 59 rows written to parquet with `_metadata.json`. Satisfies #267's "at least one BSEE dataset writes successfully".
- Lint: `black --check` / `isort` clean on touched files; `flake8` clean on touched `src/` files (CI lints `src/` only).

## #267 acceptance criteria

- [x] Live run no longer assumes all payloads are zip-with-CSV in first entry
- [x] HTML/error responses are detected and surfaced cleanly
- [x] At least one BSEE dataset writes successfully (live e2e: two)
- [x] Remaining dataset-specific failures classified explicitly (deterministic vs transient, #460)
- [x] Runtime evidence captured (this PR body)

## Out of scope (left for next runs)

- #49's KeyError `'Total Depth Date'` is in the analysis path (`bsee/analysis/well_api12.py:511`), not the refresh path — documented in the docs page, not touched.
- Lease-area (`lab`) / serial-register datasets as additional `scheduler_datasets` entries; multi-member (non-primary-table) extraction.
- Alignment with the #462 acceptance-contract artifacts once PR #464 merges (contract files are not yet on main).

Refs: #267, #423, #9, #11, #12, #460, #462