### PR TITLE
feat(hse): grounding demand signal — log requests, rank coverage gaps (#491)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -314,3 +314,4 @@ archive/
 # Agent worktrees (local-only, must not be tracked as gitlinks)
 .claude/worktrees/
 examples/workflows/*/outputs/
+data/modules/hse/grounding_demand.jsonl

--- a/src/worldenergydata/hse/grounding_demand.py
+++ b/src/worldenergydata/hse/grounding_demand.py
@@ -1,0 +1,235 @@
+# ABOUTME: Demand signal for HSE incident grounding — logs requests, ranks coverage gaps.
+# ABOUTME: Misses (unknown / thin failure modes) name the next coverage to build (#491).
+
+"""Grounding demand signal.
+
+What turns the grounded-analysis stream (epic #486) from a static library into a
+flywheel: log which failure modes get *requested*, then roll the log up into a
+ranked list of coverage gaps. A request for a mode we don't have — or one whose
+corpus is too thin to fill 2-latest + 2-severe — is the gold: it names the next
+``FAILURE_MODES`` entry to add (feeding the coverage child #488).
+
+Mirrors the deckhand demand-signal pattern (deckhand#368): read the signal, rank
+into priority tiers, emit markdown.
+
+Flow::
+
+    from worldenergydata.hse.grounding_demand import ground_and_log, rollup, load_demand
+
+    ground_and_log("riser_viv_fatigue")     # unknown -> logged as a GAP, re-raises
+    ground_and_log("mooring_fatigue")        # covered -> logged as a HIT
+    print(render_rollup_md(rollup(load_demand())))
+
+CLI::
+
+    python -m worldenergydata.hse.grounding_demand --rollup [--out FILE]
+    python -m worldenergydata.hse.grounding_demand --record <failure_mode>
+
+The log is JSONL (one request per line) so it is append-only and trivially
+mergeable. ``MIN_COVERAGE`` is the corpus size needed to fill a card (2+2).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Optional
+
+from worldenergydata.hse.grounding import FAILURE_MODES, ground
+
+# Need >= 4 matched incidents to fill 2-latest + 2-highest-severity.
+MIN_COVERAGE = 4
+
+DEFAULT_LOG = (
+    Path(__file__).resolve().parents[3] / "data/modules/hse/grounding_demand.jsonl"
+)
+
+
+def _today() -> str:
+    return dt.date.today().isoformat()
+
+
+def record_demand(
+    failure_mode: str,
+    *,
+    covered: bool,
+    n_incidents: int,
+    reason: str = "",
+    when: Optional[str] = None,
+    log_path: str | Path = DEFAULT_LOG,
+) -> dict[str, Any]:
+    """Append one demand record (JSONL) and return it."""
+    rec = {
+        "when": when or _today(),
+        "failure_mode": failure_mode,
+        "covered": bool(covered),
+        "n_incidents": int(n_incidents),
+        "reason": reason,
+    }
+    p = Path(log_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(rec) + "\n")
+    return rec
+
+
+def _matched_count(grounding) -> int:
+    return sum(v for v in grounding.source_counts.values() if isinstance(v, int))
+
+
+def ground_and_log(
+    failure_mode: str,
+    *,
+    when: Optional[str] = None,
+    log_path: str | Path = DEFAULT_LOG,
+    bsee_path: Optional[Path] = None,
+):
+    """Run :func:`ground` and record the demand. Returns the Grounding.
+
+    Records a GAP and re-raises ``KeyError`` for an unknown mode; records a GAP
+    (``reason='thin_corpus'``) when a known mode matches < ``MIN_COVERAGE``; else
+    records a HIT.
+    """
+    if failure_mode not in FAILURE_MODES:
+        record_demand(
+            failure_mode,
+            covered=False,
+            n_incidents=0,
+            reason="unknown_mode",
+            when=when,
+            log_path=log_path,
+        )
+        raise KeyError(
+            f"unknown failure_mode {failure_mode!r}; known: {sorted(FAILURE_MODES)}"
+        )
+    g = ground(failure_mode, bsee_path=bsee_path)
+    n = _matched_count(g)
+    covered = n >= MIN_COVERAGE
+    record_demand(
+        failure_mode,
+        covered=covered,
+        n_incidents=n,
+        reason="" if covered else "thin_corpus",
+        when=when,
+        log_path=log_path,
+    )
+    return g
+
+
+def load_demand(log_path: str | Path = DEFAULT_LOG) -> list[dict[str, Any]]:
+    p = Path(log_path)
+    if not p.exists():
+        return []
+    out = []
+    for line in p.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            out.append(json.loads(line))
+    return out
+
+
+def rollup(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate demand per failure mode and rank coverage gaps first.
+
+    A mode is a GAP if it is unknown (not in ``FAILURE_MODES``) or its corpus is
+    thin (every request saw < ``MIN_COVERAGE`` incidents). Gaps rank by request
+    count (most-requested gap = build next).
+    """
+    agg: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {"requests": 0, "max_incidents": 0, "reasons": set()}
+    )
+    for r in records:
+        a = agg[r["failure_mode"]]
+        a["requests"] += 1
+        a["max_incidents"] = max(a["max_incidents"], int(r.get("n_incidents", 0)))
+        if r.get("reason"):
+            a["reasons"].add(r["reason"])
+
+    gaps, covered = [], []
+    for mode, a in agg.items():
+        known = mode in FAILURE_MODES
+        is_gap = (not known) or a["max_incidents"] < MIN_COVERAGE
+        entry = {
+            "failure_mode": mode,
+            "requests": a["requests"],
+            "max_incidents": a["max_incidents"],
+            "status": ("unknown" if not known else "thin" if is_gap else "covered"),
+            "reasons": sorted(a["reasons"]),
+        }
+        (gaps if is_gap else covered).append(entry)
+
+    gaps.sort(key=lambda e: (e["requests"], -ord(e["status"][0])), reverse=True)
+    covered.sort(key=lambda e: e["requests"], reverse=True)
+    return {
+        "total_requests": sum(a["requests"] for a in agg.values()),
+        "gaps": gaps,
+        "covered": covered,
+    }
+
+
+def render_rollup_md(roll: dict[str, Any]) -> str:
+    L = ["# HSE grounding — demand signal", ""]
+    L.append(
+        "> Generated by `worldenergydata.hse.grounding_demand` (#491). "
+        "Ranks requested failure modes; **gaps are the next coverage to build** (#488)."
+    )
+    L.append("")
+    L.append(
+        f"**{roll['total_requests']} requests** · "
+        f"{len(roll['gaps'])} coverage gap(s) · {len(roll['covered'])} covered."
+    )
+    L.append("")
+    if roll["gaps"]:
+        L.append("## Coverage gaps — build next (most-requested first)")
+        L.append("")
+        L.append("| Failure mode | Requests | Status | Max incidents |")
+        L.append("|---|---:|---|---:|")
+        for e in roll["gaps"]:
+            L.append(
+                f"| `{e['failure_mode']}` | {e['requests']} | {e['status']} "
+                f"| {e['max_incidents']} |"
+            )
+        L.append("")
+    if roll["covered"]:
+        L.append("## Covered (served a full 2+2 card)")
+        L.append("")
+        for e in roll["covered"]:
+            L.append(f"- `{e['failure_mode']}` — {e['requests']} request(s)")
+    return "\n".join(L)
+
+
+def _main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="HSE grounding demand signal")
+    ap.add_argument("--log", default=str(DEFAULT_LOG))
+    ap.add_argument(
+        "--rollup", action="store_true", help="emit the ranked rollup (markdown)"
+    )
+    ap.add_argument(
+        "--record", metavar="MODE", help="run + log a grounding request for MODE"
+    )
+    ap.add_argument("--out", help="write rollup markdown to FILE instead of stdout")
+    a = ap.parse_args(argv)
+
+    if a.record:
+        try:
+            g = ground_and_log(a.record, log_path=a.log)
+            print(f"logged HIT: {a.record} ({_matched_count(g)} incidents)")
+        except KeyError:
+            print(f"logged GAP: {a.record} (unknown mode)")
+        return 0
+
+    md = render_rollup_md(rollup(load_demand(a.log)))
+    if a.out:
+        Path(a.out).parent.mkdir(parents=True, exist_ok=True)
+        Path(a.out).write_text(md, encoding="utf-8")
+        print(f"wrote {a.out}")
+    else:
+        print(md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tests/unit/hse/test_grounding_demand.py
+++ b/tests/unit/hse/test_grounding_demand.py
@@ -1,0 +1,131 @@
+# ABOUTME: Tests for worldenergydata.hse.grounding_demand — request logging + gap rollup.
+# ABOUTME: Fixture-backed; no NFS share or network dependency in CI.
+
+"""Tests for the grounding demand signal (#491)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from worldenergydata.hse.grounding_demand import (
+    ground_and_log,
+    load_demand,
+    record_demand,
+    render_rollup_md,
+    rollup,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "bsee_incinv_sample.txt"
+
+
+def test_record_and_load_roundtrip(tmp_path):
+    log = tmp_path / "demand.jsonl"
+    record_demand(
+        "mooring_fatigue", covered=True, n_incidents=6, when="2026-06-19", log_path=log
+    )
+    record_demand(
+        "riser_viv",
+        covered=False,
+        n_incidents=0,
+        reason="unknown_mode",
+        when="2026-06-19",
+        log_path=log,
+    )
+    recs = load_demand(log)
+    assert len(recs) == 2
+    assert recs[0]["failure_mode"] == "mooring_fatigue" and recs[0]["covered"] is True
+    assert recs[1]["reason"] == "unknown_mode"
+
+
+def test_ground_and_log_hit_for_known_mode(tmp_path):
+    log = tmp_path / "demand.jsonl"
+    g = ground_and_log(
+        "mooring_fatigue", when="2026-06-19", log_path=log, bsee_path=FIXTURE
+    )
+    assert g.failure_mode.startswith("Mooring")
+    rec = load_demand(log)[0]
+    assert rec["covered"] is True and rec["n_incidents"] >= 4
+
+
+def test_ground_and_log_gap_for_unknown_mode(tmp_path):
+    log = tmp_path / "demand.jsonl"
+    with pytest.raises(KeyError):
+        ground_and_log(
+            "riser_viv_fatigue", when="2026-06-19", log_path=log, bsee_path=FIXTURE
+        )
+    rec = load_demand(log)[0]
+    assert rec["failure_mode"] == "riser_viv_fatigue"
+    assert rec["covered"] is False and rec["reason"] == "unknown_mode"
+
+
+def test_rollup_ranks_gaps_by_request_count(tmp_path):
+    log = tmp_path / "demand.jsonl"
+    # riser_viv requested 3x (unknown), subsea_landslide 1x (unknown), mooring covered
+    for _ in range(3):
+        record_demand(
+            "riser_viv",
+            covered=False,
+            n_incidents=0,
+            reason="unknown_mode",
+            when="2026-06-19",
+            log_path=log,
+        )
+    record_demand(
+        "subsea_landslide",
+        covered=False,
+        n_incidents=0,
+        reason="unknown_mode",
+        when="2026-06-19",
+        log_path=log,
+    )
+    record_demand(
+        "mooring_fatigue", covered=True, n_incidents=6, when="2026-06-19", log_path=log
+    )
+
+    roll = rollup(load_demand(log))
+    assert roll["total_requests"] == 5
+    gap_modes = [g["failure_mode"] for g in roll["gaps"]]
+    assert gap_modes[0] == "riser_viv"  # most-requested gap ranks first
+    assert "subsea_landslide" in gap_modes
+    assert [c["failure_mode"] for c in roll["covered"]] == ["mooring_fatigue"]
+
+
+def test_thin_corpus_counts_as_gap(tmp_path):
+    log = tmp_path / "demand.jsonl"
+    # a known mode that only ever matched 2 incidents -> thin, still a gap
+    record_demand(
+        "dropped_object",
+        covered=False,
+        n_incidents=2,
+        reason="thin_corpus",
+        when="2026-06-19",
+        log_path=log,
+    )
+    roll = rollup(load_demand(log))
+    statuses = {g["failure_mode"]: g["status"] for g in roll["gaps"]}
+    assert statuses["dropped_object"] == "thin"
+
+
+def test_render_rollup_md_flags_gaps():
+    roll = rollup(
+        [
+            {
+                "failure_mode": "riser_viv",
+                "covered": False,
+                "n_incidents": 0,
+                "reason": "unknown_mode",
+            },
+            {
+                "failure_mode": "mooring_fatigue",
+                "covered": True,
+                "n_incidents": 6,
+                "reason": "",
+            },
+        ]
+    )
+    md = render_rollup_md(roll)
+    assert "Coverage gaps — build next" in md
+    assert "riser_viv" in md
+    assert "next coverage to build" in md


### PR DESCRIPTION
## Feedback slice — what makes it a flywheel (#491)

Closes #491. Turns the grounded-analysis stream (epic #486) from a static library into a self-feeding loop: log which failure modes get **requested**, then rank coverage gaps so the most-demanded missing mode is the next one to build (#488).

Mirrors the deckhand demand-signal pattern (deckhand#368): read signal → rank → emit markdown.

### What's here
- `src/worldenergydata/hse/grounding_demand.py`
  - `ground_and_log()` — runs `ground()` and records the demand: **HIT** (covered), **thin** (known but < 4 incidents, can't fill 2+2), or **unknown** (no such mode → re-raises).
  - `record_demand()` / `load_demand()` — append-only JSONL (mergeable across hosts).
  - `rollup()` — aggregates per mode; gaps ranked by request count, most-requested first. `render_rollup_md()` emits the build-next table.
  - CLI: `python -m worldenergydata.hse.grounding_demand --record <mode> | --rollup [--out FILE]`.
- demand log is gitignored (runtime artifact).
- `tests/unit/hse/test_grounding_demand.py` — 6 tests.

### The loop, demonstrated
```
$ ... --record riser_viv_fatigue      # logged GAP: unknown mode
$ ... --record riser_viv_fatigue      # logged GAP
$ ... --record mooring_fatigue        # logged HIT: 6 incidents
$ ... --rollup
## Coverage gaps — build next (most-requested first)
| Failure mode        | Requests | Status  | Max incidents |
| `riser_viv_fatigue` | 2        | unknown | 0             |
```
The most-requested missing mode surfaces as the #1 thing to add — directly feeding the coverage child #488.

### Verified
6 tests pass; black + isort + flake8 clean.

Part of epic #486. Follow-up: wire `ground_and_log()` into the live bot grounding call path so real chat requests populate the signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
