### PR TITLE
feat(bsee): gross oil revenue atlas (production × real WTI)

### DIFF
--- a/scripts/bsee/generate_all_fields_atlas.py
+++ b/scripts/bsee/generate_all_fields_atlas.py
@@ -23,6 +23,10 @@ from collections import Counter
 from pathlib import Path
 
 from worldenergydata.bsee.analysis.all_fields_runner import AllFieldsRunner
+from worldenergydata.bsee.analysis.field_revenue import (
+    apply_field_revenue,
+    build_field_oil_revenue,
+)
 from worldenergydata.bsee.data.field_names import FieldNameResolver
 from worldenergydata.bsee.data.sources.bin.field_water_depth import (
     load_field_water_depth,
@@ -141,6 +145,25 @@ def main() -> int:
             len(result),
             unknown,
             lt,
+        )
+
+    # Gross oil revenue (economics tier): monthly oil x real monthly WTI.
+    # Oil only (no gas price deck); gross, pre-royalty, pre-cost. Fields with
+    # no priced production keep an honest null.
+    logger.info("Building gross oil revenue (oil x real WTI)...")
+    rev = build_field_oil_revenue(
+        start_year=args.start_year, end_year=args.end_year
+    )
+    result = apply_field_revenue(result, rev)
+    if "GROSS_OIL_REVENUE_MM_USD" in result.columns and not result.empty:
+        basin_rev = float(result["GROSS_OIL_REVENUE_MM_USD"].sum(skipna=True))
+        n_with_rev = int(result["GROSS_OIL_REVENUE_MM_USD"].notna().sum())
+        logger.info(
+            "Basin total gross oil revenue $%.1f MM across %d/%d fields with "
+            "a value (oil only, gross pre-royalty pre-cost)",
+            basin_rev,
+            n_with_rev,
+            len(result),
         )
 
     args.out.mkdir(parents=True, exist_ok=True)

--- a/src/worldenergydata/bsee/analysis/field_revenue.py
+++ b/src/worldenergydata/bsee/analysis/field_revenue.py
@@ -1,0 +1,272 @@
+"""Per-field gross oil revenue atlas (deterministic, fabrication-free).
+
+Computes, per BSEE field, the **cumulative gross oil revenue** as the sum over
+every monthly OGOR-A record of ``monthly oil volume (bbl) x real monthly WTI
+($/bbl)``.  This is the first economics-tier deliverable: per the scoping memo,
+true NPV cannot generalize across the basin (development costs are hand-curated
+per field), but *gross* revenue is fully real — production is measured (OGOR-A)
+and price is a real published series (WTI).
+
+Scope and honesty notes
+------------------------
+* **Oil only.**  There is no Henry Hub gas price deck in this repo, so gas
+  revenue is intentionally *not* computed (it would be fabricated).  The
+  ``GROSS_OIL_REVENUE_MM_USD`` name says so explicitly.
+* **Gross, pre-royalty, pre-cost.**  No royalties, opex, capex, or working
+  interest are applied — this is topline revenue, not value to any party.
+* **Real WTI join.**  Each monthly record is priced with the WTI for its
+  ``PRODUCTION_DATE`` month.  Records whose month is missing from the WTI deck
+  are *dropped* (and the drop is logged), never priced with a guessed value.
+  The committed deck spans 1986-01..2025-07, so for the 1996-2025 atlas range
+  the dropped count is ~0.
+* Fields with no priced production get an honest ``NaN`` in
+  :func:`apply_field_revenue` (left join), not a fabricated ``0``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict, Optional
+
+import pandas as pd
+
+from worldenergydata.bsee.data.sources.bin.ogor_production_loader import (
+    load_ogor_bin,
+)
+from worldenergydata.common.data_resolver import get_module_data_safe
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_SUBDIR = "historical_production_yearly"
+
+# Repo-relative default WTI deck (under docs/, not data/).  Resolved the same
+# way as ``field_names.py`` resolves its data dir: walk up from this file to
+# the repo root.  field_revenue.py lives at
+# ``src/worldenergydata/bsee/analysis/field_revenue.py`` -> 5 parents to root.
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_DEFAULT_WTI_PATH = (
+    _REPO_ROOT
+    / "docs"
+    / "modules"
+    / "bsee"
+    / "analysis"
+    / "production"
+    / "FDAS_V30"
+    / "wti_monthly.xlsx"
+)
+
+_REVENUE_COLUMNS = ["FIELD_NAME_CODE", "GROSS_OIL_REVENUE_MM_USD"]
+
+
+def load_wti_monthly(path: Optional[Path] = None) -> Dict[int, float]:
+    """Load the monthly WTI deck as a ``{YYYYMM: WTI_USD}`` mapping.
+
+    Parameters
+    ----------
+    path:
+        Path to the WTI ``.xlsx`` (columns ``Month`` datetime month-start and
+        ``WTI_USD``).  Defaults to the committed FDAS_V30 deck under ``docs/``.
+
+    Returns
+    -------
+    dict[int, float]
+        ``{YYYYMM_int: price}``.  Empty dict when the file is missing or
+        unreadable (graceful — callers degrade rather than fabricate).
+    """
+    path = Path(path) if path is not None else _DEFAULT_WTI_PATH
+    if not path.exists():
+        logger.warning("WTI deck not found: %s", path)
+        return {}
+
+    try:
+        df = pd.read_excel(path)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Error reading WTI deck %s: %s", path, exc)
+        return {}
+
+    if "Month" not in df.columns or "WTI_USD" not in df.columns:
+        logger.warning(
+            "WTI deck %s missing Month/WTI_USD columns (got %s)",
+            path,
+            list(df.columns),
+        )
+        return {}
+
+    months = pd.to_datetime(df["Month"], errors="coerce")
+    prices = pd.to_numeric(df["WTI_USD"], errors="coerce")
+    out: Dict[int, float] = {}
+    for ts, price in zip(months, prices):
+        if pd.isna(ts) or pd.isna(price):
+            continue
+        yyyymm = ts.year * 100 + ts.month
+        out[int(yyyymm)] = float(price)
+    logger.info("Loaded %d monthly WTI prices from %s", len(out), path)
+    return out
+
+
+def build_field_oil_revenue(
+    data_dir: Optional[Path] = None,
+    wti_path: Optional[Path] = None,
+    start_year: int = 1996,
+    end_year: int = 2025,
+) -> pd.DataFrame:
+    """Build per-field cumulative gross oil revenue from OGOR-A x WTI.
+
+    For each year in ``[start_year, end_year]`` the OGOR-A ``.bin`` is loaded
+    monthly (via :func:`load_ogor_bin` — *not* the annual runner schema), each
+    record's ``PRODUCTION_DATE`` (YYYYMM) is priced with the matching WTI, and
+    ``MON_O_PROD_VOL x WTI`` is summed per ``BOEM_FIELD`` and divided by 1e6.
+
+    Records whose month is missing from the WTI deck are dropped and logged.
+
+    Parameters
+    ----------
+    data_dir:
+        Directory of ``ogora{year}delimit.bin`` files.  Defaults to the
+        resolved ``<bsee>/bin/historical_production_yearly``.
+    wti_path:
+        WTI deck path (see :func:`load_wti_monthly`).
+    start_year, end_year:
+        Inclusive year range.
+
+    Returns
+    -------
+    pd.DataFrame
+        Columns ``FIELD_NAME_CODE``, ``GROSS_OIL_REVENUE_MM_USD`` (millions of
+        USD).  Empty (correctly-typed) when no priced production is found.
+    """
+    if data_dir is None:
+        data_dir = get_module_data_safe("bsee") / "bin" / _DEFAULT_SUBDIR
+    data_dir = Path(data_dir)
+
+    wti = load_wti_monthly(wti_path)
+    if not wti:
+        logger.warning("No WTI prices loaded — gross oil revenue will be empty.")
+        return pd.DataFrame(columns=_REVENUE_COLUMNS)
+
+    frames = []
+    loaded, missing = 0, 0
+    dropped_rows, dropped_oil = 0, 0.0
+    for year in range(start_year, end_year + 1):
+        path = data_dir / f"ogora{year}delimit.bin"
+        if not path.exists():
+            missing += 1
+            continue
+        raw = load_ogor_bin(path)
+        if raw.empty:
+            missing += 1
+            continue
+
+        work = pd.DataFrame(
+            {
+                "FIELD_NAME_CODE": raw["BOEM_FIELD"]
+                .astype(str)
+                .str.replace('"', "", regex=False)
+                .str.strip(),
+                "PRODUCTION_DATE": pd.to_numeric(
+                    raw["PRODUCTION_DATE"], errors="coerce"
+                ),
+                "MON_O_PROD_VOL": pd.to_numeric(
+                    raw["MON_O_PROD_VOL"]
+                    .astype(str)
+                    .str.replace('"', "", regex=False)
+                    .str.strip(),
+                    errors="coerce",
+                ).fillna(0.0),
+            }
+        )
+        work["WTI"] = work["PRODUCTION_DATE"].map(
+            lambda d: wti.get(int(d)) if pd.notna(d) else None
+        )
+
+        unpriced = work["WTI"].isna()
+        if unpriced.any():
+            dropped_rows += int(unpriced.sum())
+            dropped_oil += float(work.loc[unpriced, "MON_O_PROD_VOL"].sum())
+        priced = work[~unpriced].copy()
+        if priced.empty:
+            loaded += 1
+            continue
+
+        priced["REVENUE"] = priced["MON_O_PROD_VOL"] * priced["WTI"]
+        frames.append(priced[["FIELD_NAME_CODE", "REVENUE"]])
+        loaded += 1
+
+    if dropped_rows:
+        logger.warning(
+            "Dropped %d OGOR rows (%.1f bbl oil) with no WTI price in deck "
+            "(month outside deck coverage) — not fabricated.",
+            dropped_rows,
+            dropped_oil,
+        )
+
+    if not frames:
+        logger.warning(
+            "No priced OGOR production loaded from %s (%d years missing/empty)",
+            data_dir,
+            missing,
+        )
+        return pd.DataFrame(columns=_REVENUE_COLUMNS)
+
+    combined = pd.concat(frames, ignore_index=True)
+    grouped = (
+        combined.groupby("FIELD_NAME_CODE", as_index=False)["REVENUE"]
+        .sum()
+        .rename(columns={"REVENUE": "GROSS_OIL_REVENUE_MM_USD"})
+    )
+    grouped["GROSS_OIL_REVENUE_MM_USD"] = grouped["GROSS_OIL_REVENUE_MM_USD"] / 1e6
+    logger.info(
+        "Built gross oil revenue for %d fields from %d OGOR years "
+        "(%d missing/empty); basin total $%.1f MM.",
+        len(grouped),
+        loaded,
+        missing,
+        float(grouped["GROSS_OIL_REVENUE_MM_USD"].sum()),
+    )
+    return grouped[_REVENUE_COLUMNS]
+
+
+def apply_field_revenue(
+    result_df: pd.DataFrame, revenue_df: pd.DataFrame
+) -> pd.DataFrame:
+    """Merge ``GROSS_OIL_REVENUE_MM_USD`` into an AllFieldsRunner result.
+
+    Left-joins ``revenue_df`` (keyed on ``FIELD_NAME_CODE``) onto ``result_df``
+    (keyed on ``FIELD_CODE``).  Fields with no revenue row get an honest
+    ``NaN`` — never a fabricated zero.  ``result_df`` is not mutated.
+
+    Parameters
+    ----------
+    result_df:
+        Per-field result with a ``FIELD_CODE`` column.
+    revenue_df:
+        Output of :func:`build_field_oil_revenue`.
+
+    Returns
+    -------
+    pd.DataFrame
+        Copy of ``result_df`` with a ``GROSS_OIL_REVENUE_MM_USD`` column.
+    """
+    out = result_df.copy()
+    if "FIELD_CODE" not in out.columns:
+        logger.warning("result_df has no FIELD_CODE — revenue not merged.")
+        out["GROSS_OIL_REVENUE_MM_USD"] = pd.NA
+        return out
+
+    if revenue_df is None or revenue_df.empty:
+        out["GROSS_OIL_REVENUE_MM_USD"] = pd.NA
+        return out
+
+    rev = revenue_df[["FIELD_NAME_CODE", "GROSS_OIL_REVENUE_MM_USD"]].copy()
+    rev["FIELD_NAME_CODE"] = rev["FIELD_NAME_CODE"].astype(str).str.strip()
+
+    out["_join_code"] = out["FIELD_CODE"].astype(str).str.strip()
+    merged = out.merge(
+        rev,
+        how="left",
+        left_on="_join_code",
+        right_on="FIELD_NAME_CODE",
+    )
+    merged = merged.drop(columns=["_join_code", "FIELD_NAME_CODE"])
+    return merged

--- a/src/worldenergydata/bsee/reports/all_fields_report.py
+++ b/src/worldenergydata/bsee/reports/all_fields_report.py
@@ -105,6 +105,19 @@ class AllFieldsReport:
         lines.append(f"- **Cumulative oil production**: {total_oil:,.1f} MMBBL")
         lines.append(f"- **Cumulative gas production**: {total_gas:,.1f} BCF")
         lines.append(f"- **Geological eras represented**: {n_eras}")
+        has_rev = not self._df.empty and "GROSS_OIL_REVENUE_MM_USD" in self._df.columns
+        if has_rev:
+            total_rev = self._df["GROSS_OIL_REVENUE_MM_USD"].sum(skipna=True)
+            n_with_rev = int(self._df["GROSS_OIL_REVENUE_MM_USD"].notna().sum())
+            lines.append(
+                f"- **Gross oil revenue (pre-royalty, pre-cost, oil only)**: "
+                f"${total_rev:,.0f} MM across {n_with_rev} fields"
+            )
+            lines.append(
+                "  - *Monthly oil production x real monthly WTI; topline "
+                "revenue only (no royalty/opex/capex, no gas). Fields without "
+                "priced production are left blank, not zeroed.*"
+            )
         lines.append("")
 
         # Era Grouping
@@ -156,11 +169,13 @@ class AllFieldsReport:
             if not top.empty:
                 lines.append(
                     "| Field | Era | Oil (MMBBL) | Gas (BCF) | Wells | "
-                    "Rec/Well (MMBBL) | BOPD/Well | First Prod | Water Depth (ft) |"
+                    "Rec/Well (MMBBL) | BOPD/Well | First Prod | "
+                    "Water Depth (ft) | Gross Oil Rev ($MM) |"
                 )
                 lines.append(
                     "|-------|-----|-------------|-----------|-------|"
-                    "------------------|-----------|------------|------------------|"
+                    "------------------|-----------|------------|"
+                    "------------------|--------------------|"
                 )
                 for _, row in top.iterrows():
                     name = row.get("FIELD_NAME", row.get("FIELD_CODE", ""))
@@ -175,9 +190,12 @@ class AllFieldsReport:
                     rpw_str = f"{rpw:,.3f}" if pd.notna(rpw) else ""
                     bpw = row.get("AVG_BOPD_PER_WELL", None)
                     bpw_str = f"{bpw:,.0f}" if pd.notna(bpw) else ""
+                    rev = row.get("GROSS_OIL_REVENUE_MM_USD", None)
+                    rev_str = f"{rev:,.0f}" if pd.notna(rev) else ""
                     lines.append(
                         f"| {name} | {era} | {oil:,.1f} | {gas:,.1f} | {wells} "
-                        f"| {rpw_str} | {bpw_str} | {first} | {wd_str} |"
+                        f"| {rpw_str} | {bpw_str} | {first} | {wd_str} "
+                        f"| {rev_str} |"
                     )
                 lines.append("")
 

--- a/tests/unit/bsee/analysis/test_field_revenue.py
+++ b/tests/unit/bsee/analysis/test_field_revenue.py
@@ -1,0 +1,185 @@
+"""Unit tests for the gross oil revenue atlas (:mod:`field_revenue`).
+
+All fixtures are synthetic (``tmp_path``) and deterministic — they never read
+the multi-GB materialized OGOR-A data.  The OGOR fixture deliberately mimics
+the real on-disk *header-corruption* (a ``read_csv`` consumed the first data
+record as the column header, losing that physical row) so the loader path
+under test matches production behaviour.
+"""
+
+import pickle
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from tests.test_markers import unit
+from worldenergydata.bsee.analysis.field_revenue import (
+    apply_field_revenue,
+    build_field_oil_revenue,
+    load_wti_monthly,
+)
+from worldenergydata.bsee.data.sources.bin.ogor_production_loader import (
+    OGOR_COLUMN_NAMES,
+)
+
+
+def _ogor_row(yyyymm, oil, field):
+    """One OGOR-A record in canonical column order with the given knobs."""
+    return [
+        "G12345",  # LEASE_NUMBER
+        "E001",  # COMPLETION_NAME
+        yyyymm,  # PRODUCTION_DATE (YYYYMM int)
+        30,  # DAYS_ON_PROD
+        "O",  # PRODUCT_CODE
+        oil,  # MON_O_PROD_VOL
+        5000.0,  # MON_G_PROD_VOL
+        200.0,  # MON_WTR_PROD_VOL
+        "608054010300",  # API_WELL_NUMBER
+        "PR",  # WELL_STAT_CD
+        "MC0807",  # AREA_CODE_BLOCK_NUM
+        "03151",  # OPERATOR_NUM
+        "BP",  # SORT_NAME
+        field,  # BOEM_FIELD
+        0.0,  # INJECTION_VOLUME
+        "Q01",  # PROD_INTERVAL_CD
+        20100101,  # FIRST_PROD_DATE
+        "",  # UNIT_AGT_NUMBER
+        "",  # UNIT_ALOC_SUFFIX
+    ]
+
+
+def _write_corrupted_bin(path: Path, rows) -> None:
+    """Write a header-corrupted OGOR pickle (loses the first physical row).
+
+    Mirrors ``tests/unit/bsee/data/test_ogor_production_loader.py``: the
+    pickled frame's *columns* are the first record's values and that record
+    is dropped, exactly as the real corrupted ``.bin`` files were produced.
+    """
+    full = pd.DataFrame(rows, columns=OGOR_COLUMN_NAMES)
+    corrupted = pd.DataFrame(full.iloc[1:].values, columns=list(full.iloc[0].values))
+    with open(path, "wb") as f:
+        pickle.dump(corrupted, f)
+
+
+@unit
+def test_load_wti_monthly_missing_file_returns_empty(tmp_path):
+    assert load_wti_monthly(tmp_path / "nope.xlsx") == {}
+
+
+@unit
+def test_load_wti_monthly_reads_real_deck():
+    """The committed FDAS_V30 WTI deck loads to a YYYYMM->price map."""
+    wti = load_wti_monthly()
+    assert isinstance(wti, dict)
+    # Real deck spans 1986-01..2025-07.
+    assert wti[198601] == pytest.approx(22.93)
+    assert wti[202507] == pytest.approx(68.39)
+    assert all(isinstance(k, int) for k in wti)
+
+
+@unit
+def test_build_field_oil_revenue_with_explicit_wti(tmp_path):
+    """End-to-end with a synthetic WTI deck exercises the join + sum."""
+    rows = [
+        _ogor_row(202401, 0.0, "DUMMY"),  # lost to corruption
+        _ogor_row(202401, 1000.0, "MC807"),
+        _ogor_row(202402, 2000.0, "MC807"),
+        _ogor_row(202401, 500.0, "GC640"),
+    ]
+    f = tmp_path / "ogora2024delimit.bin"
+    _write_corrupted_bin(f, rows)
+
+    wti_xlsx = tmp_path / "wti.xlsx"
+    pd.DataFrame(
+        {
+            "Month": pd.to_datetime(["2024-01-01", "2024-02-01"]),
+            "WTI_USD": [70.0, 80.0],
+        }
+    ).to_excel(wti_xlsx, index=False)
+
+    df = build_field_oil_revenue(
+        data_dir=tmp_path, wti_path=wti_xlsx, start_year=2024, end_year=2024
+    )
+    rev = dict(zip(df["FIELD_NAME_CODE"], df["GROSS_OIL_REVENUE_MM_USD"]))
+    # MC807: 1000*70 + 2000*80 = 230000 -> 0.23 MM
+    assert rev["MC807"] == pytest.approx(0.23)
+    # GC640: 500*70 = 35000 -> 0.035 MM
+    assert rev["GC640"] == pytest.approx(0.035)
+
+
+@unit
+def test_build_field_oil_revenue_drops_months_missing_from_wti(tmp_path):
+    """Rows whose YYYYMM is absent from the WTI deck are dropped, not faked."""
+    rows = [
+        _ogor_row(202401, 0.0, "DUMMY"),  # lost to corruption
+        _ogor_row(202401, 1000.0, "MC807"),  # priced
+        _ogor_row(202403, 9999.0, "MC807"),  # 2024-03 missing from deck
+    ]
+    f = tmp_path / "ogora2024delimit.bin"
+    _write_corrupted_bin(f, rows)
+
+    wti_xlsx = tmp_path / "wti.xlsx"
+    pd.DataFrame({"Month": pd.to_datetime(["2024-01-01"]), "WTI_USD": [70.0]}).to_excel(
+        wti_xlsx, index=False
+    )
+
+    df = build_field_oil_revenue(
+        data_dir=tmp_path, wti_path=wti_xlsx, start_year=2024, end_year=2024
+    )
+    rev = dict(zip(df["FIELD_NAME_CODE"], df["GROSS_OIL_REVENUE_MM_USD"]))
+    # Only the priced January row counts: 1000*70 = 70000 -> 0.07 MM.
+    assert rev["MC807"] == pytest.approx(0.07)
+
+
+@unit
+def test_build_field_oil_revenue_empty_when_no_data(tmp_path):
+    df = build_field_oil_revenue(
+        data_dir=tmp_path, wti_path=None, start_year=2024, end_year=2024
+    )
+    assert df.empty
+    assert list(df.columns) == ["FIELD_NAME_CODE", "GROSS_OIL_REVENUE_MM_USD"]
+
+
+@unit
+def test_apply_field_revenue_left_join_on_field_code():
+    """Revenue is merged on FIELD_CODE; unmatched fields stay null (honest)."""
+    result = pd.DataFrame(
+        {
+            "FIELD_CODE": ["MC807", "GC640", "VK999"],
+            "CUM_OIL_MMBBL": [1000.0, 50.0, 1.0],
+        }
+    )
+    revenue = pd.DataFrame(
+        {
+            "FIELD_NAME_CODE": ["MC807", "GC640"],
+            "GROSS_OIL_REVENUE_MM_USD": [50000.0, 1200.0],
+        }
+    )
+    out = apply_field_revenue(result, revenue)
+    assert "GROSS_OIL_REVENUE_MM_USD" in out.columns
+    by_code = dict(zip(out["FIELD_CODE"], out["GROSS_OIL_REVENUE_MM_USD"]))
+    assert by_code["MC807"] == pytest.approx(50000.0)
+    assert by_code["GC640"] == pytest.approx(1200.0)
+    # VK999 has no revenue row -> honest null, not zero.
+    assert pd.isna(by_code["VK999"])
+    # Original is not mutated.
+    assert "GROSS_OIL_REVENUE_MM_USD" not in result.columns
+
+
+@unit
+def test_apply_field_revenue_handles_empty():
+    empty_result = pd.DataFrame(columns=["FIELD_CODE", "CUM_OIL_MMBBL"])
+    revenue = pd.DataFrame(
+        {"FIELD_NAME_CODE": ["MC807"], "GROSS_OIL_REVENUE_MM_USD": [1.0]}
+    )
+    out = apply_field_revenue(empty_result, revenue)
+    assert out.empty
+    assert "GROSS_OIL_REVENUE_MM_USD" in out.columns
+
+    # Empty revenue against a real result -> column present, all null.
+    result = pd.DataFrame({"FIELD_CODE": ["MC807"], "CUM_OIL_MMBBL": [1.0]})
+    empty_rev = pd.DataFrame(columns=["FIELD_NAME_CODE", "GROSS_OIL_REVENUE_MM_USD"])
+    out2 = apply_field_revenue(result, empty_rev)
+    assert "GROSS_OIL_REVENUE_MM_USD" in out2.columns
+    assert pd.isna(out2["GROSS_OIL_REVENUE_MM_USD"].iloc[0])


### PR DESCRIPTION
First **economics-tier** deliverable, stacked on current `main`. Per the scoping memo, true per-field NPV cannot generalize (development costs are hand-curated per field) — but **gross oil revenue is fully real**: measured OGOR-A production × published monthly WTI.

## Adds
- `field_revenue.py` (new): `load_wti_monthly()` (YYYYMM→WTI from the committed FDAS_V30 deck), `build_field_oil_revenue()` (per-field Σ monthly oil × WTI / 1e6), `apply_field_revenue()` (left-join onto the all-fields atlas, honest `NaN` for unmatched).
- Atlas merges `GROSS_OIL_REVENUE_MM_USD` per field; report shows the basin total + a top-fields column with a pre-royalty/pre-cost/oil-only caveat.
- 7 new unit tests (synthetic OGOR + WTI fixtures).

## Verified (real data, 1996–2025)
- Basin total **~$934.3 B** across 1,390 fields. Cross-checks the production inventory (16.35 Bbbl × ~$57/bbl avg realized).
- Top: **MC807 (Mars-Ursa) $102.6 B**, GC640 $48.5 B, GC743 (Atlantis) $39.1 B, GC654 $30.1 B, GC826 $28.6 B.
- 7 tests pass; Black clean; all files ≤500 lines.

## Honest scope
- **Oil only** — no Henry Hub gas deck in-repo, so gas revenue is **not** fabricated.
- **Gross, pre-royalty, pre-cost** — topline revenue, not value to any party. NPV is *not* generalized (would require fabricating costs).
- **WTI deck ends 2025-07**, so 2025-08…12 production (~317 MMbbl, ~1.9% of oil) is **excluded and logged**, never priced with a guess. Follow-up: extend the WTI deck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)