### PR TITLE
docs(#3064): verify 9 UV workflows run green offline; document loader fixtures

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -14,6 +14,15 @@ workflows:
       - examples/workflows/bsee-production-summary/outputs/prod_raw_bsee_production_summary.xlsx
     test: tests/workflows/test_durable_workflows.py::test_registry_workflow_outputs[bsee-production-summary]
     runtime: offline
+    data_source:
+      # BSEE is a data-loader basename, but this example reads a committed
+      # fixture (input.yml has source: csv, refresh: false) so it needs no
+      # network. Verified offline 2026-06-13 (workspace-hub#3064) with HTTP
+      # fully blocked.
+      type: bundled-fixture
+      network_required: false
+      fixtures:
+        - examples/workflows/bsee-production-summary/sample_production.csv
   - id: bsee-well-comparison
     basename: bsee
     title: BSEE well comparison from bundled CSV data
@@ -27,6 +36,13 @@ workflows:
       - examples/workflows/bsee-well-comparison/outputs/prod_raw_bsee_well_comparison.xlsx
     test: tests/workflows/test_durable_workflows.py::test_registry_workflow_outputs[bsee-well-comparison]
     runtime: offline
+    data_source:
+      # See bsee-production-summary note. Committed fixture, no network.
+      # Verified offline 2026-06-13 (workspace-hub#3064).
+      type: bundled-fixture
+      network_required: false
+      fixtures:
+        - examples/workflows/bsee-well-comparison/sample_production.csv
   - id: fdas-field-npv
     basename: fdas
     title: FDAS field economics NPV from bundled cashflow CSV
@@ -168,6 +184,16 @@ workflows:
             recoverable_oil_mmbbl: 150.0
     test: tests/workflows/test_durable_workflows.py::test_registry_workflow_outputs[sodir-field-summary]
     runtime: offline
+    data_source:
+      # SODIR is a data-loader basename; this example reads committed CSV
+      # fixtures (input.yml has source: csv, input_path: data) so it needs no
+      # network. Verified offline 2026-06-13 (workspace-hub#3064) with HTTP
+      # fully blocked.
+      type: bundled-fixture
+      network_required: false
+      fixtures:
+        - examples/workflows/sodir-field-summary/data/sodir_fields.csv
+        - examples/workflows/sodir-field-summary/data/sodir_production.csv
   - id: texas-rrc-production-summary
     basename: texas_rrc
     title: Texas RRC production summary from bundled CSV data
@@ -192,3 +218,12 @@ workflows:
             gas_production: 1700.0
     test: tests/workflows/test_durable_workflows.py::test_registry_workflow_outputs[texas-rrc-production-summary]
     runtime: offline
+    data_source:
+      # Texas RRC is a data-loader basename; this example reads a committed CSV
+      # fixture (input.yml has source: csv, files.production: production.csv) so
+      # it needs no network. Verified offline 2026-06-13 (workspace-hub#3064)
+      # with HTTP fully blocked.
+      type: bundled-fixture
+      network_required: false
+      fixtures:
+        - examples/workflows/texas-rrc-production-summary/production.csv


### PR DESCRIPTION
## Summary

Verifies the UV-workflow contract for worldenergydata against workspace-hub#3064: every registry workflow runs green from a clean checkout via the canonical `uv run python -m worldenergydata <input.yml>`, and the three data-loader basenames are confirmed genuinely offline.

**No code or example changes were needed — the repo was already at full parity.** This PR's only change is additive registry metadata documenting the offline-fixture provenance of the data-loader rows.

## Verification results (all 9 green)

| # | Workflow | basename | `uv run python -m` exit | Outputs + assertions |
|---|----------|----------|------------------------|----------------------|
| 1 | bsee-production-summary | bsee | 0 | pass |
| 2 | bsee-well-comparison | bsee | 0 | pass |
| 3 | fdas-field-npv | fdas | 0 | pass |
| 4 | fdas-npv-sensitivity | fdas | 0 | pass |
| 5 | pipeline-safety-ffs | pipeline_safety | 0 | pass |
| 6 | production-forecast-arps | production_forecast | 0 | pass |
| 7 | marine-safety-stats | marine_safety | 0 | pass |
| 8 | sodir-field-summary | sodir | 0 | pass |
| 9 | texas-rrc-production-summary | texas_rrc | 0 | pass |

Durable-workflow test suite: **19 passed** (`uv run python -m pytest tests/workflows/test_durable_workflows.py`).

## Data-loader classification

The three data-loader basenames (`bsee`, `sodir`, `texas_rrc`) were checked for live-data dependence:

- All use **committed CSV fixtures** (`source: csv`, `refresh: false` / `input_path`), not external pulls.
- Each runs green with **HTTP fully blocked** (dead-proxy test) — confirmed offline, no network required.
- **None need live data**, so none were given an `offline: false` / live-data note. Instead, each loader row gets an explicit `data_source` block (`type: bundled-fixture`, `network_required: false`, `fixtures: [...]`) so the offline guarantee is self-documenting. This is additive metadata; the workflow test ignores unknown registry keys (parses + 19/19 still green after the change).

## Notes for reviewers

- **Non-canonical invocation paths (docs only, out of contract scope):** several `.claude/skills/*/SKILL.md` files and a few READMEs use bare `python -m worldenergydata.<submodule>` (e.g. `.sodir`, `.marine_safety.cli`, `.field_analyzer`) — these are submodule Typer CLIs, a different entrypoint from the engine contract, and they show `python` rather than `uv run`. Not changed here; flagging for a possible docs-hygiene follow-up.
- **Local-only environment artifact (not in this PR):** `uv run pytest` failed locally with `ModuleNotFoundError: pydantic_settings` because the local `.venv/bin/*` console-script shebangs pointed at a stale path (`/mnt/local-analysis/workspace-hub/worldenergydata/.venv`, which does not exist). `uv run python -m pytest` was unaffected, and CI is green because it builds a fresh venv at the canonical path. Repaired locally (untracked `.venv`); nothing committed.

Refs workspace-hub#3064

🤖 Generated with [Claude Code](https://claude.com/claude-code)