### PR TITLE
chore(memory): scope repo-local agent memory (epic #3084)

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,0 +1,10 @@
+# World Energy Data — repo-scoped memory
+
+Session context for THIS repo only (epic #3084 context-flow prototype).
+Keep entries scoped to worldenergydata; cross-repo facts stay in workspace-hub memory.
+
+## Project
+- BSEE/marine-safety/FDAS public-data library + CLI; public-federal-data routing.
+
+## Feedback
+- (none yet — repo-scoped feedback accrues here instead of the workspace-hub blob)

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,10 @@ dmypy.json
 .hive-mind/
 hive-mind-prompt-*.txt
 memory/
+# epic #3084: the blanket `memory/` above (claude-flow-era) also catches `.claude/memory/`.
+# Re-include repo-scoped agent memory so it travels with the repo.
+!.claude/memory/
+!.claude/memory/**
 coordination/
 memory/sessions/*
 !memory/sessions/README.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,4 +15,4 @@ Governance: `docs/DATA_RESIDENCE_POLICY.md` | Local data: `docs/data/LOCAL_DATA_
 
 ## Dirs
 `src/` `data/{raw,processed,modules}/` `reports/` `tests/`
-> Full rules inherited from workspace-hub/CLAUDE.md | Agents: `.claude/docs/agents.md`
+> Full rules inherited from workspace-hub/CLAUDE.md | Agents: `.claude/docs/agents.md` | Memory: read THIS repo's `.claude/memory/` first; consult workspace-hub memory only for cross-repo concerns


### PR DESCRIPTION
Phase-1 prototype for workspace-hub epic #3084 (context-flow backbone). Proves per-repo context scoping on ONE repo before any global change.

## Before → After (what an agent loads when cwd = worldenergydata)
**Before:** global `~/.claude/CLAUDE.md` (loaded every session) instructs "read workspace-hub/.claude/memory/" (~4 MB blob incl. kanban, GTM, FDAS, llm-wiki — all off-topic here). `worldenergydata/CLAUDE.md` only said "inherits workspace-hub" → no repo-scoped memory existed.

**After:** `worldenergydata/CLAUDE.md` now carries an explicit precedence line — *read THIS repo's `.claude/memory/` first; workspace-hub memory only for cross-repo* — and a repo-scoped `.claude/memory/MEMORY.md` exists for it to resolve to.

## Key finding (generalizable to #3084 rollout)
The repo's `.gitignore` had a blanket claude-flow-era `memory/` pattern that **also caught `.claude/memory/`** — repo-scoped memory would not have tracked. Fixed here with a negation; **every repo in the rollout will hit this**, so the #3084 scaffolder must patch `.gitignore` per repo.

## Why this is the low-risk path
This does NOT touch the global `bootstrap-machine.sh` template (which would change every session on every machine). It tests whether a per-repo `CLAUDE.md` precedence instruction is honored on top of the always-loaded global one. If validated in practice, #3084 may not need the riskier global cwd-relative change at all.

## Files
- `CLAUDE.md` — +memory-precedence line (still 18 lines, within the ≤20 cap)
- `.claude/memory/MEMORY.md` — repo-scoped memory (10 lines)
- `.gitignore` — un-ignore `.claude/memory/`

Reversible: revert restores prior behavior exactly.