### PR TITLE
feat(bsee): lift paleo eras to field level + Lower-Tertiary flag

### DIFF
--- a/scripts/bsee/generate_all_fields_atlas.py
+++ b/scripts/bsee/generate_all_fields_atlas.py
@@ -31,6 +31,10 @@ from worldenergydata.bsee.data.sources.bin.ogor_production_loader import (
     load_all_fields_production,
 )
 from worldenergydata.bsee.paleowells.era_classifier import GeologicalEraClassifier
+from worldenergydata.bsee.paleowells.field_era import (
+    apply_field_era,
+    build_field_era_map,
+)
 from worldenergydata.bsee.reports.all_fields_report import AllFieldsReport
 from worldenergydata.common.data_resolver import get_module_data_safe
 
@@ -118,6 +122,26 @@ def main() -> int:
         prod, field_water_depth=field_wd, latest_year=latest_year
     )
     logger.info("Aggregated %d fields", len(result))
+
+    # Lift paleo-well eras to the field level (all paleo wells, incl.
+    # non-producing) so far more fields than the producing-well-only
+    # classifier resolves to a real era; also stamps IS_LOWER_TERTIARY.
+    logger.info("Lifting eras to field level from all paleo wells...")
+    field_era_map = build_field_era_map()
+    result = apply_field_era(result, field_era_map)
+    if "GEOLOGICAL_ERA" in result.columns and not result.empty:
+        from_map = int(result["FIELD_CODE"].astype(str).str.strip().isin(field_era_map).sum())
+        unknown = int((result["GEOLOGICAL_ERA"] == "Unknown").sum())
+        lt = int(result["IS_LOWER_TERTIARY"].sum())
+        logger.info(
+            "Field-era map covers %d field codes; %d/%d atlas fields got era "
+            "from the field-map, %d remain Unknown, %d flagged Lower Tertiary",
+            len(field_era_map),
+            from_map,
+            len(result),
+            unknown,
+            lt,
+        )
 
     args.out.mkdir(parents=True, exist_ok=True)
     report = AllFieldsReport(result)

--- a/src/worldenergydata/bsee/paleowells/field_era.py
+++ b/src/worldenergydata/bsee/paleowells/field_era.py
@@ -1,0 +1,176 @@
+"""Field-level geological era lifting from Paleowells data.
+
+The base :class:`GeologicalEraClassifier` only credits a field with an era
+when that field's *producing* wells appear in ``Paleowells.csv`` — which
+leaves the vast majority of fields ``Unknown`` (~111/1390).
+
+This module lifts paleo-well eras to the **field** level by joining *all*
+paleo wells (producing or not) to their bottom-hole field code via the
+``mv_api_list_all`` API->field table, then assigning each field its
+dominant (most common) era.  The resulting field-level map is treated as
+authoritative when applied over an all-fields atlas.
+
+A Lower-Tertiary flag (Paleocene / Eocene / Oligocene) is also derived.
+All inputs are real BSEE public data; missing/unmaterialized files degrade
+gracefully to an empty map rather than fabricating eras.
+"""
+
+from __future__ import annotations
+
+import logging
+import pickle
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Dict, Optional
+
+import pandas as pd
+
+from worldenergydata.bsee.paleowells.era_classifier import GeologicalEraClassifier
+from worldenergydata.common.data_resolver import get_module_data_safe
+
+logger = logging.getLogger(__name__)
+
+# Lower Tertiary plays of interest (Wilcox / pre-Miocene deepwater GoM).
+LOWER_TERTIARY_ERAS = frozenset({"Paleocene", "Eocene", "Oligocene"})
+
+_PALEO_RELPATH = ("paleowells", "Paleowells.csv")
+_APIRAW_RELPATH = ("bin", "apiraw", "mv_api_list_all.bin")
+
+_API_COL = "API_WELL_NUMBER"
+_FIELD_COL = "BOTM_FLD_NAME_CD"
+
+
+def is_lower_tertiary(era: Optional[str]) -> bool:
+    """Return ``True`` iff ``era`` is one of the Lower Tertiary epochs."""
+    return era in LOWER_TERTIARY_ERAS
+
+
+def _load_apiraw_pickle(file_path: Path) -> pd.DataFrame:
+    """Load the API->field pickle, degrading to empty on stub/missing/bad type.
+
+    Mirrors the LFS-stub / missing-file / non-DataFrame guards used by
+    :class:`worldenergydata.bsee.data.field_names.FieldNameResolver`.
+    """
+    if not file_path.exists():
+        logger.warning("apiraw file not found: %s", file_path)
+        return pd.DataFrame()
+
+    try:
+        with open(file_path, "rb") as f:
+            header = f.read(40)
+        if b"version https://git-lfs" in header:
+            logger.warning("LFS stub detected (not materialized): %s", file_path)
+            return pd.DataFrame()
+
+        with open(file_path, "rb") as f:
+            obj = pickle.load(f)  # nosec B301
+
+        if isinstance(obj, pd.DataFrame):
+            return obj
+
+        logger.warning("apiraw file does not contain a DataFrame: %s", file_path)
+        return pd.DataFrame()
+
+    except Exception as e:  # pragma: no cover - defensive
+        logger.error("Error loading apiraw %s: %s", file_path, e)
+        return pd.DataFrame()
+
+
+def _build_api_to_field(apiraw: pd.DataFrame) -> Dict[str, str]:
+    """Build ``{API_WELL_NUMBER: BOTM_FLD_NAME_CD}`` from the apiraw frame."""
+    if apiraw.empty:
+        return {}
+    if _API_COL not in apiraw.columns or _FIELD_COL not in apiraw.columns:
+        logger.warning(
+            "apiraw missing expected columns %s/%s (have: %s)",
+            _API_COL,
+            _FIELD_COL,
+            list(apiraw.columns),
+        )
+        return {}
+
+    api_to_field: Dict[str, str] = {}
+    for api, field in zip(apiraw[_API_COL], apiraw[_FIELD_COL]):
+        api_str = str(api).strip()
+        field_str = str(field).strip()
+        if api_str and field_str:
+            api_to_field[api_str] = field_str
+    return api_to_field
+
+
+def build_field_era_map(data_dir: Optional[Path] = None) -> Dict[str, str]:
+    """Build a ``{field_code: dominant_era}`` map from all paleo wells.
+
+    Joins every paleo well that has an era to its bottom-hole field code,
+    accumulates era votes per field, and assigns each field its most common
+    era.  Returns an empty dict (never raises) when the apiraw join table is
+    missing/unmaterialized.
+
+    Args:
+        data_dir: BSEE module data dir; defaults to
+            ``get_module_data_safe("bsee")``.  The paleo CSV is expected at
+            ``<data_dir>/paleowells/Paleowells.csv`` and the apiraw pickle at
+            ``<data_dir>/bin/apiraw/mv_api_list_all.bin``.
+    """
+    base_dir = Path(data_dir) if data_dir is not None else get_module_data_safe("bsee")
+
+    paleo_csv = base_dir.joinpath(*_PALEO_RELPATH)
+    apiraw_bin = base_dir.joinpath(*_APIRAW_RELPATH)
+
+    well_eras = GeologicalEraClassifier(paleowells_csv=paleo_csv).get_well_eras()
+    if not well_eras:
+        logger.warning("No well eras from %s", paleo_csv)
+        return {}
+
+    api_to_field = _build_api_to_field(_load_apiraw_pickle(apiraw_bin))
+    if not api_to_field:
+        return {}
+
+    field_votes: Dict[str, Counter] = defaultdict(Counter)
+    for api, era in well_eras.items():
+        api_str = str(api).strip()
+        field = api_to_field.get(api_str)
+        if field and era:
+            field_votes[field][era] += 1
+
+    field_era: Dict[str, str] = {
+        field: votes.most_common(1)[0][0] for field, votes in field_votes.items()
+    }
+    logger.info(
+        "Built field-era map: %d fields from %d paleo wells",
+        len(field_era),
+        len(well_eras),
+    )
+    return field_era
+
+
+def apply_field_era(
+    result_df: pd.DataFrame, field_era_map: Dict[str, str]
+) -> pd.DataFrame:
+    """Override per-field era with the authoritative field-level map.
+
+    Returns a copy of ``result_df`` where ``GEOLOGICAL_ERA`` is replaced by
+    ``field_era_map[FIELD_CODE]`` for every field present in the map (the
+    field-level map uses *all* paleo wells, so it is authoritative over the
+    producing-well-only classifier).  Rows whose field is absent from the map
+    keep their existing era (which may be ``"Unknown"``).
+
+    Also adds/sets a boolean column ``IS_LOWER_TERTIARY`` derived from the
+    (possibly overridden) ``GEOLOGICAL_ERA``.
+    """
+    out = result_df.copy()
+
+    if out.empty:
+        if "IS_LOWER_TERTIARY" not in out.columns:
+            out["IS_LOWER_TERTIARY"] = pd.Series(dtype=bool)
+        return out
+
+    if "GEOLOGICAL_ERA" not in out.columns:
+        out["GEOLOGICAL_ERA"] = "Unknown"
+
+    if field_era_map and "FIELD_CODE" in out.columns:
+        mapped = out["FIELD_CODE"].astype(str).str.strip().map(field_era_map)
+        out["GEOLOGICAL_ERA"] = mapped.fillna(out["GEOLOGICAL_ERA"])
+
+    out["IS_LOWER_TERTIARY"] = out["GEOLOGICAL_ERA"].apply(is_lower_tertiary)
+    return out

--- a/tests/unit/bsee/paleowells/test_field_era.py
+++ b/tests/unit/bsee/paleowells/test_field_era.py
@@ -1,0 +1,168 @@
+"""Tests for field-level geological era lifting (field_era module).
+
+Uses only synthetic data written to ``tmp_path`` — no real BSEE files.
+"""
+
+import pickle
+
+import pandas as pd
+import pytest
+
+from worldenergydata.bsee.paleowells.field_era import (
+    LOWER_TERTIARY_ERAS,
+    apply_field_era,
+    build_field_era_map,
+    is_lower_tertiary,
+)
+
+
+def _write_synthetic_data(data_dir):
+    """Create a tiny Paleowells.csv + apiraw pickle under ``data_dir``.
+
+    Layout mirrors the real module:
+      <data_dir>/paleowells/Paleowells.csv
+      <data_dir>/bin/apiraw/mv_api_list_all.bin
+    """
+    paleo_dir = data_dir / "paleowells"
+    apiraw_dir = data_dir / "bin" / "apiraw"
+    paleo_dir.mkdir(parents=True, exist_ok=True)
+    apiraw_dir.mkdir(parents=True, exist_ok=True)
+
+    # Field FX1: two wells, both Eocene -> dominant Eocene.
+    # Field FX2: well A2 Oligocene, well A3 Miocene -> dominant Oligocene
+    #            (2 Oligocene records vs 1 Miocene).
+    paleo = pd.DataFrame(
+        {
+            "API Well Number": [
+                "100000000001",
+                "100000000001",
+                "100000000002",
+                "100000000003",
+                "100000000003",
+                "100000000004",  # well not present in apiraw -> dropped
+            ],
+            "Paleo Age": [
+                "Upper Eocene (Priabonian) Discoaster",
+                "Lower Eocene (Ypresian) Tribrachiatus",
+                "Lower Oligocene (Rupelian) Helicosphaera",
+                "Upper Oligocene (Chattian) Sphenolithus",
+                "Middle Miocene Globigerina",
+                "Upper Pliocene Foo",
+            ],
+        }
+    )
+    paleo.to_csv(paleo_dir / "Paleowells.csv", index=False)
+
+    apiraw = pd.DataFrame(
+        {
+            "API_WELL_NUMBER": [
+                "100000000001",
+                "100000000002",
+                "100000000003",
+                "999999999999",  # unrelated well
+            ],
+            "BOTM_FLD_NAME_CD": ["FX1", "FX2", "FX2", "FX9"],
+        }
+    )
+    with open(apiraw_dir / "mv_api_list_all.bin", "wb") as f:
+        pickle.dump(apiraw, f)
+
+    return data_dir
+
+
+def test_lower_tertiary_eras_membership():
+    assert LOWER_TERTIARY_ERAS == frozenset({"Paleocene", "Eocene", "Oligocene"})
+    assert "Paleocene" in LOWER_TERTIARY_ERAS
+    assert "Eocene" in LOWER_TERTIARY_ERAS
+    assert "Oligocene" in LOWER_TERTIARY_ERAS
+    assert "Miocene" not in LOWER_TERTIARY_ERAS
+
+
+def test_is_lower_tertiary():
+    assert is_lower_tertiary("Paleocene") is True
+    assert is_lower_tertiary("Eocene") is True
+    assert is_lower_tertiary("Oligocene") is True
+    assert is_lower_tertiary("Miocene") is False
+    assert is_lower_tertiary("Pliocene") is False
+    assert is_lower_tertiary("Unknown") is False
+    assert is_lower_tertiary(None) is False
+
+
+def test_build_field_era_map_dominant_era(tmp_path):
+    data_dir = _write_synthetic_data(tmp_path)
+    field_era = build_field_era_map(data_dir=data_dir)
+
+    assert field_era["FX1"] == "Eocene"
+    # FX2: two Oligocene records (one well Oligocene, second well has one
+    # Oligocene + one Miocene record) -> Oligocene dominates.
+    assert field_era["FX2"] == "Oligocene"
+    # The well not present in apiraw must not introduce a field.
+    assert all(fc in {"FX1", "FX2"} for fc in field_era)
+
+
+def test_build_field_era_map_missing_apiraw(tmp_path):
+    # Paleo CSV present but no apiraw bin -> graceful empty map, no raise.
+    paleo_dir = tmp_path / "paleowells"
+    paleo_dir.mkdir(parents=True)
+    pd.DataFrame(
+        {
+            "API Well Number": ["100000000001"],
+            "Paleo Age": ["Upper Eocene Discoaster"],
+        }
+    ).to_csv(paleo_dir / "Paleowells.csv", index=False)
+
+    assert build_field_era_map(data_dir=tmp_path) == {}
+
+
+def test_build_field_era_map_lfs_stub(tmp_path):
+    # apiraw is an LFS pointer stub -> graceful empty map.
+    paleo_dir = tmp_path / "paleowells"
+    apiraw_dir = tmp_path / "bin" / "apiraw"
+    paleo_dir.mkdir(parents=True)
+    apiraw_dir.mkdir(parents=True)
+    pd.DataFrame(
+        {
+            "API Well Number": ["100000000001"],
+            "Paleo Age": ["Upper Eocene Discoaster"],
+        }
+    ).to_csv(paleo_dir / "Paleowells.csv", index=False)
+    (apiraw_dir / "mv_api_list_all.bin").write_bytes(
+        b"version https://git-lfs.github.com/spec/v1\noid sha256:abc\n"
+    )
+
+    assert build_field_era_map(data_dir=tmp_path) == {}
+
+
+def test_apply_field_era_overrides_and_sets_flag():
+    result = pd.DataFrame(
+        {
+            "FIELD_CODE": ["FX1", "FX2", "FX3"],
+            "GEOLOGICAL_ERA": ["Unknown", "Miocene", "Pliocene"],
+        }
+    )
+    field_era = {"FX1": "Eocene", "FX2": "Oligocene"}
+
+    out = apply_field_era(result, field_era)
+
+    # Original frame untouched (copy semantics).
+    assert result.loc[0, "GEOLOGICAL_ERA"] == "Unknown"
+
+    # FX1, FX2 overridden by the authoritative field-level map.
+    assert out.loc[0, "GEOLOGICAL_ERA"] == "Eocene"
+    assert out.loc[1, "GEOLOGICAL_ERA"] == "Oligocene"
+    # FX3 not in map -> keeps existing era.
+    assert out.loc[2, "GEOLOGICAL_ERA"] == "Pliocene"
+
+    # Lower-Tertiary flag derived from the (possibly overridden) era.
+    assert out.loc[0, "IS_LOWER_TERTIARY"] is True or bool(
+        out.loc[0, "IS_LOWER_TERTIARY"]
+    )
+    assert bool(out.loc[1, "IS_LOWER_TERTIARY"]) is True
+    assert bool(out.loc[2, "IS_LOWER_TERTIARY"]) is False
+
+
+def test_apply_field_era_empty_df():
+    empty = pd.DataFrame(columns=["FIELD_CODE", "GEOLOGICAL_ERA"])
+    out = apply_field_era(empty, {"FX1": "Eocene"})
+    assert out.empty
+    assert "IS_LOWER_TERTIARY" in out.columns


### PR DESCRIPTION
**Stacked on #532** (merge #525 → #532 → this). Improves geological-era coverage of the all-fields atlas and adds a Lower-Tertiary flag — the era dimension of generalizing the LT work basin-wide.

## Problem
The base era classifier only credits a field when its own *producing* wells appear in `Paleowells.csv` → just **111/1,390** fields get an era.

## Fix
Join **all** paleo wells (producing or not) to their bottom-hole field code via the `apiraw/mv_api_list_all` API→field table, vote per field, assign the dominant era.

- `field_era.py` (new): `build_field_era_map()` (apiraw join + dominant-era vote; graceful empty on missing/LFS-stub source), `apply_field_era()` (authoritative field-level override + `IS_LOWER_TERTIARY` column), `is_lower_tertiary()`.
- Atlas script wires it in before report writes.
- 7 new unit tests (synthetic fixtures only).

## Verified (real data)
- **167 fields** with an era (up from 111): Oligocene 93 / Eocene 67 / Paleocene 7.
- Jack, St. Malo, Julia, Stones all correctly flagged Lower Tertiary.

## Honest limit
The paleo dataset is Lower-Tertiary-focused and covers only 458 wells, so this specifically improves LT coverage; **~1,220 fields remain `Unknown`** — no chronostratigraphic source exists for them in materialized BSEE data (flag, don't fabricate). Closing that gap needs external data (e.g. BOEM Atlas play assignments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)