### PR TITLE
ci: migrate per-domain PR gate to shared reusable workflow (#530)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,30 @@ jobs:
   # worldenergydata#530). wed's conventions match the reusable defaults exactly
   # (selector scripts/ci/select_test_targets.py, uv sync --all-extras, quarantine
   # scripts/ci/quarantine.txt, python-setup uv, max-parallel 10), so the caller
-  # passes no `with:` overrides. The aggregate check is now surfaced as
-  # "domain-tests / Aggregate domain results" (was the inline "Test (PR gate)" —
-  # the ruleset required check must be updated to match; see the migration PR).
+  # passes no `with:` overrides.
   domain-tests:
     if: github.event_name == 'pull_request'
     uses: vamseeachanta/workspace-hub/.github/workflows/domain-matrix.yml@main
+
+  # Name-preserving gate: the reusable workflow surfaces its own aggregate as
+  # "domain-tests / Aggregate domain results", but the branch ruleset requires a
+  # check literally named "Test (PR gate)". This thin wrapper re-publishes that
+  # exact name and gates on the reusable matrix result, so the migration needs
+  # NO ruleset change and does not break in-flight PRs. (#530)
+  pr-gate:
+    name: Test (PR gate)
+    needs: [domain-tests]
+    if: always() && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gate on domain matrix result
+        run: |
+          echo "domain-tests result: ${{ needs.domain-tests.result }}"
+          if [ "${{ needs.domain-tests.result }}" != "success" ]; then
+            echo "::error::domain matrix failed — see the 'domain-tests / *' jobs"
+            exit 1
+          fi
+          echo "All domains green ✅"
 
   # ------------------------------------------------------------ full matrix --
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,115 +29,17 @@ jobs:
   # required status check. The full 3-Python matrix still runs on push to main,
   # nightly, dispatch, or `ci-full` PRs.
 
-  discover:
-    name: Discover domains
-    runs-on: ubuntu-latest
+  # The discover -> test-domain (matrix) -> aggregate scaffolding now lives in
+  # the shared reusable workflow (workspace-hub#.../domain-matrix.yml, P4
+  # worldenergydata#530). wed's conventions match the reusable defaults exactly
+  # (selector scripts/ci/select_test_targets.py, uv sync --all-extras, quarantine
+  # scripts/ci/quarantine.txt, python-setup uv, max-parallel 10), so the caller
+  # passes no `with:` overrides. The aggregate check is now surfaced as
+  # "domain-tests / Aggregate domain results" (was the inline "Test (PR gate)" —
+  # the ruleset required check must be updated to match; see the migration PR).
+  domain-tests:
     if: github.event_name == 'pull_request'
-    outputs:
-      matrix: ${{ steps.sel.outputs.matrix }}
-      scope: ${{ steps.sel.outputs.scope }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0  # need the base commit to diff changed files
-      - name: Select domain matrix
-        id: sel
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          # Stdlib only — no uv sync needed (keeps discovery fast).
-          git diff --name-only "$BASE_SHA"...HEAD > changed-files.txt
-          echo "Changed files:"; cat changed-files.txt
-          python3 scripts/ci/select_test_targets.py \
-            --emit-matrix --files-from changed-files.txt >> "$GITHUB_OUTPUT"
-          echo "--- matrix ---"; grep '^matrix=' "$GITHUB_OUTPUT" || true
-
-  test-domain:
-    name: Domain ${{ matrix.name }}
-    needs: discover
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false  # one red domain must not cancel the others
-      max-parallel: 10  # bound the fan-out (core changes can be ~70 domains)
-      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-      - name: Set up Python
-        run: uv python install ${{ env.PYTHON_VERSION_DEFAULT }}
-      - name: Install dependencies
-        run: uv sync --all-extras
-      - name: Run domain tests (${{ matrix.name }})
-        env:
-          TARGETS: ${{ matrix.targets }}
-          MODE: ${{ matrix.mode }}
-          SHARD: ${{ matrix.name }}
-        run: |
-          # Build --deselect args for quarantined tests (known-broken on main,
-          # tracked by issues; see scripts/ci/quarantine.txt). They still RUN
-          # but do not block, at test granularity (never whole shards).
-          DESELECT=()
-          if [ -f scripts/ci/quarantine.txt ]; then
-            while IFS= read -r raw; do
-              line="${raw%%#*}"
-              line="$(echo "$line" | xargs || true)"
-              [ -z "$line" ] && continue
-              DESELECT+=(--deselect "$line")
-            done < scripts/ci/quarantine.txt
-          fi
-          [ "${#DESELECT[@]}" -gt 0 ] && echo "Quarantine: ${DESELECT[*]}"
-          XDIST=()
-          [ "$MODE" = "xdist" ] && XDIST=(-n auto)
-          echo "Shard '$SHARD' ($MODE): $TARGETS"
-          set +e
-          # shellcheck disable=SC2086 (TARGETS is an intentional target list)
-          uv run --with pytest-xdist pytest $TARGETS "${XDIST[@]}" "${DESELECT[@]}" \
-            --tb=short --junitxml="test-results-${SHARD}.xml"
-          rc=$?
-          set -e
-          # exit code 5 = "no tests collected" (empty / norecursedirs-excluded
-          # shard) — not a failure for a per-domain shard.
-          if [ "$rc" -eq 5 ]; then
-            echo "::notice::shard '$SHARD' collected no tests — treating as pass"
-            rc=0
-          fi
-          exit "$rc"
-      - name: Upload domain test results
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: test-results-${{ matrix.name }}
-          path: test-results-*.xml
-          if-no-files-found: ignore
-
-  pr-gate:
-    name: Test (PR gate)  # REQUIRED status check — do not rename (branch protection)
-    needs: [discover, test-domain]
-    if: always() && github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Aggregate domain results
-        run: |
-          echo "discover:    ${{ needs.discover.result }}"
-          echo "test-domain: ${{ needs.test-domain.result }}"
-          echo "scope:       ${{ needs.discover.outputs.scope }}"
-          if [ "${{ needs.discover.result }}" != "success" ]; then
-            echo "::error::domain discovery failed"; exit 1
-          fi
-          # test-domain is a matrix; its result is 'success' only when every
-          # domain job passed (fail-fast is off, so all run to completion).
-          if [ "${{ needs.test-domain.result }}" != "success" ]; then
-            echo "::error::one or more domain jobs failed — see the Domain * jobs"
-            exit 1
-          fi
-          echo "All domains green ✅"
+    uses: vamseeachanta/workspace-hub/.github/workflows/domain-matrix.yml@main
 
   # ------------------------------------------------------------ full matrix --
   test:


### PR DESCRIPTION
## What

Migrate worldenergydata's modular per-domain PR gate from the **inline**
`discover -> test-domain (matrix) -> pr-gate` jobs (added in #531) to a single
**caller** of the shared reusable workflow hosted in `workspace-hub`:

```yaml
domain-tests:
  if: github.event_name == 'pull_request'
  uses: vamseeachanta/workspace-hub/.github/workflows/domain-matrix.yml@main
  # defaults already match wed: selector scripts/ci/select_test_targets.py,
  # install `uv sync --all-extras`, quarantine scripts/ci/quarantine.txt,
  # python-setup uv, max-parallel 10 — so no `with:` overrides are needed.
```

Refs #530 (P4) · #526.

## Unchanged

- `test` (full 3-Python matrix), `lint`, `type-check`, `security`, `build`, `docs` jobs — byte-for-byte identical.
- `scripts/ci/select_test_targets.py` and `scripts/ci/quarantine.txt` — kept as-is.
- The PR-only guard (`if: github.event_name == 'pull_request'`) on the caller.

Net diff: `.github/workflows/ci.yml` only — 10 insertions, 108 deletions.

## ⚠️ Ruleset update required (owner action — do NOT merge before this)

The reusable workflow's aggregate status-check name is namespaced by the caller
job id, so the required check name **changes**:

| Before | After |
|--------|-------|
| `Test (PR gate)` | `domain-tests / Aggregate domain results` |

This repo is RULESET-protected (`protect_repo`, id `6547740`) and lists
`Test (PR gate)` as a required check. Until the ruleset is updated, **this PR
(and all future PRs) will show as BLOCKED** because the old required check no
longer reports. That is expected and is the whole reason for this note.

**Exact command for the owner to swap the required check** (replaces only
`Test (PR gate)` -> `domain-tests / Aggregate domain results`, leaving the other
10 required checks unchanged):

```bash
gh api -X PUT repos/vamseeachanta/worldenergydata/rulesets/6547740 \
  --input - <<'JSON'
{
  "rules": [
    {
      "type": "required_status_checks",
      "parameters": {
        "strict_required_status_checks_policy": true,
        "do_not_enforce_on_create": false,
        "required_status_checks": [
          { "context": "Validate PR Title" },
          { "context": "Lint" },
          { "context": "Type Check" },
          { "context": "Check File Sizes" },
          { "context": "Check Sensitive Files" },
          { "context": "Security Scan" },
          { "context": "Changelog Check" },
          { "context": "Documentation" },
          { "context": "Code Owners Check" },
          { "context": "GitGuardian Security Checks" },
          { "context": "domain-tests / Aggregate domain results" }
        ]
      }
    }
  ]
}
JSON
```

Note: a `PUT` to `/rulesets/{id}` with only `rules` replaces the rules array, so
all 11 entries above must be present (the 10 unchanged + the renamed one). To be
safe, the owner may instead edit the required check in the GitHub UI
(Settings -> Rules -> `protect_repo` -> Require status checks) — remove
`Test (PR gate)`, add `domain-tests / Aggregate domain results`.

Do NOT modify rulesets as part of merging this PR via automation; this is an
owner action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
