### PR TITLE
ci: single-source module-scoped PR gate via testable selector (#496)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,125 +18,22 @@ env:
 
 jobs:
   # ---------------------------------------------------------------- PR gate --
-  # Module-scoped fast gate (#474): PRs test only the modules their changed
-  # paths touch (plus the always-on cross-cutting core), on one Python, with
-  # xdist and no coverage. The full 3-Python matrix runs on push to main,
-  # nightly, manual dispatch, or PRs labeled `ci-full`.
-  changes:
-    name: Detect changed modules
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    outputs:
-      core: ${{ steps.filter.outputs.core }}
-      matched: ${{ steps.filter.outputs.changes }}
-      unclassified: ${{ steps.filter.outputs.unclassified }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Classify changed paths
-        uses: dorny/paths-filter@v4
-        id: filter
-        with:
-          filters: |
-            core:
-              - 'src/worldenergydata/engine.py'
-              - 'src/worldenergydata/__main__.py'
-              - 'src/worldenergydata/base_configs/**'
-              - 'src/worldenergydata/common/**'
-              - 'pyproject.toml'
-              - 'uv.lock'
-              - 'tests/conftest.py'
-              - 'tests/pytest.ini'
-              - '.github/workflows/ci.yml'
-            bsee:
-              - 'src/worldenergydata/bsee/**'
-              - 'tests/unit/bsee/**'
-              - 'tests/integration/modules/bsee/**'
-            fdas:
-              - 'src/worldenergydata/fdas/**'
-              - 'tests/unit/fdas/**'
-            sodir:
-              - 'src/worldenergydata/sodir/**'
-              - 'tests/unit/sodir/**'
-            texas_rrc:
-              - 'src/worldenergydata/texas_rrc/**'
-              - 'tests/unit/texas_rrc/**'
-            canada:
-              - 'src/worldenergydata/canada/**'
-              - 'tests/unit/canada/**'
-            mexico_cnh:
-              - 'src/worldenergydata/mexico_cnh/**'
-              - 'tests/unit/mexico_cnh/**'
-            landman:
-              - 'src/worldenergydata/landman/**'
-              - 'tests/unit/landman/**'
-            marine_safety:
-              - 'src/worldenergydata/marine_safety/**'
-              - 'tests/unit/marine_safety/**'
-            pipeline_safety:
-              - 'src/worldenergydata/pipeline_safety/**'
-              - 'tests/unit/pipeline_safety/**'
-            production:
-              - 'src/worldenergydata/production/**'
-              - 'tests/unit/production/**'
-            cli:
-              - 'src/worldenergydata/cli/**'
-              - 'tests/unit/cli/**'
-            workflows:
-              - 'docs/registry/**'
-              - 'examples/workflows/**'
-              - 'tests/workflows/**'
-            docs_only:
-              - '**/*.md'
-              - 'docs/**'
-            unclassified:
-              - '!src/worldenergydata/engine.py'
-              - '!src/worldenergydata/__main__.py'
-              - '!src/worldenergydata/base_configs/**'
-              - '!src/worldenergydata/common/**'
-              - '!pyproject.toml'
-              - '!uv.lock'
-              - '!tests/conftest.py'
-              - '!tests/pytest.ini'
-              - '!.github/workflows/ci.yml'
-              - '!src/worldenergydata/bsee/**'
-              - '!tests/unit/bsee/**'
-              - '!tests/integration/modules/bsee/**'
-              - '!src/worldenergydata/fdas/**'
-              - '!tests/unit/fdas/**'
-              - '!src/worldenergydata/sodir/**'
-              - '!tests/unit/sodir/**'
-              - '!src/worldenergydata/texas_rrc/**'
-              - '!tests/unit/texas_rrc/**'
-              - '!src/worldenergydata/canada/**'
-              - '!tests/unit/canada/**'
-              - '!src/worldenergydata/mexico_cnh/**'
-              - '!tests/unit/mexico_cnh/**'
-              - '!src/worldenergydata/landman/**'
-              - '!tests/unit/landman/**'
-              - '!src/worldenergydata/marine_safety/**'
-              - '!tests/unit/marine_safety/**'
-              - '!src/worldenergydata/pipeline_safety/**'
-              - '!tests/unit/pipeline_safety/**'
-              - '!src/worldenergydata/production/**'
-              - '!tests/unit/production/**'
-              - '!src/worldenergydata/cli/**'
-              - '!tests/unit/cli/**'
-              - '!docs/registry/**'
-              - '!examples/workflows/**'
-              - '!tests/workflows/**'
-              - '!**/*.md'
-              - '!docs/**'
+  # Module-scoped fast gate (#474, #496): a PR tests only the modules its changed
+  # paths touch (+ the always-on cross-cutting core), on one Python, xdist, no
+  # coverage. Targets come from scripts/ci/select_test_targets.py — the single
+  # source of truth (a module is mapped iff tests/unit/<module>/ exists; new
+  # modules auto-map, guarded by tests/ci/test_select_test_targets.py). The full
+  # 3-Python matrix runs on push to main, nightly, dispatch, or `ci-full` PRs.
 
   test-pr:
     name: Test (PR gate)
     runs-on: ubuntu-latest
-    needs: changes
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # need the base commit to diff changed files
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -153,59 +50,15 @@ jobs:
       - name: Select test targets
         id: targets
         env:
-          CORE: ${{ needs.changes.outputs.core }}
-          MATCHED: ${{ needs.changes.outputs.matched }}
-          UNCLASSIFIED: ${{ needs.changes.outputs.unclassified }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          # Always-on cross-cutting set: engine contract, assetutilities
-          # contracts, and the durable-workflow registry.
-          # Two execution buckets:
-          #   xdist — unit-style dirs, parallel-safe
-          #   seq   — tests/integration/** (a CLI edge-case test hard-exits
-          #           the process and kills xdist workers) and
-          #           tests/performance (wall-clock assertions)
-          xdist="tests/unit/core tests/unit/common tests/contracts tests/workflows"
-          seq=""
-          declare -A module_xdist=(
-            [bsee]="tests/unit/bsee"
-            [fdas]="tests/unit/fdas"
-            [sodir]="tests/unit/sodir"
-            [texas_rrc]="tests/unit/texas_rrc"
-            [canada]="tests/unit/canada"
-            [mexico_cnh]="tests/unit/mexico_cnh"
-            [landman]="tests/unit/landman"
-            [marine_safety]="tests/unit/marine_safety"
-            [pipeline_safety]="tests/unit/pipeline_safety"
-            [production]="tests/unit/production"
-            [cli]="tests/unit/cli"
-          )
-          declare -A module_seq=(
-            [bsee]="tests/integration/modules/bsee"
-          )
-          if [ "$CORE" = "true" ] || echo "$UNCLASSIFIED" | grep -q true; then
-            # Core or unmapped paths changed: fail safe, run the whole tree.
-            # Enumerate explicit targets rather than recursing tests/ with
-            # --ignore: tests/pytest.ini makes pytest's rootdir tests/, which
-            # breaks cwd-relative --ignore matching.
-            full=$(find tests -maxdepth 1 -mindepth 1 \( -type d ! -name performance ! -name integration ! -name __pycache__ \) -o -maxdepth 1 -name 'test_*.py' | sort | tr '\n' ' ')
-            echo "scope=full" >> "$GITHUB_OUTPUT"
-            echo "xdist_targets=$full" >> "$GITHUB_OUTPUT"
-            echo "seq_targets=tests/integration tests/performance" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          for mod in "${!module_xdist[@]}"; do
-            if echo "$MATCHED" | grep -q "\"$mod\""; then
-              for d in ${module_xdist[$mod]}; do
-                [ -d "$d" ] && xdist="$xdist $d"
-              done
-              for d in ${module_seq[$mod]:-}; do
-                [ -d "$d" ] && seq="$seq $d"
-              done
-            fi
-          done
-          echo "scope=modules" >> "$GITHUB_OUTPUT"
-          echo "xdist_targets=$xdist" >> "$GITHUB_OUTPUT"
-          echo "seq_targets=$seq" >> "$GITHUB_OUTPUT"
+          # Single source of truth: scripts/ci/select_test_targets.py maps the
+          # changed files to pytest targets (auto-discovers modules from the
+          # filesystem; core paths -> full tree; docs/reports-only -> just the
+          # always-on cross-cutting set). Stdlib only — no uv sync needed.
+          git diff --name-only "$BASE_SHA"...HEAD > changed-files.txt
+          echo "Changed files:"; cat changed-files.txt
+          python3 scripts/ci/select_test_targets.py --files-from changed-files.txt >> "$GITHUB_OUTPUT"
 
       - name: Run module-scoped tests (xdist)
         run: |

--- a/scripts/ci/select_test_targets.py
+++ b/scripts/ci/select_test_targets.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+# ABOUTME: Single-source PR-gate test selector — maps changed files -> pytest targets.
+# ABOUTME: Auto-discovers modules from the filesystem so new modules never drift (#496).
+
+"""Select pytest targets for the PR gate from a list of changed files.
+
+Replaces the three hand-maintained, drift-prone lists that used to live in
+``ci.yml`` (the ``dorny/paths-filter`` filters, the ``unclassified`` negation
+list, and the bash ``module_xdist`` map). The module list is now the filesystem:
+a module is "mapped" iff ``tests/unit/<module>/`` exists. Adding a module needs
+no CI edit — and the drift-guard test (``tests/ci/test_select_test_targets.py``)
+fails if any ``tests/unit/<module>`` stops being selected.
+
+Decision tree (first match wins):
+  * a **core** path changed (engine, common, base_configs, packaging, conftest,
+    the workflow itself, this selector) -> ``scope=full`` (whole tree).
+  * otherwise collect the modules touched under ``src/worldenergydata/<m>/`` or
+    ``tests/unit/<m>/`` (+ integration under ``tests/integration/modules/<m>/``)
+    and any contract routed by an exact path (e.g. ``config/repo_structure.yml``
+    -> ``tests/repo_structure``) -> ``scope=modules``.
+  * if nothing test-relevant changed (docs / reports / notebooks only)
+    -> ``scope=skip`` — still runs the cheap always-on cross-cutting set so the
+    required "Test (PR gate)" check passes fast, never the full tree.
+
+The always-on set always runs, so the xdist target list is never empty.
+
+Usage::
+
+    python3 scripts/ci/select_test_targets.py --files-from changed.txt
+    git diff --name-only BASE...HEAD | python3 scripts/ci/select_test_targets.py -
+
+Emits ``scope=`` / ``xdist_targets=`` / ``seq_targets=`` lines (GitHub Actions
+``$GITHUB_OUTPUT`` format).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Always-on cross-cutting set: engine contract, assetutilities contracts, the
+# durable-workflow registry. Runs for every PR (so xdist is never empty).
+ALWAYS_XDIST = [
+    "tests/unit/core",
+    "tests/unit/common",
+    "tests/contracts",
+    "tests/workflows",
+]
+
+# Changing any of these can affect every module -> run the whole tree.
+CORE_EXACT = {
+    "src/worldenergydata/engine.py",
+    "src/worldenergydata/__main__.py",
+    "pyproject.toml",
+    "uv.lock",
+    "tests/conftest.py",
+    "tests/pytest.ini",
+    ".github/workflows/ci.yml",
+}
+CORE_PREFIXES = (
+    "src/worldenergydata/base_configs/",
+    "src/worldenergydata/common/",
+    "scripts/ci/",  # the selector itself / its tests -> fail safe to full
+)
+
+# Exact non-module paths that should run a specific contract suite.
+CONTRACT_ROUTES = {
+    "config/repo_structure.yml": "tests/repo_structure",
+}
+
+# Paths that exercise the durable-workflow registry (covered by tests/workflows,
+# already in ALWAYS_XDIST) but should still count as "test-relevant".
+WORKFLOW_PREFIXES = (
+    "docs/registry/",
+    "examples/workflows/",
+    "tests/workflows/",
+)
+
+_MODULE_RE = re.compile(r"^(?:src/worldenergydata|tests/unit)/([^/]+)/")
+_INTEGRATION_RE = re.compile(r"^tests/integration/modules/([^/]+)/")
+
+
+def _is_core(path: str) -> bool:
+    return path in CORE_EXACT or path.startswith(CORE_PREFIXES)
+
+
+def select(changed: list[str], root: Path) -> dict:
+    """Return {scope, xdist, seq} for the given changed files."""
+    if any(_is_core(p) for p in changed):
+        full = _full_tree(root)
+        return {
+            "scope": "full",
+            "xdist": full,
+            "seq": ["tests/integration", "tests/performance"],
+        }
+
+    modules: set[str] = set()
+    seq_modules: set[str] = set()
+    contracts: set[str] = set()
+    relevant = False
+
+    for p in changed:
+        if p in CONTRACT_ROUTES:
+            contracts.add(CONTRACT_ROUTES[p])
+            relevant = True
+            continue
+        if p.startswith(WORKFLOW_PREFIXES):
+            relevant = True  # covered by ALWAYS_XDIST tests/workflows
+            continue
+        m = _MODULE_RE.match(p)
+        if m:
+            modules.add(m.group(1))
+            relevant = True
+        mi = _INTEGRATION_RE.match(p)
+        if mi:
+            seq_modules.add(mi.group(1))
+            relevant = True
+        # anything else (reports/, notebooks/, *.md, docs/ non-registry,
+        # scripts/ non-ci, examples/ non-workflow) is not test-relevant.
+
+    xdist = list(ALWAYS_XDIST)
+    for mod in sorted(modules):
+        xdist.append(f"tests/unit/{mod}")
+    xdist.extend(sorted(contracts))
+    seq = [f"tests/integration/modules/{m}" for m in sorted(seq_modules)]
+
+    # keep only dirs that exist, dedupe, preserve order
+    xdist = _existing_unique(xdist, root)
+    seq = _existing_unique(seq, root)
+    return {"scope": "modules" if relevant else "skip", "xdist": xdist, "seq": seq}
+
+
+def _existing_unique(targets: list[str], root: Path) -> list[str]:
+    seen, out = set(), []
+    for t in targets:
+        if t not in seen and (root / t).is_dir():
+            seen.add(t)
+            out.append(t)
+    return out
+
+
+def _full_tree(root: Path) -> list[str]:
+    tests = root / "tests"
+    out = []
+    for child in sorted(tests.iterdir()):
+        if child.is_dir() and child.name not in {
+            "performance",
+            "integration",
+            "__pycache__",
+        }:
+            out.append(f"tests/{child.name}")
+        elif (
+            child.is_file() and child.name.startswith("test_") and child.suffix == ".py"
+        ):
+            out.append(f"tests/{child.name}")
+    return out
+
+
+def _read_changed(args) -> list[str]:
+    if args.files_from == "-":
+        text = sys.stdin.read()
+    elif args.files_from:
+        text = Path(args.files_from).read_text(encoding="utf-8")
+    else:
+        return list(args.files)
+    return [ln.strip() for ln in text.splitlines() if ln.strip()]
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("files", nargs="*", help="changed file paths")
+    ap.add_argument(
+        "--files-from", help="read changed paths from FILE (or - for stdin)"
+    )
+    ap.add_argument("--root", default=str(Path(__file__).resolve().parents[2]))
+    a = ap.parse_args(argv)
+    result = select(_read_changed(a), Path(a.root))
+    print(f"scope={result['scope']}")
+    print(f"xdist_targets={' '.join(result['xdist'])}")
+    print(f"seq_targets={' '.join(result['seq'])}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/test_select_test_targets.py
+++ b/tests/ci/test_select_test_targets.py
@@ -1,0 +1,70 @@
+# ABOUTME: Drift guard for the PR-gate test selector (#496).
+# ABOUTME: Fails if any tests/unit/<module> stops being selected, or routing regresses.
+
+"""Tests for scripts/ci/select_test_targets.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "ci"))
+
+from select_test_targets import ALWAYS_XDIST, select  # noqa: E402
+
+
+def _unit_modules() -> list[str]:
+    base = REPO_ROOT / "tests" / "unit"
+    return sorted(
+        d.name for d in base.iterdir() if d.is_dir() and d.name != "__pycache__"
+    )
+
+
+def test_core_change_runs_full_tree():
+    r = select(["src/worldenergydata/engine.py"], REPO_ROOT)
+    assert r["scope"] == "full"
+    assert "tests/integration" in r["seq"] and "tests/performance" in r["seq"]
+
+
+def test_selector_self_change_is_core():
+    assert select(["scripts/ci/select_test_targets.py"], REPO_ROOT)["scope"] == "full"
+
+
+def test_hse_change_is_module_scoped_not_full():
+    r = select(["src/worldenergydata/hse/grounding.py"], REPO_ROOT)
+    assert r["scope"] == "modules"
+    assert "tests/unit/hse" in r["xdist"]
+    # the always-on cross-cutting set is always present
+    assert all(t in r["xdist"] for t in ALWAYS_XDIST)
+
+
+def test_noncode_only_change_skips_full_tree():
+    for path in ("reports/hse/x.html", "notebooks/demo.ipynb", "README.md"):
+        r = select([path], REPO_ROOT)
+        assert r["scope"] == "skip", path
+        # skip still runs the cheap always-on set, never module/full dirs
+        assert r["xdist"] == [t for t in ALWAYS_XDIST if (REPO_ROOT / t).is_dir()]
+
+
+def test_config_repo_structure_routes_to_its_contract():
+    r = select(["config/repo_structure.yml"], REPO_ROOT)
+    assert r["scope"] == "modules"
+    assert "tests/repo_structure" in r["xdist"]
+
+
+@pytest.mark.parametrize("module", _unit_modules())
+def test_every_unit_module_is_selected(module):
+    """Drift guard: a change under any tests/unit/<module> must be module-scoped
+    and pull in that module's dir (no module silently regresses to full/skip)."""
+    r = select([f"tests/unit/{module}/test_smoke.py"], REPO_ROOT)
+    assert r["scope"] == "modules"
+    assert f"tests/unit/{module}" in r["xdist"]
+
+
+def test_integration_module_adds_seq_target():
+    r = select(["tests/integration/modules/bsee/test_x.py"], REPO_ROOT)
+    if (REPO_ROOT / "tests/integration/modules/bsee").is_dir():
+        assert "tests/integration/modules/bsee" in r["seq"]


### PR DESCRIPTION
## Single-source module-scoped PR gate (#496)

Closes #496. The PR gate from #474 only mapped **11 of ~40 modules**; everything else (`hse`, `safety_analysis`, `eia`, `west_africa`, …) plus any non-code path (`reports/`, `scripts/`, `config/`, `notebooks/`) hit the `unclassified` fail-safe and ran the **full ~11.7k-test tree (~8 min)**. And three hand-maintained lists (dorny filters, the `unclassified` negation list, the bash `module_xdist` map) drifted out of sync.

### Fix: one testable selector replaces all three lists
- **`scripts/ci/select_test_targets.py`** — maps changed files → pytest targets. A module is mapped **iff `tests/unit/<module>/` exists** (the filesystem is the single source of truth; new modules auto-map). Decision tree:
  - core path (engine / common / base_configs / packaging / conftest / the workflow / the selector) → **full tree**;
  - module paths (`src/worldenergydata/<m>/`, `tests/unit/<m>/`, `tests/integration/modules/<m>/`) → **module-scoped** + always-on cross-cutting set;
  - `config/repo_structure.yml` → its contract (`tests/repo_structure`);
  - docs / reports / notebooks only → **skip** (runs just the cheap always-on set, never the full tree).
- **`ci.yml` `test-pr`** — computes changed files via `git diff BASE...HEAD` (`fetch-depth: 0`) and calls the selector. Removed the dorny `changes` job and its drifting lists. The required check **"Test (PR gate)" keeps its name**.
- **`tests/ci/test_select_test_targets.py`** — drift guard: **parametrized over every `tests/unit/<module>`**, fails if any stops being selected; plus core→full, noncode→skip, hse→module, config→contract cases. **54 tests pass.**

### Effect
An `hse`-only PR now runs `tests/unit/hse` + cross-cutting (seconds) instead of 8 minutes. A reports/docs-only PR runs only the always-on set.

> Note: this PR changes `scripts/ci/` (a core path), so the selector routes **itself** to a full run — expected; it's the safe default when the selector changes. The speed-up lands on the next module PR.

### Verified
`pytest tests/ci/` → 54 passed; YAML parses; no dangling `needs.changes` refs; black + isort + flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
