### PR TITLE
fix(contract): real fixes for #523 hse scheduler index + #524 site_assets root

### DIFF
--- a/MODULE_INDEX.md
+++ b/MODULE_INDEX.md
@@ -156,9 +156,10 @@ Modules wired into the WRK-076 automated refresh scheduler:
 | `eia_us` | `eia_us_refresh` | `config/scheduler/scheduler_config.yml` |
 | `metocean` | `metocean_refresh` | `config/scheduler/scheduler_config.yml` |
 | `lng_terminals` | `lng_terminals_refresh` | `config/scheduler/scheduler_config.yml` |
+| `hse` | `hse_refresh` | `config/scheduler/scheduler_config.yml` |
 
 Config-only, no active scheduler job (config present but not wired):
 `texas_rrc` (config/texas_rrc.yml), `mexico_cnh` (config/mexico_cnh.yml)
 
 Not yet scheduled:
-`canada`, `hse`, `marine_safety`, `pipeline_safety`
+`canada`, `marine_safety`, `pipeline_safety`

--- a/config/repo_structure.yml
+++ b/config/repo_structure.yml
@@ -14,6 +14,7 @@ allowed_roots:
   - notebooks
   - subseaiq
   - systemd
+  - site_assets  # tracked static web assets (e.g. site_assets/julia_well_path_threejs.html)
   - _archive
 
   # Agent/tooling and repo metadata roots intentionally tracked today
@@ -133,6 +134,9 @@ temporary_exceptions:
       - reports/lower_tertiary/field_economics_stones_v30.md
       - reports/lower_tertiary/jack_st_malo_npv_stackup.html
       - reports/lower_tertiary/julia_npv_stackup.html
+      - reports/lower_tertiary/lt_field_performance_comparison.md
+      - reports/lower_tertiary/lt_well_benchmark_lower_tertiary_2010_latest.csv
+      - reports/lower_tertiary/lt_well_benchmark_lower_tertiary_2010_latest.md
       - reports/lower_tertiary/portfolio_economics.html
       - reports/lower_tertiary/shenandoah_npv_stackup.html
       - reports/lower_tertiary/stones_npv_stackup.html
@@ -168,3 +172,4 @@ temporary_exceptions:
       - reports/modules/marketing/marketing_brochure_well_production_dashboard.md
       - reports/modules/marketing/reference_hurricane_mooring_safety_infographic_prior_draft.html
       - reports/modules/marketing/reference_hurricane_mooring_safety_infographic_prior_draft_stats.json
+      - reports/subsea/subsea_manifold_market_intelligence.md


### PR DESCRIPTION
Real fixes for the two `domain:quality` quarantined contract failures so they stop being quarantined. Both use the contract's established, owner-blessed mechanisms — no file moves or deletions (respects the #394 contract scope). Diff is exactly two files; `uv.lock` deliberately excluded.

## Fix 1 — #524 (repo_structure contract: `site_assets` + tracked `reports/` drift)
`tests/repo_structure/test_repo_structure_contract.py::test_current_contract_accepts_approved_roots_and_exceptions` was red on `main` with **6** violations.

- Added `site_assets` to `allowed_roots` in `config/repo_structure.yml` — `site_assets/` is a legitimate tracked directory and `site_assets/julia_well_path_threejs.html` was the violation named in #524 (cleared 2 of the 6 violations: the file + its root).
- The remaining 4 violations were a **separate, pre-existing drift on `main`**: tracked `reports/` artifacts not yet in the `temporary_exceptions.reports` durable-evidence allowlist (`generated-path-not-classified`). Since #524 quarantines the **entire** test, the test only goes green — and the quarantine entry only becomes a true no-op — once these are also classified. Added them via the same existing whitelist mechanism:
  - `reports/lower_tertiary/lt_field_performance_comparison.md`
  - `reports/lower_tertiary/lt_well_benchmark_lower_tertiary_2010_latest.csv`
  - `reports/lower_tertiary/lt_well_benchmark_lower_tertiary_2010_latest.md`
  - `reports/subsea/subsea_manifold_market_intelligence.md`

## Fix 2 — #523 (hse scheduler/MODULE_INDEX drift)
`config/scheduler/scheduler_config.yml` defines an `hse_refresh` job that is `enabled: true` (keeps the grounded incident corpus #486/#489 fresh) — i.e. hse **is** wired. So:
- Added `| \`hse\` | \`hse_refresh\` | config/scheduler/scheduler_config.yml |` to the "Modules wired into the WRK-076 automated refresh scheduler" table in `MODULE_INDEX.md`.
- Removed `hse` from the "Not yet scheduled" line. (Note: the issue text said hse was under "Config-only, no active scheduler job"; on `main` it was actually under "Not yet scheduled" — corrected the right line.)

**hse decision confidence: high.** The job is enabled with a substantive purpose and output dir; index-fix (option a) is clearly correct over removing the job (option b).

### Note on `module-manifest.yaml`
`module-manifest.yaml` still has hse `in_scheduler: false`. No test enforces manifest↔index consistency (`test_manifest_scheduler_matches_config` only checks the manifest doesn't claim `wired` *without* a job, which `false` satisfies), so it's out of scope here and left untouched to keep the diff minimal. Recommend a trivial follow-up flipping it to `true` for consistency.

## Local verification
`uv run pytest tests/repo_structure tests/unit/cli/test_capability_drift.py -q` → **19 passed** (incl. `test_scheduler_config_wired_modules_in_index`). `uv.lock` reset out of the diff.

## Relationship to PR #531 (domain-matrix CI gate)
Independent of #531's branch — this PR does **not** touch #531 or its `scripts/ci/quarantine.txt`. Once both this PR and #531 merge, the #523 and #524 quarantine entries in `scripts/ci/quarantine.txt` become no-ops and can be removed in a trivial follow-up.

Refs #523 #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)