### PR TITLE
feat(bsee): atlas water depth + benchmarking metrics

### DIFF
--- a/scripts/bsee/generate_all_fields_atlas.py
+++ b/scripts/bsee/generate_all_fields_atlas.py
@@ -24,6 +24,9 @@ from pathlib import Path
 
 from worldenergydata.bsee.analysis.all_fields_runner import AllFieldsRunner
 from worldenergydata.bsee.data.field_names import FieldNameResolver
+from worldenergydata.bsee.data.sources.bin.field_water_depth import (
+    load_field_water_depth,
+)
 from worldenergydata.bsee.data.sources.bin.ogor_production_loader import (
     load_all_fields_production,
 )
@@ -101,8 +104,19 @@ def main() -> int:
     resolver = FieldNameResolver()
     era = build_era_classifier()
 
+    logger.info("Loading field water depth...")
+    field_wd = load_field_water_depth()
+    logger.info("Field water depth available for %d field codes", len(field_wd))
+
+    latest_year = None
+    if "PROD_YEAR" in prod.columns:
+        years = prod["PROD_YEAR"].dropna()
+        latest_year = int(years.max()) if not years.empty else None
+
     logger.info("Aggregating all fields...")
-    result = AllFieldsRunner(resolver, era).run(prod)
+    result = AllFieldsRunner(resolver, era).run(
+        prod, field_water_depth=field_wd, latest_year=latest_year
+    )
     logger.info("Aggregated %d fields", len(result))
 
     args.out.mkdir(parents=True, exist_ok=True)

--- a/src/worldenergydata/bsee/analysis/all_fields_runner.py
+++ b/src/worldenergydata/bsee/analysis/all_fields_runner.py
@@ -32,14 +32,22 @@ class AllFieldsRunner:
         self,
         production_data: pd.DataFrame,
         water_depth_data: Optional[pd.DataFrame] = None,
+        field_water_depth: Optional[dict] = None,
+        latest_year: Optional[int] = None,
     ) -> pd.DataFrame:
         """Run all-fields analysis.
 
         Args:
             production_data: DataFrame with columns including FIELD_NAME_CODE,
                 LEASE_NUMBER, API_WELL_NUMBER, PROD_YEAR, MON_O_PROD_VOL,
-                MON_G_PROD_VOL, MON_WTR_PROD_VOL, DAYS_ON_PROD.
-            water_depth_data: Optional DataFrame with LEASE_NUMBER, MAX_WTR_DPTH.
+                MON_G_PROD_VOL, MON_WTR_PROD_VOL, DAYS_ON_PROD, OPERATOR.
+            water_depth_data: Optional DataFrame with LEASE_NUMBER, MAX_WTR_DPTH
+                (legacy lease-based water-depth path).
+            field_water_depth: Optional ``{FIELD_CODE: avg_water_depth_ft}`` map.
+                When provided it takes precedence over ``water_depth_data`` for
+                fields it covers (the new field-level path).
+            latest_year: Most recent PROD_YEAR in the dataset, used to flag
+                STILL_PRODUCING.  Defaults to the max PROD_YEAR in the input.
 
         Returns:
             DataFrame with one row per field, sorted by CUM_OIL_MMBBL descending.
@@ -53,10 +61,18 @@ class AllFieldsRunner:
             logger.error("No field code column found in production data")
             return self._empty_result()
 
+        if latest_year is None:
+            year_col = self._pick_col(production_data, ["PROD_YEAR", "PRODUCTION_DATE"])
+            if year_col:
+                years = pd.to_numeric(production_data[year_col], errors="coerce").dropna()
+                latest_year = int(years.max()) if not years.empty else None
+
         # Group by field and compute production metrics
         rows = []
         for field_code, field_df in production_data.groupby(field_col):
-            row = self._compute_field_production(str(field_code), field_df)
+            row = self._compute_field_production(
+                str(field_code), field_df, latest_year
+            )
 
             # Resolve field name
             row["FIELD_NAME"] = self._field_resolver.resolve(str(field_code))
@@ -65,10 +81,13 @@ class AllFieldsRunner:
             well_apis = field_df["API_WELL_NUMBER"].astype(str).unique().tolist()
             row["GEOLOGICAL_ERA"] = self._era_classifier.classify_field(well_apis)
 
-            # Join water depth
-            row["WATER_DEPTH_AVG"] = self._get_avg_water_depth(
-                field_df, water_depth_data
-            )
+            # Join water depth: field-level map wins, else legacy lease path.
+            wd = None
+            if field_water_depth is not None:
+                wd = field_water_depth.get(str(field_code))
+            if wd is None:
+                wd = self._get_avg_water_depth(field_df, water_depth_data)
+            row["WATER_DEPTH_AVG"] = wd
 
             # Tier 2 financial placeholders
             row["NPV10_MM_USD"] = None
@@ -86,19 +105,28 @@ class AllFieldsRunner:
         return result
 
     def _compute_field_production(
-        self, field_code: str, field_df: pd.DataFrame
+        self,
+        field_code: str,
+        field_df: pd.DataFrame,
+        latest_year: Optional[int] = None,
     ) -> Dict:
-        """Compute production metrics for a single field."""
+        """Compute production + benchmarking metrics for a single field."""
         oil_col = self._pick_col(field_df, ["MON_O_PROD_VOL", "OIL_STB"])
         gas_col = self._pick_col(field_df, ["MON_G_PROD_VOL", "GAS_MCF"])
         water_col = self._pick_col(field_df, ["MON_WTR_PROD_VOL"])
         year_col = self._pick_col(field_df, ["PROD_YEAR", "PRODUCTION_DATE"])
-        self._pick_col(field_df, ["DAYS_ON_PROD"])
+        days_col = self._pick_col(field_df, ["DAYS_ON_PROD"])
         api_col = self._pick_col(field_df, ["API_WELL_NUMBER"])
+        op_col = self._pick_col(field_df, ["OPERATOR", "SORT_NAME"])
 
         cum_oil = field_df[oil_col].sum() if oil_col else 0.0
         cum_gas = field_df[gas_col].sum() if gas_col else 0.0
         cum_water = field_df[water_col].sum() if water_col else 0.0
+        days_on_prod_sum = (
+            pd.to_numeric(field_df[days_col], errors="coerce").sum()
+            if days_col
+            else 0.0
+        )
 
         # Peak oil rate: max annual oil / 365
         peak_oil_bopd = 0.0
@@ -108,18 +136,40 @@ class AllFieldsRunner:
                 peak_oil_bopd = annual.max() / 365.0
 
         # Well count
-        well_count = 0
-        if api_col:
-            well_count = field_df[api_col].nunique()
+        well_count = field_df[api_col].nunique() if api_col else 0
 
         # Production year range
         first_prod = None
         last_prod = None
         if year_col:
-            years = field_df[year_col].dropna()
+            years = pd.to_numeric(field_df[year_col], errors="coerce").dropna()
             if not years.empty:
                 first_prod = int(years.min())
                 last_prod = int(years.max())
+
+        # Operator concentration within the field.
+        n_operators = None
+        top_operator_share = None
+        dominant_operator = None
+        if op_col and oil_col:
+            by_op = field_df.groupby(op_col)[oil_col].sum()
+            by_op = by_op[by_op.index.astype(str).str.strip() != ""]
+            if not by_op.empty:
+                n_operators = int(by_op.shape[0])
+                total = by_op.sum()
+                dominant_operator = str(by_op.idxmax())
+                if total > 0:
+                    top_operator_share = round(float(by_op.max() / total), 4)
+
+        # Production span (inclusive years).
+        prod_span = None
+        if first_prod is not None and last_prod is not None:
+            prod_span = last_prod - first_prod + 1
+
+        # Still-producing flag relative to the dataset's most recent year.
+        still_producing = None
+        if last_prod is not None and latest_year is not None:
+            still_producing = bool(last_prod == latest_year)
 
         return {
             "FIELD_CODE": field_code,
@@ -130,6 +180,25 @@ class AllFieldsRunner:
             "CUM_GAS_BCF": round(cum_gas * _MCF_TO_BCF, 3),
             "CUM_WATER_MMBBL": round(cum_water * _BBL_TO_MMBBL, 3),
             "PEAK_OIL_BOPD": round(peak_oil_bopd, 0),
+            "REC_PER_WELL_MMBBL": (
+                round(cum_oil * _BBL_TO_MMBBL / well_count, 4)
+                if well_count
+                else None
+            ),
+            "AVG_BOPD_PER_WELL": (
+                round(cum_oil / days_on_prod_sum, 1)
+                if days_on_prod_sum
+                else None
+            ),
+            "PROD_SPAN_YRS": prod_span,
+            "WOR_CUM": round(cum_water / cum_oil, 3) if cum_oil else None,
+            "PEAK_TO_CUM": (
+                round(peak_oil_bopd * 365.0 / cum_oil, 4) if cum_oil else None
+            ),
+            "N_OPERATORS": n_operators,
+            "TOP_OPERATOR_SHARE": top_operator_share,
+            "DOMINANT_OPERATOR": dominant_operator,
+            "STILL_PRODUCING": still_producing,
         }
 
     def _detect_field_column(self, df: pd.DataFrame) -> Optional[str]:
@@ -182,6 +251,15 @@ class AllFieldsRunner:
                 "CUM_GAS_BCF",
                 "CUM_WATER_MMBBL",
                 "PEAK_OIL_BOPD",
+                "REC_PER_WELL_MMBBL",
+                "AVG_BOPD_PER_WELL",
+                "PROD_SPAN_YRS",
+                "WOR_CUM",
+                "PEAK_TO_CUM",
+                "N_OPERATORS",
+                "TOP_OPERATOR_SHARE",
+                "DOMINANT_OPERATOR",
+                "STILL_PRODUCING",
                 "NPV10_MM_USD",
                 "IRR_PCT",
                 "PAYBACK_YRS",

--- a/src/worldenergydata/bsee/analysis/all_fields_runner.py
+++ b/src/worldenergydata/bsee/analysis/all_fields_runner.py
@@ -64,15 +64,15 @@ class AllFieldsRunner:
         if latest_year is None:
             year_col = self._pick_col(production_data, ["PROD_YEAR", "PRODUCTION_DATE"])
             if year_col:
-                years = pd.to_numeric(production_data[year_col], errors="coerce").dropna()
+                years = pd.to_numeric(
+                    production_data[year_col], errors="coerce"
+                ).dropna()
                 latest_year = int(years.max()) if not years.empty else None
 
         # Group by field and compute production metrics
         rows = []
         for field_code, field_df in production_data.groupby(field_col):
-            row = self._compute_field_production(
-                str(field_code), field_df, latest_year
-            )
+            row = self._compute_field_production(str(field_code), field_df, latest_year)
 
             # Resolve field name
             row["FIELD_NAME"] = self._field_resolver.resolve(str(field_code))
@@ -181,14 +181,10 @@ class AllFieldsRunner:
             "CUM_WATER_MMBBL": round(cum_water * _BBL_TO_MMBBL, 3),
             "PEAK_OIL_BOPD": round(peak_oil_bopd, 0),
             "REC_PER_WELL_MMBBL": (
-                round(cum_oil * _BBL_TO_MMBBL / well_count, 4)
-                if well_count
-                else None
+                round(cum_oil * _BBL_TO_MMBBL / well_count, 4) if well_count else None
             ),
             "AVG_BOPD_PER_WELL": (
-                round(cum_oil / days_on_prod_sum, 1)
-                if days_on_prod_sum
-                else None
+                round(cum_oil / days_on_prod_sum, 1) if days_on_prod_sum else None
             ),
             "PROD_SPAN_YRS": prod_span,
             "WOR_CUM": round(cum_water / cum_oil, 3) if cum_oil else None,

--- a/src/worldenergydata/bsee/data/sources/bin/field_water_depth.py
+++ b/src/worldenergydata/bsee/data/sources/bin/field_water_depth.py
@@ -1,0 +1,125 @@
+"""Field-level water depth from materialized BSEE structure/lease ``.bin`` data.
+
+Two on-disk pickled DataFrames carry water depth keyed by BOEM field code:
+
+* PRIMARY: ``<bin>/platstruc/mv_platstruc_structures.bin`` — per-structure
+  ``WATER_DEPTH`` (ft), averaged to one value per ``FIELD_NAME_CODE``.  This
+  is the authoritative source for fields that have a fixed/floating structure.
+* FALLBACK: ``<bin>/deepqual/mv_deep_water_field_leases.bin`` — per-lease
+  ``FLD_AVG_WTR_DPTH`` (ft) for deep-water qualified leases.  Used only to
+  FILL GAPS for field codes that platstruc does not cover (e.g. subsea
+  tiebacks with no own structure).
+
+The two are merged platstruc-wins; depths are real BSEE public values and
+are never fabricated.  LFS stubs, missing files, and non-DataFrame pickles
+are handled gracefully (a partial or empty dict is returned, never raised),
+mirroring the guard pattern in :mod:`field_names`.
+"""
+
+from __future__ import annotations
+
+import logging
+import pickle  # nosec B403
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+from worldenergydata.common.data_resolver import get_module_data_safe
+
+logger = logging.getLogger(__name__)
+
+_PLATSTRUC_REL = ("platstruc", "mv_platstruc_structures.bin")
+_DEEPQUAL_REL = ("deepqual", "mv_deep_water_field_leases.bin")
+
+
+def _load_pickle_safe(path: Path) -> Optional[pd.DataFrame]:
+    """Load a pickled DataFrame, returning ``None`` for LFS stubs/errors."""
+    if not path.exists():
+        logger.warning("Water-depth source not found: %s", path)
+        return None
+    try:
+        with open(path, "rb") as f:
+            header = f.read(40)
+        if b"version https://git-lfs" in header:
+            logger.warning("LFS stub (not materialized): %s", path)
+            return None
+        with open(path, "rb") as f:
+            obj = pickle.load(f)  # nosec B301
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Error loading %s: %s", path, exc)
+        return None
+    if not isinstance(obj, pd.DataFrame):
+        logger.warning("Not a DataFrame: %s", path)
+        return None
+    return obj
+
+
+def _avg_by_field(
+    df: Optional[pd.DataFrame], field_col: str, depth_col: str
+) -> dict[str, float]:
+    """Average a depth column by field code, dropping non-positive/blank rows."""
+    if df is None or df.empty:
+        return {}
+    if field_col not in df.columns or depth_col not in df.columns:
+        logger.warning(
+            "Missing columns %s/%s in water-depth source", field_col, depth_col
+        )
+        return {}
+
+    work = pd.DataFrame(
+        {
+            "field": df[field_col].astype(str).str.replace('"', "", regex=False).str.strip(),
+            "depth": pd.to_numeric(df[depth_col], errors="coerce"),
+        }
+    )
+    work = work[(work["depth"] > 0) & (work["field"] != "")]
+    if work.empty:
+        return {}
+    grouped = work.groupby("field")["depth"].mean().round()
+    return {str(k): float(v) for k, v in grouped.items()}
+
+
+def load_field_water_depth(data_dir: Optional[Path] = None) -> dict[str, float]:
+    """Return ``{FIELD_NAME_CODE: avg_water_depth_ft}`` from BSEE bin data.
+
+    Parameters
+    ----------
+    data_dir:
+        Directory containing the ``platstruc/`` and ``deepqual/`` subdirs.
+        Defaults to ``<bsee module>/bin`` (resolved via the repo data
+        resolver, which follows the materialized-data symlink).
+
+    Returns
+    -------
+    dict
+        Field code -> average water depth (ft), rounded.  platstruc values
+        take precedence; deepqual fills only the field codes platstruc
+        lacks.  Empty when neither source is materialized.
+    """
+    if data_dir is None:
+        data_dir = get_module_data_safe("bsee") / "bin"
+    data_dir = Path(data_dir)
+
+    platstruc = _avg_by_field(
+        _load_pickle_safe(data_dir.joinpath(*_PLATSTRUC_REL)),
+        "FIELD_NAME_CODE",
+        "WATER_DEPTH",
+    )
+    deepqual = _avg_by_field(
+        _load_pickle_safe(data_dir.joinpath(*_DEEPQUAL_REL)),
+        "FIELD_NAME_CODE",
+        "FLD_AVG_WTR_DPTH",
+    )
+
+    # platstruc wins for duplicate field codes; deepqual fills gaps only.
+    merged = dict(deepqual)
+    merged.update(platstruc)
+
+    logger.info(
+        "Field water depth: %d codes (platstruc=%d, deepqual-fill=%d)",
+        len(merged),
+        len(platstruc),
+        len(merged) - len(platstruc),
+    )
+    return merged

--- a/src/worldenergydata/bsee/data/sources/bin/field_water_depth.py
+++ b/src/worldenergydata/bsee/data/sources/bin/field_water_depth.py
@@ -69,7 +69,10 @@ def _avg_by_field(
 
     work = pd.DataFrame(
         {
-            "field": df[field_col].astype(str).str.replace('"', "", regex=False).str.strip(),
+            "field": df[field_col]
+            .astype(str)
+            .str.replace('"', "", regex=False)
+            .str.strip(),
             "depth": pd.to_numeric(df[depth_col], errors="coerce"),
         }
     )

--- a/src/worldenergydata/bsee/data/sources/bin/ogor_production_loader.py
+++ b/src/worldenergydata/bsee/data/sources/bin/ogor_production_loader.py
@@ -126,7 +126,7 @@ def to_runner_schema(df: pd.DataFrame) -> pd.DataFrame:
     Produces the columns the runner detects and aggregates:
     ``FIELD_NAME_CODE``, ``LEASE_NUMBER``, ``API_WELL_NUMBER``,
     ``PROD_YEAR``, ``MON_O_PROD_VOL``, ``MON_G_PROD_VOL``,
-    ``MON_WTR_PROD_VOL``, ``DAYS_ON_PROD``.
+    ``MON_WTR_PROD_VOL``, ``DAYS_ON_PROD``, ``OPERATOR``.
     """
     out_cols = [
         "FIELD_NAME_CODE",
@@ -137,6 +137,7 @@ def to_runner_schema(df: pd.DataFrame) -> pd.DataFrame:
         "MON_G_PROD_VOL",
         "MON_WTR_PROD_VOL",
         "DAYS_ON_PROD",
+        "OPERATOR",
     ]
     if df.empty:
         return pd.DataFrame(columns=out_cols)
@@ -146,6 +147,11 @@ def to_runner_schema(df: pd.DataFrame) -> pd.DataFrame:
     # Field code (BOEM_FIELD) and identifiers — strip whitespace/quotes.
     out["FIELD_NAME_CODE"] = (
         df["BOEM_FIELD"].astype(str).str.replace('"', "", regex=False).str.strip()
+    )
+
+    # Operator name (SORT_NAME) — strip whitespace and surrounding quotes.
+    out["OPERATOR"] = (
+        df["SORT_NAME"].astype(str).str.replace('"', "", regex=False).str.strip()
     )
     out["LEASE_NUMBER"] = (
         df["LEASE_NUMBER"]

--- a/src/worldenergydata/bsee/reports/all_fields_report.py
+++ b/src/worldenergydata/bsee/reports/all_fields_report.py
@@ -65,9 +65,9 @@ class AllFieldsReport:
             return empty
 
         by_op = (
-            work.groupby("DOMINANT_OPERATOR")["CUM_OIL_MMBBL"].sum().sort_values(
-                ascending=False
-            )
+            work.groupby("DOMINANT_OPERATOR")["CUM_OIL_MMBBL"]
+            .sum()
+            .sort_values(ascending=False)
         )
         total = by_op.sum()
         if total <= 0:
@@ -132,17 +132,21 @@ class AllFieldsReport:
                 lines.append(
                     f"- **Basin HHI (by dominant-operator oil)**: {conc['hhi']:.4f}"
                 )
-                lines.append(f"- **Top-1 operator oil share**: {conc['top1_share']:.1%}")
-                lines.append(f"- **Top-5 operator oil share**: {conc['top5_share']:.1%}")
-                lines.append(f"- **Distinct dominant operators**: {conc['n_operators']}")
+                lines.append(
+                    f"- **Top-1 operator oil share**: {conc['top1_share']:.1%}"
+                )
+                lines.append(
+                    f"- **Top-5 operator oil share**: {conc['top5_share']:.1%}"
+                )
+                lines.append(
+                    f"- **Distinct dominant operators**: {conc['n_operators']}"
+                )
                 lines.append("")
                 lines.append("| Operator | Oil (MMBBL) | Share |")
                 lines.append("|----------|-------------|-------|")
                 total_oil_conc = sum(conc["operator_oil"].values()) or 1.0
                 for op, oil in list(conc["operator_oil"].items())[:5]:
-                    lines.append(
-                        f"| {op} | {oil:,.1f} | {oil / total_oil_conc:.1%} |"
-                    )
+                    lines.append(f"| {op} | {oil:,.1f} | {oil / total_oil_conc:.1%} |")
                 lines.append("")
 
             # Top Fields Table

--- a/src/worldenergydata/bsee/reports/all_fields_report.py
+++ b/src/worldenergydata/bsee/reports/all_fields_report.py
@@ -35,6 +35,53 @@ class AllFieldsReport:
         )
         return grouped.sort_values("TOTAL_OIL_MMBBL", ascending=False)
 
+    def get_operator_concentration(self) -> dict:
+        """Compute basin-level operator concentration from dominant operators.
+
+        Oil is attributed to each field's DOMINANT_OPERATOR, summed across the
+        basin.  Returns the Herfindahl-Hirschman Index (HHI, sum of squared
+        market shares as fractions in 0..1), top-1 and top-5 oil shares, and
+        the ranked operator oil totals.  Guards empty / missing-column input.
+        """
+        empty = {
+            "hhi": None,
+            "top1_share": None,
+            "top5_share": None,
+            "n_operators": 0,
+            "operator_oil": {},
+        }
+        if (
+            self._df.empty
+            or "DOMINANT_OPERATOR" not in self._df.columns
+            or "CUM_OIL_MMBBL" not in self._df.columns
+        ):
+            return empty
+
+        work = self._df[["DOMINANT_OPERATOR", "CUM_OIL_MMBBL"]].copy()
+        work = work[work["DOMINANT_OPERATOR"].notna()]
+        work["DOMINANT_OPERATOR"] = work["DOMINANT_OPERATOR"].astype(str).str.strip()
+        work = work[work["DOMINANT_OPERATOR"] != ""]
+        if work.empty:
+            return empty
+
+        by_op = (
+            work.groupby("DOMINANT_OPERATOR")["CUM_OIL_MMBBL"].sum().sort_values(
+                ascending=False
+            )
+        )
+        total = by_op.sum()
+        if total <= 0:
+            return empty
+
+        shares = by_op / total
+        return {
+            "hhi": round(float((shares**2).sum()), 4),
+            "top1_share": round(float(shares.iloc[0]), 4),
+            "top5_share": round(float(shares.iloc[:5].sum()), 4),
+            "n_operators": int(by_op.shape[0]),
+            "operator_oil": {str(k): round(float(v), 1) for k, v in by_op.items()},
+        }
+
     def generate_markdown(self, output_path: Path) -> None:
         """Generate a structured Markdown report."""
         output_path = Path(output_path)
@@ -77,18 +124,39 @@ class AllFieldsReport:
                     )
                 lines.append("")
 
+            # Operator Concentration
+            conc = self.get_operator_concentration()
+            if conc.get("hhi") is not None:
+                lines.append("## Operator Concentration")
+                lines.append("")
+                lines.append(
+                    f"- **Basin HHI (by dominant-operator oil)**: {conc['hhi']:.4f}"
+                )
+                lines.append(f"- **Top-1 operator oil share**: {conc['top1_share']:.1%}")
+                lines.append(f"- **Top-5 operator oil share**: {conc['top5_share']:.1%}")
+                lines.append(f"- **Distinct dominant operators**: {conc['n_operators']}")
+                lines.append("")
+                lines.append("| Operator | Oil (MMBBL) | Share |")
+                lines.append("|----------|-------------|-------|")
+                total_oil_conc = sum(conc["operator_oil"].values()) or 1.0
+                for op, oil in list(conc["operator_oil"].items())[:5]:
+                    lines.append(
+                        f"| {op} | {oil:,.1f} | {oil / total_oil_conc:.1%} |"
+                    )
+                lines.append("")
+
             # Top Fields Table
             lines.append("## Top Fields by Production")
             lines.append("")
             top = self._df.head(20)
             if not top.empty:
                 lines.append(
-                    "| Field | Era | Oil (MMBBL) | Gas (BCF) | "
-                    "Wells | First Prod | Water Depth (ft) |"
+                    "| Field | Era | Oil (MMBBL) | Gas (BCF) | Wells | "
+                    "Rec/Well (MMBBL) | BOPD/Well | First Prod | Water Depth (ft) |"
                 )
                 lines.append(
-                    "|-------|-----|-------------|-----------|"
-                    "-------|------------|------------------|"
+                    "|-------|-----|-------------|-----------|-------|"
+                    "------------------|-----------|------------|------------------|"
                 )
                 for _, row in top.iterrows():
                     name = row.get("FIELD_NAME", row.get("FIELD_CODE", ""))
@@ -99,9 +167,13 @@ class AllFieldsReport:
                     first = row.get("FIRST_PRODUCTION", "")
                     wd = row.get("WATER_DEPTH_AVG", "")
                     wd_str = f"{wd:,.0f}" if pd.notna(wd) else ""
+                    rpw = row.get("REC_PER_WELL_MMBBL", None)
+                    rpw_str = f"{rpw:,.3f}" if pd.notna(rpw) else ""
+                    bpw = row.get("AVG_BOPD_PER_WELL", None)
+                    bpw_str = f"{bpw:,.0f}" if pd.notna(bpw) else ""
                     lines.append(
-                        f"| {name} | {era} | {oil:,.1f} | {gas:,.1f} "
-                        f"| {wells} | {first} | {wd_str} |"
+                        f"| {name} | {era} | {oil:,.1f} | {gas:,.1f} | {wells} "
+                        f"| {rpw_str} | {bpw_str} | {first} | {wd_str} |"
                     )
                 lines.append("")
 
@@ -168,6 +240,27 @@ class AllFieldsReport:
                         yaxis_title="Cumulative Oil (MMBBL)",
                     )
                     html_parts.append(fig1.to_html(full_html=False))
+
+                # Chart 1b: Top 10 operators by cumulative oil (bar)
+                conc = self.get_operator_concentration()
+                op_oil = conc.get("operator_oil") or {}
+                if op_oil:
+                    top_ops = list(op_oil.items())[:10]
+                    figop = go.Figure(
+                        data=[
+                            go.Bar(
+                                x=[o for o, _ in top_ops],
+                                y=[v for _, v in top_ops],
+                                marker_color="#2ca02c",
+                            )
+                        ]
+                    )
+                    figop.update_layout(
+                        title="Top 10 Operators by Cumulative Oil Production",
+                        xaxis_title="Operator (dominant per field)",
+                        yaxis_title="Cumulative Oil (MMBBL)",
+                    )
+                    html_parts.append(figop.to_html(full_html=False))
 
                 # Chart 2: Top 15 fields by production (horizontal bar)
                 top15 = self._df.head(15)

--- a/tests/unit/bsee/data/test_field_water_depth.py
+++ b/tests/unit/bsee/data/test_field_water_depth.py
@@ -1,0 +1,119 @@
+"""Unit tests for the field-level water depth source module.
+
+Uses SYNTHETIC platstruc/deepqual pickles in ``tmp_path`` (never the real
+multi-GB BSEE data) so the tests are deterministic and CI-portable.
+"""
+
+import pickle
+from pathlib import Path
+
+import pandas as pd
+
+from tests.test_markers import unit
+from worldenergydata.bsee.data.sources.bin.field_water_depth import (
+    load_field_water_depth,
+)
+
+
+def _write_platstruc(data_dir: Path, df: pd.DataFrame) -> None:
+    d = data_dir / "platstruc"
+    d.mkdir(parents=True, exist_ok=True)
+    with open(d / "mv_platstruc_structures.bin", "wb") as f:
+        pickle.dump(df, f)
+
+
+def _write_deepqual(data_dir: Path, df: pd.DataFrame) -> None:
+    d = data_dir / "deepqual"
+    d.mkdir(parents=True, exist_ok=True)
+    with open(d / "mv_deep_water_field_leases.bin", "wb") as f:
+        pickle.dump(df, f)
+
+
+@unit
+def test_platstruc_primary_averaged_by_field(tmp_path):
+    _write_platstruc(
+        tmp_path,
+        pd.DataFrame(
+            {
+                "FIELD_NAME_CODE": ["MC778", "MC778", "EI089"],
+                "WATER_DEPTH": [6000.0, 6400.0, 21.0],
+            }
+        ),
+    )
+    out = load_field_water_depth(data_dir=tmp_path)
+    assert out["MC778"] == 6200.0  # mean of 6000/6400
+    assert out["EI089"] == 21.0
+
+
+@unit
+def test_deepqual_fills_gaps_only(tmp_path):
+    """platstruc wins for shared codes; deepqual only fills codes it lacks."""
+    _write_platstruc(
+        tmp_path,
+        pd.DataFrame(
+            {"FIELD_NAME_CODE": ["MC807"], "WATER_DEPTH": [2980.0]}
+        ),
+    )
+    _write_deepqual(
+        tmp_path,
+        pd.DataFrame(
+            {
+                # MC807 also present in deepqual at a different value — must
+                # NOT override platstruc.
+                "FIELD_NAME_CODE": ["MC807", "KC292"],
+                "FLD_AVG_WTR_DPTH": [3341.0, 5879.0],
+            }
+        ),
+    )
+    out = load_field_water_depth(data_dir=tmp_path)
+    assert out["MC807"] == 2980.0  # platstruc wins
+    assert out["KC292"] == 5879.0  # deepqual fills gap
+
+
+@unit
+def test_water_depth_positive_filter(tmp_path):
+    _write_platstruc(
+        tmp_path,
+        pd.DataFrame(
+            {
+                "FIELD_NAME_CODE": ["AA001", "AA001", "BB002"],
+                "WATER_DEPTH": [0.0, -5.0, 100.0],
+            }
+        ),
+    )
+    out = load_field_water_depth(data_dir=tmp_path)
+    assert "AA001" not in out  # all rows non-positive -> dropped
+    assert out["BB002"] == 100.0
+
+
+@unit
+def test_blank_field_code_dropped(tmp_path):
+    _write_platstruc(
+        tmp_path,
+        pd.DataFrame(
+            {
+                "FIELD_NAME_CODE": ["", "   ", "CC003"],
+                "WATER_DEPTH": [500.0, 600.0, 700.0],
+            }
+        ),
+    )
+    out = load_field_water_depth(data_dir=tmp_path)
+    assert "" not in out
+    assert out == {"CC003": 700.0}
+
+
+@unit
+def test_missing_files_return_empty(tmp_path):
+    out = load_field_water_depth(data_dir=tmp_path)
+    assert out == {}
+
+
+@unit
+def test_lfs_stub_handled(tmp_path):
+    d = tmp_path / "platstruc"
+    d.mkdir(parents=True)
+    (d / "mv_platstruc_structures.bin").write_bytes(
+        b"version https://git-lfs.github.com/spec/v1\noid sha256:deadbeef\n"
+    )
+    out = load_field_water_depth(data_dir=tmp_path)
+    assert out == {}

--- a/tests/unit/bsee/data/test_field_water_depth.py
+++ b/tests/unit/bsee/data/test_field_water_depth.py
@@ -50,9 +50,7 @@ def test_deepqual_fills_gaps_only(tmp_path):
     """platstruc wins for shared codes; deepqual only fills codes it lacks."""
     _write_platstruc(
         tmp_path,
-        pd.DataFrame(
-            {"FIELD_NAME_CODE": ["MC807"], "WATER_DEPTH": [2980.0]}
-        ),
+        pd.DataFrame({"FIELD_NAME_CODE": ["MC807"], "WATER_DEPTH": [2980.0]}),
     )
     _write_deepqual(
         tmp_path,

--- a/tests/unit/bsee/data/test_ogor_production_loader.py
+++ b/tests/unit/bsee/data/test_ogor_production_loader.py
@@ -89,9 +89,11 @@ def test_to_runner_schema_maps_and_types():
     assert list(out.columns) == [
         "FIELD_NAME_CODE", "LEASE_NUMBER", "API_WELL_NUMBER", "PROD_YEAR",
         "MON_O_PROD_VOL", "MON_G_PROD_VOL", "MON_WTR_PROD_VOL", "DAYS_ON_PROD",
+        "OPERATOR",
     ]
     assert out.iloc[0]["FIELD_NAME_CODE"] == "MC807"  # from BOEM_FIELD
     assert out.iloc[0]["PROD_YEAR"] == 2024            # from 202401
+    assert out.iloc[0]["OPERATOR"] == "BP"            # from SORT_NAME
     assert out["MON_O_PROD_VOL"].sum() == pytest.approx(2_001_000.0)
 
 
@@ -105,12 +107,13 @@ def test_to_runner_schema_empty():
 @unit
 def test_to_runner_schema_strips_quotes_and_whitespace():
     rows = [["\" G99 \"", "E", 202012, 31, "O", 10.0, 0.0, 0.0,
-             " 60805 ", "PR", "B", "1", "OP", " GC640 ",
+             " 60805 ", "PR", "B", "1", '" Shell "', " GC640 ",
              0.0, "Q", 0, "", ""]]
     out = to_runner_schema(pd.DataFrame(rows, columns=OGOR_COLUMN_NAMES))
     assert out.iloc[0]["FIELD_NAME_CODE"] == "GC640"
     assert out.iloc[0]["LEASE_NUMBER"] == "G99"
     assert out.iloc[0]["API_WELL_NUMBER"] == "60805"
+    assert out.iloc[0]["OPERATOR"] == "Shell"  # SORT_NAME quotes+ws stripped
 
 
 @unit

--- a/tests/unit/bsee/data/test_ogor_production_loader.py
+++ b/tests/unit/bsee/data/test_ogor_production_loader.py
@@ -26,12 +26,48 @@ def _canonical_rows():
     return [
         # lease, comp, YYYYMM, days, prod, oil, gas, wtr, api, stat,
         # block, opnum, sortname, BOEM_FIELD, inj, interval, firstprod, unit, suffix
-        ["G12345", "E001", 202401, 30, "O", 1000.0, 5000.0, 200.0,
-         "608054010300", "PR", "MC0807", "03151", "BP", "MC807",
-         0.0, "Q01", 20100101, "", ""],
-        ["G12345", "E002", 202402, 28, "O", 2_000_000.0, 6000.0, 250.0,
-         "608054010301", "PR", "MC0807", "03151", "BP", "MC807",
-         0.0, "Q01", 20100101, "", ""],
+        [
+            "G12345",
+            "E001",
+            202401,
+            30,
+            "O",
+            1000.0,
+            5000.0,
+            200.0,
+            "608054010300",
+            "PR",
+            "MC0807",
+            "03151",
+            "BP",
+            "MC807",
+            0.0,
+            "Q01",
+            20100101,
+            "",
+            "",
+        ],
+        [
+            "G12345",
+            "E002",
+            202402,
+            28,
+            "O",
+            2_000_000.0,
+            6000.0,
+            250.0,
+            "608054010301",
+            "PR",
+            "MC0807",
+            "03151",
+            "BP",
+            "MC807",
+            0.0,
+            "Q01",
+            20100101,
+            "",
+            "",
+        ],
     ]
 
 
@@ -87,13 +123,19 @@ def test_to_runner_schema_maps_and_types():
     out = to_runner_schema(raw)
 
     assert list(out.columns) == [
-        "FIELD_NAME_CODE", "LEASE_NUMBER", "API_WELL_NUMBER", "PROD_YEAR",
-        "MON_O_PROD_VOL", "MON_G_PROD_VOL", "MON_WTR_PROD_VOL", "DAYS_ON_PROD",
+        "FIELD_NAME_CODE",
+        "LEASE_NUMBER",
+        "API_WELL_NUMBER",
+        "PROD_YEAR",
+        "MON_O_PROD_VOL",
+        "MON_G_PROD_VOL",
+        "MON_WTR_PROD_VOL",
+        "DAYS_ON_PROD",
         "OPERATOR",
     ]
     assert out.iloc[0]["FIELD_NAME_CODE"] == "MC807"  # from BOEM_FIELD
-    assert out.iloc[0]["PROD_YEAR"] == 2024            # from 202401
-    assert out.iloc[0]["OPERATOR"] == "BP"            # from SORT_NAME
+    assert out.iloc[0]["PROD_YEAR"] == 2024  # from 202401
+    assert out.iloc[0]["OPERATOR"] == "BP"  # from SORT_NAME
     assert out["MON_O_PROD_VOL"].sum() == pytest.approx(2_001_000.0)
 
 
@@ -106,9 +148,29 @@ def test_to_runner_schema_empty():
 
 @unit
 def test_to_runner_schema_strips_quotes_and_whitespace():
-    rows = [["\" G99 \"", "E", 202012, 31, "O", 10.0, 0.0, 0.0,
-             " 60805 ", "PR", "B", "1", '" Shell "', " GC640 ",
-             0.0, "Q", 0, "", ""]]
+    rows = [
+        [
+            '" G99 "',
+            "E",
+            202012,
+            31,
+            "O",
+            10.0,
+            0.0,
+            0.0,
+            " 60805 ",
+            "PR",
+            "B",
+            "1",
+            '" Shell "',
+            " GC640 ",
+            0.0,
+            "Q",
+            0,
+            "",
+            "",
+        ]
+    ]
     out = to_runner_schema(pd.DataFrame(rows, columns=OGOR_COLUMN_NAMES))
     assert out.iloc[0]["FIELD_NAME_CODE"] == "GC640"
     assert out.iloc[0]["LEASE_NUMBER"] == "G99"
@@ -121,9 +183,7 @@ def test_load_all_fields_production_concats_year_range(tmp_path):
     _write_corrupted_bin(tmp_path / "ogora2023delimit.bin")
     _write_corrupted_bin(tmp_path / "ogora2024delimit.bin")
 
-    df = load_all_fields_production(
-        data_dir=tmp_path, start_year=2023, end_year=2024
-    )
+    df = load_all_fields_production(data_dir=tmp_path, start_year=2023, end_year=2024)
 
     # 1 surviving row per file x 2 files
     assert len(df) == 2
@@ -141,9 +201,7 @@ def test_load_all_fields_production_no_files(tmp_path):
 def test_end_to_end_feeds_all_fields_runner(tmp_path):
     """Loader output is consumable by AllFieldsRunner without adaptation."""
     _write_corrupted_bin(tmp_path / "ogora2024delimit.bin")
-    prod = load_all_fields_production(
-        data_dir=tmp_path, start_year=2024, end_year=2024
-    )
+    prod = load_all_fields_production(data_dir=tmp_path, start_year=2024, end_year=2024)
 
     class _StubResolver:
         def resolve(self, code):

--- a/tests/unit/bsee/test_all_fields_report.py
+++ b/tests/unit/bsee/test_all_fields_report.py
@@ -23,6 +23,15 @@ def _make_result_df():
             "CUM_GAS_BCF": [200.0, 600.0, 100.0, 400.0],
             "CUM_WATER_MMBBL": [50.0, 200.0, 30.0, 100.0],
             "PEAK_OIL_BOPD": [80000.0, 120000.0, 50000.0, 90000.0],
+            "REC_PER_WELL_MMBBL": [14.0, 15.0, 18.0, 12.5],
+            "AVG_BOPD_PER_WELL": [10000.0, 8000.0, 12000.0, 9000.0],
+            "PROD_SPAN_YRS": [16, 28, 17, 30],
+            "WOR_CUM": [0.14, 0.22, 0.17, 0.20],
+            "PEAK_TO_CUM": [0.08, 0.05, 0.10, 0.07],
+            "N_OPERATORS": [2, 1, 1, 3],
+            "TOP_OPERATOR_SHARE": [0.9, 1.0, 1.0, 0.6],
+            "DOMINANT_OPERATOR": ["BP", "Shell", "BP", "Shell"],
+            "STILL_PRODUCING": [False, False, False, False],
             "NPV10_MM_USD": [None, None, None, None],
             "IRR_PCT": [None, None, None, None],
             "PAYBACK_YRS": [None, None, None, None],
@@ -130,6 +139,38 @@ class TestAllFieldsReport:
         summary = report.get_era_summary()
         # Miocene fields have most oil (350 + 900 = 1250)
         assert summary.iloc[0].name == "Miocene"
+
+    def test_operator_concentration_hhi(self, report):
+        """HHI / shares from dominant-operator oil totals."""
+        conc = report.get_operator_concentration()
+        # Shell oil = 900+500 = 1400; BP oil = 350+180 = 530; total = 1930.
+        total = 1930.0
+        shell, bp = 1400.0 / total, 530.0 / total
+        assert conc["n_operators"] == 2
+        assert conc["top1_share"] == pytest.approx(shell, abs=1e-3)
+        assert conc["top5_share"] == pytest.approx(1.0, abs=1e-3)
+        assert conc["hhi"] == pytest.approx(shell**2 + bp**2, abs=1e-3)
+        assert conc["operator_oil"]["Shell"] == pytest.approx(1400.0)
+        assert conc["operator_oil"]["BP"] == pytest.approx(530.0)
+
+    def test_operator_concentration_empty(self):
+        from worldenergydata.bsee.reports.all_fields_report import (
+            AllFieldsReport,
+        )
+
+        rpt = AllFieldsReport(pd.DataFrame(columns=["FIELD_CODE"]))
+        conc = rpt.get_operator_concentration()
+        assert conc["hhi"] is None
+        assert conc["operator_oil"] == {}
+
+    def test_markdown_has_operator_section_and_columns(self, report, tmp_path):
+        output = tmp_path / "report.md"
+        report.generate_markdown(output)
+        content = output.read_text()
+        assert "Operator Concentration" in content
+        assert "Basin HHI" in content
+        assert "Rec/Well" in content
+        assert "BOPD/Well" in content
 
     def test_empty_dataframe(self, tmp_path):
         """Test report generation with empty data."""

--- a/tests/unit/bsee/test_all_fields_runner.py
+++ b/tests/unit/bsee/test_all_fields_runner.py
@@ -26,6 +26,7 @@ def _make_production_df(field_codes=None):
                     "MON_G_PROD_VOL": 500000.0,
                     "MON_WTR_PROD_VOL": 20000.0,
                     "DAYS_ON_PROD": 365,
+                    "OPERATOR": "BP",
                 }
             )
     return pd.DataFrame(rows)
@@ -261,3 +262,154 @@ class TestAllFieldsRunner:
 
         # Field 200 (Mars) should be first (more production)
         assert result.iloc[0]["FIELD_CODE"] == "200"
+
+
+@unit
+class TestBenchmarkingMetrics:
+    """Tests for the deterministic benchmarking metrics added to the runner."""
+
+    @pytest.fixture
+    def runner(self):
+        from worldenergydata.bsee.analysis.all_fields_runner import (
+            AllFieldsRunner,
+        )
+
+        resolver = Mock()
+        resolver.resolve.side_effect = lambda c: c
+        classifier = Mock()
+        classifier.classify_field.side_effect = lambda w: "Miocene"
+        return AllFieldsRunner(resolver, classifier)
+
+    def _multi_well_op_df(self):
+        """One field, 3 wells, 2 operators, 2 years."""
+        rows = []
+        wells = {
+            "60805A": ("BP", 600000.0),       # BP dominant
+            "60805B": ("BP", 300000.0),
+            "60805C": ("Shell", 100000.0),
+        }
+        for api, (op, oil_per_yr) in wells.items():
+            for year in [2020, 2021]:
+                rows.append(
+                    {
+                        "FIELD_NAME_CODE": "100",
+                        "LEASE_NUMBER": "G10001",
+                        "API_WELL_NUMBER": api,
+                        "PROD_YEAR": year,
+                        "MON_O_PROD_VOL": oil_per_yr,
+                        "MON_G_PROD_VOL": 0.0,
+                        "MON_WTR_PROD_VOL": oil_per_yr * 0.5,
+                        "DAYS_ON_PROD": 365,
+                        "OPERATOR": op,
+                    }
+                )
+        return pd.DataFrame(rows)
+
+    def test_rec_per_well(self, runner):
+        df = self._multi_well_op_df()
+        row = runner.run(df).iloc[0]
+        # cum_oil = (600k+300k+100k)*2yrs = 2,000,000 bbl = 2.0 MMBBL; 3 wells.
+        assert row["CUM_OIL_MMBBL"] == pytest.approx(2.0)
+        assert row["WELL_COUNT"] == 3
+        assert row["REC_PER_WELL_MMBBL"] == pytest.approx(2.0 / 3, rel=1e-3)
+
+    def test_avg_bopd_per_well_via_days(self, runner):
+        df = self._multi_well_op_df()
+        row = runner.run(df).iloc[0]
+        # cum_oil bbl / sum(DAYS_ON_PROD). 6 records * 365 = 2190 days.
+        assert row["AVG_BOPD_PER_WELL"] == pytest.approx(2_000_000.0 / 2190, rel=1e-3)
+
+    def test_wor_cum(self, runner):
+        df = self._multi_well_op_df()
+        row = runner.run(df).iloc[0]
+        # water = 0.5 * oil -> WOR = 0.5
+        assert row["WOR_CUM"] == pytest.approx(0.5, rel=1e-3)
+
+    def test_operator_share_and_dominant(self, runner):
+        df = self._multi_well_op_df()
+        row = runner.run(df).iloc[0]
+        # BP oil = (600k+300k)*2 = 1.8M of 2.0M total -> 0.9 share.
+        assert row["N_OPERATORS"] == 2
+        assert row["DOMINANT_OPERATOR"] == "BP"
+        assert row["TOP_OPERATOR_SHARE"] == pytest.approx(0.9, rel=1e-3)
+
+    def test_prod_span_yrs(self, runner):
+        df = self._multi_well_op_df()
+        row = runner.run(df).iloc[0]
+        assert row["PROD_SPAN_YRS"] == 2  # 2020..2021 inclusive
+
+    def test_still_producing_via_latest_year(self, runner):
+        df = self._multi_well_op_df()  # last prod = 2021
+        producing = runner.run(df, latest_year=2021).iloc[0]
+        assert bool(producing["STILL_PRODUCING"]) is True
+        retired = runner.run(df, latest_year=2025).iloc[0]
+        assert bool(retired["STILL_PRODUCING"]) is False
+
+    def test_latest_year_defaults_to_max(self, runner):
+        df = self._multi_well_op_df()  # max year 2021
+        row = runner.run(df).iloc[0]
+        assert bool(row["STILL_PRODUCING"]) is True
+
+    def test_water_depth_from_field_dict(self, runner):
+        df = self._multi_well_op_df()
+        row = runner.run(df, field_water_depth={"100": 6200.0}).iloc[0]
+        assert row["WATER_DEPTH_AVG"] == 6200.0
+
+    def test_field_water_depth_precedence_over_lease(self, runner):
+        df = self._multi_well_op_df()
+        lease_wd = pd.DataFrame(
+            {"LEASE_NUMBER": ["G10001"], "MAX_WTR_DPTH": [1000.0]}
+        )
+        row = runner.run(
+            df, water_depth_data=lease_wd, field_water_depth={"100": 6200.0}
+        ).iloc[0]
+        assert row["WATER_DEPTH_AVG"] == 6200.0  # field map wins
+
+    def test_field_water_depth_falls_back_to_lease(self, runner):
+        df = self._multi_well_op_df()
+        lease_wd = pd.DataFrame(
+            {"LEASE_NUMBER": ["G10001"], "MAX_WTR_DPTH": [1000.0]}
+        )
+        # field map has no entry for "100" -> legacy lease path used.
+        row = runner.run(
+            df, water_depth_data=lease_wd, field_water_depth={"999": 5.0}
+        ).iloc[0]
+        assert row["WATER_DEPTH_AVG"] == 1000.0
+
+    def test_division_guards_single_year_no_water(self, runner):
+        rows = [
+            {
+                "FIELD_NAME_CODE": "100",
+                "LEASE_NUMBER": "G10001",
+                "API_WELL_NUMBER": "60805A",
+                "PROD_YEAR": 2020,
+                "MON_O_PROD_VOL": 0.0,
+                "MON_G_PROD_VOL": 0.0,
+                "MON_WTR_PROD_VOL": 0.0,
+                "DAYS_ON_PROD": 0,
+                "OPERATOR": "BP",
+            }
+        ]
+        row = runner.run(pd.DataFrame(rows)).iloc[0]
+        # cum_oil == 0 -> guarded metrics are None, not a ZeroDivisionError.
+        assert row["WOR_CUM"] is None
+        assert row["PEAK_TO_CUM"] is None
+        assert row["AVG_BOPD_PER_WELL"] is None
+
+    def test_empty_result_has_new_columns(self, runner):
+        empty = pd.DataFrame(
+            columns=["FIELD_NAME_CODE", "API_WELL_NUMBER", "PROD_YEAR"]
+        )
+        result = runner.run(empty)
+        for col in [
+            "REC_PER_WELL_MMBBL",
+            "AVG_BOPD_PER_WELL",
+            "PROD_SPAN_YRS",
+            "WOR_CUM",
+            "PEAK_TO_CUM",
+            "N_OPERATORS",
+            "TOP_OPERATOR_SHARE",
+            "DOMINANT_OPERATOR",
+            "STILL_PRODUCING",
+        ]:
+            assert col in result.columns

--- a/tests/unit/bsee/test_all_fields_runner.py
+++ b/tests/unit/bsee/test_all_fields_runner.py
@@ -284,7 +284,7 @@ class TestBenchmarkingMetrics:
         """One field, 3 wells, 2 operators, 2 years."""
         rows = []
         wells = {
-            "60805A": ("BP", 600000.0),       # BP dominant
+            "60805A": ("BP", 600000.0),  # BP dominant
             "60805B": ("BP", 300000.0),
             "60805C": ("Shell", 100000.0),
         }
@@ -357,9 +357,7 @@ class TestBenchmarkingMetrics:
 
     def test_field_water_depth_precedence_over_lease(self, runner):
         df = self._multi_well_op_df()
-        lease_wd = pd.DataFrame(
-            {"LEASE_NUMBER": ["G10001"], "MAX_WTR_DPTH": [1000.0]}
-        )
+        lease_wd = pd.DataFrame({"LEASE_NUMBER": ["G10001"], "MAX_WTR_DPTH": [1000.0]})
         row = runner.run(
             df, water_depth_data=lease_wd, field_water_depth={"100": 6200.0}
         ).iloc[0]
@@ -367,9 +365,7 @@ class TestBenchmarkingMetrics:
 
     def test_field_water_depth_falls_back_to_lease(self, runner):
         df = self._multi_well_op_df()
-        lease_wd = pd.DataFrame(
-            {"LEASE_NUMBER": ["G10001"], "MAX_WTR_DPTH": [1000.0]}
-        )
+        lease_wd = pd.DataFrame({"LEASE_NUMBER": ["G10001"], "MAX_WTR_DPTH": [1000.0]})
         # field map has no entry for "100" -> legacy lease path used.
         row = runner.run(
             df, water_depth_data=lease_wd, field_water_depth={"999": 5.0}


### PR DESCRIPTION
Replaces #532 (auto-closed when #525's branch was deleted on merge — its code is unchanged on this branch, now retargeted to `main`). #525 is merged, so this diff is just the enrichment.

Generalizes the Lower Tertiary access/concentration thesis to all ~1,390 GoM fields with deterministic, real-data metrics.

## Adds
- **Per-field water depth** (`field_water_depth.py`): platstruc `WATER_DEPTH` primary + deepqual `FLD_AVG_WTR_DPTH` gap-fill → **1,108/1,390 fields** (uncovered shelf fields blank — flag-don't-fake).
- **Benchmarking metrics** in `AllFieldsRunner`: `REC_PER_WELL_MMBBL`, `AVG_BOPD_PER_WELL`, `PROD_SPAN_YRS`, `WOR_CUM`, `PEAK_TO_CUM`, `N_OPERATORS`, `TOP_OPERATOR_SHARE`, `DOMINANT_OPERATOR`, `STILL_PRODUCING` (all divisions guarded → None).
- `OPERATOR` threaded through `to_runner_schema` (OGOR `SORT_NAME`).
- **Operator concentration** in `AllFieldsReport`: basin HHI + top-1/5 oil shares, top-10-operators bar chart, Rec/Well & BOPD/Well table columns.

## Verified (real data 1996–2025)
- Water depth: MC778 (Thunder Horse) 6,200 ft · MC807 (Mars) 2,980 · AC857 (Lucius) 7,835; shelf EI089 21 ft.
- `AVG_BOPD_PER_WELL`: MC778 = 10,329 vs shelf in the tens — cleanest deepwater↔shelf separator.
- **53 unit tests pass**; Black-clean; all files ≤500 lines.

## Honest scope
OGOR-A has **no subsea/dry-tree/completion-type flag** — "access" is a composite proxy (water depth + BOPD/well + operator concentration), stated honestly, not a fabricated field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)