### PR TITLE
feat(bsee): per-field decommissioning liability (BSEE P50/P70/P90)

### DIFF
--- a/scripts/bsee/generate_all_fields_atlas.py
+++ b/scripts/bsee/generate_all_fields_atlas.py
@@ -23,6 +23,10 @@ from collections import Counter
 from pathlib import Path
 
 from worldenergydata.bsee.analysis.all_fields_runner import AllFieldsRunner
+from worldenergydata.bsee.analysis.field_decom import (
+    apply_field_decom,
+    build_field_decom_liability,
+)
 from worldenergydata.bsee.analysis.field_revenue import (
     apply_field_revenue,
     build_field_oil_revenue,
@@ -163,6 +167,29 @@ def main() -> int:
             "a value (oil only, gross pre-royalty pre-cost)",
             basin_rev,
             n_with_rev,
+            len(result),
+        )
+
+    # Decommissioning liability (Rank-2 economics): BSEE-provided P50/P70/P90
+    # future abandonment cost estimates, summed across cost-category rows per
+    # lease and rolled up to field via the OGOR-A lease->field crosswalk. These
+    # are BSEE estimates with their own uncertainty bands, not our model; fields
+    # with no decom estimate keep an honest null.
+    logger.info("Building decommissioning liability (BSEE P50/P70/P90)...")
+    decom = build_field_decom_liability(
+        ogor_dir=args.data_dir, start_year=args.start_year, end_year=args.end_year
+    )
+    result = apply_field_decom(result, decom)
+    if "DECOM_P50_MM_USD" in result.columns and not result.empty:
+        basin_p50 = float(result["DECOM_P50_MM_USD"].sum(skipna=True))
+        basin_p90 = float(result["DECOM_P90_MM_USD"].sum(skipna=True))
+        n_with_decom = int(result["DECOM_P50_MM_USD"].notna().sum())
+        logger.info(
+            "Basin decommissioning liability (BSEE estimate): P50 $%.1f MM, "
+            "P90 $%.1f MM across %d/%d fields with a decom estimate.",
+            basin_p50,
+            basin_p90,
+            n_with_decom,
             len(result),
         )
 

--- a/src/worldenergydata/bsee/analysis/field_decom.py
+++ b/src/worldenergydata/bsee/analysis/field_decom.py
@@ -1,0 +1,353 @@
+"""Per-field decommissioning liability view (deterministic, fabrication-free).
+
+Rolls up **BSEE-provided** P50/P70/P90 future abandonment cost estimates to the
+field level.  This is the Rank-2 economics deliverable: unlike NPV (which needs
+hand-curated per-field development costs), decom liability is sourced directly
+from BSEE's ``mv_decom_cost_totals`` materialized view — these are BSEE
+estimates with their own uncertainty bands (hence P50/P70/P90), not anything
+this repo computes or guesses.
+
+Pipeline
+--------
+1. :func:`load_decom_totals` reads the lease-level cost rows (one per cost
+   category ``TYPE``) and coerces P50/P70/P90 to numbers.
+2. :func:`build_lease_to_field` builds a lease->field crosswalk from OGOR-A,
+   mapping each lease to its **dominant** producing field (most OGOR rows).
+3. :func:`build_field_decom_liability` sums each lease across its TYPE rows,
+   maps lease->field, sums per field, and divides by 1e6 (-> $MM).
+4. :func:`apply_field_decom` left-joins the three DECOM_* columns onto an
+   AllFieldsRunner result.
+
+Honesty notes
+-------------
+* **BSEE estimate, not our model.**  P50/P70/P90 are BSEE's own probabilistic
+  abandonment cost bands.  We only sum and roll up.
+* **Future liability.**  These are *future* abandonment costs, not realized
+  spend; treat the rollup as an order-of-magnitude liability, not a precise
+  obligation.
+* **Honest coverage.**  Decom rows are keyed by ``AUTH_NUMBER`` (lease, ROW,
+  or RUE).  Only leases that map to a producing field via OGOR-A are rolled in;
+  leases/ROW/RUE that map to no producing field are **dropped and logged**
+  (with their unmapped P50 total) — never forced onto an arbitrary field.
+* Fields with no decom estimate get an honest ``NaN`` in
+  :func:`apply_field_decom` (left join), not a fabricated ``0``.
+"""
+
+from __future__ import annotations
+
+import logging
+import pickle  # nosec B403
+from pathlib import Path
+from typing import Dict, Optional
+
+import pandas as pd
+
+from worldenergydata.bsee.data.sources.bin.ogor_production_loader import (
+    load_ogor_bin,
+)
+from worldenergydata.common.data_resolver import get_module_data_safe
+
+logger = logging.getLogger(__name__)
+
+_DECOM_SUBDIR = ("bin", "decomcost")
+_DECOM_FILE = "mv_decom_cost_totals.bin"
+_OGOR_SUBDIR = "historical_production_yearly"
+
+_DECOM_OUT_COLUMNS = [
+    "FIELD_NAME_CODE",
+    "DECOM_P50_MM_USD",
+    "DECOM_P70_MM_USD",
+    "DECOM_P90_MM_USD",
+]
+_LOADED_COLUMNS = ["AUTH_NUMBER", "TYPE", "P50_COST", "P70_COST", "P90_COST"]
+
+
+def _normalize_lease(series: pd.Series) -> pd.Series:
+    """Normalize a lease/AUTH series: strip, drop quotes + internal spaces, upper.
+
+    OGOR leases arrive as ``' 00016'`` (leading-space shelf) and ``'G23740'``;
+    decom ``AUTH_NUMBER`` is clean ``'G#'``.  Both sides are normalized through
+    here so they join.
+    """
+    return (
+        series.astype(str)
+        .str.replace('"', "", regex=False)
+        .str.replace("'", "", regex=False)
+        .str.replace(" ", "", regex=False)
+        .str.strip()
+        .str.upper()
+    )
+
+
+def load_decom_totals(data_dir: Optional[Path] = None) -> pd.DataFrame:
+    """Load the lease-level BSEE decom cost totals.
+
+    Parameters
+    ----------
+    data_dir:
+        Directory containing :data:`_DECOM_FILE`.  Defaults to the resolved
+        ``<bsee module>/bin/decomcost``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Columns ``AUTH_NUMBER``, ``TYPE``, ``P50_COST``, ``P70_COST``,
+        ``P90_COST`` (costs coerced numeric, NaN->0).  Empty (correctly-typed)
+        when the file is an LFS stub, missing, unreadable, or not a DataFrame.
+    """
+    if data_dir is None:
+        data_dir = get_module_data_safe("bsee").joinpath(*_DECOM_SUBDIR)
+    path = Path(data_dir) / _DECOM_FILE
+
+    if not path.exists():
+        logger.warning("Decom totals file not found: %s", path)
+        return pd.DataFrame(columns=_LOADED_COLUMNS)
+
+    try:
+        with open(path, "rb") as f:
+            header = f.read(40)
+        if b"version https://git-lfs" in header:
+            logger.warning("Decom totals is an LFS stub (not materialized): %s", path)
+            return pd.DataFrame(columns=_LOADED_COLUMNS)
+        with open(path, "rb") as f:
+            obj = pickle.load(f)  # nosec B301
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Error loading decom totals %s: %s", path, exc)
+        return pd.DataFrame(columns=_LOADED_COLUMNS)
+
+    if not isinstance(obj, pd.DataFrame):
+        logger.warning("Decom totals is not a DataFrame: %s", path)
+        return pd.DataFrame(columns=_LOADED_COLUMNS)
+
+    required = {"AUTH_NUMBER", "TYPE", "P50_COST", "P70_COST", "P90_COST"}
+    if not required <= set(obj.columns):
+        logger.warning(
+            "Decom totals %s missing required columns (got %s)",
+            path,
+            list(obj.columns),
+        )
+        return pd.DataFrame(columns=_LOADED_COLUMNS)
+
+    out = pd.DataFrame(
+        {
+            "AUTH_NUMBER": obj["AUTH_NUMBER"],
+            "TYPE": obj["TYPE"],
+        }
+    )
+    for col in ("P50_COST", "P70_COST", "P90_COST"):
+        out[col] = pd.to_numeric(
+            obj[col].astype(str).str.replace('"', "", regex=False).str.strip(),
+            errors="coerce",
+        ).fillna(0.0)
+    logger.info("Loaded %d decom cost rows from %s", len(out), path)
+    return out[_LOADED_COLUMNS]
+
+
+def build_lease_to_field(
+    data_dir: Optional[Path] = None,
+    start_year: int = 1996,
+    end_year: int = 2025,
+) -> Dict[str, str]:
+    """Build a normalized ``{lease: dominant BOEM_FIELD}`` crosswalk from OGOR-A.
+
+    Each lease is mapped to its **dominant** field, chosen as the field with the
+    most OGOR-A rows for that lease (row count, not oil — simplest deterministic
+    tiebreak; documented choice).  Lease numbers are normalized via
+    :func:`_normalize_lease` so the ``' 00016'`` shelf format and clean ``'G#'``
+    format both join against decom ``AUTH_NUMBER``.
+
+    Parameters
+    ----------
+    data_dir:
+        Directory of ``ogora{year}delimit.bin`` files.  Defaults to the
+        resolved ``<bsee>/bin/historical_production_yearly``.
+    start_year, end_year:
+        Inclusive year range.
+
+    Returns
+    -------
+    dict[str, str]
+        ``{normalized_lease: field_code}``.  Empty when no OGOR data is found.
+    """
+    if data_dir is None:
+        data_dir = get_module_data_safe("bsee") / "bin" / _OGOR_SUBDIR
+    data_dir = Path(data_dir)
+
+    frames = []
+    loaded, missing = 0, 0
+    for year in range(start_year, end_year + 1):
+        path = data_dir / f"ogora{year}delimit.bin"
+        if not path.exists():
+            missing += 1
+            continue
+        raw = load_ogor_bin(path)
+        if raw.empty:
+            missing += 1
+            continue
+        work = pd.DataFrame(
+            {
+                "LEASE": _normalize_lease(raw["LEASE_NUMBER"]),
+                "FIELD": raw["BOEM_FIELD"]
+                .astype(str)
+                .str.replace('"', "", regex=False)
+                .str.strip(),
+            }
+        )
+        frames.append(work)
+        loaded += 1
+
+    if not frames:
+        logger.warning("No OGOR production bins loaded from %s", data_dir)
+        return {}
+
+    combined = pd.concat(frames, ignore_index=True)
+    combined = combined[(combined["LEASE"] != "") & (combined["FIELD"] != "")]
+    if combined.empty:
+        return {}
+
+    counts = combined.groupby(["LEASE", "FIELD"]).size().reset_index(name="N")
+    # Dominant field per lease: most rows; deterministic tiebreak by field code.
+    counts = counts.sort_values(["LEASE", "N", "FIELD"], ascending=[True, False, True])
+    dominant = counts.drop_duplicates("LEASE", keep="first")
+    mapping = dict(zip(dominant["LEASE"], dominant["FIELD"]))
+    logger.info(
+        "Built lease->field crosswalk: %d leases from %d OGOR years "
+        "(%d missing/empty)",
+        len(mapping),
+        loaded,
+        missing,
+    )
+    return mapping
+
+
+def build_field_decom_liability(
+    data_dir: Optional[Path] = None,
+    ogor_dir: Optional[Path] = None,
+    start_year: int = 1996,
+    end_year: int = 2025,
+) -> pd.DataFrame:
+    """Build per-field decom liability (BSEE P50/P70/P90 estimates, $MM).
+
+    Sums each lease across its cost-category (``TYPE``) rows, maps lease->field
+    via :func:`build_lease_to_field`, sums per field, and divides by 1e6.
+
+    The lease-join hit-rate (how many decom leases mapped to a producing field
+    vs unmapped) and the unmapped P50 total are logged for honest coverage.
+    Leases that map to no producing field are dropped (and logged), not forced.
+
+    Parameters
+    ----------
+    data_dir:
+        Directory of the decom totals bin (see :func:`load_decom_totals`).
+    ogor_dir:
+        Directory of the OGOR ``.bin`` files for the lease->field crosswalk.
+        Defaults to the resolved ``<bsee>/bin/historical_production_yearly``.
+    start_year, end_year:
+        Inclusive OGOR year range for the crosswalk.
+
+    Returns
+    -------
+    pd.DataFrame
+        Columns ``FIELD_NAME_CODE``, ``DECOM_P50_MM_USD``, ``DECOM_P70_MM_USD``,
+        ``DECOM_P90_MM_USD`` (millions of USD).  Empty (correctly-typed) when
+        no decom data is found.
+    """
+    decom = load_decom_totals(data_dir)
+    if decom.empty:
+        logger.warning("No decom totals loaded — field decom liability empty.")
+        return pd.DataFrame(columns=_DECOM_OUT_COLUMNS)
+
+    # Sum each lease across its cost-category TYPE rows.
+    decom = decom.copy()
+    decom["LEASE"] = _normalize_lease(decom["AUTH_NUMBER"])
+    per_lease = decom.groupby("LEASE", as_index=False)[
+        ["P50_COST", "P70_COST", "P90_COST"]
+    ].sum()
+
+    crosswalk = build_lease_to_field(
+        data_dir=ogor_dir, start_year=start_year, end_year=end_year
+    )
+    per_lease["FIELD_NAME_CODE"] = per_lease["LEASE"].map(crosswalk)
+
+    mapped = per_lease[per_lease["FIELD_NAME_CODE"].notna()]
+    unmapped = per_lease[per_lease["FIELD_NAME_CODE"].isna()]
+    logger.info(
+        "Decom lease join: %d/%d leases mapped to a producing field "
+        "(%d unmapped, $%.1f MM P50 dropped — leases/ROW/RUE with no "
+        "producing field, not fabricated).",
+        len(mapped),
+        len(per_lease),
+        len(unmapped),
+        float(unmapped["P50_COST"].sum()) / 1e6,
+    )
+
+    if mapped.empty:
+        logger.warning("No decom leases mapped to a producing field.")
+        return pd.DataFrame(columns=_DECOM_OUT_COLUMNS)
+
+    by_field = mapped.groupby("FIELD_NAME_CODE", as_index=False)[
+        ["P50_COST", "P70_COST", "P90_COST"]
+    ].sum()
+    out = pd.DataFrame(
+        {
+            "FIELD_NAME_CODE": by_field["FIELD_NAME_CODE"],
+            "DECOM_P50_MM_USD": by_field["P50_COST"] / 1e6,
+            "DECOM_P70_MM_USD": by_field["P70_COST"] / 1e6,
+            "DECOM_P90_MM_USD": by_field["P90_COST"] / 1e6,
+        }
+    )
+    logger.info(
+        "Built decom liability for %d fields; basin P50 $%.1f MM, "
+        "P90 $%.1f MM (BSEE estimates).",
+        len(out),
+        float(out["DECOM_P50_MM_USD"].sum()),
+        float(out["DECOM_P90_MM_USD"].sum()),
+    )
+    return out[_DECOM_OUT_COLUMNS]
+
+
+def apply_field_decom(result_df: pd.DataFrame, decom_df: pd.DataFrame) -> pd.DataFrame:
+    """Merge the three DECOM_* columns into an AllFieldsRunner result.
+
+    Left-joins ``decom_df`` (keyed on ``FIELD_NAME_CODE``) onto ``result_df``
+    (keyed on ``FIELD_CODE``).  Fields with no decom estimate get an honest
+    ``NaN`` — never a fabricated zero.  ``result_df`` is not mutated.
+
+    Parameters
+    ----------
+    result_df:
+        Per-field result with a ``FIELD_CODE`` column.
+    decom_df:
+        Output of :func:`build_field_decom_liability`.
+
+    Returns
+    -------
+    pd.DataFrame
+        Copy of ``result_df`` with the three ``DECOM_*`` columns.
+    """
+    decom_cols = ["DECOM_P50_MM_USD", "DECOM_P70_MM_USD", "DECOM_P90_MM_USD"]
+    out = result_df.copy()
+
+    if "FIELD_CODE" not in out.columns:
+        logger.warning("result_df has no FIELD_CODE — decom not merged.")
+        for col in decom_cols:
+            out[col] = pd.NA
+        return out
+
+    if decom_df is None or decom_df.empty:
+        for col in decom_cols:
+            out[col] = pd.NA
+        return out
+
+    dec = decom_df[["FIELD_NAME_CODE", *decom_cols]].copy()
+    dec["FIELD_NAME_CODE"] = dec["FIELD_NAME_CODE"].astype(str).str.strip()
+
+    out["_join_code"] = out["FIELD_CODE"].astype(str).str.strip()
+    merged = out.merge(
+        dec,
+        how="left",
+        left_on="_join_code",
+        right_on="FIELD_NAME_CODE",
+    )
+    merged = merged.drop(columns=["_join_code", "FIELD_NAME_CODE"])
+    return merged

--- a/src/worldenergydata/bsee/reports/all_fields_report.py
+++ b/src/worldenergydata/bsee/reports/all_fields_report.py
@@ -118,6 +118,23 @@ class AllFieldsReport:
                 "revenue only (no royalty/opex/capex, no gas). Fields without "
                 "priced production are left blank, not zeroed.*"
             )
+        has_decom = not self._df.empty and "DECOM_P50_MM_USD" in self._df.columns
+        if has_decom:
+            decom_p50 = self._df["DECOM_P50_MM_USD"].sum(skipna=True)
+            decom_p90 = self._df["DECOM_P90_MM_USD"].sum(skipna=True)
+            n_with_decom = int(self._df["DECOM_P50_MM_USD"].notna().sum())
+            lines.append(
+                f"- **Decommissioning liability (BSEE estimate, P50/P90)**: "
+                f"${decom_p50:,.0f} MM / ${decom_p90:,.0f} MM across "
+                f"{n_with_decom} fields"
+            )
+            lines.append(
+                "  - *Future abandonment liability; BSEE-provided P50/P70/P90 "
+                "estimates (their own uncertainty bands), summed across cost "
+                "categories per lease and rolled up to field. Covers only "
+                "leases with a decom estimate that map to a producing field, "
+                "not all fields; fields without an estimate are left blank.*"
+            )
         lines.append("")
 
         # Era Grouping
@@ -170,12 +187,12 @@ class AllFieldsReport:
                 lines.append(
                     "| Field | Era | Oil (MMBBL) | Gas (BCF) | Wells | "
                     "Rec/Well (MMBBL) | BOPD/Well | First Prod | "
-                    "Water Depth (ft) | Gross Oil Rev ($MM) |"
+                    "Water Depth (ft) | Gross Oil Rev ($MM) | Decom P50 ($MM) |"
                 )
                 lines.append(
                     "|-------|-----|-------------|-----------|-------|"
                     "------------------|-----------|------------|"
-                    "------------------|--------------------|"
+                    "------------------|--------------------|-----------------|"
                 )
                 for _, row in top.iterrows():
                     name = row.get("FIELD_NAME", row.get("FIELD_CODE", ""))
@@ -192,10 +209,12 @@ class AllFieldsReport:
                     bpw_str = f"{bpw:,.0f}" if pd.notna(bpw) else ""
                     rev = row.get("GROSS_OIL_REVENUE_MM_USD", None)
                     rev_str = f"{rev:,.0f}" if pd.notna(rev) else ""
+                    dec = row.get("DECOM_P50_MM_USD", None)
+                    dec_str = f"{dec:,.0f}" if pd.notna(dec) else ""
                     lines.append(
                         f"| {name} | {era} | {oil:,.1f} | {gas:,.1f} | {wells} "
                         f"| {rpw_str} | {bpw_str} | {first} | {wd_str} "
-                        f"| {rev_str} |"
+                        f"| {rev_str} | {dec_str} |"
                     )
                 lines.append("")
 

--- a/tests/unit/bsee/analysis/test_field_decom.py
+++ b/tests/unit/bsee/analysis/test_field_decom.py
@@ -1,0 +1,326 @@
+"""Unit tests for the per-field decommissioning liability view
+(:mod:`field_decom`).
+
+All fixtures are synthetic (``tmp_path``) and deterministic — they never read
+the multi-GB materialized OGOR-A data nor the real decom totals bin.  The OGOR
+fixture deliberately mimics the real on-disk *header-corruption* (a
+``read_csv`` consumed the first data record as the column header, losing that
+physical row), reusing the pattern from
+``tests/unit/bsee/data/test_ogor_production_loader.py`` so the loader path
+under test matches production behaviour.
+
+These are BSEE-provided P50/P70/P90 abandonment cost estimates (USD) summed
+across cost-category rows per lease, rolled up to field via the OGOR-A
+lease->field crosswalk.  Nothing is fabricated: leases that do not map to a
+producing field are dropped (and logged), never forced.
+"""
+
+import pickle
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from tests.test_markers import unit
+from worldenergydata.bsee.analysis.field_decom import (
+    apply_field_decom,
+    build_field_decom_liability,
+    build_lease_to_field,
+    load_decom_totals,
+)
+from worldenergydata.bsee.data.sources.bin.ogor_production_loader import (
+    OGOR_COLUMN_NAMES,
+)
+
+DECOM_COLUMNS = [
+    "AUTH_TYPE_CODE",
+    "AUTH_NUMBER",
+    "TYPE",
+    "CNT",
+    "P50_COST",
+    "P70_COST",
+    "P90_COST",
+    "DTR_COST",
+]
+
+
+def _decom_row(auth, type_, p50, p70, p90, auth_type="LSE", cnt=1):
+    return [auth_type, auth, type_, cnt, p50, p70, p90, 0]
+
+
+def _write_decom_bin(path: Path, rows) -> None:
+    """Write a synthetic mv_decom_cost_totals pickle (proper headers)."""
+    df = pd.DataFrame(rows, columns=DECOM_COLUMNS)
+    with open(path, "wb") as f:
+        pickle.dump(df, f)
+
+
+def _ogor_row(lease, field, oil=1000.0, yyyymm=202401):
+    """One OGOR-A record in canonical column order with the given knobs."""
+    return [
+        lease,  # LEASE_NUMBER
+        "E001",  # COMPLETION_NAME
+        yyyymm,  # PRODUCTION_DATE (YYYYMM int)
+        30,  # DAYS_ON_PROD
+        "O",  # PRODUCT_CODE
+        oil,  # MON_O_PROD_VOL
+        5000.0,  # MON_G_PROD_VOL
+        200.0,  # MON_WTR_PROD_VOL
+        "608054010300",  # API_WELL_NUMBER
+        "PR",  # WELL_STAT_CD
+        "MC0807",  # AREA_CODE_BLOCK_NUM
+        "03151",  # OPERATOR_NUM
+        "OPERATOR",  # SORT_NAME
+        field,  # BOEM_FIELD
+        0.0,  # INJECTION_VOLUME
+        "Q01",  # PROD_INTERVAL_CD
+        20100101,  # FIRST_PROD_DATE
+        "",  # UNIT_AGT_NUMBER
+        "",  # UNIT_ALOC_SUFFIX
+    ]
+
+
+def _write_corrupted_ogor_bin(path: Path, rows) -> None:
+    """Write a header-corrupted OGOR pickle (loses the first physical row).
+
+    Mirrors ``tests/unit/bsee/data/test_ogor_production_loader.py``: the
+    pickled frame's *columns* are the first record's values and that record
+    is dropped, exactly as the real corrupted ``.bin`` files were produced.
+    """
+    full = pd.DataFrame(rows, columns=OGOR_COLUMN_NAMES)
+    corrupted = pd.DataFrame(full.iloc[1:].values, columns=list(full.iloc[0].values))
+    with open(path, "wb") as f:
+        pickle.dump(corrupted, f)
+
+
+# --------------------------------------------------------------------------
+# load_decom_totals
+# --------------------------------------------------------------------------
+@unit
+def test_load_decom_totals_missing_file_returns_empty(tmp_path):
+    df = load_decom_totals(data_dir=tmp_path)
+    assert df.empty
+    assert {"AUTH_NUMBER", "TYPE", "P50_COST", "P70_COST", "P90_COST"} <= set(
+        df.columns
+    )
+
+
+@unit
+def test_load_decom_totals_lfs_stub_returns_empty(tmp_path):
+    f = tmp_path / "mv_decom_cost_totals.bin"
+    f.write_bytes(b"version https://git-lfs.github.com/spec/v1\noid sha256:abc\n")
+    df = load_decom_totals(data_dir=tmp_path)
+    assert df.empty
+
+
+@unit
+def test_load_decom_totals_coerces_costs_numeric(tmp_path):
+    rows = [
+        _decom_row("G100", "Wells Decom Cost", "1000", "1500", "2000"),
+        _decom_row("G100", "Platforms Decom Cost", 500, 700, 900),
+        _decom_row("G100", "Bad Cost", "not-a-number", "", None),
+    ]
+    f = tmp_path / "mv_decom_cost_totals.bin"
+    _write_decom_bin(f, rows)
+    df = load_decom_totals(data_dir=tmp_path)
+    assert len(df) == 3
+    # Strings coerced to numbers; non-numeric -> 0 (NaN->0).
+    assert df["P50_COST"].sum() == pytest.approx(1500.0)
+    assert df["P70_COST"].sum() == pytest.approx(2200.0)
+    assert df["P90_COST"].sum() == pytest.approx(2900.0)
+
+
+# --------------------------------------------------------------------------
+# build_lease_to_field
+# --------------------------------------------------------------------------
+@unit
+def test_build_lease_to_field_dominant_mapping_and_normalization(tmp_path):
+    """Lease maps to the field with the most rows; lease formats normalized."""
+    rows = [
+        _ogor_row("DUMMY", "DUMMY"),  # lost to corruption
+        # Lease with a leading-space shelf format -> normalizes to "00016".
+        _ogor_row(" 00016", "SHELF1"),
+        _ogor_row(" 00016", "SHELF1"),
+        _ogor_row(" 00016", "SHELF2"),  # SHELF1 dominates (2 vs 1)
+        # Clean deepwater lease.
+        _ogor_row("G23740", "DEEP1"),
+    ]
+    f = tmp_path / "ogora2024delimit.bin"
+    _write_corrupted_ogor_bin(f, rows)
+
+    mapping = build_lease_to_field(data_dir=tmp_path, start_year=2024, end_year=2024)
+    # Normalized key (no leading space) maps to the dominant field.
+    assert mapping["00016"] == "SHELF1"
+    assert mapping["G23740"] == "DEEP1"
+    # Keys are normalized (no leading-space variant survives).
+    assert " 00016" not in mapping
+
+
+@unit
+def test_build_lease_to_field_empty_when_no_data(tmp_path):
+    mapping = build_lease_to_field(data_dir=tmp_path, start_year=2024, end_year=2024)
+    assert mapping == {}
+
+
+# --------------------------------------------------------------------------
+# build_field_decom_liability
+# --------------------------------------------------------------------------
+@unit
+def test_build_field_decom_liability_rollup(tmp_path):
+    """Per-lease sum across TYPE rows, lease->field map, field rollup /1e6."""
+    decom_rows = [
+        # Lease G100 -> two TYPE rows, summed per lease.
+        _decom_row("G100", "Wells Decom Cost", 1_000_000, 1_500_000, 2_000_000),
+        _decom_row("G100", "Platforms Decom Cost", 500_000, 700_000, 900_000),
+        # Lease 00016 (shelf) -> one TYPE row.
+        _decom_row("00016", "Wells Decom Cost", 250_000, 300_000, 400_000),
+        # Lease G999 -> not in OGOR crosswalk -> dropped + logged.
+        _decom_row("G999", "Wells Decom Cost", 9_000_000, 9_000_000, 9_000_000),
+    ]
+    decom_f = tmp_path / "mv_decom_cost_totals.bin"
+    _write_decom_bin(decom_f, decom_rows)
+
+    ogor_rows = [
+        _ogor_row("DUMMY", "DUMMY"),  # lost to corruption
+        _ogor_row("G100", "FIELDA"),
+        _ogor_row("G100", "FIELDA"),
+        # Leading-space lease format normalizes to "00016".
+        _ogor_row(" 00016", "FIELDA"),
+        _ogor_row("G200", "FIELDB"),
+    ]
+    ogor_dir = tmp_path / "ogor"
+    ogor_dir.mkdir()
+    _write_corrupted_ogor_bin(ogor_dir / "ogora2024delimit.bin", ogor_rows)
+
+    df = build_field_decom_liability(
+        data_dir=tmp_path,
+        ogor_dir=ogor_dir,
+        start_year=2024,
+        end_year=2024,
+    )
+    assert list(df.columns) == [
+        "FIELD_NAME_CODE",
+        "DECOM_P50_MM_USD",
+        "DECOM_P70_MM_USD",
+        "DECOM_P90_MM_USD",
+    ]
+    by_field = df.set_index("FIELD_NAME_CODE")
+    # FIELDA = G100 (1.0M+0.5M=1.5M P50) + 00016 (0.25M P50) = 1.75M -> 1.75 MM
+    assert by_field.loc["FIELDA", "DECOM_P50_MM_USD"] == pytest.approx(1.75)
+    # P70: (1.5M+0.7M) + 0.3M = 2.5M -> 2.5 MM
+    assert by_field.loc["FIELDA", "DECOM_P70_MM_USD"] == pytest.approx(2.5)
+    # P90: (2.0M+0.9M) + 0.4M = 3.3M -> 3.3 MM
+    assert by_field.loc["FIELDA", "DECOM_P90_MM_USD"] == pytest.approx(3.3)
+    # G999 is unmapped -> dropped, not present anywhere.
+    assert "FIELDB" not in by_field.index  # FIELDB had no decom lease either
+    assert by_field["DECOM_P50_MM_USD"].sum() == pytest.approx(1.75)
+
+
+@unit
+def test_build_field_decom_liability_drops_unmapped_lease(tmp_path):
+    """A decom lease with no producing field is dropped (honest coverage)."""
+    decom_rows = [
+        _decom_row("G100", "Wells Decom Cost", 1_000_000, 1_000_000, 1_000_000),
+        _decom_row("ROWXYZ", "Pipelines Decom Cost", 5_000_000, 5_000_000, 5_000_000),
+    ]
+    decom_f = tmp_path / "mv_decom_cost_totals.bin"
+    _write_decom_bin(decom_f, decom_rows)
+
+    ogor_rows = [
+        _ogor_row("DUMMY", "DUMMY"),
+        _ogor_row("G100", "FIELDA"),
+    ]
+    ogor_dir = tmp_path / "ogor"
+    ogor_dir.mkdir()
+    _write_corrupted_ogor_bin(ogor_dir / "ogora2024delimit.bin", ogor_rows)
+
+    df = build_field_decom_liability(
+        data_dir=tmp_path,
+        ogor_dir=ogor_dir,
+        start_year=2024,
+        end_year=2024,
+    )
+    # Only FIELDA survives; ROWXYZ pipeline lease is dropped.
+    assert set(df["FIELD_NAME_CODE"]) == {"FIELDA"}
+    assert df["DECOM_P50_MM_USD"].sum() == pytest.approx(1.0)
+
+
+@unit
+def test_build_field_decom_liability_empty_when_no_decom_file(tmp_path):
+    ogor_dir = tmp_path / "ogor"
+    ogor_dir.mkdir()
+    df = build_field_decom_liability(
+        data_dir=tmp_path,
+        ogor_dir=ogor_dir,
+        start_year=2024,
+        end_year=2024,
+    )
+    assert df.empty
+    assert list(df.columns) == [
+        "FIELD_NAME_CODE",
+        "DECOM_P50_MM_USD",
+        "DECOM_P70_MM_USD",
+        "DECOM_P90_MM_USD",
+    ]
+
+
+# --------------------------------------------------------------------------
+# apply_field_decom
+# --------------------------------------------------------------------------
+@unit
+def test_apply_field_decom_left_join_on_field_code():
+    """Decom is merged on FIELD_CODE; unmatched fields stay null (honest)."""
+    result = pd.DataFrame(
+        {
+            "FIELD_CODE": ["FIELDA", "FIELDB", "VK999"],
+            "CUM_OIL_MMBBL": [1000.0, 50.0, 1.0],
+        }
+    )
+    decom = pd.DataFrame(
+        {
+            "FIELD_NAME_CODE": ["FIELDA", "FIELDB"],
+            "DECOM_P50_MM_USD": [1.75, 0.5],
+            "DECOM_P70_MM_USD": [2.5, 0.7],
+            "DECOM_P90_MM_USD": [3.3, 0.9],
+        }
+    )
+    out = apply_field_decom(result, decom)
+    for col in ("DECOM_P50_MM_USD", "DECOM_P70_MM_USD", "DECOM_P90_MM_USD"):
+        assert col in out.columns
+    by_code = out.set_index("FIELD_CODE")
+    assert by_code.loc["FIELDA", "DECOM_P50_MM_USD"] == pytest.approx(1.75)
+    assert by_code.loc["FIELDB", "DECOM_P90_MM_USD"] == pytest.approx(0.9)
+    # VK999 has no decom row -> honest null, not zero.
+    assert pd.isna(by_code.loc["VK999", "DECOM_P50_MM_USD"])
+    # Original is not mutated.
+    assert "DECOM_P50_MM_USD" not in result.columns
+
+
+@unit
+def test_apply_field_decom_handles_empty():
+    empty_result = pd.DataFrame(columns=["FIELD_CODE", "CUM_OIL_MMBBL"])
+    decom = pd.DataFrame(
+        {
+            "FIELD_NAME_CODE": ["FIELDA"],
+            "DECOM_P50_MM_USD": [1.0],
+            "DECOM_P70_MM_USD": [1.0],
+            "DECOM_P90_MM_USD": [1.0],
+        }
+    )
+    out = apply_field_decom(empty_result, decom)
+    assert out.empty
+    assert "DECOM_P50_MM_USD" in out.columns
+
+    # Empty decom against a real result -> columns present, all null.
+    result = pd.DataFrame({"FIELD_CODE": ["FIELDA"], "CUM_OIL_MMBBL": [1.0]})
+    empty_decom = pd.DataFrame(
+        columns=[
+            "FIELD_NAME_CODE",
+            "DECOM_P50_MM_USD",
+            "DECOM_P70_MM_USD",
+            "DECOM_P90_MM_USD",
+        ]
+    )
+    out2 = apply_field_decom(result, empty_decom)
+    assert "DECOM_P50_MM_USD" in out2.columns
+    assert pd.isna(out2["DECOM_P50_MM_USD"].iloc[0])


### PR DESCRIPTION
Rank-2 **economics-tier** deliverable, stacked on current `main`. Rolls BSEE-provided future abandonment cost estimates up to the field level — real BSEE probabilistic estimates (P50/P70/P90), not anything this repo computes.

## Adds
- `field_decom.py` (new): `load_decom_totals` (from `decomcost/mv_decom_cost_totals.bin`), `build_lease_to_field` (dominant field per lease via OGOR, lease-format normalized), `build_field_decom_liability` (per-lease sum across cost categories → field rollup → $MM), `apply_field_decom` (left-join onto atlas, honest NaN).
- Atlas merges `DECOM_P50/P70/P90_MM_USD`; report shows basin P50/P90 + a `Decom P50 ($MM)` column with a future-liability/BSEE-estimate caveat.
- 10 new unit tests (synthetic decom + OGOR fixtures).

## Verified (real data)
- Lease-level total: **$28.75 B P50 / $43.32 B P90**.
- Field rollup: **417 fields**, basin **$27.02 B P50 / $40.69 B P90**.
- Lease-join coverage: 997/2,277 leases by count, but **~94% of dollars** (only $1.74 B P50 unmapped — mostly ROW/RUE pipeline auths with no producing field, **dropped + logged**, never forced).
- Top: MC807 $1,272.5 MM, GC640 $1,056.8 MM, GC743 (Atlantis) $967.1 MM.
- 10 tests pass; Black clean; all files ≤500 lines.

## Honest scope
Future abandonment **liability**, not realized spend; BSEE estimate, order-of-magnitude. Lease-keyed → covers the leases that map to a producing field (the 94%-of-dollars subset), not all 1,390 fields; fields without an estimate get `NaN`, not 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)