### PR TITLE
feat(hse): mooring-fatigue grounded card — first published demo artifact (#490)

### DIFF
--- a/config/repo_structure.yml
+++ b/config/repo_structure.yml
@@ -110,6 +110,7 @@ temporary_exceptions:
       - reports/gtm/2026-05-04-gtm-production-decline-forecast.html
       - reports/hse/intervention-hse-patterns-2026-05-18-explore.json
       - reports/hse/intervention-hse-patterns-2026-05-18.md
+      - reports/hse/mooring-fatigue-grounded-card.html
       - reports/hse/wrk012_hse_data_audit.md
       - reports/hse/wrk013_hse_mishap_analysis.md
       - reports/imo_gisis_analysis_report.py

--- a/reports/hse/mooring-fatigue-grounded-card.html
+++ b/reports/hse/mooring-fatigue-grounded-card.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Mooring Fatigue — Deepwater Semi, 8-line Chain-Polyester — Grounded Analysis</title>
+<script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+<style>
+  :root { --ink:#0f172a; --muted:#475569; --line:#e2e8f0; --accent:#0b5394; }
+  * { box-sizing:border-box; }
+  body { font:15px/1.5 -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
+         color:var(--ink); margin:0; background:#f8fafc; }
+  .card { max-width:880px; margin:24px auto; background:#fff; border:1px solid var(--line);
+          border-radius:12px; overflow:hidden; box-shadow:0 1px 3px rgba(0,0,0,.06); }
+  header { padding:20px 24px; background:var(--accent); color:#fff; }
+  header h1 { margin:0; font-size:20px; }
+  header p { margin:4px 0 0; opacity:.9; font-size:13px; }
+  section { padding:18px 24px; border-top:1px solid var(--line); }
+  section h2 { font-size:13px; text-transform:uppercase; letter-spacing:.04em;
+               color:var(--muted); margin:0 0 12px; }
+  .headline { font-size:17px; font-weight:600; margin:0 0 12px; }
+  .metrics { display:flex; gap:18px; flex-wrap:wrap; }
+  .metric { background:#f1f5f9; border-radius:8px; padding:10px 14px; min-width:120px; }
+  .m-val { font-size:18px; font-weight:700; color:var(--accent); }
+  .m-lab { font-size:12px; color:var(--muted); }
+  .basis { font-size:12px; color:var(--muted); margin-top:10px; }
+  ul.incidents { list-style:none; margin:0; padding:0; }
+  li.incident { display:grid; grid-template-columns:92px 110px 1fr; gap:6px 12px;
+                align-items:baseline; padding:10px 0; border-bottom:1px dashed var(--line); }
+  li.incident:last-child { border-bottom:none; }
+  .date { font-variant-numeric:tabular-nums; font-weight:600; }
+  .badge { color:#fff; font-size:11px; padding:2px 8px; border-radius:10px; text-align:center;
+           justify-self:start; }
+  .loc { grid-column:3; font-weight:600; }
+  .desc { grid-column:3; color:var(--ink); }
+  .src { grid-column:3; font-size:12px; color:var(--muted); }
+  #timeline { width:100%; height:300px; }
+  footer { padding:14px 24px; background:#f1f5f9; font-size:12px; color:var(--muted); }
+  footer .vintage { font-weight:600; color:var(--ink); }
+</style></head>
+<body><div class="card">
+  <header>
+    <h1>Mooring Fatigue — Deepwater Semi, 8-line Chain-Polyester</h1>
+    <p>Engineering analysis, grounded in real-world precedent</p>
+  </header>
+
+  <section>
+    <h2>Engineering result</h2>
+    <p class="headline">Minimum fatigue life 18.4 yr at the fairlead chain — below the 25-yr design basis.</p>
+    <div class="metrics"><div class="metric"><div class="m-val">Min fatigue life (fairlead)</div><div class="m-lab">18.4 yr</div></div><div class="metric"><div class="m-val">Max annual damage / line</div><div class="m-lab">0.74</div></div><div class="metric"><div class="m-val">Governing line</div><div class="m-lab">Line 3</div></div><div class="metric"><div class="m-val">Design basis</div><div class="m-lab">25 yr</div></div></div>
+    <p class="basis">T-N curve screening (DNV-OS-E301), spectral fatigue across the scatter diagram · Illustrative result from the mooring_fatigue workflow (parametric pilot, dm#796); replace with a live run when wired.</p>
+  </section>
+
+  <section>
+    <h2>Real-world precedent — Mooring / station-keeping failure</h2>
+    <div id="timeline"></div>
+    <p style="font-size:13px;color:var(--muted);margin:.5em 0 0">
+      Latest on record (circles) and highest-consequence on record (diamonds). Hover for detail.</p>
+  </section>
+
+  <section>
+    <h2>Latest on record</h2>
+    <ul class="incidents"><li class="incident"><span class="date">2020-01-29</span><span class="badge" style="background:#1d4ed8">property_&gt;$25k</span><span class="loc">MC 437 G33733</span><span class="desc">Incident &gt;$25K - Mooring line</span><span class="src">BSEE (offshore)</span></li><li class="incident"><span class="date">2006-12-24</span><span class="badge" style="background:#a16207">environmental</span><span class="loc">GoM (unspecified)</span><span class="desc">Pollution - Anchor drag</span><span class="src">BSEE (offshore)</span></li></ul>
+  </section>
+
+  <section>
+    <h2>Highest-consequence on record</h2>
+    <ul class="incidents"><li class="incident"><span class="date">2005-09-23</span><span class="badge" style="background:#b91c1c">catastrophic</span><span class="loc">GC 237 G15563</span><span class="desc">Pollution - Capsized - Mooring Failure</span><span class="src">BSEE (offshore)</span></li><li class="incident"><span class="date">2002-10-03</span><span class="badge" style="background:#b91c1c">catastrophic</span><span class="loc">SS 126 G12940</span><span class="desc">Pollution - Capsized during Hurricane Lili</span><span class="src">BSEE (offshore)</span></li></ul>
+  </section>
+
+  <footer>
+    <div class="vintage">Data vintage: BSEE incident investigations; corpus current to 2026-01-08.</div>
+    Source: BSEE incident investigations (data.bsee.gov), public record. Incidents are cited by area block + lease and date only —
+    no operator names (aggregation policy). Generated 2026-06-18.
+  </footer>
+</div>
+<script>
+  Plotly.newPlot("timeline", [{"x": ["2020-01-29", "2006-12-24"], "y": [30, 50], "text": ["2020-01-29 \u00b7 MC 437 G33733<br>Incident >$25K - Mooring line<br><b>property_>$25k</b> (BSEE (offshore))", "2006-12-24 \u00b7 GoM (unspecified)<br>Pollution - Anchor drag<br><b>environmental</b> (BSEE (offshore))"], "mode": "markers", "name": "Latest on record", "type": "scatter", "marker": {"size": 16, "symbol": "circle", "color": ["#1d4ed8", "#a16207"], "line": {"width": 1.5, "color": "#1e293b"}}, "hovertemplate": "%{text}<extra></extra>"}, {"x": ["2005-09-23", "2002-10-03"], "y": [90, 90], "text": ["2005-09-23 \u00b7 GC 237 G15563<br>Pollution - Capsized - Mooring Failure<br><b>catastrophic</b> (BSEE (offshore))", "2002-10-03 \u00b7 SS 126 G12940<br>Pollution - Capsized during Hurricane Lili<br><b>catastrophic</b> (BSEE (offshore))"], "mode": "markers", "name": "Highest-consequence", "type": "scatter", "marker": {"size": 16, "symbol": "diamond", "color": ["#b91c1c", "#b91c1c"], "line": {"width": 1.5, "color": "#1e293b"}}, "hovertemplate": "%{text}<extra></extra>"}], {
+    margin:{t:10,r:10,b:36,l:44},
+    xaxis:{title:"Incident date", type:"date"},
+    yaxis:{title:"Severity rank", range:[0,105]},
+    legend:{orientation:"h", y:1.15},
+    hoverlabel:{align:"left"},
+    plot_bgcolor:"#fff", paper_bgcolor:"#fff"
+  }, {displaylogo:false, responsive:true});
+</script>
+</body></html>

--- a/scripts/demo/generate_mooring_grounded_card.py
+++ b/scripts/demo/generate_mooring_grounded_card.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# ABOUTME: Generates the first published mooring-fatigue grounded card (demo, #490).
+# ABOUTME: Pairs the live BSEE grounding with a mooring_fatigue analysis result -> HTML.
+
+"""Generate the mooring-fatigue grounded card.
+
+Tracer artifact for the grounded-analysis demo stream (#486, demo slice #490):
+runs the real BSEE grounding for mooring fatigue and pairs it with a
+representative mooring_fatigue engineering result (from the parametric pilot,
+dm#796), rendering one self-contained HTML card.
+
+Usage::
+
+    python scripts/demo/generate_mooring_grounded_card.py \
+        [--out reports/hse/mooring-fatigue-grounded-card.html]
+
+The grounding numbers are 100% real public BSEE records; the engineering panel
+is labelled as illustrative from the mooring_fatigue workflow until wired to a
+live run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+from pathlib import Path
+
+from worldenergydata.hse.grounding import ground
+from worldenergydata.hse.grounding_card import AnalysisSummary, render_html
+
+# Representative mooring_fatigue result (illustrative; from the workflow pilot).
+ANALYSIS = AnalysisSummary(
+    title="Mooring Fatigue — Deepwater Semi, 8-line Chain-Polyester",
+    headline="Minimum fatigue life 18.4 yr at the fairlead chain — below the 25-yr design basis.",
+    metrics=[
+        ("18.4 yr", "Min fatigue life (fairlead)"),
+        ("0.74", "Max annual damage / line"),
+        ("Line 3", "Governing line"),
+        ("25 yr", "Design basis"),
+    ],
+    method="T-N curve screening (DNV-OS-E301), spectral fatigue across the scatter diagram",
+    basis="Illustrative result from the mooring_fatigue workflow (parametric pilot, dm#796); "
+    "replace with a live run when wired.",
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", default="reports/hse/mooring-fatigue-grounded-card.html")
+    a = ap.parse_args(argv)
+
+    g = ground("mooring_fatigue")
+    generated_on = dt.date.today().isoformat()
+    html_doc = render_html(g.to_dict(), ANALYSIS, generated_on)
+
+    out = Path(a.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(html_doc, encoding="utf-8")
+
+    counts = g.source_counts
+    print(f"wrote {out} ({len(html_doc):,} bytes)")
+    print(f"  failure mode : {g.failure_mode}")
+    print(f"  latest       : {[i.date for i in g.latest]}")
+    print(f"  most severe  : {[(i.date, i.severity) for i in g.most_severe]}")
+    print(f"  sources      : {counts}")
+    print(f"  vintage      : {g.vintage_note}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/worldenergydata/hse/grounding_card.py
+++ b/src/worldenergydata/hse/grounding_card.py
@@ -1,0 +1,208 @@
+# ABOUTME: Renders an HSE grounding as a self-contained HTML card for client-facing demos.
+# ABOUTME: Pairs an engineering analysis result with real-world precedent incidents + vintage.
+
+"""Grounding card renderer.
+
+Turns a :class:`~worldenergydata.hse.grounding.Grounding` plus a short engineering
+analysis summary into one self-contained HTML card — the client-facing artifact
+of the grounded-analysis demo stream (epic #486): an engineering result, then the
+real-world incidents that ground it, then a data-vintage trust stamp.
+
+Per HTML_REPORTING_STANDARDS the card carries an interactive Plotly timeline of
+the precedent incidents (hover = description/location/severity). The card is
+pure: no network, no session state; it takes the grounding dict
+(``Grounding.to_dict()``) and an :class:`AnalysisSummary`.
+
+Operator Aggregation Contract (#423): the grounding cites lease blocks + dates,
+never operator names — enforced upstream in ``grounding.py`` and tested here.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+from dataclasses import dataclass, field
+
+PLOTLY_CDN = "https://cdn.plot.ly/plotly-2.35.2.min.js"
+
+
+@dataclass
+class AnalysisSummary:
+    """The engineering result the grounding is attached to.
+
+    Values are populated from a real digitalmodel run when wired; for the demo
+    they come from the mooring_fatigue workflow (parametric pilot dm#796) and
+    are labelled accordingly via ``basis``.
+    """
+
+    title: str
+    headline: str  # one-line result, e.g. "Min fatigue life 18.4 yr at fairlead"
+    metrics: list[tuple[str, str]] = field(default_factory=list)  # (label, value)
+    method: str = ""
+    basis: str = ""  # provenance/attribution for the analysis numbers
+
+
+_SEVERITY_COLOR = {
+    "fatality": "#7f1d1d",
+    "catastrophic": "#b91c1c",
+    "lost_time": "#c2410c",
+    "environmental": "#a16207",
+    "injury": "#b45309",
+    "property_>$25k": "#1d4ed8",
+    "minor": "#475569",
+}
+
+
+def _esc(s: str) -> str:
+    return html.escape(str(s), quote=True)
+
+
+def _incident_li(i: dict) -> str:
+    color = _SEVERITY_COLOR.get(i["severity"], "#475569")
+    return (
+        '<li class="incident">'
+        f'<span class="date">{_esc(i["date"])}</span>'
+        f'<span class="badge" style="background:{color}">{_esc(i["severity"])}</span>'
+        f'<span class="loc">{_esc(i["location"])}</span>'
+        f'<span class="desc">{_esc(i["description"])}</span>'
+        f'<span class="src">{_esc(i["source"])}</span>'
+        "</li>"
+    )
+
+
+def _timeline_traces(grounding: dict) -> str:
+    """Build the Plotly data array (JSON) for the incident timeline."""
+
+    def pts(items, name, symbol):
+        return {
+            "x": [i["date"] for i in items],
+            "y": [i["severity_rank"] for i in items],
+            "text": [
+                f"{i['date']} · {i['location']}<br>{i['description']}<br>"
+                f"<b>{i['severity']}</b> ({i['source']})"
+                for i in items
+            ],
+            "mode": "markers",
+            "name": name,
+            "type": "scatter",
+            "marker": {
+                "size": 16,
+                "symbol": symbol,
+                "color": [_SEVERITY_COLOR.get(i["severity"], "#475569") for i in items],
+                "line": {"width": 1.5, "color": "#1e293b"},
+            },
+            "hovertemplate": "%{text}<extra></extra>",
+        }
+
+    data = [
+        pts(grounding["latest_2"], "Latest on record", "circle"),
+        pts(grounding["most_severe_2"], "Highest-consequence", "diamond"),
+    ]
+    return json.dumps(data)
+
+
+def render_html(
+    grounding: dict,
+    analysis: AnalysisSummary,
+    generated_on: str,
+    *,
+    data_source: str = "BSEE incident investigations (data.bsee.gov), public record",
+) -> str:
+    """Render the grounding + analysis as one self-contained HTML document."""
+    latest = "".join(_incident_li(i) for i in grounding["latest_2"])
+    severe = "".join(_incident_li(i) for i in grounding["most_severe_2"])
+    metrics = "".join(
+        f'<div class="metric"><div class="m-val">{_esc(v)}</div>'
+        f'<div class="m-lab">{_esc(k)}</div></div>'
+        for k, v in analysis.metrics
+    )
+    vintage = grounding.get("vintage_note", "")
+    traces = _timeline_traces(grounding)
+    sep = " · " if analysis.method and analysis.basis else ""
+    basis_line = f"{_esc(analysis.method)}{sep}{_esc(analysis.basis)}"
+
+    return f"""<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{_esc(analysis.title)} — Grounded Analysis</title>
+<script src="{PLOTLY_CDN}"></script>
+<style>
+  :root {{ --ink:#0f172a; --muted:#475569; --line:#e2e8f0; --accent:#0b5394; }}
+  * {{ box-sizing:border-box; }}
+  body {{ font:15px/1.5 -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
+         color:var(--ink); margin:0; background:#f8fafc; }}
+  .card {{ max-width:880px; margin:24px auto; background:#fff; border:1px solid var(--line);
+          border-radius:12px; overflow:hidden; box-shadow:0 1px 3px rgba(0,0,0,.06); }}
+  header {{ padding:20px 24px; background:var(--accent); color:#fff; }}
+  header h1 {{ margin:0; font-size:20px; }}
+  header p {{ margin:4px 0 0; opacity:.9; font-size:13px; }}
+  section {{ padding:18px 24px; border-top:1px solid var(--line); }}
+  section h2 {{ font-size:13px; text-transform:uppercase; letter-spacing:.04em;
+               color:var(--muted); margin:0 0 12px; }}
+  .headline {{ font-size:17px; font-weight:600; margin:0 0 12px; }}
+  .metrics {{ display:flex; gap:18px; flex-wrap:wrap; }}
+  .metric {{ background:#f1f5f9; border-radius:8px; padding:10px 14px; min-width:120px; }}
+  .m-val {{ font-size:18px; font-weight:700; color:var(--accent); }}
+  .m-lab {{ font-size:12px; color:var(--muted); }}
+  .basis {{ font-size:12px; color:var(--muted); margin-top:10px; }}
+  ul.incidents {{ list-style:none; margin:0; padding:0; }}
+  li.incident {{ display:grid; grid-template-columns:92px 110px 1fr; gap:6px 12px;
+                align-items:baseline; padding:10px 0; border-bottom:1px dashed var(--line); }}
+  li.incident:last-child {{ border-bottom:none; }}
+  .date {{ font-variant-numeric:tabular-nums; font-weight:600; }}
+  .badge {{ color:#fff; font-size:11px; padding:2px 8px; border-radius:10px; text-align:center;
+           justify-self:start; }}
+  .loc {{ grid-column:3; font-weight:600; }}
+  .desc {{ grid-column:3; color:var(--ink); }}
+  .src {{ grid-column:3; font-size:12px; color:var(--muted); }}
+  #timeline {{ width:100%; height:300px; }}
+  footer {{ padding:14px 24px; background:#f1f5f9; font-size:12px; color:var(--muted); }}
+  footer .vintage {{ font-weight:600; color:var(--ink); }}
+</style></head>
+<body><div class="card">
+  <header>
+    <h1>{_esc(analysis.title)}</h1>
+    <p>Engineering analysis, grounded in real-world precedent</p>
+  </header>
+
+  <section>
+    <h2>Engineering result</h2>
+    <p class="headline">{_esc(analysis.headline)}</p>
+    <div class="metrics">{metrics}</div>
+    <p class="basis">{basis_line}</p>
+  </section>
+
+  <section>
+    <h2>Real-world precedent — {_esc(grounding["failure_mode"])}</h2>
+    <div id="timeline"></div>
+    <p style="font-size:13px;color:var(--muted);margin:.5em 0 0">
+      Latest on record (circles) and highest-consequence on record (diamonds). Hover for detail.</p>
+  </section>
+
+  <section>
+    <h2>Latest on record</h2>
+    <ul class="incidents">{latest}</ul>
+  </section>
+
+  <section>
+    <h2>Highest-consequence on record</h2>
+    <ul class="incidents">{severe}</ul>
+  </section>
+
+  <footer>
+    <div class="vintage">Data vintage: {_esc(vintage)}.</div>
+    Source: {_esc(data_source)}. Incidents are cited by area block + lease and date only —
+    no operator names (aggregation policy). Generated {_esc(generated_on)}.
+  </footer>
+</div>
+<script>
+  Plotly.newPlot("timeline", {traces}, {{
+    margin:{{t:10,r:10,b:36,l:44}},
+    xaxis:{{title:"Incident date", type:"date"}},
+    yaxis:{{title:"Severity rank", range:[0,105]}},
+    legend:{{orientation:"h", y:1.15}},
+    hoverlabel:{{align:"left"}},
+    plot_bgcolor:"#fff", paper_bgcolor:"#fff"
+  }}, {{displaylogo:false, responsive:true}});
+</script>
+</body></html>"""

--- a/tests/unit/hse/test_grounding_card.py
+++ b/tests/unit/hse/test_grounding_card.py
@@ -1,0 +1,76 @@
+# ABOUTME: Tests for worldenergydata.hse.grounding_card — HTML grounding card renderer.
+# ABOUTME: Pure render; no network. Verifies structure, vintage, and no-operator-names.
+
+"""Tests for the grounding card renderer (#490)."""
+
+from __future__ import annotations
+
+from html.parser import HTMLParser
+from pathlib import Path
+
+from worldenergydata.hse.grounding import ground
+from worldenergydata.hse.grounding_card import AnalysisSummary, render_html
+
+FIXTURE = Path(__file__).parent / "fixtures" / "bsee_incinv_sample.txt"
+
+ANALYSIS = AnalysisSummary(
+    title="Mooring Fatigue — Test",
+    headline="Min fatigue life 18.4 yr at the fairlead.",
+    metrics=[("18.4 yr", "Min fatigue life"), ("Line 3", "Governing line")],
+    method="T-N screening",
+    basis="illustrative",
+)
+
+
+def _doc():
+    g = ground("mooring_fatigue", bsee_path=FIXTURE).to_dict()
+    return render_html(g, ANALYSIS, generated_on="2026-06-18")
+
+
+def test_html_is_well_formed():
+    # HTMLParser raises on malformed markup via our error override path
+    class P(HTMLParser):
+        def error(self, message):  # pragma: no cover - only on bad markup
+            raise ValueError(message)
+
+    P().feed(_doc())
+
+
+def test_card_carries_interactive_plot():
+    doc = _doc()
+    assert "cdn.plot.ly" in doc
+    assert "Plotly.newPlot" in doc
+
+
+def test_vintage_stamp_present():
+    assert "current to 2020-01-29" in _doc()  # fixture's newest record
+
+
+def test_analysis_panel_rendered():
+    doc = _doc()
+    assert "Min fatigue life 18.4 yr at the fairlead." in doc
+    assert "Line 3" in doc
+
+
+def test_real_incidents_present():
+    doc = _doc()
+    assert "MC 437" in doc and "GC 237" in doc
+
+
+def test_no_operator_names_and_attribution():
+    doc = _doc().lower()
+    # no operator/company names (Operator Aggregation Contract, #423)
+    for banned in ("chevron", "shell", "apache", "exxon", "hess", "talos"):
+        assert banned not in doc
+    # the policy disclaimer + data attribution must be present
+    assert "no operator names" in doc
+    assert "data.bsee.gov" in doc
+
+
+def test_html_escaping_of_analysis_fields():
+    a = AnalysisSummary(title="A & B <x>", headline="risk > 1", metrics=[])
+    doc = render_html(
+        ground("mooring_fatigue", bsee_path=FIXTURE).to_dict(), a, "2026-06-18"
+    )
+    assert "A &amp; B &lt;x&gt;" in doc
+    assert "risk &gt; 1" in doc


### PR DESCRIPTION
## First published artifact of the grounded-analysis stream (#486)

Render + demo slice — closes #490. Pairs an engineering result with its
real-world precedent in one self-contained HTML card.

### What's here
- `src/worldenergydata/hse/grounding_card.py` — `render_html(grounding, AnalysisSummary, generated_on)`. Pure renderer (no network/session). Interactive **Plotly** incident timeline per HTML_REPORTING_STANDARDS, severity badges, vintage trust stamp, data attribution.
- `scripts/demo/generate_mooring_grounded_card.py` — pairs the **live BSEE mooring grounding** (4 real GoM incidents) with the `mooring_fatigue` workflow result (parametric pilot dm#796).
- `reports/hse/mooring-fatigue-grounded-card.html` — the published artifact (6.6 KB, self-contained).
- `tests/unit/hse/test_grounding_card.py` — 7 tests (well-formedness, interactive plot, vintage, HTML escaping, no operator names, attribution).

### The card
- **Engineering result:** min fatigue life 18.4 yr at the fairlead vs 25-yr design (illustrative, labelled as from the mooring_fatigue workflow until wired to a live run).
- **Real-world precedent (100% real public BSEE):** latest = 2020 mooring-line incident (MC 437), 2006 anchor drag; most severe = 2005 capsize/mooring failure (GC 237), 2002 jack-up capsize during Hurricane Lili (SS 126).
- **Vintage stamp:** "BSEE incident investigations; corpus current to 2026-01-08."

### Contract compliance
Incidents cited by area block + lease + date only — **no operator names** (Operator Aggregation Contract, #423), enforced by a test. Data attributed to data.bsee.gov.

### Verified
`pytest tests/unit/hse/test_grounding.py tests/unit/hse/test_grounding_card.py` → **16 passed**. black + isort + flake8 clean.

Part of epic #486 · pairs with deckhand #448 (publish to the sandbox gallery). Builds on #487 (engine, merged via #492).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
