### PR TITLE
feat(hse): wire demand signal into live path + restore HSE staleness monitoring

### DIFF
--- a/scripts/demo/generate_mooring_grounded_card.py
+++ b/scripts/demo/generate_mooring_grounded_card.py
@@ -25,8 +25,8 @@ import argparse
 import datetime as dt
 from pathlib import Path
 
-from worldenergydata.hse.grounding import ground
 from worldenergydata.hse.grounding_card import AnalysisSummary, render_html
+from worldenergydata.hse.grounding_demand import ground_and_log
 
 # Representative mooring_fatigue result (illustrative; from the workflow pilot).
 ANALYSIS = AnalysisSummary(
@@ -49,7 +49,9 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--out", default="reports/hse/mooring-fatigue-grounded-card.html")
     a = ap.parse_args(argv)
 
-    g = ground("mooring_fatigue")
+    # ground_and_log: produce the grounding AND record the request in the demand
+    # signal (#491), so this live demo path feeds the coverage-gap rollup.
+    g = ground_and_log("mooring_fatigue")
     generated_on = dt.date.today().isoformat()
     html_doc = render_html(g.to_dict(), ANALYSIS, generated_on)
 

--- a/src/worldenergydata/hse/__init__.py
+++ b/src/worldenergydata/hse/__init__.py
@@ -44,6 +44,10 @@ from worldenergydata.hse.database import (
 # Incident-grounding query (#487): failure-mode -> real precedent incidents
 from worldenergydata.hse.grounding import Grounding, ground
 
+# Demand-logging entry point (#491): the canonical call for bots/agents — logs
+# which failure modes get requested so coverage gaps surface as the next build.
+from worldenergydata.hse.grounding_demand import ground_and_log
+
 # Importers
 from worldenergydata.hse.importers.base_importer import BaseImporter
 from worldenergydata.hse.importers.bsee_incidents_importer import (
@@ -78,9 +82,10 @@ __all__ = [
     "EPATRIImporter",
     # Validation
     "DataQualityValidator",
-    # Incident grounding (#487)
+    # Incident grounding (#487) + demand logging (#491)
     "ground",
     "Grounding",
+    "ground_and_log",
 ]
 
 _logger = get_logger(__name__)

--- a/src/worldenergydata/scheduler/staleness.py
+++ b/src/worldenergydata/scheduler/staleness.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 STALENESS_THRESHOLDS: Dict[str, timedelta] = {
     "sodir_refresh": timedelta(hours=36),
     "bsee_refresh": timedelta(days=10),
+    "hse_refresh": timedelta(days=10),
     "eia_us_refresh": timedelta(days=45),
 }
 

--- a/tests/unit/scheduler/test_staleness.py
+++ b/tests/unit/scheduler/test_staleness.py
@@ -42,6 +42,7 @@ class TestCheckStaleness:
         # EIA ran 20 days ago (threshold 45d) — OK
         status = _make_status(
             {
+                "hse_refresh": _job_entry((FROZEN_NOW - timedelta(days=5)).isoformat()),
                 "sodir_refresh": _job_entry(
                     (FROZEN_NOW - timedelta(hours=12)).isoformat()
                 ),
@@ -64,6 +65,7 @@ class TestCheckStaleness:
 
         status = _make_status(
             {
+                "hse_refresh": _job_entry((FROZEN_NOW - timedelta(days=5)).isoformat()),
                 "sodir_refresh": _job_entry(
                     (FROZEN_NOW - timedelta(hours=40)).isoformat()
                 ),
@@ -86,6 +88,7 @@ class TestCheckStaleness:
 
         status = _make_status(
             {
+                "hse_refresh": _job_entry((FROZEN_NOW - timedelta(days=5)).isoformat()),
                 "sodir_refresh": _job_entry(
                     (FROZEN_NOW - timedelta(hours=1)).isoformat()
                 ),
@@ -108,6 +111,7 @@ class TestCheckStaleness:
 
         status = _make_status(
             {
+                "hse_refresh": _job_entry((FROZEN_NOW - timedelta(days=5)).isoformat()),
                 "sodir_refresh": _job_entry(
                     (FROZEN_NOW - timedelta(hours=1)).isoformat()
                 ),
@@ -130,6 +134,7 @@ class TestCheckStaleness:
 
         status = _make_status(
             {
+                "hse_refresh": _job_entry((FROZEN_NOW - timedelta(days=5)).isoformat()),
                 "sodir_refresh": _job_entry(None),
                 "bsee_refresh": _job_entry(
                     (FROZEN_NOW - timedelta(days=1)).isoformat()
@@ -151,6 +156,7 @@ class TestCheckStaleness:
         # Only tracked jobs present, plus an untracked one
         status = _make_status(
             {
+                "hse_refresh": _job_entry((FROZEN_NOW - timedelta(days=5)).isoformat()),
                 "sodir_refresh": _job_entry(
                     (FROZEN_NOW - timedelta(hours=1)).isoformat()
                 ),
@@ -176,6 +182,7 @@ class TestCheckStaleness:
 
         status = _make_status(
             {
+                "hse_refresh": _job_entry((FROZEN_NOW - timedelta(days=5)).isoformat()),
                 "sodir_refresh": _job_entry(
                     (FROZEN_NOW - timedelta(hours=40)).isoformat()
                 ),
@@ -186,7 +193,7 @@ class TestCheckStaleness:
             }
         )
         details = get_staleness_details(status)
-        assert len(details) == 3
+        assert len(details) == 4  # sodir, bsee, hse, eia
 
         # Check structure
         for d in details:
@@ -219,6 +226,9 @@ class TestStalenessThresholds:
 
     def test_bsee_threshold_10_days(self):
         assert STALENESS_THRESHOLDS["bsee_refresh"] == timedelta(days=10)
+
+    def test_hse_threshold_10_days(self):
+        assert STALENESS_THRESHOLDS["hse_refresh"] == timedelta(days=10)
 
     def test_eia_threshold_45_days(self):
         assert STALENESS_THRESHOLDS["eia_us_refresh"] == timedelta(days=45)


### PR DESCRIPTION
## Round out the grounded-analysis initiative — two deferred enhancements

### 1. Demand signal goes live (#491 follow-up)
The feedback loop existed but nothing fed it. Now:
- `ground_and_log` is exported from `worldenergydata.hse` as the **canonical bot/agent entry** (logs which failure mode was requested → coverage-gap rollup).
- the demo card generator switches `ground()` → `ground_and_log()`, so producing a card records the request.

Verified end-to-end: generating the mooring card logs `{mooring_fatigue, covered, 6}` and `--rollup` reflects it (log gitignored). Deckhand-side callers import `worldenergydata.hse.ground_and_log`.

### 2. HSE staleness monitoring (deferred from the hse_refresh PR #507)
Add `hse_refresh` (10-day threshold) to `STALENESS_THRESHOLDS` so the scheduler monitor flags a stale HSE corpus — completing the freshness story. Updated the exact-set staleness tests (each status fixture carries a within-threshold `hse_refresh`; details count 3→4; added a threshold assertion).

### Verified
`pytest tests/unit/scheduler tests/unit/hse` → **613 passed, 3 skipped**. black + isort + flake8 clean.

Closes the two in-repo follow-ups noted on epic #486. (Remaining: operator-side public gallery publish of the mooring card — outward-facing, PR-only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
