### PR TITLE
feat(hse): incident-grounding query — failure-mode → real precedent incidents (#487)

### DIFF
--- a/scripts/exploration/hse_incident_grounding.py
+++ b/scripts/exploration/hse_incident_grounding.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""HSE incident grounding — prototype.
+
+Given an engineering failure mode, pull real precedent incidents from the public
+HSE corpus and return "2 latest + 2 highest-severity", each stamped with source +
+data vintage so freshness/staleness is transparent (never hidden).
+
+Purpose: an additional Deckhand demo stream — every digitalmodel engineering
+analysis ships with real-world precedent. Numbers persuade engineers; real
+incidents persuade decision-makers.
+
+Pilot failure mode: mooring fatigue (matches digitalmodel #796 parametric pilot).
+
+Sources queried (per operator decision: "all sources"):
+  - BSEE incident investigations (mv_acc_investigations.txt) -- offshore, narrative, fresh
+  - EPA TRI oil/gas releases                                 -- environmental, annual
+  - OSHA accident narratives (osha_accident.csv)             -- onshore, historical
+
+Read-only against the NFS share. Nothing is copied or written back to the share.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import json
+import re
+import sys
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+
+DATA_ROOT = Path("/mnt/remote/ace-linux-1/ace/worldenergydata/data/modules")
+
+# --- failure-mode keyword library (extend per analysis type) ------------------
+# Per-mode source routing: query only the sources that are on-domain for that
+# failure mode. Offshore structural modes -> BSEE only (decision 2026-06-18).
+# OSHA/EPA are reserved for modes where they are genuinely on-domain (onshore
+# process safety, spills) -- not bolted onto offshore modes where they add noise.
+FAILURE_MODES: dict[str, dict] = {
+    "mooring_fatigue": {
+        "label": "Mooring / station-keeping failure",
+        "sources": ["bsee"],
+        # offshore-mooring sense, not generic "moored vessel"
+        "include": re.compile(
+            r"moor(ing)?\s*(line|failure|chain)|fairlead|anchor\s*(drag|chain|line)"
+            r"|anchor contact|station[- ]keep|capsiz",
+            re.I,
+        ),
+    },
+}
+
+# --- BSEE ACCIDENT_TYPE -> severity rank (higher = worse) ----------------------
+SEVERITY_RANK = [
+    (re.compile(r"fatalit", re.I), 100, "fatality"),
+    (re.compile(r"capsiz|blowout|explosion", re.I), 90, "catastrophic"),
+    (re.compile(r"\bLTA\b|lost time|required evacuation", re.I), 60, "lost_time"),
+    (re.compile(r"pollution|spill|h2s|gas release", re.I), 50, "environmental"),
+    (re.compile(r"injury|RW/JT", re.I), 40, "injury"),
+    (re.compile(r">\$25K|incident >\$25k", re.I), 30, "property_>$25k"),
+]
+
+
+def severity_of(text: str) -> tuple[int, str]:
+    best = (10, "minor")
+    for rx, score, name in SEVERITY_RANK:
+        if rx.search(text) and score > best[0]:
+            best = (score, name)
+    return best
+
+
+@dataclass
+class Incident:
+    source: str
+    date: str          # ISO
+    location: str
+    description: str
+    severity: str
+    severity_rank: int
+    offshore: bool
+    vintage_note: str
+    _dt: dt.date = field(repr=False, default=None)
+
+
+def _parse_date(s: str, fmts) -> dt.date | None:
+    for f in fmts:
+        try:
+            return dt.datetime.strptime(s.strip(), f).date()
+        except (ValueError, AttributeError):
+            continue
+    return None
+
+
+def load_bsee(mode: dict) -> list[Incident]:
+    f = DATA_ROOT / "hse/raw/bsee/IncInvRawData/mv_acc_investigations.txt"
+    out: list[Incident] = []
+    rows = list(csv.DictReader(open(f, encoding="latin-1")))
+    newest = max((_parse_date(r["DATE_OCCURRED"], ["%m/%d/%Y"]) or dt.date.min) for r in rows)
+    vintage = f"BSEE incident investigations; corpus current to {newest.isoformat()}"
+    for r in rows:
+        atype = (r.get("ACCIDENT_TYPE") or "").strip(" -")
+        if not mode["include"].search(atype):
+            continue
+        d = _parse_date(r["DATE_OCCURRED"], ["%m/%d/%Y"])
+        if not d:
+            continue
+        rank, sev = severity_of(atype)
+        loc = " ".join(x for x in [(r.get("AREA_BLOCK") or "").strip(),
+                                   (r.get("LEASE_NUMBER") or "").strip()] if x and x != "Not Applicable")
+        out.append(Incident(
+            source="BSEE (offshore)", date=d.isoformat(), location=loc or "GoM (unspecified)",
+            description=atype, severity=sev, severity_rank=rank, offshore=True,
+            vintage_note=vintage, _dt=d))
+    return out
+
+
+def load_osha(mode: dict) -> list[Incident]:
+    f = DATA_ROOT / "hse/raw/osha/osha_accident.csv"
+    if not f.exists():
+        return []
+    out: list[Incident] = []
+    for r in csv.DictReader(open(f, encoding="latin-1")):
+        desc = ((r.get("event_desc") or "") + " " + (r.get("abstract_text") or "")).strip()
+        if not mode["include"].search(desc):
+            continue
+        d = _parse_date((r.get("event_date") or "")[:10], ["%Y-%m-%d", "%m/%d/%Y"])
+        if not d:
+            continue
+        # OSHA is onshore-source; require strong offshore signal and no recreational/inland tells
+        offshore = bool(re.search(r"offshore|platform|fpso|spar|jack[- ]?up|outer continental", desc, re.I)) \
+            and not re.search(r"kayak|jon boat|canoe|weed harvester|pontoon|recreational|lake|pond|dock", desc, re.I)
+        rank = 100 if (r.get("fatality") or "").strip().upper() == "X" else 40
+        sev = "fatality" if rank == 100 else "injury"
+        out.append(Incident(
+            source="OSHA (onshore)", date=d.isoformat(), location=r.get("state_flag", "") or "US",
+            description=desc[:140], severity=sev, severity_rank=rank, offshore=offshore,
+            vintage_note="OSHA accident file; historical (data ends ~1999 on disk -- re-acquire for current)",
+            _dt=d))
+    return out
+
+
+def load_epa(mode: dict) -> list[Incident]:
+    # TRI is chemical-release inventory, not incident-level; mooring will not match.
+    # Included to honour "all sources" and to show honest empty result.
+    return []
+
+
+def ground(mode_key: str) -> dict:
+    mode = FAILURE_MODES[mode_key]
+    routed = set(mode.get("sources", ["bsee", "osha", "epa_tri"]))
+    pool: list[Incident] = []
+    counts = {}
+    for name, key, loader in (("BSEE", "bsee", load_bsee),
+                              ("OSHA", "osha", load_osha),
+                              ("EPA_TRI", "epa_tri", load_epa)):
+        if key not in routed:
+            counts[name] = "not routed (off-domain for this mode)"
+            continue
+        got = loader(mode)
+        counts[name] = len(got)
+        pool.extend(got)
+
+    # relevance gate: offshore-domain only for the headline picks
+    relevant = [i for i in pool if i.offshore]
+    off_domain = [i for i in pool if not i.offshore]
+
+    latest = sorted(relevant, key=lambda i: i._dt, reverse=True)[:2]
+    picked_ids = {id(i) for i in latest}
+    severe = sorted([i for i in relevant if id(i) not in picked_ids],
+                    key=lambda i: (i.severity_rank, i._dt), reverse=True)[:2]
+
+    return {
+        "failure_mode": mode["label"],
+        "source_counts": counts,
+        "relevant_offshore": len(relevant),
+        "off_domain_excluded": len(off_domain),
+        "off_domain_examples": [f"{i.date} {i.severity}: {i.description[:60]}" for i in off_domain[:3]],
+        "latest_2": [{k: v for k, v in asdict(i).items() if not k.startswith("_")} for i in latest],
+        "most_severe_2": [{k: v for k, v in asdict(i).items() if not k.startswith("_")} for i in severe],
+    }
+
+
+def render_card(g: dict) -> str:
+    L = []
+    L.append(f"### Real-world precedent — {g['failure_mode']}")
+    L.append("")
+    L.append("**Latest on record:**")
+    for i in g["latest_2"]:
+        L.append(f"- **{i['date']}** — {i['location']} — {i['description']} "
+                 f"_({i['severity']}; {i['source']})_")
+    L.append("")
+    L.append("**Highest-consequence on record:**")
+    for i in g["most_severe_2"]:
+        L.append(f"- **{i['date']}** — {i['location']} — {i['description']} "
+                 f"_({i['severity']}; {i['source']})_")
+    L.append("")
+    src = g["source_counts"]
+    routed = ", ".join(f"{k}={v}" for k, v in src.items())
+    L.append(f"_Sources ({routed}). Domain-routed: only on-domain sources queried for this failure mode._")
+    # always stamp vintage (decision 2026-06-18)
+    vintage = (g["latest_2"] + g["most_severe_2"])
+    if vintage:
+        L.append(f"_Data vintage: {vintage[0]['vintage_note']}._")
+    return "\n".join(L)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", default="mooring_fatigue", choices=list(FAILURE_MODES))
+    ap.add_argument("--json", action="store_true", help="emit JSON instead of card")
+    a = ap.parse_args()
+    g = ground(a.mode)
+    if a.json:
+        print(json.dumps(g, indent=2))
+    else:
+        print(render_card(g))
+        print("\n---\nsource_counts:", g["source_counts"],
+              "| off-domain excluded:", g["off_domain_excluded"])
+        if g["off_domain_examples"]:
+            print("off-domain examples:", *g["off_domain_examples"], sep="\n  ")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/worldenergydata/hse/__init__.py
+++ b/src/worldenergydata/hse/__init__.py
@@ -57,6 +57,9 @@ from worldenergydata.hse.importers.data_quality_validator import (
 )
 from worldenergydata.hse.importers.epa_tri_importer import EPATRIImporter
 
+# Incident-grounding query (#487): failure-mode -> real precedent incidents
+from worldenergydata.hse.grounding import Grounding, ground
+
 __version__ = "1.0.0"
 __all__ = [
     # Database models
@@ -75,6 +78,9 @@ __all__ = [
     "EPATRIImporter",
     # Validation
     "DataQualityValidator",
+    # Incident grounding (#487)
+    "ground",
+    "Grounding",
 ]
 
 _logger = get_logger(__name__)

--- a/src/worldenergydata/hse/__init__.py
+++ b/src/worldenergydata/hse/__init__.py
@@ -41,6 +41,9 @@ from worldenergydata.hse.database import (
     ViolationIncident,
 )
 
+# Incident-grounding query (#487): failure-mode -> real precedent incidents
+from worldenergydata.hse.grounding import Grounding, ground
+
 # Importers
 from worldenergydata.hse.importers.base_importer import BaseImporter
 from worldenergydata.hse.importers.bsee_incidents_importer import (
@@ -56,9 +59,6 @@ from worldenergydata.hse.importers.data_quality_validator import (
     DataQualityValidator,
 )
 from worldenergydata.hse.importers.epa_tri_importer import EPATRIImporter
-
-# Incident-grounding query (#487): failure-mode -> real precedent incidents
-from worldenergydata.hse.grounding import Grounding, ground
 
 __version__ = "1.0.0"
 __all__ = [

--- a/src/worldenergydata/hse/grounding.py
+++ b/src/worldenergydata/hse/grounding.py
@@ -1,0 +1,269 @@
+# ABOUTME: HSE incident-grounding query — failure-mode -> real-world precedent incidents.
+# ABOUTME: Returns 2 latest + 2 highest-severity BSEE incidents per failure mode, vintage-stamped.
+
+"""HSE incident grounding.
+
+Given an engineering failure mode (mooring fatigue, well control, …), return real
+precedent incidents from the public HSE corpus: the **2 most-recent** and the
+**2 highest-severity** records for that mode, each stamped with the corpus data
+vintage so freshness is transparent (never hidden).
+
+Purpose: ground every digitalmodel engineering analysis in real-world precedent.
+Numbers persuade engineers; real incidents persuade decision-makers; the
+fresh-vs-historic contrast answers the "is this stale?" objection.
+
+Design decisions (2026-06-18, epic #486):
+- **Per-mode source routing.** Offshore structural modes (mooring/riser/well
+  control) route to **BSEE only** — OSHA is onshore + stale (~1999) and adds
+  off-domain noise. OSHA/EPA are reserved for modes where they are on-domain.
+- **Pick = 2 newest by date + 2 highest-severity** of all time.
+- **Always stamp data vintage.**
+- **Operator Aggregation Contract (#423):** output cites lease blocks + dates,
+  never operator names.
+
+Usage::
+
+    from worldenergydata.hse.grounding import ground
+
+    g = ground("mooring_fatigue")
+    print(g.render_card())          # markdown card
+    g.to_dict()                     # JSON-serialisable sidecar
+
+CLI::
+
+    uv run python -m worldenergydata.hse.grounding --mode mooring_fatigue [--json]
+
+The default BSEE data path resolves from ``$WED_HSE_DATA_ROOT`` or the ace-linux-1
+share; tests inject a fixture path so CI needs neither the share nor network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import json
+import os
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Callable, Optional
+
+# --- failure-mode registry ----------------------------------------------------
+# Each mode: human label, routed sources, and an include-regex over the BSEE
+# ACCIDENT_TYPE field. Extend per #488 (coverage). Keep mooring first/pilot.
+
+
+@dataclass(frozen=True)
+class FailureMode:
+    key: str
+    label: str
+    sources: tuple[str, ...]
+    include: re.Pattern
+
+
+FAILURE_MODES: dict[str, FailureMode] = {
+    "mooring_fatigue": FailureMode(
+        key="mooring_fatigue",
+        label="Mooring / station-keeping failure",
+        sources=("bsee",),
+        include=re.compile(
+            r"moor(ing)?\s*(line|failure|chain)|fairlead|anchor\s*(drag|chain|line)"
+            r"|anchor contact|station[- ]keep|capsiz",
+            re.I,
+        ),
+    ),
+}
+
+# --- BSEE ACCIDENT_TYPE -> severity rank (higher = worse) ---------------------
+SEVERITY_RANK: list[tuple[re.Pattern, int, str]] = [
+    (re.compile(r"fatalit", re.I), 100, "fatality"),
+    (re.compile(r"capsiz|blowout|explosion", re.I), 90, "catastrophic"),
+    (re.compile(r"\bLTA\b|lost time|required evacuation", re.I), 60, "lost_time"),
+    (re.compile(r"pollution|spill|h2s|gas release", re.I), 50, "environmental"),
+    (re.compile(r"injury|RW/JT", re.I), 40, "injury"),
+    (re.compile(r">\$25K|incident >\$25k", re.I), 30, "property_>$25k"),
+]
+
+
+def severity_of(text: str) -> tuple[int, str]:
+    """Map a BSEE ACCIDENT_TYPE string to (rank, label). Higher rank = worse."""
+    best = (10, "minor")
+    for rx, score, name in SEVERITY_RANK:
+        if rx.search(text) and score > best[0]:
+            best = (score, name)
+    return best
+
+
+# --- data model ---------------------------------------------------------------
+@dataclass
+class Incident:
+    source: str
+    date: str  # ISO yyyy-mm-dd
+    location: str  # area block + lease, never operator name
+    description: str
+    severity: str
+    severity_rank: int
+    vintage_note: str
+    _dt: dt.date = field(repr=False, default=dt.date.min)
+
+    def public(self) -> dict:
+        return {k: v for k, v in asdict(self).items() if not k.startswith("_")}
+
+
+@dataclass
+class Grounding:
+    failure_mode: str
+    latest: list[Incident]
+    most_severe: list[Incident]
+    source_counts: dict[str, object]
+    vintage_note: str
+
+    def to_dict(self) -> dict:
+        return {
+            "failure_mode": self.failure_mode,
+            "source_counts": self.source_counts,
+            "vintage_note": self.vintage_note,
+            "latest_2": [i.public() for i in self.latest],
+            "most_severe_2": [i.public() for i in self.most_severe],
+        }
+
+    def render_card(self) -> str:
+        L = [f"### Real-world precedent — {self.failure_mode}", ""]
+        L.append("**Latest on record:**")
+        for i in self.latest:
+            L.append(f"- **{i.date}** — {i.location} — {i.description} "
+                     f"_({i.severity}; {i.source})_")
+        L.append("")
+        L.append("**Highest-consequence on record:**")
+        for i in self.most_severe:
+            L.append(f"- **{i.date}** — {i.location} — {i.description} "
+                     f"_({i.severity}; {i.source})_")
+        L.append("")
+        routed = ", ".join(f"{k}={v}" for k, v in self.source_counts.items())
+        L.append(f"_Sources ({routed}). Domain-routed: only on-domain sources "
+                 f"queried for this failure mode._")
+        if self.vintage_note:
+            L.append(f"_Data vintage: {self.vintage_note}._")
+        return "\n".join(L)
+
+
+# --- BSEE data source (CI-safe, fixture-injectable) ---------------------------
+SHARE_DEFAULT = Path(
+    "/mnt/remote/ace-linux-1/ace/worldenergydata/data/modules/hse/raw/bsee"
+    "/IncInvRawData/mv_acc_investigations.txt"
+)
+
+
+def default_bsee_path() -> Optional[Path]:
+    """Resolve the BSEE incident-investigation file.
+
+    Order: ``$WED_HSE_DATA_ROOT/.../mv_acc_investigations.txt`` -> repo-local
+    ``data/modules/...`` -> ace-linux-1 share. Returns None if none exist.
+    """
+    candidates = []
+    root = os.environ.get("WED_HSE_DATA_ROOT")
+    if root:
+        candidates.append(Path(root) / "hse/raw/bsee/IncInvRawData/mv_acc_investigations.txt")
+    repo = Path(__file__).resolve().parents[3] / "data/modules/hse/raw/bsee/IncInvRawData/mv_acc_investigations.txt"
+    candidates.append(repo)
+    candidates.append(SHARE_DEFAULT)
+    for c in candidates:
+        if c.exists():
+            return c
+    return None
+
+
+def _parse_date(s: str) -> Optional[dt.date]:
+    for fmt in ("%m/%d/%Y", "%Y-%m-%d"):
+        try:
+            return dt.datetime.strptime((s or "").strip(), fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def load_bsee(mode: FailureMode, path: Optional[Path] = None) -> list[Incident]:
+    """Load BSEE incident-investigation records matching ``mode``.
+
+    ``path`` overrides resolution (tests pass a fixture). Vintage is the max
+    incident date in the corpus, computed from the data — not file mtime.
+    """
+    path = path or default_bsee_path()
+    if path is None or not Path(path).exists():
+        return []
+    rows = list(csv.DictReader(open(path, encoding="latin-1")))
+    if not rows:
+        return []
+    newest = max((_parse_date(r.get("DATE_OCCURRED", "")) or dt.date.min) for r in rows)
+    vintage = f"BSEE incident investigations; corpus current to {newest.isoformat()}"
+    out: list[Incident] = []
+    for r in rows:
+        atype = (r.get("ACCIDENT_TYPE") or "").strip(" -")
+        if not mode.include.search(atype):
+            continue
+        d = _parse_date(r.get("DATE_OCCURRED", ""))
+        if not d:
+            continue
+        rank, sev = severity_of(atype)
+        loc = " ".join(
+            x for x in [(r.get("AREA_BLOCK") or "").strip(), (r.get("LEASE_NUMBER") or "").strip()]
+            if x and x != "Not Applicable"
+        )
+        out.append(Incident(
+            source="BSEE (offshore)", date=d.isoformat(), location=loc or "GoM (unspecified)",
+            description=atype, severity=sev, severity_rank=rank, vintage_note=vintage, _dt=d))
+    return out
+
+
+SOURCE_LOADERS: dict[str, Callable[..., list[Incident]]] = {
+    "bsee": load_bsee,
+}
+
+
+# --- public API ---------------------------------------------------------------
+def ground(failure_mode: str, *, bsee_path: Optional[Path] = None) -> Grounding:
+    """Return a :class:`Grounding` for ``failure_mode``.
+
+    Queries only the sources routed for the mode (off-domain sources report
+    ``"not routed"``). Picks 2 newest + 2 highest-severity (disjoint).
+    """
+    if failure_mode not in FAILURE_MODES:
+        raise KeyError(f"unknown failure_mode {failure_mode!r}; "
+                       f"known: {sorted(FAILURE_MODES)}")
+    mode = FAILURE_MODES[failure_mode]
+    pool: list[Incident] = []
+    counts: dict[str, object] = {}
+    for name in ("bsee", "osha", "epa_tri"):
+        if name not in mode.sources:
+            counts[name.upper()] = "not routed (off-domain for this mode)"
+            continue
+        loader = SOURCE_LOADERS[name]
+        got = loader(mode, bsee_path) if name == "bsee" else loader(mode)
+        counts[name.upper()] = len(got)
+        pool.extend(got)
+
+    latest = sorted(pool, key=lambda i: i._dt, reverse=True)[:2]
+    picked = {id(i) for i in latest}
+    most_severe = sorted(
+        [i for i in pool if id(i) not in picked],
+        key=lambda i: (i.severity_rank, i._dt), reverse=True,
+    )[:2]
+    vintage = (latest + most_severe)[0].vintage_note if (latest or most_severe) else ""
+    return Grounding(
+        failure_mode=mode.label, latest=latest, most_severe=most_severe,
+        source_counts=counts, vintage_note=vintage)
+
+
+def _main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="HSE incident grounding for a failure mode")
+    ap.add_argument("--mode", default="mooring_fatigue", choices=sorted(FAILURE_MODES))
+    ap.add_argument("--json", action="store_true", help="emit JSON sidecar instead of card")
+    a = ap.parse_args(argv)
+    g = ground(a.mode)
+    print(json.dumps(g.to_dict(), indent=2) if a.json else g.render_card())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/src/worldenergydata/hse/grounding.py
+++ b/src/worldenergydata/hse/grounding.py
@@ -132,17 +132,23 @@ class Grounding:
         L = [f"### Real-world precedent — {self.failure_mode}", ""]
         L.append("**Latest on record:**")
         for i in self.latest:
-            L.append(f"- **{i.date}** — {i.location} — {i.description} "
-                     f"_({i.severity}; {i.source})_")
+            L.append(
+                f"- **{i.date}** — {i.location} — {i.description} "
+                f"_({i.severity}; {i.source})_"
+            )
         L.append("")
         L.append("**Highest-consequence on record:**")
         for i in self.most_severe:
-            L.append(f"- **{i.date}** — {i.location} — {i.description} "
-                     f"_({i.severity}; {i.source})_")
+            L.append(
+                f"- **{i.date}** — {i.location} — {i.description} "
+                f"_({i.severity}; {i.source})_"
+            )
         L.append("")
         routed = ", ".join(f"{k}={v}" for k, v in self.source_counts.items())
-        L.append(f"_Sources ({routed}). Domain-routed: only on-domain sources "
-                 f"queried for this failure mode._")
+        L.append(
+            f"_Sources ({routed}). Domain-routed: only on-domain sources "
+            f"queried for this failure mode._"
+        )
         if self.vintage_note:
             L.append(f"_Data vintage: {self.vintage_note}._")
         return "\n".join(L)
@@ -164,8 +170,13 @@ def default_bsee_path() -> Optional[Path]:
     candidates = []
     root = os.environ.get("WED_HSE_DATA_ROOT")
     if root:
-        candidates.append(Path(root) / "hse/raw/bsee/IncInvRawData/mv_acc_investigations.txt")
-    repo = Path(__file__).resolve().parents[3] / "data/modules/hse/raw/bsee/IncInvRawData/mv_acc_investigations.txt"
+        candidates.append(
+            Path(root) / "hse/raw/bsee/IncInvRawData/mv_acc_investigations.txt"
+        )
+    repo = (
+        Path(__file__).resolve().parents[3]
+        / "data/modules/hse/raw/bsee/IncInvRawData/mv_acc_investigations.txt"
+    )
     candidates.append(repo)
     candidates.append(SHARE_DEFAULT)
     for c in candidates:
@@ -207,12 +218,25 @@ def load_bsee(mode: FailureMode, path: Optional[Path] = None) -> list[Incident]:
             continue
         rank, sev = severity_of(atype)
         loc = " ".join(
-            x for x in [(r.get("AREA_BLOCK") or "").strip(), (r.get("LEASE_NUMBER") or "").strip()]
+            x
+            for x in [
+                (r.get("AREA_BLOCK") or "").strip(),
+                (r.get("LEASE_NUMBER") or "").strip(),
+            ]
             if x and x != "Not Applicable"
         )
-        out.append(Incident(
-            source="BSEE (offshore)", date=d.isoformat(), location=loc or "GoM (unspecified)",
-            description=atype, severity=sev, severity_rank=rank, vintage_note=vintage, _dt=d))
+        out.append(
+            Incident(
+                source="BSEE (offshore)",
+                date=d.isoformat(),
+                location=loc or "GoM (unspecified)",
+                description=atype,
+                severity=sev,
+                severity_rank=rank,
+                vintage_note=vintage,
+                _dt=d,
+            )
+        )
     return out
 
 
@@ -229,8 +253,9 @@ def ground(failure_mode: str, *, bsee_path: Optional[Path] = None) -> Grounding:
     ``"not routed"``). Picks 2 newest + 2 highest-severity (disjoint).
     """
     if failure_mode not in FAILURE_MODES:
-        raise KeyError(f"unknown failure_mode {failure_mode!r}; "
-                       f"known: {sorted(FAILURE_MODES)}")
+        raise KeyError(
+            f"unknown failure_mode {failure_mode!r}; " f"known: {sorted(FAILURE_MODES)}"
+        )
     mode = FAILURE_MODES[failure_mode]
     pool: list[Incident] = []
     counts: dict[str, object] = {}
@@ -247,18 +272,27 @@ def ground(failure_mode: str, *, bsee_path: Optional[Path] = None) -> Grounding:
     picked = {id(i) for i in latest}
     most_severe = sorted(
         [i for i in pool if id(i) not in picked],
-        key=lambda i: (i.severity_rank, i._dt), reverse=True,
+        key=lambda i: (i.severity_rank, i._dt),
+        reverse=True,
     )[:2]
     vintage = (latest + most_severe)[0].vintage_note if (latest or most_severe) else ""
     return Grounding(
-        failure_mode=mode.label, latest=latest, most_severe=most_severe,
-        source_counts=counts, vintage_note=vintage)
+        failure_mode=mode.label,
+        latest=latest,
+        most_severe=most_severe,
+        source_counts=counts,
+        vintage_note=vintage,
+    )
 
 
 def _main(argv: Optional[list[str]] = None) -> int:
-    ap = argparse.ArgumentParser(description="HSE incident grounding for a failure mode")
+    ap = argparse.ArgumentParser(
+        description="HSE incident grounding for a failure mode"
+    )
     ap.add_argument("--mode", default="mooring_fatigue", choices=sorted(FAILURE_MODES))
-    ap.add_argument("--json", action="store_true", help="emit JSON sidecar instead of card")
+    ap.add_argument(
+        "--json", action="store_true", help="emit JSON sidecar instead of card"
+    )
     a = ap.parse_args(argv)
     g = ground(a.mode)
     print(json.dumps(g.to_dict(), indent=2) if a.json else g.render_card())

--- a/tests/unit/hse/fixtures/bsee_incinv_sample.txt
+++ b/tests/unit/hse/fixtures/bsee_incinv_sample.txt
@@ -1,0 +1,8 @@
+"DATE_OCCURRED","MILITARY_TIME","LEASE_NUMBER","AREA_BLOCK","ACCIDENT_TYPE","PANEL_DISTRICT","STATUS"
+1/29/2020,"15:00","G33733","MC 437","- Incident >$25K - Mooring line","DISTRICT","Complete"
+12/24/2006,"08:00","Not Applicable","","- Pollution - Anchor drag","DISTRICT","Complete"
+9/23/2005,"14:00","G15563","GC 237","- Pollution - Capsized - Mooring Failure","DISTRICT","Complete"
+10/3/2002,"06:00","G12940","SS 126","- Pollution - Capsized during Hurricane Lili","DISTRICT","Complete"
+8/26/2004,"11:00","G15565","GC 248","- Anchor Contact with Wellhead","DISTRICT","Complete"
+7/22/2005,"15:00","G15610","GC 782","- Dropped Object","DISTRICT","Complete"
+5/1/2018,"09:00","G09988","EW 910","- Fire","DISTRICT","Complete"

--- a/tests/unit/hse/test_grounding.py
+++ b/tests/unit/hse/test_grounding.py
@@ -1,0 +1,94 @@
+# ABOUTME: Tests for worldenergydata.hse.grounding — failure-mode incident grounding.
+# ABOUTME: Fixture-backed; no NFS share or network dependency in CI.
+
+"""Tests for the HSE incident-grounding query (#487).
+
+Uses a small committed BSEE fixture so CI needs neither the ace-linux-1 share
+nor network. Verifies: mode filtering, 2-latest + 2-severe selection, severity
+ranking, vintage stamp computed from data, per-mode source routing, and the
+Operator Aggregation Contract (no operator names in output).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from worldenergydata.hse.grounding import (
+    FAILURE_MODES,
+    ground,
+    load_bsee,
+    severity_of,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "bsee_incinv_sample.txt"
+
+
+def _g():
+    return ground("mooring_fatigue", bsee_path=FIXTURE)
+
+
+def test_mode_filter_excludes_non_mooring():
+    incidents = load_bsee(FAILURE_MODES["mooring_fatigue"], FIXTURE)
+    descs = " ".join(i.description for i in incidents)
+    # the fixture's "Dropped Object" and bare "Fire" rows must not match
+    assert "Dropped Object" not in descs
+    assert all("Fire" != i.description for i in incidents)
+    # all five mooring/anchor/capsize rows match
+    assert len(incidents) == 5
+
+
+def test_latest_two_are_newest_by_date():
+    g = _g()
+    assert [i.date for i in g.latest] == ["2020-01-29", "2006-12-24"]
+
+
+def test_most_severe_two_are_highest_rank_and_disjoint_from_latest():
+    g = _g()
+    latest_dates = {i.date for i in g.latest}
+    assert all(i.date not in latest_dates for i in g.most_severe)
+    # both capsize rows are catastrophic (rank 90), beating anchor-contact/minor
+    assert [i.severity for i in g.most_severe] == ["catastrophic", "catastrophic"]
+    assert {i.date for i in g.most_severe} == {"2005-09-23", "2002-10-03"}
+
+
+def test_severity_ranking():
+    assert severity_of("Fatality")[1] == "fatality"
+    assert severity_of("Pollution - Capsized")[1] == "catastrophic"
+    assert severity_of("Incident >$25K - Mooring line")[1] == "property_>$25k"
+
+
+def test_vintage_stamp_computed_from_data_not_mtime():
+    g = _g()
+    # newest DATE_OCCURRED in the fixture is 2020-01-29
+    assert "current to 2020-01-29" in g.vintage_note
+    assert "current to 2020-01-29" in g.render_card()
+
+
+def test_per_mode_source_routing_offshore_is_bsee_only():
+    g = _g()
+    assert g.source_counts["BSEE"] == 5
+    assert "not routed" in str(g.source_counts["OSHA"])
+    assert "not routed" in str(g.source_counts["EPA_TRI"])
+
+
+def test_no_operator_names_in_output():
+    # Operator Aggregation Contract (#423): lease blocks + dates only.
+    g = _g()
+    blob = g.render_card().lower()
+    for banned in ("chevron", "shell", "apache", "bp", "exxon", "operator"):
+        assert banned not in blob
+
+
+def test_card_and_dict_shapes():
+    g = _g()
+    d = g.to_dict()
+    assert len(d["latest_2"]) == 2 and len(d["most_severe_2"]) == 2
+    assert d["latest_2"][0]["location"] == "MC 437 G33733"
+    assert "Real-world precedent" in g.render_card()
+
+
+def test_unknown_mode_raises():
+    with pytest.raises(KeyError):
+        ground("does_not_exist", bsee_path=FIXTURE)


### PR DESCRIPTION
## Engine slice of the grounded-analysis stream (#486)

Promotes the grounding prototype into a first-class library method,
`worldenergydata.hse.grounding.ground(failure_mode)` — closes #487.

Every digitalmodel engineering analysis can now ship with real-world precedent:
the **2 most-recent + 2 highest-severity** real BSEE incidents for the failure
mode, each stamped with corpus data vintage.

### What's here
- `src/worldenergydata/hse/grounding.py` — `ground()` → `Grounding` (`to_dict()` JSON sidecar + `render_card()` markdown); `FailureMode` registry (mooring pilot), severity ranking, per-mode source routing.
- `ground` / `Grounding` exported from `worldenergydata.hse`.
- CLI: `python -m worldenergydata.hse.grounding --mode mooring_fatigue [--json]`.
- `tests/unit/hse/test_grounding.py` (9 tests) + committed BSEE fixture.

### Design (locked 2026-06-18, epic #486)
- **Per-mode source routing** — offshore modes (mooring/riser/well control) → **BSEE only**. OSHA is onshore + stale (~1999) and adds off-domain noise; reserved for on-domain modes. Off-domain sources report `not routed`.
- **Pick** = 2 newest by date + 2 highest-severity (disjoint).
- **Always stamp vintage**, computed from `max(incident_date)` in the data — not file mtime. (Addresses the provenance gap that marks HSE `stale` despite fresh data; full fix in #489.)
- **Operator Aggregation Contract (#423):** cites lease blocks + dates, never operator names — enforced by a test.

### CI-safe
BSEE path resolves via `$WED_HSE_DATA_ROOT` → repo-local `data/modules/...` → ace-linux-1 share. Tests inject a committed fixture, so **no share or network** is needed in CI. Does **not** depend on the #366 ingest pipeline.

### Verified
- `pytest tests/unit/hse/test_grounding.py` → **9 passed**.
- CLI against the live BSEE corpus returns the expected 4 picks (MC 437, anchor drag, GC 237 capsize, SS 126 Hurricane Lili), vintage **current to 2026-01-08**.

Part of epic #486 · parent pipeline #423. Next: render (deckhand #448) + demo tracer #490.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
