### PR TITLE
feat(bsee): all-fields production atlas + OGOR .bin loader glue

### DIFF
--- a/scripts/bsee/generate_all_fields_atlas.py
+++ b/scripts/bsee/generate_all_fields_atlas.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+"""Generate the GoM all-fields production atlas from materialized OGOR-A bins.
+
+Wires the deterministic OGOR ``.bin`` loader into the existing
+:class:`AllFieldsRunner` and :class:`AllFieldsReport`, producing a
+gulf-wide field table (CSV) plus an interactive HTML atlas and a Markdown
+summary.  All inputs are real BSEE public data; nothing is fabricated.
+
+Usage::
+
+    .venv/bin/python scripts/bsee/generate_all_fields_atlas.py \
+        --start-year 1996 --end-year 2025 --out reports/bsee/all_fields
+
+Era classification is best-effort: wells absent from Paleowells.csv are
+reported as ``Unknown`` rather than guessed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from collections import Counter
+from pathlib import Path
+
+from worldenergydata.bsee.analysis.all_fields_runner import AllFieldsRunner
+from worldenergydata.bsee.data.field_names import FieldNameResolver
+from worldenergydata.bsee.data.sources.bin.ogor_production_loader import (
+    load_all_fields_production,
+)
+from worldenergydata.bsee.paleowells.era_classifier import GeologicalEraClassifier
+from worldenergydata.bsee.reports.all_fields_report import AllFieldsReport
+from worldenergydata.common.data_resolver import get_module_data_safe
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger("all_fields_atlas")
+
+
+class FastEraClassifier:
+    """O(1)-per-well era classifier with the same ``classify_field`` contract.
+
+    The base :class:`GeologicalEraClassifier.classify_field` re-scans the
+    paleo table for every API, which is O(wells x paleo_rows) — far too slow
+    for ~30k gulf-wide wells.  This wrapper precomputes the well->era map
+    once and resolves each field by majority vote via dict lookups, giving
+    results identical to the base classifier.
+    """
+
+    def __init__(self, base: GeologicalEraClassifier) -> None:
+        self._well_eras = base.get_well_eras()
+
+    def classify_field(self, field_wells) -> str:
+        if not field_wells:
+            return "Unknown"
+        counter: Counter = Counter()
+        for api in field_wells:
+            era = self._well_eras.get(str(api))
+            if era:
+                counter[era] += 1
+        if not counter:
+            return "Unknown"
+        return counter.most_common(1)[0][0]
+
+
+def build_era_classifier() -> FastEraClassifier:
+    """Construct a fast era classifier from the Paleowells CSV (best-effort)."""
+    paleo = get_module_data_safe("bsee") / "paleowells" / "Paleowells.csv"
+    if paleo.exists():
+        return FastEraClassifier(GeologicalEraClassifier(paleowells_csv=paleo))
+    logger.warning("Paleowells.csv not found at %s — eras will be Unknown", paleo)
+    return FastEraClassifier(GeologicalEraClassifier())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--start-year", type=int, default=1996)
+    parser.add_argument("--end-year", type=int, default=2025)
+    parser.add_argument("--out", type=Path, default=Path("reports/bsee/all_fields"))
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=None,
+        help="OGOR bin dir (default: resolved bsee module bin/historical_production_yearly)",
+    )
+    args = parser.parse_args()
+
+    logger.info("Loading OGOR production %d-%d...", args.start_year, args.end_year)
+    prod = load_all_fields_production(
+        data_dir=args.data_dir,
+        start_year=args.start_year,
+        end_year=args.end_year,
+    )
+    if prod.empty:
+        logger.error("No production data loaded — aborting.")
+        return 1
+    logger.info(
+        "Loaded %d production rows across %d fields",
+        len(prod),
+        prod["FIELD_NAME_CODE"].nunique(),
+    )
+
+    resolver = FieldNameResolver()
+    era = build_era_classifier()
+
+    logger.info("Aggregating all fields...")
+    result = AllFieldsRunner(resolver, era).run(prod)
+    logger.info("Aggregated %d fields", len(result))
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    report = AllFieldsReport(result)
+    report.generate_csv(args.out / "gom_all_fields_atlas.csv")
+    report.generate_html(args.out / "gom_all_fields_atlas.html")
+    report.generate_markdown(args.out / "gom_all_fields_atlas.md")
+    logger.info("Atlas written to %s", args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/worldenergydata/bsee/data/field_names.py
+++ b/src/worldenergydata/bsee/data/field_names.py
@@ -30,19 +30,17 @@ class FieldNameResolver:
     directory. Handles LFS stubs and missing files gracefully.
     """
 
-    # Sources to load, in priority order (first wins for duplicate codes)
+    # Sources to load, in priority order (first wins for duplicate codes).
+    # The deep-water-leases table carries the authoritative field nickname
+    # (``FLD_NICK_NAME``, e.g. "Mars-Ursa"); the platform-structures table
+    # only has *structure* names ("A (Mars)"), so it is intentionally not
+    # used as a field-name source (it would mislabel fields).
     _SOURCES = [
         {
             "subdir": "deepqual",
             "file": "mv_deep_water_field_leases.bin",
             "code_col": "FIELD_NAME_CODE",
-            "name_col": "FIELD_NAME",
-        },
-        {
-            "subdir": "platstruc",
-            "file": "mv_platstruc_structures.bin",
-            "code_col": "FIELD_NAME_CODE",
-            "name_col": "FIELD_NAME",
+            "name_col": "FLD_NICK_NAME",
         },
     ]
 

--- a/src/worldenergydata/bsee/data/sources/bin/ogor_production_loader.py
+++ b/src/worldenergydata/bsee/data/sources/bin/ogor_production_loader.py
@@ -1,0 +1,228 @@
+"""Loader for materialized BSEE OGOR-A production ``.bin`` pickles.
+
+The yearly OGOR-A archives are stored on disk as pickled DataFrames at
+``data/modules/bsee/bin/historical_production_yearly/ogora{year}delimit.bin``.
+These pickles are **header-corrupted**: they were created by a ``read_csv``
+that consumed the first data record as the column header, so every file
+loads with garbage column labels and is missing its first physical row.
+
+This module recovers them deterministically by positionally re-labelling
+the 19 OGOR-A columns, then adapts the result to the column schema that
+:class:`~worldenergydata.bsee.analysis.all_fields_runner.AllFieldsRunner`
+expects.  This is the bridge between the materialized binary data and the
+all-fields analysis pipeline (the canonical ``load_ogor_production`` reads
+``.zip`` archives, which are not materialized on this deployment).
+
+Known limitation: because the on-disk pickle lost its first record to the
+corrupted header, each file contributes ~1 fewer row than the source.  On
+~4.55M rows across 30 years this is ~30 rows (<0.001%); it is flagged via
+:func:`load_all_fields_production` logging rather than silently fabricated.
+"""
+
+from __future__ import annotations
+
+import logging
+import pickle  # nosec B403
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+from worldenergydata.common.data_resolver import get_module_data_safe
+
+logger = logging.getLogger(__name__)
+
+# Positional OGOR-A column schema (19 columns), matching
+# ``lower_tertiary.v30_reproducer.load_ogor_production``.
+OGOR_COLUMN_NAMES = [
+    "LEASE_NUMBER",
+    "COMPLETION_NAME",
+    "PRODUCTION_DATE",  # YYYYMM integer
+    "DAYS_ON_PROD",
+    "PRODUCT_CODE",
+    "MON_O_PROD_VOL",
+    "MON_G_PROD_VOL",
+    "MON_WTR_PROD_VOL",
+    "API_WELL_NUMBER",
+    "WELL_STAT_CD",
+    "AREA_CODE_BLOCK_NUM",
+    "OPERATOR_NUM",
+    "SORT_NAME",
+    "BOEM_FIELD",  # field code used for all-fields grouping
+    "INJECTION_VOLUME",
+    "PROD_INTERVAL_CD",
+    "FIRST_PROD_DATE",
+    "UNIT_AGT_NUMBER",
+    "UNIT_ALOC_SUFFIX",
+]
+
+_N_COLS = len(OGOR_COLUMN_NAMES)
+_DEFAULT_SUBDIR = "historical_production_yearly"
+
+
+def _load_pickle_safe(path: Path) -> Optional[pd.DataFrame]:
+    """Load a pickled DataFrame, returning ``None`` for LFS stubs/errors."""
+    try:
+        with open(path, "rb") as f:
+            header = f.read(40)
+        if b"version https://git-lfs" in header:
+            logger.warning("LFS stub (not materialized): %s", path)
+            return None
+        with open(path, "rb") as f:
+            obj = pickle.load(f)  # nosec B301
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Error loading %s: %s", path, exc)
+        return None
+
+    if not isinstance(obj, pd.DataFrame):
+        logger.warning("Not a DataFrame: %s", path)
+        return None
+    return obj
+
+
+def load_ogor_bin(path: Path) -> pd.DataFrame:
+    """Load one OGOR-A ``.bin`` pickle and positionally re-label its columns.
+
+    Parameters
+    ----------
+    path:
+        Path to an ``ogora{year}delimit.bin`` pickle.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with the canonical :data:`OGOR_COLUMN_NAMES` columns.
+        Returns an empty (correctly-typed) frame when the file is an LFS
+        stub, unreadable, or does not have the expected 19 columns.
+    """
+    path = Path(path)
+    if not path.exists():
+        logger.warning("OGOR file not found: %s", path)
+        return pd.DataFrame(columns=OGOR_COLUMN_NAMES)
+
+    df = _load_pickle_safe(path)
+    if df is None:
+        return pd.DataFrame(columns=OGOR_COLUMN_NAMES)
+
+    if df.shape[1] != _N_COLS:
+        logger.warning(
+            "Unexpected column count %d (need %d) in %s — skipping",
+            df.shape[1],
+            _N_COLS,
+            path.name,
+        )
+        return pd.DataFrame(columns=OGOR_COLUMN_NAMES)
+
+    # Positional re-label. If the file already carries the canonical names
+    # (e.g. a non-corrupted source), this is a harmless rename.
+    df = df.copy()
+    df.columns = OGOR_COLUMN_NAMES
+    return df
+
+
+def to_runner_schema(df: pd.DataFrame) -> pd.DataFrame:
+    """Adapt raw OGOR-A columns to the AllFieldsRunner input schema.
+
+    Produces the columns the runner detects and aggregates:
+    ``FIELD_NAME_CODE``, ``LEASE_NUMBER``, ``API_WELL_NUMBER``,
+    ``PROD_YEAR``, ``MON_O_PROD_VOL``, ``MON_G_PROD_VOL``,
+    ``MON_WTR_PROD_VOL``, ``DAYS_ON_PROD``.
+    """
+    out_cols = [
+        "FIELD_NAME_CODE",
+        "LEASE_NUMBER",
+        "API_WELL_NUMBER",
+        "PROD_YEAR",
+        "MON_O_PROD_VOL",
+        "MON_G_PROD_VOL",
+        "MON_WTR_PROD_VOL",
+        "DAYS_ON_PROD",
+    ]
+    if df.empty:
+        return pd.DataFrame(columns=out_cols)
+
+    out = pd.DataFrame(index=df.index)
+
+    # Field code (BOEM_FIELD) and identifiers — strip whitespace/quotes.
+    out["FIELD_NAME_CODE"] = (
+        df["BOEM_FIELD"].astype(str).str.replace('"', "", regex=False).str.strip()
+    )
+    out["LEASE_NUMBER"] = (
+        df["LEASE_NUMBER"]
+        .astype(str)
+        .str.replace('"', "", regex=False)
+        .str.replace(" ", "", regex=False)
+        .str.upper()
+    )
+    out["API_WELL_NUMBER"] = (
+        df["API_WELL_NUMBER"].astype(str).str.replace('"', "", regex=False).str.strip()
+    )
+
+    # Production year from YYYYMM integer.
+    prod_date = pd.to_numeric(df["PRODUCTION_DATE"], errors="coerce")
+    out["PROD_YEAR"] = (prod_date // 100).astype("Int64")
+
+    # Volumes and days — numeric, NaN -> 0.
+    for col in ("MON_O_PROD_VOL", "MON_G_PROD_VOL", "MON_WTR_PROD_VOL", "DAYS_ON_PROD"):
+        out[col] = pd.to_numeric(
+            df[col].astype(str).str.replace('"', "", regex=False).str.strip(),
+            errors="coerce",
+        ).fillna(0.0)
+
+    return out[out_cols]
+
+
+def load_all_fields_production(
+    data_dir: Optional[Path] = None,
+    start_year: int = 1996,
+    end_year: int = 2025,
+) -> pd.DataFrame:
+    """Load and concatenate all yearly OGOR-A bins into runner-ready data.
+
+    Parameters
+    ----------
+    data_dir:
+        Directory containing ``ogora{year}delimit.bin`` files.  Defaults to
+        ``<bsee module>/bin/historical_production_yearly`` (resolved via the
+        repo data resolver, which follows the materialized-data symlink).
+    start_year, end_year:
+        Inclusive year range to load.
+
+    Returns
+    -------
+    pd.DataFrame
+        Concatenated production in the AllFieldsRunner schema.  Empty (with
+        correct columns) when no files are found.
+    """
+    if data_dir is None:
+        data_dir = get_module_data_safe("bsee") / "bin" / _DEFAULT_SUBDIR
+    data_dir = Path(data_dir)
+
+    frames = []
+    loaded, missing = 0, 0
+    for year in range(start_year, end_year + 1):
+        path = data_dir / f"ogora{year}delimit.bin"
+        if not path.exists():
+            missing += 1
+            continue
+        raw = load_ogor_bin(path)
+        if raw.empty:
+            missing += 1
+            continue
+        frames.append(to_runner_schema(raw))
+        loaded += 1
+
+    if not frames:
+        logger.warning("No OGOR production bins loaded from %s", data_dir)
+        return to_runner_schema(pd.DataFrame())
+
+    result = pd.concat(frames, ignore_index=True)
+    logger.info(
+        "Loaded %d OGOR years (%d missing/empty) from %s — %d rows. "
+        "Note: ~1 row/file lost to source header-corruption.",
+        loaded,
+        missing,
+        data_dir,
+        len(result),
+    )
+    return result

--- a/tests/unit/bsee/data/test_ogor_production_loader.py
+++ b/tests/unit/bsee/data/test_ogor_production_loader.py
@@ -26,12 +26,48 @@ def _canonical_rows():
     return [
         # lease, comp, YYYYMM, days, prod, oil, gas, wtr, api, stat,
         # block, opnum, sortname, BOEM_FIELD, inj, interval, firstprod, unit, suffix
-        ["G12345", "E001", 202401, 30, "O", 1000.0, 5000.0, 200.0,
-         "608054010300", "PR", "MC0807", "03151", "BP", "MC807",
-         0.0, "Q01", 20100101, "", ""],
-        ["G12345", "E002", 202402, 28, "O", 2_000_000.0, 6000.0, 250.0,
-         "608054010301", "PR", "MC0807", "03151", "BP", "MC807",
-         0.0, "Q01", 20100101, "", ""],
+        [
+            "G12345",
+            "E001",
+            202401,
+            30,
+            "O",
+            1000.0,
+            5000.0,
+            200.0,
+            "608054010300",
+            "PR",
+            "MC0807",
+            "03151",
+            "BP",
+            "MC807",
+            0.0,
+            "Q01",
+            20100101,
+            "",
+            "",
+        ],
+        [
+            "G12345",
+            "E002",
+            202402,
+            28,
+            "O",
+            2_000_000.0,
+            6000.0,
+            250.0,
+            "608054010301",
+            "PR",
+            "MC0807",
+            "03151",
+            "BP",
+            "MC807",
+            0.0,
+            "Q01",
+            20100101,
+            "",
+            "",
+        ],
     ]
 
 
@@ -87,11 +123,17 @@ def test_to_runner_schema_maps_and_types():
     out = to_runner_schema(raw)
 
     assert list(out.columns) == [
-        "FIELD_NAME_CODE", "LEASE_NUMBER", "API_WELL_NUMBER", "PROD_YEAR",
-        "MON_O_PROD_VOL", "MON_G_PROD_VOL", "MON_WTR_PROD_VOL", "DAYS_ON_PROD",
+        "FIELD_NAME_CODE",
+        "LEASE_NUMBER",
+        "API_WELL_NUMBER",
+        "PROD_YEAR",
+        "MON_O_PROD_VOL",
+        "MON_G_PROD_VOL",
+        "MON_WTR_PROD_VOL",
+        "DAYS_ON_PROD",
     ]
     assert out.iloc[0]["FIELD_NAME_CODE"] == "MC807"  # from BOEM_FIELD
-    assert out.iloc[0]["PROD_YEAR"] == 2024            # from 202401
+    assert out.iloc[0]["PROD_YEAR"] == 2024  # from 202401
     assert out["MON_O_PROD_VOL"].sum() == pytest.approx(2_001_000.0)
 
 
@@ -104,9 +146,29 @@ def test_to_runner_schema_empty():
 
 @unit
 def test_to_runner_schema_strips_quotes_and_whitespace():
-    rows = [["\" G99 \"", "E", 202012, 31, "O", 10.0, 0.0, 0.0,
-             " 60805 ", "PR", "B", "1", "OP", " GC640 ",
-             0.0, "Q", 0, "", ""]]
+    rows = [
+        [
+            '" G99 "',
+            "E",
+            202012,
+            31,
+            "O",
+            10.0,
+            0.0,
+            0.0,
+            " 60805 ",
+            "PR",
+            "B",
+            "1",
+            "OP",
+            " GC640 ",
+            0.0,
+            "Q",
+            0,
+            "",
+            "",
+        ]
+    ]
     out = to_runner_schema(pd.DataFrame(rows, columns=OGOR_COLUMN_NAMES))
     assert out.iloc[0]["FIELD_NAME_CODE"] == "GC640"
     assert out.iloc[0]["LEASE_NUMBER"] == "G99"
@@ -118,9 +180,7 @@ def test_load_all_fields_production_concats_year_range(tmp_path):
     _write_corrupted_bin(tmp_path / "ogora2023delimit.bin")
     _write_corrupted_bin(tmp_path / "ogora2024delimit.bin")
 
-    df = load_all_fields_production(
-        data_dir=tmp_path, start_year=2023, end_year=2024
-    )
+    df = load_all_fields_production(data_dir=tmp_path, start_year=2023, end_year=2024)
 
     # 1 surviving row per file x 2 files
     assert len(df) == 2
@@ -138,9 +198,7 @@ def test_load_all_fields_production_no_files(tmp_path):
 def test_end_to_end_feeds_all_fields_runner(tmp_path):
     """Loader output is consumable by AllFieldsRunner without adaptation."""
     _write_corrupted_bin(tmp_path / "ogora2024delimit.bin")
-    prod = load_all_fields_production(
-        data_dir=tmp_path, start_year=2024, end_year=2024
-    )
+    prod = load_all_fields_production(data_dir=tmp_path, start_year=2024, end_year=2024)
 
     class _StubResolver:
         def resolve(self, code):

--- a/tests/unit/bsee/data/test_ogor_production_loader.py
+++ b/tests/unit/bsee/data/test_ogor_production_loader.py
@@ -1,0 +1,161 @@
+"""Unit tests for the OGOR-A ``.bin`` production loader.
+
+Uses a synthetic *header-corrupted* pickle fixture (never the 3.5 GB real
+data) so the tests are deterministic and run anywhere, including CI without
+the materialized data mount.
+"""
+
+import pickle
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from tests.test_markers import unit
+from worldenergydata.bsee.analysis.all_fields_runner import AllFieldsRunner
+from worldenergydata.bsee.data.sources.bin.ogor_production_loader import (
+    OGOR_COLUMN_NAMES,
+    load_all_fields_production,
+    load_ogor_bin,
+    to_runner_schema,
+)
+
+
+def _canonical_rows():
+    """Two production records in canonical OGOR-A column order."""
+    return [
+        # lease, comp, YYYYMM, days, prod, oil, gas, wtr, api, stat,
+        # block, opnum, sortname, BOEM_FIELD, inj, interval, firstprod, unit, suffix
+        ["G12345", "E001", 202401, 30, "O", 1000.0, 5000.0, 200.0,
+         "608054010300", "PR", "MC0807", "03151", "BP", "MC807",
+         0.0, "Q01", 20100101, "", ""],
+        ["G12345", "E002", 202402, 28, "O", 2_000_000.0, 6000.0, 250.0,
+         "608054010301", "PR", "MC0807", "03151", "BP", "MC807",
+         0.0, "Q01", 20100101, "", ""],
+    ]
+
+
+def _write_corrupted_bin(path: Path, rows=None) -> None:
+    """Write a header-corrupted OGOR pickle.
+
+    Mimics the real on-disk artefact: a ``read_csv`` consumed the first data
+    record as the header, so the pickled frame's *columns* are that first
+    record's values and the frame is missing that first physical row.
+    """
+    if rows is None:
+        rows = _canonical_rows()
+    full = pd.DataFrame(rows, columns=OGOR_COLUMN_NAMES)
+    corrupted = pd.DataFrame(full.iloc[1:].values, columns=list(full.iloc[0].values))
+    with open(path, "wb") as f:
+        pickle.dump(corrupted, f)
+
+
+@unit
+def test_load_ogor_bin_relabels_columns(tmp_path):
+    """load_ogor_bin restores the canonical 19-column schema."""
+    f = tmp_path / "ogora2024delimit.bin"
+    _write_corrupted_bin(f)
+
+    df = load_ogor_bin(f)
+
+    assert list(df.columns) == OGOR_COLUMN_NAMES
+    # One row survives (row0 lost to source header-corruption — documented).
+    assert len(df) == 1
+    assert df.iloc[0]["BOEM_FIELD"] == "MC807"
+    assert df.iloc[0]["API_WELL_NUMBER"] == "608054010301"
+
+
+@unit
+def test_load_ogor_bin_missing_file_returns_empty(tmp_path):
+    df = load_ogor_bin(tmp_path / "nope.bin")
+    assert df.empty
+    assert list(df.columns) == OGOR_COLUMN_NAMES
+
+
+@unit
+def test_load_ogor_bin_wrong_column_count_skipped(tmp_path):
+    f = tmp_path / "bad.bin"
+    with open(f, "wb") as fh:
+        pickle.dump(pd.DataFrame({"a": [1], "b": [2]}), fh)
+    df = load_ogor_bin(f)
+    assert df.empty
+
+
+@unit
+def test_to_runner_schema_maps_and_types():
+    raw = pd.DataFrame(_canonical_rows(), columns=OGOR_COLUMN_NAMES)
+    out = to_runner_schema(raw)
+
+    assert list(out.columns) == [
+        "FIELD_NAME_CODE", "LEASE_NUMBER", "API_WELL_NUMBER", "PROD_YEAR",
+        "MON_O_PROD_VOL", "MON_G_PROD_VOL", "MON_WTR_PROD_VOL", "DAYS_ON_PROD",
+    ]
+    assert out.iloc[0]["FIELD_NAME_CODE"] == "MC807"  # from BOEM_FIELD
+    assert out.iloc[0]["PROD_YEAR"] == 2024            # from 202401
+    assert out["MON_O_PROD_VOL"].sum() == pytest.approx(2_001_000.0)
+
+
+@unit
+def test_to_runner_schema_empty():
+    out = to_runner_schema(pd.DataFrame())
+    assert out.empty
+    assert "FIELD_NAME_CODE" in out.columns
+
+
+@unit
+def test_to_runner_schema_strips_quotes_and_whitespace():
+    rows = [["\" G99 \"", "E", 202012, 31, "O", 10.0, 0.0, 0.0,
+             " 60805 ", "PR", "B", "1", "OP", " GC640 ",
+             0.0, "Q", 0, "", ""]]
+    out = to_runner_schema(pd.DataFrame(rows, columns=OGOR_COLUMN_NAMES))
+    assert out.iloc[0]["FIELD_NAME_CODE"] == "GC640"
+    assert out.iloc[0]["LEASE_NUMBER"] == "G99"
+    assert out.iloc[0]["API_WELL_NUMBER"] == "60805"
+
+
+@unit
+def test_load_all_fields_production_concats_year_range(tmp_path):
+    _write_corrupted_bin(tmp_path / "ogora2023delimit.bin")
+    _write_corrupted_bin(tmp_path / "ogora2024delimit.bin")
+
+    df = load_all_fields_production(
+        data_dir=tmp_path, start_year=2023, end_year=2024
+    )
+
+    # 1 surviving row per file x 2 files
+    assert len(df) == 2
+    assert set(df["FIELD_NAME_CODE"]) == {"MC807"}
+
+
+@unit
+def test_load_all_fields_production_no_files(tmp_path):
+    df = load_all_fields_production(data_dir=tmp_path, start_year=2023, end_year=2024)
+    assert df.empty
+    assert "FIELD_NAME_CODE" in df.columns
+
+
+@unit
+def test_end_to_end_feeds_all_fields_runner(tmp_path):
+    """Loader output is consumable by AllFieldsRunner without adaptation."""
+    _write_corrupted_bin(tmp_path / "ogora2024delimit.bin")
+    prod = load_all_fields_production(
+        data_dir=tmp_path, start_year=2024, end_year=2024
+    )
+
+    class _StubResolver:
+        def resolve(self, code):
+            return {"MC807": "Thunder Horse"}.get(code, code)
+
+    class _StubEra:
+        def classify_field(self, apis):
+            return "Miocene"
+
+    result = AllFieldsRunner(_StubResolver(), _StubEra()).run(prod)
+
+    assert len(result) == 1
+    row = result.iloc[0]
+    assert row["FIELD_CODE"] == "MC807"
+    assert row["FIELD_NAME"] == "Thunder Horse"
+    assert row["GEOLOGICAL_ERA"] == "Miocene"
+    # Only the second canonical row survives the header-corruption (2.0 MMbbl).
+    assert row["CUM_OIL_MMBBL"] == pytest.approx(2.0, rel=1e-6)

--- a/tests/unit/bsee/test_field_names.py
+++ b/tests/unit/bsee/test_field_names.py
@@ -158,3 +158,40 @@ class TestFieldNameResolver:
         result = self.resolver.get_all_field_names()
         result["999"] = "New Field"
         assert "999" not in self.resolver._field_names
+
+    def test_sources_use_deepwater_field_nickname(self):
+        """The deep-water-leases nickname column is the field-name source.
+
+        Locks the fix for the materialized-data vintage: the name column is
+        ``FLD_NICK_NAME`` (not ``FIELD_NAME``), and the platform-structures
+        table is not used as a name source.
+        """
+        from worldenergydata.bsee.data.field_names import FieldNameResolver
+
+        sources = FieldNameResolver._SOURCES
+        assert len(sources) == 1
+        assert sources[0]["subdir"] == "deepqual"
+        assert sources[0]["name_col"] == "FLD_NICK_NAME"
+
+    def test_resolve_loads_from_deepqual_bin(self, tmp_path):
+        """End-to-end resolve from a synthetic deep-water-leases pickle."""
+        import pickle
+
+        from worldenergydata.bsee.data.field_names import FieldNameResolver
+
+        deepqual = tmp_path / "deepqual"
+        deepqual.mkdir()
+        df = pd.DataFrame(
+            {
+                "FIELD_NAME_CODE": ["MC807", "GC640"],
+                "FLD_NICK_NAME": ["Mars-Ursa", "K2"],
+            }
+        )
+        with open(deepqual / "mv_deep_water_field_leases.bin", "wb") as f:
+            pickle.dump(df, f)
+
+        resolver = FieldNameResolver(data_dir=tmp_path)
+        assert resolver.resolve("MC807") == "Mars-Ursa"
+        assert resolver.resolve("GC640") == "K2"
+        # Unknown (shelf) field falls back to its code — never fabricated.
+        assert resolver.resolve("ST295") == "ST295"


### PR DESCRIPTION
Rebased clean replacement for #520 (its branch was built on a stale, diverged local `main`, making it unmergeable; this branch is cherry-picked directly onto current `origin/main`, conflict-free).

## What

Generalizes the prior 7-field Lower Tertiary production work to **all ~1,390 GoM fields** by adding the one missing piece: a deterministic loader bridging the materialized OGOR-A `.bin` pickles to the existing `AllFieldsRunner` / `AllFieldsReport` pipeline (the canonical loader reads `.zip` archives that aren't materialized here).

## Changes

- **`ogor_production_loader.py`** (new) — `load_ogor_bin` positionally re-labels the header-corrupted OGOR pickles (row 0 was consumed as the header); `to_runner_schema` adapts `BOEM_FIELD` → `FIELD_NAME_CODE`; `load_all_fields_production` concatenates the yearly bins. Pure, deterministic, real-data-only.
- **`generate_all_fields_atlas.py`** (new) — wires loader → `AllFieldsRunner` → `AllFieldsReport` (CSV/HTML/MD). Includes `FastEraClassifier` (precomputed well→era map; base classifier is O(wells×paleo) and hangs at ~30k wells).
- **`field_names.py`** (fix) — pre-existing bug: `_SOURCES` looked for an absent `FIELD_NAME` column. The deep-water-leases table carries the field nickname in `FLD_NICK_NAME` (e.g. `MC807` → `Mars-Ursa`). Dropped `platstruc` (it holds *structure* names, not field names).
- **11 new unit tests** using synthetic header-corrupted fixtures (never the 3.5 GB real data).

## Verification (real data, 1996–2025, 4.55M rows)

- **1,390 fields · 29,674 wells · 16.35 Bbbl oil · 75.9 Tcf gas** — sane vs. known GoM history.
- Names resolve: Mars-Ursa, Tahiti, Atlantis, Mad Dog, Shenzi, Thunder Horse. Mars-Ursa 1.855 Bbbl matches the prior session.
- Era split surfaces the Lower Tertiary play basin-wide: Oligocene 60 / Eocene 47 / Paleocene 4 / Unknown 1,279.
- 26 tests pass against current `origin/main`.

## Scope / deferred (intentionally not faked)

- **Water depth** column blank (OGOR↔deepqual lease-format join deferred).
- **Economics (NPV/IRR)** null (needs real per-field cost inputs that exist only for the 7 LT fields).
- Reports (`reports/` is gitignored) regenerate via the script, not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)