### PR TITLE
feat(bsee): access/concentration HTML atlas visualizations

### DIFF
--- a/src/worldenergydata/bsee/reports/all_fields_report.py
+++ b/src/worldenergydata/bsee/reports/all_fields_report.py
@@ -219,11 +219,55 @@ class AllFieldsReport:
             import plotly.graph_objects as go
             from plotly.subplots import make_subplots  # noqa: F401
 
+            from worldenergydata.bsee.reports.atlas_charts import (
+                access_scatter_figure,
+                access_scatter_frame,
+                rec_per_well_by_era,
+                rec_per_well_figure,
+                water_depth_figure,
+                water_depth_split,
+            )
+
             html_parts = []
             html_parts.append(
                 "<html><head><title>BSEE All-Fields Dashboard</title></head><body>"
             )
-            html_parts.append("<h1>BSEE All-Fields Analysis Dashboard</h1>")
+            html_parts.append(self._html_header())
+
+            if not self._df.empty:
+                # Headline: access / concentration scatter (Lower Tertiary thesis)
+                scatter_sub = access_scatter_frame(self._df)
+                n_shown = len(scatter_sub)
+                n_total = len(self._df)
+                logger.info(
+                    "Access scatter: %d/%d fields shown (material, >=3 wells, "
+                    "water depth present); %d dropped",
+                    n_shown,
+                    n_total,
+                    n_total - n_shown,
+                )
+                html_parts.append(
+                    access_scatter_figure(scatter_sub).to_html(full_html=False)
+                )
+                html_parts.append(
+                    f"<p style='color:#555;font-size:0.9em'>Access scatter shows "
+                    f"{n_shown} of {n_total} fields (material: cumulative oil &ge; 1 "
+                    f"MMBBL, &ge; 3 wells, water depth present); "
+                    f"{n_total - n_shown} dropped for missing/insufficient data.</p>"
+                )
+
+                # Recovery per well by era cohort
+                cohorts = rec_per_well_by_era(self._df)
+                html_parts.append(rec_per_well_figure(cohorts).to_html(full_html=False))
+
+                # Water depth distribution + deepwater/shelf split
+                split = water_depth_split(self._df)
+                html_parts.append(water_depth_figure(self._df).to_html(full_html=False))
+                html_parts.append(
+                    f"<p style='color:#555;font-size:0.9em'>{split['n_deepwater']} "
+                    f"deepwater (&gt;1000 ft) vs {split['n_shelf']} shelf fields of "
+                    f"{split['n_with_depth']} with a water-depth source.</p>"
+                )
 
             if not self._df.empty:
                 # Chart 1: Oil production by era (bar)
@@ -286,6 +330,7 @@ class AllFieldsReport:
                     )
                     html_parts.append(fig2.to_html(full_html=False))
 
+            html_parts.append(self._html_footnote())
             html_parts.append("</body></html>")
             output_path.write_text("\n".join(html_parts))
             logger.info("HTML dashboard written to %s", output_path)
@@ -294,6 +339,30 @@ class AllFieldsReport:
             # Fallback: simple HTML table without Plotly
             logger.warning("Plotly not available — generating basic HTML table")
             self._generate_html_table_fallback(output_path)
+
+    @staticmethod
+    def _html_header() -> str:
+        """Report title + data-vintage note block."""
+        return (
+            "<h1>BSEE Gulf of Mexico All-Fields Atlas</h1>"
+            "<p style='color:#444;max-width:60em'>"
+            "Visualizing the Lower-Tertiary <b>access / concentration</b> thesis "
+            "basin-wide: deepwater, high-recovery-per-well hubs (few hard-to-reach "
+            "wells) versus the shallow shelf.</p>"
+            "<p style='color:#666;font-size:0.9em'>"
+            "Data vintage: BSEE OGOR-A public production, 1996&ndash;2025.</p>"
+        )
+
+    @staticmethod
+    def _html_footnote() -> str:
+        """Honest coverage caveat footnote."""
+        return (
+            "<hr/><p style='color:#777;font-size:0.85em;max-width:60em'>"
+            "<b>Footnote.</b> Access is a composite proxy (water depth + BOPD/well "
+            "+ operator concentration); OGOR-A has no subsea/dry-tree completion "
+            "flag. Fields without a water-depth or era source are shown as "
+            "blank/Unknown, not estimated.</p>"
+        )
 
     def _generate_html_table_fallback(self, output_path: Path) -> None:
         """Generate a basic HTML table when Plotly is not available."""

--- a/src/worldenergydata/bsee/reports/atlas_charts.py
+++ b/src/worldenergydata/bsee/reports/atlas_charts.py
@@ -1,0 +1,335 @@
+"""Pure data-prep + Plotly figure builders for the all-fields atlas.
+
+These functions take a per-field result DataFrame (as produced by
+:class:`AllFieldsRunner` and enriched with geological era + water depth)
+and return either a filtered DataFrame or a :class:`plotly.graph_objects.Figure`.
+
+Design rules:
+- Deterministic, no side effects, no I/O.
+- Flag-don't-fake: rows lacking a required real value are dropped, never
+  imputed; the figure builders surface counts so callers can log coverage.
+
+Plotting the Lower-Tertiary "access / concentration" thesis: deepwater,
+high-recovery-per-well hubs (few hard-to-reach wells) vs the shallow shelf.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+# Thresholds for the headline access/concentration scatter.
+MIN_CUM_OIL_MMBBL = 1.0
+MIN_WELL_COUNT = 3
+# Minimum number of fields for a geological-era cohort to be charted.
+MIN_COHORT_FIELDS = 3
+# Deepwater / shelf cutoff (ft).
+DEEPWATER_FT = 1000.0
+
+_LT_COLOR = "#d62728"  # Lower Tertiary
+_OTHER_COLOR = "#1f77b4"  # Other
+
+
+def access_scatter_frame(df: pd.DataFrame) -> pd.DataFrame:
+    """Return the subset of fields plotted in the access/concentration scatter.
+
+    Keeps only *material* fields with enough wells and a real water depth:
+    ``CUM_OIL_MMBBL >= 1`` AND ``WELL_COUNT >= 3`` AND ``WATER_DEPTH_AVG``
+    present.  Nulls/outliers are dropped honestly (never imputed).
+    """
+    required = {
+        "WATER_DEPTH_AVG",
+        "REC_PER_WELL_MMBBL",
+        "WELL_COUNT",
+        "CUM_OIL_MMBBL",
+    }
+    if df is None or df.empty or not required.issubset(df.columns):
+        return pd.DataFrame()
+
+    work = df.copy()
+    mask = (
+        (pd.to_numeric(work["CUM_OIL_MMBBL"], errors="coerce") >= MIN_CUM_OIL_MMBBL)
+        & (pd.to_numeric(work["WELL_COUNT"], errors="coerce") >= MIN_WELL_COUNT)
+        & work["WATER_DEPTH_AVG"].notna()
+        & work["REC_PER_WELL_MMBBL"].notna()
+    )
+    return work[mask].reset_index(drop=True)
+
+
+def rec_per_well_by_era(df: pd.DataFrame) -> pd.DataFrame:
+    """Median REC_PER_WELL_MMBBL grouped by geological era cohort.
+
+    Restricted to *material* fields (``CUM_OIL_MMBBL >= 1`` AND
+    ``WELL_COUNT >= 3`` when those columns are present) so the comparison
+    reflects producing fields' per-well recovery — otherwise the paleo-based
+    era map tags many near-zero-production exploration fields, dragging a
+    cohort's median to ~0 and obscuring the signal.
+
+    Only cohorts with at least :data:`MIN_COHORT_FIELDS` fields and a real
+    (non-``Unknown``) era are returned, sorted by median recovery descending.
+    Columns: ``GEOLOGICAL_ERA``, ``MEDIAN_REC_PER_WELL``, ``FIELD_COUNT``,
+    ``IS_LOWER_TERTIARY``.
+    """
+    needed = {"GEOLOGICAL_ERA", "REC_PER_WELL_MMBBL"}
+    if df is None or df.empty or not needed.issubset(df.columns):
+        return pd.DataFrame(
+            columns=[
+                "GEOLOGICAL_ERA",
+                "MEDIAN_REC_PER_WELL",
+                "FIELD_COUNT",
+                "IS_LOWER_TERTIARY",
+            ]
+        )
+
+    work = df.copy()
+    work = work[work["GEOLOGICAL_ERA"].notna()]
+    work = work[work["GEOLOGICAL_ERA"].astype(str).str.strip() != "Unknown"]
+    work = work[work["REC_PER_WELL_MMBBL"].notna()]
+    # Material-field filter (consistent with the access scatter's universe).
+    if "CUM_OIL_MMBBL" in work.columns:
+        work = work[
+            pd.to_numeric(work["CUM_OIL_MMBBL"], errors="coerce") >= MIN_CUM_OIL_MMBBL
+        ]
+    if "WELL_COUNT" in work.columns:
+        work = work[
+            pd.to_numeric(work["WELL_COUNT"], errors="coerce") >= MIN_WELL_COUNT
+        ]
+    if work.empty:
+        return pd.DataFrame(
+            columns=[
+                "GEOLOGICAL_ERA",
+                "MEDIAN_REC_PER_WELL",
+                "FIELD_COUNT",
+                "IS_LOWER_TERTIARY",
+            ]
+        )
+
+    has_lt = "IS_LOWER_TERTIARY" in work.columns
+    rows = []
+    for era, grp in work.groupby("GEOLOGICAL_ERA"):
+        if len(grp) < MIN_COHORT_FIELDS:
+            continue
+        rows.append(
+            {
+                "GEOLOGICAL_ERA": era,
+                "MEDIAN_REC_PER_WELL": float(grp["REC_PER_WELL_MMBBL"].median()),
+                "FIELD_COUNT": int(len(grp)),
+                "IS_LOWER_TERTIARY": (
+                    bool(grp["IS_LOWER_TERTIARY"].any()) if has_lt else False
+                ),
+            }
+        )
+    out = pd.DataFrame(
+        rows,
+        columns=[
+            "GEOLOGICAL_ERA",
+            "MEDIAN_REC_PER_WELL",
+            "FIELD_COUNT",
+            "IS_LOWER_TERTIARY",
+        ],
+    )
+    if out.empty:
+        return out
+    return out.sort_values("MEDIAN_REC_PER_WELL", ascending=False).reset_index(
+        drop=True
+    )
+
+
+def water_depth_split(df: pd.DataFrame) -> dict:
+    """Summarize the deepwater (>1000 ft) vs shelf water-depth split.
+
+    Returns counts and medians over fields that have a real ``WATER_DEPTH_AVG``.
+    """
+    empty = {
+        "n_with_depth": 0,
+        "n_deepwater": 0,
+        "n_shelf": 0,
+        "deepwater_median_ft": None,
+        "shelf_median_ft": None,
+    }
+    if df is None or df.empty or "WATER_DEPTH_AVG" not in df.columns:
+        return empty
+
+    wd = pd.to_numeric(df["WATER_DEPTH_AVG"], errors="coerce").dropna()
+    if wd.empty:
+        return empty
+
+    deep = wd[wd > DEEPWATER_FT]
+    shelf = wd[wd <= DEEPWATER_FT]
+    return {
+        "n_with_depth": int(wd.shape[0]),
+        "n_deepwater": int(deep.shape[0]),
+        "n_shelf": int(shelf.shape[0]),
+        "deepwater_median_ft": float(deep.median()) if not deep.empty else None,
+        "shelf_median_ft": float(shelf.median()) if not shelf.empty else None,
+    }
+
+
+def _empty_figure(title: str, note: str):
+    import plotly.graph_objects as go
+
+    fig = go.Figure()
+    fig.update_layout(
+        title=title,
+        annotations=[
+            dict(
+                text=note,
+                xref="paper",
+                yref="paper",
+                x=0.5,
+                y=0.5,
+                showarrow=False,
+            )
+        ],
+    )
+    return fig
+
+
+def access_scatter_figure(sub: pd.DataFrame):
+    """Headline scatter: REC_PER_WELL vs WATER_DEPTH, split by Lower Tertiary.
+
+    ``sub`` should already be the output of :func:`access_scatter_frame`.
+    Marker size ~ WELL_COUNT, color by IS_LOWER_TERTIARY.
+    """
+    import plotly.graph_objects as go
+
+    title = "Recovery per Well vs Water Depth (Access / Concentration)"
+    if sub is None or sub.empty:
+        return _empty_figure(title, "No fields meet the material-field filter.")
+
+    fig = go.Figure()
+    has_lt = "IS_LOWER_TERTIARY" in sub.columns
+    groups = (
+        [(True, "Lower Tertiary", _LT_COLOR), (False, "Other", _OTHER_COLOR)]
+        if has_lt
+        else [(None, "Fields", _OTHER_COLOR)]
+    )
+    for flag, label, color in groups:
+        part = sub[sub["IS_LOWER_TERTIARY"] == flag] if has_lt else sub
+        if part.empty:
+            continue
+        wells = pd.to_numeric(part["WELL_COUNT"], errors="coerce").fillna(1.0)
+        sizes = (wells.clip(lower=1) ** 0.5) * 4.0
+        hover = [
+            (
+                f"{r.get('FIELD_NAME', r.get('FIELD_CODE', ''))}<br>"
+                f"Water depth: {r['WATER_DEPTH_AVG']:,.0f} ft<br>"
+                f"Rec/well: {r['REC_PER_WELL_MMBBL']:,.2f} MMBBL<br>"
+                f"BOPD/well: {r.get('AVG_BOPD_PER_WELL', float('nan')):,.0f}<br>"
+                f"Wells: {int(r['WELL_COUNT'])}<br>"
+                f"Era: {r.get('GEOLOGICAL_ERA', 'Unknown')}"
+            )
+            for _, r in part.iterrows()
+        ]
+        fig.add_trace(
+            go.Scatter(
+                x=part["WATER_DEPTH_AVG"].tolist(),
+                y=part["REC_PER_WELL_MMBBL"].tolist(),
+                mode="markers",
+                name=label,
+                marker=dict(
+                    size=sizes.tolist(),
+                    color=color,
+                    sizemode="diameter",
+                    line=dict(width=0.5, color="#333"),
+                    opacity=0.75,
+                ),
+                text=hover,
+                hoverinfo="text",
+            )
+        )
+    fig.update_layout(
+        title=title,
+        xaxis_title="Average Water Depth (ft)",
+        yaxis_title="Recovery per Well (MMBBL)",
+        legend_title="Geological group",
+        height=560,
+    )
+    return fig
+
+
+def rec_per_well_figure(cohorts: pd.DataFrame):
+    """Bar of median recovery per well by era cohort (>=3 fields each)."""
+    import plotly.graph_objects as go
+
+    title = (
+        "Median Recovery per Well by Geological Era "
+        "(material fields: >=1 MMBBL, >=3 wells; cohorts >= 3 fields)"
+    )
+    if cohorts is None or cohorts.empty:
+        return _empty_figure(title, "No era cohort has at least 3 fields.")
+
+    colors = [
+        _LT_COLOR if bool(lt) else _OTHER_COLOR
+        for lt in cohorts["IS_LOWER_TERTIARY"].tolist()
+    ]
+    text = [
+        f"n={n}" + (" (LT)" if bool(lt) else "")
+        for n, lt in zip(
+            cohorts["FIELD_COUNT"].tolist(), cohorts["IS_LOWER_TERTIARY"].tolist()
+        )
+    ]
+    fig = go.Figure(
+        data=[
+            go.Bar(
+                x=cohorts["GEOLOGICAL_ERA"].tolist(),
+                y=cohorts["MEDIAN_REC_PER_WELL"].tolist(),
+                marker_color=colors,
+                text=text,
+                textposition="outside",
+            )
+        ]
+    )
+    fig.update_layout(
+        title=title,
+        xaxis_title="Geological Era",
+        yaxis_title="Median Recovery per Well (MMBBL)",
+        height=460,
+        annotations=[
+            dict(
+                text="Red = Lower Tertiary cohort; blue = Other.",
+                xref="paper",
+                yref="paper",
+                x=0.0,
+                y=1.08,
+                showarrow=False,
+                font=dict(size=11, color="#555"),
+            )
+        ],
+    )
+    return fig
+
+
+def water_depth_figure(df: pd.DataFrame):
+    """Histogram of field average water depth, with a deepwater/shelf cutline."""
+    import plotly.graph_objects as go
+
+    title = "Field Water Depth Distribution"
+    if df is None or df.empty or "WATER_DEPTH_AVG" not in df.columns:
+        return _empty_figure(title, "No water-depth data available.")
+
+    wd = pd.to_numeric(df["WATER_DEPTH_AVG"], errors="coerce").dropna()
+    if wd.empty:
+        return _empty_figure(title, "No water-depth data available.")
+
+    split = water_depth_split(df)
+    fig = go.Figure(
+        data=[go.Histogram(x=wd.tolist(), marker_color=_OTHER_COLOR, nbinsx=40)]
+    )
+    fig.add_vline(
+        x=DEEPWATER_FT,
+        line_width=1.5,
+        line_dash="dash",
+        line_color=_LT_COLOR,
+        annotation_text="1000 ft (deepwater)",
+        annotation_position="top",
+    )
+    fig.update_layout(
+        title=(
+            f"{title} - {split['n_deepwater']} deepwater (>1000 ft) "
+            f"vs {split['n_shelf']} shelf of {split['n_with_depth']} fields"
+        ),
+        xaxis_title="Average Water Depth (ft)",
+        yaxis_title="Number of Fields",
+        height=420,
+    )
+    return fig

--- a/tests/unit/bsee/reports/test_all_fields_report.py
+++ b/tests/unit/bsee/reports/test_all_fields_report.py
@@ -1,0 +1,124 @@
+"""Unit tests for AllFieldsReport HTML enrichment (access/concentration)."""
+
+import numpy as np
+import pandas as pd
+
+from tests.test_markers import unit
+
+
+def _make_result_df():
+    """Per-field result frame with the enriched atlas columns."""
+    return pd.DataFrame(
+        {
+            "FIELD_CODE": ["100", "200", "300", "400", "500", "600"],
+            "FIELD_NAME": [
+                "Thunder Horse",
+                "Mars",
+                "Cascade",
+                "Auger",
+                "Stones",
+                "Shelf Field",
+            ],
+            "GEOLOGICAL_ERA": [
+                "Miocene",
+                "Miocene",
+                "Paleocene",
+                "Pliocene",
+                "Paleocene",
+                "Pleistocene",
+            ],
+            "IS_LOWER_TERTIARY": [False, False, True, False, True, False],
+            "WATER_DEPTH_AVG": [6300.0, 2940.0, 8200.0, 2860.0, 9500.0, 300.0],
+            "WELL_COUNT": [25, 60, 5, 40, 4, 12],
+            "FIRST_PRODUCTION": [2008, 1996, 2012, 1994, 2016, 1998],
+            "CUM_OIL_MMBBL": [350.0, 900.0, 60.0, 500.0, 45.0, 20.0],
+            "CUM_GAS_BCF": [200.0, 600.0, 30.0, 400.0, 25.0, 15.0],
+            "PEAK_OIL_BOPD": [80000.0, 120000.0, 20000.0, 90000.0, 18000.0, 5000.0],
+            "REC_PER_WELL_MMBBL": [14.0, 15.0, 12.0, 12.5, 11.25, 1.7],
+            "AVG_BOPD_PER_WELL": [10000.0, 8000.0, 7000.0, 9000.0, 6500.0, 1500.0],
+            "PROD_SPAN_YRS": [16, 28, 10, 30, 8, 25],
+            "WOR_CUM": [0.14, 0.22, 0.12, 0.20, 0.10, 0.40],
+            "N_OPERATORS": [2, 1, 1, 3, 1, 2],
+            "TOP_OPERATOR_SHARE": [0.9, 1.0, 1.0, 0.6, 1.0, 0.8],
+            "DOMINANT_OPERATOR": ["BP", "Shell", "Chevron", "Shell", "Shell", "BP"],
+            "STILL_PRODUCING": [False, False, True, False, True, False],
+            "NPV10_MM_USD": [None] * 6,
+            "IRR_PCT": [None] * 6,
+            "PAYBACK_YRS": [None] * 6,
+        }
+    )
+
+
+@unit
+class TestAllFieldsReportHtmlEnrichment:
+    def _report(self):
+        from worldenergydata.bsee.reports.all_fields_report import AllFieldsReport
+
+        return AllFieldsReport(_make_result_df())
+
+    def test_html_has_new_section_titles(self, tmp_path):
+        out = tmp_path / "dash.html"
+        self._report().generate_html(out)
+        content = out.read_text()
+        # Headline access/concentration scatter
+        assert "Recovery per Well vs Water Depth" in content
+        # Recovery per well by era cohort
+        assert "Median Recovery per Well by Geological Era" in content
+        # Water depth distribution
+        assert "Water Depth" in content
+
+    def test_html_has_header_and_footnote(self, tmp_path):
+        out = tmp_path / "dash.html"
+        self._report().generate_html(out)
+        content = out.read_text()
+        assert "BSEE OGOR-A" in content
+        assert "1996" in content and "2025" in content
+        # Honest caveat footnote
+        assert "composite proxy" in content
+        assert "subsea" in content.lower()
+
+    def test_html_keeps_existing_charts(self, tmp_path):
+        out = tmp_path / "dash.html"
+        self._report().generate_html(out)
+        content = out.read_text()
+        assert "Top 15 Fields by Cumulative Oil Production" in content
+        assert "Cumulative Oil Production by Geological Era" in content
+        assert "Top 10 Operators by Cumulative Oil Production" in content
+
+    def test_html_well_formed(self, tmp_path):
+        out = tmp_path / "dash.html"
+        self._report().generate_html(out)
+        content = out.read_text()
+        assert "<html" in content.lower()
+        assert "</html>" in content.lower()
+
+    def test_html_empty_dataframe(self, tmp_path):
+        from worldenergydata.bsee.reports.all_fields_report import AllFieldsReport
+
+        empty = pd.DataFrame(
+            columns=[
+                "FIELD_CODE",
+                "FIELD_NAME",
+                "GEOLOGICAL_ERA",
+                "IS_LOWER_TERTIARY",
+                "WATER_DEPTH_AVG",
+                "WELL_COUNT",
+                "CUM_OIL_MMBBL",
+                "CUM_GAS_BCF",
+                "REC_PER_WELL_MMBBL",
+                "AVG_BOPD_PER_WELL",
+                "DOMINANT_OPERATOR",
+            ]
+        )
+        out = tmp_path / "dash.html"
+        AllFieldsReport(empty).generate_html(out)
+        assert out.exists()
+
+    def test_html_handles_all_null_water_depth(self, tmp_path):
+        from worldenergydata.bsee.reports.all_fields_report import AllFieldsReport
+
+        df = _make_result_df()
+        df["WATER_DEPTH_AVG"] = np.nan
+        out = tmp_path / "dash.html"
+        AllFieldsReport(df).generate_html(out)
+        assert out.exists()

--- a/tests/unit/bsee/reports/test_atlas_charts.py
+++ b/tests/unit/bsee/reports/test_atlas_charts.py
@@ -1,0 +1,217 @@
+"""Unit tests for atlas_charts pure data-prep + figure builders."""
+
+import numpy as np
+import pandas as pd
+
+from tests.test_markers import unit
+
+
+def _frame():
+    """Synthetic per-field frame covering filter edge cases.
+
+    - deep_keep: material, >=3 wells, has WD, Lower Tertiary -> kept
+    - shelf_keep: material, >=3 wells, has WD, not LT -> kept
+    - tiny_oil: CUM_OIL < 1 -> dropped
+    - few_wells: WELL_COUNT < 3 -> dropped
+    - no_wd: WATER_DEPTH_AVG null -> dropped
+    """
+    return pd.DataFrame(
+        {
+            "FIELD_CODE": ["1", "2", "3", "4", "5"],
+            "FIELD_NAME": ["deep_keep", "shelf_keep", "tiny_oil", "few_wells", "no_wd"],
+            "GEOLOGICAL_ERA": [
+                "Paleocene",
+                "Miocene",
+                "Miocene",
+                "Eocene",
+                "Pliocene",
+            ],
+            "IS_LOWER_TERTIARY": [True, False, False, True, False],
+            "WATER_DEPTH_AVG": [7000.0, 400.0, 5000.0, 6000.0, np.nan],
+            "WELL_COUNT": [12, 20, 8, 2, 10],
+            "CUM_OIL_MMBBL": [200.0, 150.0, 0.5, 50.0, 80.0],
+            "CUM_GAS_BCF": [100.0, 90.0, 1.0, 30.0, 40.0],
+            "PEAK_OIL_BOPD": [50000.0, 40000.0, 1000.0, 9000.0, 20000.0],
+            "REC_PER_WELL_MMBBL": [16.6, 7.5, 0.06, 25.0, 8.0],
+            "AVG_BOPD_PER_WELL": [11000.0, 3000.0, 100.0, 9000.0, 4000.0],
+            "DOMINANT_OPERATOR": ["A", "B", "C", "A", "B"],
+        }
+    )
+
+
+@unit
+class TestAccessScatterFrame:
+    def test_filters_applied(self):
+        from worldenergydata.bsee.reports.atlas_charts import access_scatter_frame
+
+        out = access_scatter_frame(_frame())
+        names = set(out["FIELD_NAME"])
+        assert names == {"deep_keep", "shelf_keep"}
+
+    def test_drops_count(self):
+        from worldenergydata.bsee.reports.atlas_charts import access_scatter_frame
+
+        df = _frame()
+        out = access_scatter_frame(df)
+        assert len(out) == 2
+        # 5 total, 3 dropped (tiny_oil, few_wells, no_wd)
+        assert len(df) - len(out) == 3
+
+    def test_handles_missing_columns(self):
+        from worldenergydata.bsee.reports.atlas_charts import access_scatter_frame
+
+        out = access_scatter_frame(pd.DataFrame({"FIELD_CODE": ["1"]}))
+        assert out.empty
+
+    def test_empty(self):
+        from worldenergydata.bsee.reports.atlas_charts import access_scatter_frame
+
+        out = access_scatter_frame(pd.DataFrame())
+        assert out.empty
+
+
+@unit
+class TestRecPerWellByEra:
+    def test_cohort_threshold(self):
+        from worldenergydata.bsee.reports.atlas_charts import rec_per_well_by_era
+
+        # Build a frame with one era having 3 fields, another with 1.
+        df = pd.DataFrame(
+            {
+                "GEOLOGICAL_ERA": ["Miocene", "Miocene", "Miocene", "Eocene"],
+                "REC_PER_WELL_MMBBL": [10.0, 20.0, 30.0, 99.0],
+                "IS_LOWER_TERTIARY": [False, False, False, True],
+            }
+        )
+        out = rec_per_well_by_era(df)
+        assert list(out["GEOLOGICAL_ERA"]) == ["Miocene"]
+        # median of 10,20,30 = 20
+        assert out.iloc[0]["MEDIAN_REC_PER_WELL"] == 20.0
+        assert out.iloc[0]["FIELD_COUNT"] == 3
+
+    def test_drops_unknown_era(self):
+        from worldenergydata.bsee.reports.atlas_charts import rec_per_well_by_era
+
+        df = pd.DataFrame(
+            {
+                "GEOLOGICAL_ERA": ["Unknown"] * 4,
+                "REC_PER_WELL_MMBBL": [1.0, 2.0, 3.0, 4.0],
+                "IS_LOWER_TERTIARY": [False] * 4,
+            }
+        )
+        out = rec_per_well_by_era(df)
+        assert out.empty
+
+    def test_lt_flag_per_cohort(self):
+        from worldenergydata.bsee.reports.atlas_charts import rec_per_well_by_era
+
+        df = pd.DataFrame(
+            {
+                "GEOLOGICAL_ERA": ["Paleocene"] * 3,
+                "REC_PER_WELL_MMBBL": [5.0, 6.0, 7.0],
+                "IS_LOWER_TERTIARY": [True, True, True],
+            }
+        )
+        out = rec_per_well_by_era(df)
+        assert bool(out.iloc[0]["IS_LOWER_TERTIARY"]) is True
+
+    def test_material_filter_excludes_nonproducing(self):
+        from worldenergydata.bsee.reports.atlas_charts import rec_per_well_by_era
+
+        # 3 producing Eocene fields + 3 near-zero exploration Eocene fields.
+        # Only the producing ones should drive the median (the paleo era map
+        # tags exploration fields, which must not drag the cohort to ~0).
+        df = pd.DataFrame(
+            {
+                "GEOLOGICAL_ERA": ["Eocene"] * 6,
+                "REC_PER_WELL_MMBBL": [3.0, 4.0, 5.0, 0.0, 0.0, 0.0],
+                "CUM_OIL_MMBBL": [50.0, 60.0, 70.0, 0.0, 0.0, 0.0],
+                "WELL_COUNT": [10, 12, 14, 1, 1, 1],
+                "IS_LOWER_TERTIARY": [True] * 6,
+            }
+        )
+        out = rec_per_well_by_era(df)
+        assert list(out["GEOLOGICAL_ERA"]) == ["Eocene"]
+        assert out.iloc[0]["FIELD_COUNT"] == 3  # exploration fields excluded
+        assert out.iloc[0]["MEDIAN_REC_PER_WELL"] == 4.0  # median of 3,4,5
+
+    def test_empty(self):
+        from worldenergydata.bsee.reports.atlas_charts import rec_per_well_by_era
+
+        assert rec_per_well_by_era(pd.DataFrame()).empty
+
+
+@unit
+class TestWaterDepthSplit:
+    def test_split_counts(self):
+        from worldenergydata.bsee.reports.atlas_charts import water_depth_split
+
+        out = water_depth_split(_frame())
+        # WD present: 7000, 400, 5000, 6000 (no_wd dropped) = 4
+        assert out["n_with_depth"] == 4
+        # deepwater >1000: 7000,5000,6000 = 3; shelf: 400 = 1
+        assert out["n_deepwater"] == 3
+        assert out["n_shelf"] == 1
+
+    def test_medians(self):
+        from worldenergydata.bsee.reports.atlas_charts import water_depth_split
+
+        out = water_depth_split(_frame())
+        assert out["deepwater_median_ft"] == 6000.0
+        assert out["shelf_median_ft"] == 400.0
+
+    def test_empty(self):
+        from worldenergydata.bsee.reports.atlas_charts import water_depth_split
+
+        out = water_depth_split(pd.DataFrame())
+        assert out["n_with_depth"] == 0
+        assert out["n_deepwater"] == 0
+
+
+@unit
+class TestFigureBuilders:
+    def test_access_scatter_figure(self):
+        import plotly.graph_objects as go
+
+        from worldenergydata.bsee.reports.atlas_charts import (
+            access_scatter_figure,
+            access_scatter_frame,
+        )
+
+        sub = access_scatter_frame(_frame())
+        fig = access_scatter_figure(sub)
+        assert isinstance(fig, go.Figure)
+
+    def test_access_scatter_figure_empty(self):
+        import plotly.graph_objects as go
+
+        from worldenergydata.bsee.reports.atlas_charts import access_scatter_figure
+
+        fig = access_scatter_figure(pd.DataFrame())
+        assert isinstance(fig, go.Figure)
+
+    def test_rec_per_well_figure(self):
+        import plotly.graph_objects as go
+
+        from worldenergydata.bsee.reports.atlas_charts import (
+            rec_per_well_by_era,
+            rec_per_well_figure,
+        )
+
+        df = pd.DataFrame(
+            {
+                "GEOLOGICAL_ERA": ["Miocene", "Miocene", "Miocene"],
+                "REC_PER_WELL_MMBBL": [10.0, 20.0, 30.0],
+                "IS_LOWER_TERTIARY": [False, False, False],
+            }
+        )
+        fig = rec_per_well_figure(rec_per_well_by_era(df))
+        assert isinstance(fig, go.Figure)
+
+    def test_water_depth_figure(self):
+        import plotly.graph_objects as go
+
+        from worldenergydata.bsee.reports.atlas_charts import water_depth_figure
+
+        fig = water_depth_figure(_frame())
+        assert isinstance(fig, go.Figure)


### PR DESCRIPTION
**Stacked on #533** (merge order: #534 → #533 → this). Turns the enriched atlas into an interactive report that visualizes the Lower Tertiary **access / concentration** thesis across all GoM fields.

## Adds
- `atlas_charts.py` (new): pure data-prep + Plotly builders.
  - **Access/concentration scatter** (headline): recovery-per-well vs water depth, split by Lower Tertiary, marker size ~ well count.
  - **Recovery-per-well by era cohort** (material fields only: ≥1 MMBBL, ≥3 wells).
  - **Water-depth distribution** with a 1,000 ft deepwater cutline.
- `all_fields_report.generate_html`: wires the three charts + a header (BSEE OGOR-A 1996–2025 vintage) and an honest footnote.
- Tests for the data-prep + figure builders.

## Verified (real data)
- Access scatter: **444 material fields** shown (deepwater hubs vs shelf reads clearly); 946 honestly dropped (no depth / immaterial).
- Water-depth split: **264 deepwater** (median 4,028 ft) vs **844 shelf** (104 ft).
- Era cohort (material-filtered): **Eocene 2.59 · Oligocene 2.23 · Paleocene 0.33** MMBBL/well — all Lower Tertiary.
- Tests pass; Black clean; files ≤500 lines.

## Note
The era-cohort bar is restricted to *material* fields because #533's paleo-based era map tags many near-zero-production exploration fields; without the filter a cohort median collapses to ~0 (misleading). The headline access scatter is where the basin-wide thesis reads best. Era coverage remains honestly sparse (~1,235 fields `Unknown`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)