### PR TITLE
feat(pages): per-domain build isolation for the data site (#528)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,12 +3,31 @@ name: Deploy Data Outputs to Pages
 # Publishes deterministic, unit-tested analysis outputs as a static site.
 # The site is REBUILT from frozen report artifacts on every run — no committed
 # HTML build output — so what ships always matches the source reports.
+#
+# Per-domain BUILD isolation (P2, issue #528)
+# -------------------------------------------
+# GitHub Pages publishes exactly ONE artifact for the whole site:
+# actions/deploy-pages replaces the entire published tree from the single
+# upload-pages-artifact tarball. There is NO per-domain *publish* — you cannot
+# deploy a partial artifact without clobbering the rest of the site. So P2 is
+# per-domain *build* isolation merged into one published tree, NOT separate
+# per-domain Pages sites.
+#
+# How the merge works without committing build output: we restore the
+# previously-published public/ from the Actions cache, rebuild ONLY the domain(s)
+# whose reports/<domain>/** changed (always regenerating the landing index over
+# the restored tree), then upload the full merged tree through the same single
+# Pages artifact and deploy step as before. Any change to shared chrome
+# (build_pages.py, the CSS/template, or site_assets/**) affects every page and so
+# forces a --clean full rebuild. A cache miss also degrades safely to a full
+# rebuild. workflow_dispatch always full-rebuilds (safety hatch).
 
 on:
   push:
     branches: [main]
     paths:
       - 'reports/**'
+      - 'site_assets/**'
       - 'scripts/build_pages.py'
       - '.github/workflows/pages.yml'
   workflow_dispatch:
@@ -27,11 +46,111 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Need the previous commit so we can diff which domains changed.
+          fetch-depth: 2
+
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
+
+      - name: Decide build scope (per-domain vs. full rebuild)
+        id: scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Known domains come straight from the build script — single source of truth.
+          mapfile -t KNOWN < <(python scripts/build_pages.py --list-domains)
+
+          full=false
+          domains=""
+
+          if [ "${{ github.event_name }}" != "push" ]; then
+            # workflow_dispatch (or anything non-push) → always full rebuild.
+            full=true
+          else
+            BEFORE='${{ github.event.before }}'
+            AFTER='${{ github.sha }}'
+            # First push to a new branch / unknown base → full rebuild.
+            if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$BEFORE^{commit}" 2>/dev/null; then
+              full=true
+              changed="$(git show --name-only --pretty=format: "$AFTER" | grep -v '^$' || true)"
+            else
+              changed="$(git diff --name-only "$BEFORE" "$AFTER")"
+            fi
+            echo "Changed files:"; echo "$changed"
+
+            # Shared chrome / script / workflow / global assets → full rebuild.
+            if echo "$changed" | grep -Eq '^(scripts/build_pages\.py|\.github/workflows/pages\.yml|site_assets/)'; then
+              full=true
+            fi
+
+            if [ "$full" != "true" ]; then
+              # Map changed reports/<domain>/** paths to known domain keys.
+              sel=""
+              for d in "${KNOWN[@]}"; do
+                if echo "$changed" | grep -Eq "^reports/${d}/"; then
+                  sel="${sel:+$sel,}$d"
+                fi
+              done
+              # Top-level lower_tertiary_field_summary.md feeds the lower_tertiary domain.
+              if echo "$changed" | grep -Eq '^reports/lower_tertiary_field_summary\.md'; then
+                case ",$sel," in *",lower_tertiary,"*) ;; *) sel="${sel:+$sel,}lower_tertiary";; esac
+              fi
+              # A reports/** change we couldn't attribute to a known domain → full rebuild
+              # (be conservative; never silently skip changed content).
+              if echo "$changed" | grep -Eq '^reports/' && [ -z "$sel" ]; then
+                full=true
+              fi
+              domains="$sel"
+            fi
+          fi
+
+          if [ "$full" = "true" ]; then
+            echo "full=true"  >> "$GITHUB_OUTPUT"
+            echo "domains="    >> "$GITHUB_OUTPUT"
+            echo "Scope: FULL --clean rebuild (all domains)."
+          else
+            echo "full=false" >> "$GITHUB_OUTPUT"
+            echo "domains=$domains" >> "$GITHUB_OUTPUT"
+            echo "Scope: incremental rebuild of domains: ${domains:-<none>}"
+          fi
+
+      - name: Restore previously-published tree
+        # Only matters for incremental builds: seeds public/ with the last run's
+        # output so untouched domains survive into the merged upload. Full
+        # rebuilds wipe public/ via --clean regardless of what is restored.
+        if: steps.scope.outputs.full != 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: public
+          key: pages-public-${{ github.sha }}
+          restore-keys: |
+            pages-public-
+
       - name: Build static site (stdlib only)
-        run: python scripts/build_pages.py
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.scope.outputs.full }}" = "true" ]; then
+            python scripts/build_pages.py --clean
+          elif [ -n "${{ steps.scope.outputs.domains }}" ]; then
+            python scripts/build_pages.py --domains "${{ steps.scope.outputs.domains }}"
+          else
+            # Nothing domain-relevant changed (e.g. a reports/ file outside any
+            # domain that also isn't shared chrome) — still regenerate the index
+            # over the restored tree so the published site stays self-consistent.
+            python scripts/build_pages.py --domains ""
+          fi
+
+      - name: Save published tree to cache
+        # Persist the freshly merged tree so the NEXT incremental run can restore
+        # it. Keyed per-commit; restore-keys above match the most recent prefix.
+        uses: actions/cache/save@v4
+        with:
+          path: public
+          key: pages-public-${{ github.sha }}
+
       - uses: actions/upload-pages-artifact@v3
         with:
           path: public

--- a/scripts/build_pages.py
+++ b/scripts/build_pages.py
@@ -16,12 +16,40 @@ never alter a sanctioned number. Run:
     uv run scripts/build_pages.py        # or: python scripts/build_pages.py
 
 Output lands in `public/`, which the Pages workflow publishes verbatim.
+
+Per-domain build isolation (P2, issue #528)
+-------------------------------------------
+Rendering is organised as a registry of per-domain builders (``DOMAINS``) plus
+a small set of shared assets (CSS + viz HTML) and an always-regenerated landing
+``index.html``. This lets CI rebuild only the domain(s) whose ``reports/<domain>/``
+content changed, instead of re-rendering the whole site on every push:
+
+    python scripts/build_pages.py                       # full build (all domains)
+    python scripts/build_pages.py --domains lower_tertiary
+    python scripts/build_pages.py --clean               # wipe public/ then full build
+
+HONEST CONSTRAINT — GitHub Pages publishes exactly ONE artifact for the whole
+site (``actions/deploy-pages`` replaces the entire published tree from a single
+``upload-pages-artifact`` tarball). There is NO native per-domain *publish*: you
+cannot deploy a partial artifact without clobbering the rest of the site.
+Therefore P2 is per-domain *build* isolation (skip re-rendering untouched
+domains) merged into ONE published tree, NOT separate per-domain Pages sites.
+CI achieves the "merge" by restoring the previously-published ``public/`` from
+the Actions cache, overwriting only the touched domain's files, and re-uploading
+the full merged tree. A change to shared chrome (this script, the CSS, the page
+template, or ``site_assets/``) affects every page and so forces a ``--clean``
+full rebuild.
+
+With no arguments the output is byte-for-byte identical to the pre-P2 monolithic
+build — the refactor is presentation-preserving.
 """
 from __future__ import annotations
 
+import argparse
 import html
 import re
 import shutil
+import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -243,23 +271,42 @@ hr{border:0;border-top:1px solid var(--line);margin:1.6em 0}
 """
 
 
-def build():
-    PUBLIC.mkdir(exist_ok=True)
-    ASSETS.mkdir(exist_ok=True)
+# ---------------------------------------------------------------------------
+# Shared assets — written on every build regardless of which domains are
+# selected, because they are the chrome every domain page links to.
+# ---------------------------------------------------------------------------
+
+def build_shared_assets() -> dict[str, bool]:
+    """Write the stylesheet and copy the shared viz assets. Returns the set of
+    viz assets that are available (used by domain builders that embed them)."""
+    ASSETS.mkdir(parents=True, exist_ok=True)
     (ASSETS / "style.css").write_text(STYLE, encoding="utf-8")
 
     # --- copy the self-contained viz HTML as assets ---
     # Prefer the committed site_assets/ copy (what CI publishes); fall back to the
     # gitignored reports/bsee/ scratch output for local-only rebuilds.
     viz_names = ["julia_well_path_plotly.html", "julia_well_path_threejs.html"]
-    available_viz = {}
+    available_viz: dict[str, bool] = {}
     for name in viz_names:
         for src in (SITE_ASSETS / name, REPORTS / "bsee" / name):
             if src.exists():
                 shutil.copy2(src, ASSETS / name)
                 available_viz[name] = True
                 break
+    return available_viz
 
+
+# ---------------------------------------------------------------------------
+# Per-domain builders. Each one writes ONLY its own output files into public/
+# and returns whatever the landing-page builder needs from it. A domain builder
+# never wipes public/, so it composes cleanly over a cache-restored tree.
+# ---------------------------------------------------------------------------
+
+def build_lower_tertiary(available_viz: dict[str, bool]) -> list[tuple]:
+    """Render the Lower-Tertiary surface: per-field economics, benchmark,
+    portfolio summary, and the Julia 3D well-path page. Returns the list of
+    ``(slug, display, filename, npv_str, npv_value)`` tuples the landing page
+    uses to build its economics table."""
     # --- Economics pages (sanctioned V30), one per Lower-Tertiary field ---
     field_names = {
         "anchor": "Anchor", "big_foot": "Big Foot", "cascade_chinook": "Cascade&ndash;Chinook",
@@ -361,7 +408,49 @@ def build():
             ),
         ), encoding="utf-8")
 
-    # --- Landing page ---
+    return fields
+
+
+# Registry of per-domain builders. Add new domains here (key == reports/<domain>/
+# subdir name) as their surfaces come online. ``build(domains=...)`` iterates this.
+DOMAINS = {
+    "lower_tertiary": build_lower_tertiary,
+}
+
+
+# ---------------------------------------------------------------------------
+# Landing page — ALWAYS regenerated. It indexes whatever exists in public/ (so a
+# partial build still produces a correct landing page over the restored tree)
+# and derives the economics table straight from the source reports so it stays
+# correct even when the lower_tertiary domain was not part of this build.
+# ---------------------------------------------------------------------------
+
+def _lower_tertiary_fields() -> list[tuple]:
+    """Parse per-field NPV out of the source reports — independent of whether the
+    lower_tertiary domain pages were (re)built this run. Mirrors the parse in
+    build_lower_tertiary so the landing economics table is always accurate."""
+    field_names = {
+        "anchor": "Anchor", "big_foot": "Big Foot", "cascade_chinook": "Cascade&ndash;Chinook",
+        "jack_st_malo": "Jack / St. Malo", "julia": "Julia", "shenandoah": "Shenandoah",
+        "stones": "Stones",
+    }
+    npv_re = re.compile(r"Terminal cumulative NPV = \*\*([^*]+)\*\*")
+    fields = []
+    for md in sorted((REPORTS / "lower_tertiary").glob("field_economics_*_v30.md")):
+        slug = md.name[len("field_economics_"):-len("_v30.md")]
+        display = field_names.get(slug, slug.replace("_", " ").title())
+        text = md.read_text(encoding="utf-8")
+        m = npv_re.search(text)
+        npv_str = m.group(1).strip() if m else "&mdash;"
+        try:
+            npv_val = float(npv_str.replace("$", "").replace(",", "").replace("M", "").strip())
+        except ValueError:
+            npv_val = 0.0
+        fields.append((slug, display, f"economics-{slug}.html", npv_str, npv_val))
+    return fields
+
+
+def build_index() -> None:
     cards = []
     if (PUBLIC / "portfolio.html").exists():
         cards.append('<a class="card" href="portfolio.html"><h3>Portfolio Summary &rarr;</h3>'
@@ -373,9 +462,12 @@ def build():
         cards.append('<a class="card" href="well-path.html"><h3>Julia Well Paths (3D) &rarr;</h3>'
                      '<p>Interactive 3D directional surveys, two renderers from one data contract.</p></a>')
 
-    # Portfolio economics table, worst NPV first
+    # Portfolio economics table, worst NPV first. Only list fields whose page
+    # exists on disk, so the index stays consistent with the published tree.
     rows = []
-    for slug, display, fname, npv_str, npv_val in sorted(fields, key=lambda f: f[4]):
+    for slug, display, fname, npv_str, npv_val in sorted(_lower_tertiary_fields(), key=lambda f: f[4]):
+        if not (PUBLIC / fname).exists():
+            continue
         rows.append(
             f'<tr><td><a href="{fname}">{display}</a></td>'
             f'<td style="text-align:right">{npv_str}</td></tr>'
@@ -411,10 +503,79 @@ def build():
     )
     (PUBLIC / "index.html").write_text(landing, encoding="utf-8")
 
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+def build(domains: list[str] | None = None, *, clean: bool = False) -> None:
+    """Build the site. ``domains=None`` (default) builds every registered domain,
+    reproducing the pre-P2 monolithic output byte-for-byte. Pass a subset to do an
+    incremental per-domain build over an existing (e.g. cache-restored) public/.
+    The shared assets and the landing index are ALWAYS regenerated.
+    ``clean=True`` wipes public/ first for a guaranteed-fresh full rebuild."""
+    if clean and PUBLIC.exists():
+        shutil.rmtree(PUBLIC)
+
+    selected = list(DOMAINS) if domains is None else domains
+    unknown = [d for d in selected if d not in DOMAINS]
+    if unknown:
+        raise SystemExit(
+            f"Unknown domain(s): {', '.join(unknown)}. "
+            f"Known domains: {', '.join(DOMAINS)}."
+        )
+
+    PUBLIC.mkdir(parents=True, exist_ok=True)
+    available_viz = build_shared_assets()
+
+    for name in selected:
+        DOMAINS[name](available_viz)
+
+    # Landing index always reflects the full on-disk tree.
+    build_index()
+
     pages = sorted(p.name for p in PUBLIC.glob("*.html"))
-    print(f"Built {len(pages)} pages into {PUBLIC.relative_to(ROOT)}/: {', '.join(pages)}")
+    scope = "all domains" if domains is None else f"domains: {', '.join(selected)}"
+    try:
+        where = f"{PUBLIC.relative_to(ROOT)}/"
+    except ValueError:  # PUBLIC redirected outside the repo (e.g. under test)
+        where = str(PUBLIC)
+    print(f"Built {len(pages)} page(s) into {where} ({scope}): {', '.join(pages)}")
     print(f"Copied {len(available_viz)} viz asset(s).")
 
 
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--domains",
+        help="Comma-separated list of domains to (re)build (default: all). "
+             f"Known domains: {', '.join(DOMAINS)}.",
+    )
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="Wipe public/ before building (full fresh rebuild).",
+    )
+    parser.add_argument(
+        "--list-domains",
+        action="store_true",
+        help="Print the known domain keys (one per line) and exit.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.list_domains:
+        for name in DOMAINS:
+            print(name)
+        return
+
+    # ``--domains`` absent → None (full build). ``--domains ""`` (explicitly empty)
+    # → build no domain pages but still regenerate shared assets + landing index
+    # over the existing public/ tree.
+    domains = None
+    if args.domains is not None:
+        domains = [d.strip() for d in args.domains.split(",") if d.strip()]
+    build(domains=domains, clean=args.clean)
+
+
 if __name__ == "__main__":
-    build()
+    main(sys.argv[1:])

--- a/tests/test_build_pages.py
+++ b/tests/test_build_pages.py
@@ -10,6 +10,7 @@ These verify the per-domain build isolation contract:
 The builder writes to module-level ``PUBLIC``/``ASSETS`` paths under the repo;
 we redirect those to a tmp dir so tests never touch the working tree.
 """
+
 from __future__ import annotations
 
 import importlib.util
@@ -89,4 +90,6 @@ def test_registry_keys_match_reports_dirs(bp):
     # Each registered domain key should correspond to a reports/<domain>/ dir.
     reports = Path(bp.REPORTS)
     for name in bp.DOMAINS:
-        assert (reports / name).is_dir(), f"DOMAINS key {name!r} has no reports/{name}/ dir"
+        assert (
+            reports / name
+        ).is_dir(), f"DOMAINS key {name!r} has no reports/{name}/ dir"

--- a/tests/test_build_pages.py
+++ b/tests/test_build_pages.py
@@ -1,0 +1,92 @@
+"""Tests for the per-domain static-site builder (scripts/build_pages.py, P2 #528).
+
+These verify the per-domain build isolation contract:
+- a full build (no args) renders the whole site;
+- ``--domains lower_tertiary`` builds just that domain + the landing index and
+  leaves a pre-seeded foreign-domain file untouched (incremental compose);
+- ``--clean`` wipes the tree;
+- the landing index is always regenerated.
+
+The builder writes to module-level ``PUBLIC``/``ASSETS`` paths under the repo;
+we redirect those to a tmp dir so tests never touch the working tree.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "build_pages.py"
+
+
+@pytest.fixture
+def bp(tmp_path, monkeypatch):
+    """Import build_pages with PUBLIC/ASSETS redirected to a tmp dir."""
+    spec = importlib.util.spec_from_file_location("build_pages_under_test", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    public = tmp_path / "public"
+    monkeypatch.setattr(mod, "PUBLIC", public)
+    monkeypatch.setattr(mod, "ASSETS", public / "assets")
+    return mod
+
+
+def test_full_build_renders_whole_site(bp):
+    bp.build()
+    public = bp.PUBLIC
+    assert (public / "index.html").exists()
+    assert (public / "assets" / "style.css").exists()
+    # Lower-Tertiary surface present.
+    assert (public / "portfolio.html").exists()
+    assert (public / "benchmark.html").exists()
+    econ = list(public.glob("economics-*.html"))
+    assert econ, "expected per-field economics pages"
+
+
+def test_partial_build_only_touches_its_domain(bp):
+    public = bp.PUBLIC
+    # Seed a foreign domain's output as if restored from cache.
+    (public / "subsea").mkdir(parents=True)
+    seeded = public / "subsea" / "index.html"
+    seeded.write_text("<html>seeded subsea</html>", encoding="utf-8")
+
+    bp.build(domains=["lower_tertiary"])
+
+    # Foreign domain output survives the incremental build.
+    assert seeded.read_text(encoding="utf-8") == "<html>seeded subsea</html>"
+    # Lower-Tertiary + landing index were (re)built.
+    assert (public / "index.html").exists()
+    assert (public / "portfolio.html").exists()
+
+
+def test_index_always_regenerated(bp):
+    public = bp.PUBLIC
+    bp.build(domains=["lower_tertiary"])
+    first = (public / "index.html").read_text(encoding="utf-8")
+    # Rebuild with no domains: index must still be (re)written over the tree.
+    (public / "index.html").unlink()
+    bp.build(domains=[])
+    assert (public / "index.html").exists()
+    assert (public / "index.html").read_text(encoding="utf-8") == first
+
+
+def test_clean_wipes_tree(bp):
+    public = bp.PUBLIC
+    (public / "subsea").mkdir(parents=True)
+    (public / "subsea" / "index.html").write_text("stale", encoding="utf-8")
+    bp.build(clean=True)
+    assert not (public / "subsea").exists()
+    assert (public / "index.html").exists()
+
+
+def test_unknown_domain_raises(bp):
+    with pytest.raises(SystemExit):
+        bp.build(domains=["does_not_exist"])
+
+
+def test_registry_keys_match_reports_dirs(bp):
+    # Each registered domain key should correspond to a reports/<domain>/ dir.
+    reports = Path(bp.REPORTS)
+    for name in bp.DOMAINS:
+        assert (reports / name).is_dir(), f"DOMAINS key {name!r} has no reports/{name}/ dir"


### PR DESCRIPTION
Implements **P2** (#528): per-domain BUILD isolation for the Pages data site.

## The honest constraint (stated in code + here)
GitHub Pages publishes **exactly one artifact for the whole site** — `actions/deploy-pages` replaces the entire published tree from the single `upload-pages-artifact` tarball. There is **no per-domain *publish***: you cannot deploy a partial artifact without clobbering the rest. So this PR delivers per-domain **build** isolation (skip re-rendering untouched domains; per-domain pass/fail) **merged into one published tree**, NOT separate per-domain Pages sites. The deploy step/artifact mechanism is unchanged.

## `scripts/build_pages.py`
- Monolithic `build()` refactored into: `build_shared_assets()` (CSS + viz), a per-domain builder registry `DOMAINS = {"lower_tertiary": build_lower_tertiary}`, and an always-regenerated `build_index()`.
- CLI: `--domains <comma-list>` (default = all), `--clean` (wipe `public/` first), `--list-domains` (single source of truth for CI).
- Domain builders never wipe `public/`, so they compose over a cache-restored tree (untouched domains survive).
- The landing index is always regenerated and derives its economics table straight from the source reports + on-disk page existence, so it stays correct even on a partial build.
- **Full build (no args) output is byte-for-byte identical to before** (verified by snapshot diff, exit 0).

## `.github/workflows/pages.yml`
- New `scope` step diffs `github.event.before..sha` (full rebuild on first push / unknown base / `workflow_dispatch`) and maps changed `reports/<domain>/**` paths to domain keys (top-level `lower_tertiary_field_summary.md` → `lower_tertiary`). An unattributable `reports/**` change → conservative full rebuild.
- Shared-chrome changes (`build_pages.py`, `pages.yml`, `site_assets/**`) force `--clean` (they affect every page). `site_assets/**` also added to the `paths:` trigger.
- `actions/cache/restore@v4` seeds `public/` from the last run (restore-keys → graceful full rebuild on miss); `actions/cache/save@v4` persists the merged tree.
- **`upload-pages-artifact` → `deploy-pages` tail unchanged.** `concurrency: pages` + `cancel-in-progress` unchanged.

## Tests — `tests/test_build_pages.py` (6, all pass)
Full build; per-domain incremental compose over a pre-seeded foreign domain (survives); index always regenerated; `--clean` wipes; unknown-domain raises; registry keys ↔ `reports/<domain>/` dirs.

## Risks / caveats
- **Whole-artifact deploy stays** — saving is render CPU + per-domain failure isolation, not a smaller deploy.
- **Stale-tree on deletion:** an incremental build over a restored tree won't remove HTML for a *deleted* report; mitigate with periodic/`workflow_dispatch` `--clean`.
- **Flat namespace today** (`economics-anchor.html`, not `lower_tertiary/...`); kept flat to preserve existing URLs / byte-identical output. Per-domain subdirs can come later with redirects.
- No committed build output (`public/` is gitignored — preserved). `uv.lock` intentionally kept out of the diff.

Effort ≈ ~1 day, low-to-moderate risk. Do **not** merge yet.