### PR TITLE
feat(bsee): per-field netback / break-even sensitivity (oil)

### DIFF
--- a/scripts/bsee/generate_all_fields_atlas.py
+++ b/scripts/bsee/generate_all_fields_atlas.py
@@ -27,6 +27,12 @@ from worldenergydata.bsee.analysis.field_decom import (
     apply_field_decom,
     build_field_decom_liability,
 )
+from worldenergydata.bsee.analysis.field_netback import (
+    OPEX_BAND_HIGH_USD_BBL,
+    OPEX_BAND_LOW_USD_BBL,
+    ROYALTY_RATE_DEFAULT,
+    compute_field_netback,
+)
 from worldenergydata.bsee.analysis.field_revenue import (
     apply_field_revenue,
     build_field_oil_revenue,
@@ -191,6 +197,35 @@ def main() -> int:
             basin_p90,
             n_with_decom,
             len(result),
+        )
+
+    # Netback / break-even SENSITIVITY (Rank-3 economics): pure-derived from
+    # the real gross oil revenue + a labeled royalty assumption + a transparent
+    # opex band. This is a sensitivity range, NOT a point NPV (no per-field
+    # development costs exist to generalize). No new data file is loaded.
+    logger.info(
+        "Computing netback / break-even sensitivity "
+        "(royalty %.4f assumed; opex band $%.1f-$%.1f/bbl)...",
+        ROYALTY_RATE_DEFAULT,
+        OPEX_BAND_LOW_USD_BBL,
+        OPEX_BAND_HIGH_USD_BBL,
+    )
+    result = compute_field_netback(result)
+    if "NET_REVENUE_AFTER_ROYALTY_MM_USD" in result.columns and not result.empty:
+        basin_net = float(
+            result["NET_REVENUE_AFTER_ROYALTY_MM_USD"].sum(skipna=True)
+        )
+        n_with_net = int(result["NET_REVENUE_AFTER_ROYALTY_MM_USD"].notna().sum())
+        logger.info(
+            "Basin net revenue after royalty $%.1f MM across %d/%d fields "
+            "(royalty %.4f assumed [deepwater default, not per-lease]; opex band "
+            "$%.1f-$%.1f/bbl; oil only; SENSITIVITY, not NPV).",
+            basin_net,
+            n_with_net,
+            len(result),
+            ROYALTY_RATE_DEFAULT,
+            OPEX_BAND_LOW_USD_BBL,
+            OPEX_BAND_HIGH_USD_BBL,
         )
 
     args.out.mkdir(parents=True, exist_ok=True)

--- a/src/worldenergydata/bsee/analysis/field_netback.py
+++ b/src/worldenergydata/bsee/analysis/field_netback.py
@@ -1,0 +1,165 @@
+"""Per-field netback / break-even *sensitivity* (deterministic, pure-derived).
+
+This is the Rank-3 economics deliverable.  It is explicitly a **sensitivity**,
+not a point NPV: per the scoping memo, a true NPV cannot generalize across the
+basin because there are no hand-curated per-field development costs.  What we
+*can* state honestly combines:
+
+* **Real revenue** — ``GROSS_OIL_REVENUE_MM_USD`` (monthly oil x real WTI),
+  already on the atlas result.
+* **A real, labeled royalty assumption** — the deepwater GoM statutory default
+  (:data:`ROYALTY_RATE_DEFAULT`).  This is an *applied assumption*, not a
+  per-lease royalty lookup; it is overridable.
+* **A transparent opex band** — a *range* (:data:`OPEX_BAND_LOW_USD_BBL` to
+  :data:`OPEX_BAND_HIGH_USD_BBL`), never a single fabricated opex number.
+
+Everything here is pure-derived from columns already on the result DataFrame —
+**no new data file is loaded** and there is no I/O.  Divisions are guarded:
+fields missing ``GROSS_OIL_REVENUE_MM_USD`` or with non-positive
+``CUM_OIL_MMBBL`` get an honest ``NaN`` in the derived columns, never a
+fabricated zero.
+
+Honesty notes
+-------------
+* **Sensitivity, not a forecast or NPV.**  The netback band is a what-if range
+  over the opex assumption; it excludes capex and is oil-only.  Decommissioning
+  liability is reported separately (it is not netted in here).
+* **Royalty is an assumption.**  18.75% is the deepwater statutory default
+  applied uniformly, not a per-lease royalty.  Override via ``royalty=``.
+* **Opex is a band.**  We never emit a single point opex; ``$5/bbl`` and
+  ``$25/bbl`` bracket a transparent sensitivity range.  Override via
+  ``opex_low=`` / ``opex_high=``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+# --- Labeled, overridable assumptions -------------------------------------
+# Deepwater GoM statutory royalty default. This is an APPLIED ASSUMPTION used
+# uniformly across fields, NOT a per-lease royalty lookup. Override via the
+# ``royalty`` argument.
+ROYALTY_RATE_DEFAULT = 0.1875
+
+# Transparent opex sensitivity BAND ($/bbl). We never emit a single fabricated
+# opex number; these two bracket a what-if range. Override via the
+# ``opex_low`` / ``opex_high`` arguments.
+OPEX_BAND_LOW_USD_BBL = 5.0
+OPEX_BAND_HIGH_USD_BBL = 25.0
+
+# Source columns consumed off the result DataFrame.
+_REVENUE_COL = "GROSS_OIL_REVENUE_MM_USD"
+_OIL_COL = "CUM_OIL_MMBBL"
+
+# Derived columns this module adds (in output order).
+_DERIVED_COLUMNS = [
+    "REALIZED_OIL_PRICE_USD_BBL",
+    "NET_REVENUE_AFTER_ROYALTY_MM_USD",
+    "OPEX_LOW_MM_USD",
+    "OPEX_HIGH_MM_USD",
+    "NETBACK_HIGH_MM_USD",
+    "NETBACK_LOW_MM_USD",
+    "BREAKEVEN_OPEX_USD_BBL",
+]
+
+
+def compute_field_netback(
+    result_df: pd.DataFrame,
+    royalty: float = ROYALTY_RATE_DEFAULT,
+    opex_low: float = OPEX_BAND_LOW_USD_BBL,
+    opex_high: float = OPEX_BAND_HIGH_USD_BBL,
+) -> pd.DataFrame:
+    """Add per-field netback / break-even sensitivity columns (pure-derived).
+
+    Returns a **copy** of ``result_df`` with the derived columns appended;
+    ``result_df`` is never mutated.  No data file is loaded.
+
+    Derived columns (all in $MM except the two $/bbl columns)::
+
+        REALIZED_OIL_PRICE_USD_BBL       = gross_rev / cum_oil   (both $MM/MMBBL)
+        NET_REVENUE_AFTER_ROYALTY_MM_USD = gross_rev x (1 - royalty)
+        OPEX_LOW_MM_USD                  = opex_low  x cum_oil
+        OPEX_HIGH_MM_USD                 = opex_high x cum_oil
+        NETBACK_HIGH_MM_USD              = net_rev - OPEX_LOW   (low opex -> high)
+        NETBACK_LOW_MM_USD               = net_rev - OPEX_HIGH
+        BREAKEVEN_OPEX_USD_BBL           = realized_price x (1 - royalty)
+
+    Honest nulls: rows missing :data:`_REVENUE_COL` or with non-positive
+    :data:`_OIL_COL` get ``NaN`` in the revenue-derived columns (never a
+    fabricated ``0``).  The opex columns depend only on oil, so for a field
+    with zero oil they are a legitimate ``0`` (no oil to operate), not a guess.
+
+    Parameters
+    ----------
+    result_df:
+        AllFieldsRunner+revenue result with ``GROSS_OIL_REVENUE_MM_USD`` and
+        ``CUM_OIL_MMBBL`` columns.  Missing columns are tolerated (the
+        corresponding outputs are all-``NaN``).
+    royalty:
+        Royalty fraction in ``[0, 1)`` applied uniformly (assumption).
+    opex_low, opex_high:
+        Opex band endpoints in ``$/bbl`` (sensitivity range).
+
+    Returns
+    -------
+    pd.DataFrame
+        Copy of ``result_df`` with :data:`_DERIVED_COLUMNS` appended.
+    """
+    out = result_df.copy()
+
+    # Empty frame: still declare the derived columns (correctly typed) so
+    # downstream callers can rely on them existing.
+    if out.empty:
+        for col in _DERIVED_COLUMNS:
+            out[col] = pd.Series(dtype="float64")
+        return out
+
+    n = len(out)
+    nan_series = pd.Series(np.nan, index=out.index, dtype="float64")
+
+    # Real revenue (honest NaN where the source column is absent or null).
+    if _REVENUE_COL in out.columns:
+        gross_rev = pd.to_numeric(out[_REVENUE_COL], errors="coerce")
+    else:
+        gross_rev = nan_series.copy()
+
+    # Cumulative oil; non-positive oil is treated as "missing" for any ratio
+    # (can't realize a price on zero/negative oil) -> guarded to NaN.
+    if _OIL_COL in out.columns:
+        cum_oil = pd.to_numeric(out[_OIL_COL], errors="coerce")
+    else:
+        cum_oil = nan_series.copy()
+    oil_positive = cum_oil > 0
+    oil_for_ratio = cum_oil.where(oil_positive)  # NaN where not positive
+
+    # Realized price: revenue / oil (both in millions -> $/bbl). Guarded.
+    realized = gross_rev / oil_for_ratio
+
+    # Net revenue after royalty (royalty is a labeled assumption).
+    net_rev = gross_rev * (1.0 - royalty)
+
+    # Opex band ($MM = $/bbl x MMBBL). Depends only on oil; for zero oil this
+    # is a legitimate 0 (nothing to operate), not a fabricated figure. Negative
+    # oil is nonsensical -> guard to NaN.
+    oil_for_opex = cum_oil.where(cum_oil >= 0)
+    opex_low_mm = opex_low * oil_for_opex
+    opex_high_mm = opex_high * oil_for_opex
+
+    # Netback band: low opex -> high netback, and vice versa.
+    netback_high = net_rev - opex_low_mm
+    netback_low = net_rev - opex_high_mm
+
+    # Break-even opex ($/bbl) at which netback == 0.
+    breakeven = realized * (1.0 - royalty)
+
+    out["REALIZED_OIL_PRICE_USD_BBL"] = realized
+    out["NET_REVENUE_AFTER_ROYALTY_MM_USD"] = net_rev
+    out["OPEX_LOW_MM_USD"] = opex_low_mm
+    out["OPEX_HIGH_MM_USD"] = opex_high_mm
+    out["NETBACK_HIGH_MM_USD"] = netback_high
+    out["NETBACK_LOW_MM_USD"] = netback_low
+    out["BREAKEVEN_OPEX_USD_BBL"] = breakeven
+
+    assert len(out) == n  # pure-derived: no rows added or dropped
+    return out

--- a/src/worldenergydata/bsee/reports/all_fields_report.py
+++ b/src/worldenergydata/bsee/reports/all_fields_report.py
@@ -135,6 +135,24 @@ class AllFieldsReport:
                 "leases with a decom estimate that map to a producing field, "
                 "not all fields; fields without an estimate are left blank.*"
             )
+        has_netback = (
+            not self._df.empty
+            and "NET_REVENUE_AFTER_ROYALTY_MM_USD" in self._df.columns
+        )
+        if has_netback:
+            net_total = self._df["NET_REVENUE_AFTER_ROYALTY_MM_USD"].sum(skipna=True)
+            n_with_net = int(self._df["NET_REVENUE_AFTER_ROYALTY_MM_USD"].notna().sum())
+            lines.append(
+                f"- **Netback sensitivity (oil; SENSITIVITY, not NPV)**: "
+                f"basin net revenue after royalty ${net_total:,.0f} MM across "
+                f"{n_with_net} fields"
+            )
+            lines.append(
+                "  - *Royalty 18.75% assumed (deepwater default, not a "
+                "per-lease lookup); opex band $5-$25/bbl (assumption); oil "
+                "only; excludes capex; decommissioning shown separately. This "
+                "is a sensitivity range, not a forecast or NPV.*"
+            )
         lines.append("")
 
         # Era Grouping
@@ -187,12 +205,14 @@ class AllFieldsReport:
                 lines.append(
                     "| Field | Era | Oil (MMBBL) | Gas (BCF) | Wells | "
                     "Rec/Well (MMBBL) | BOPD/Well | First Prod | "
-                    "Water Depth (ft) | Gross Oil Rev ($MM) | Decom P50 ($MM) |"
+                    "Water Depth (ft) | Gross Oil Rev ($MM) | Decom P50 ($MM) | "
+                    "Breakeven Opex ($/bbl) |"
                 )
                 lines.append(
                     "|-------|-----|-------------|-----------|-------|"
                     "------------------|-----------|------------|"
                     "------------------|--------------------|-----------------|"
+                    "------------------------|"
                 )
                 for _, row in top.iterrows():
                     name = row.get("FIELD_NAME", row.get("FIELD_CODE", ""))
@@ -211,10 +231,12 @@ class AllFieldsReport:
                     rev_str = f"{rev:,.0f}" if pd.notna(rev) else ""
                     dec = row.get("DECOM_P50_MM_USD", None)
                     dec_str = f"{dec:,.0f}" if pd.notna(dec) else ""
+                    be = row.get("BREAKEVEN_OPEX_USD_BBL", None)
+                    be_str = f"{be:,.2f}" if pd.notna(be) else ""
                     lines.append(
                         f"| {name} | {era} | {oil:,.1f} | {gas:,.1f} | {wells} "
                         f"| {rpw_str} | {bpw_str} | {first} | {wd_str} "
-                        f"| {rev_str} | {dec_str} |"
+                        f"| {rev_str} | {dec_str} | {be_str} |"
                     )
                 lines.append("")
 

--- a/tests/unit/bsee/analysis/test_field_netback.py
+++ b/tests/unit/bsee/analysis/test_field_netback.py
@@ -1,0 +1,173 @@
+"""Unit tests for the per-field netback / break-even sensitivity.
+
+All fixtures are pure synthetic DataFrames — no I/O, no materialized data.
+The module under test (:mod:`field_netback`) is pure-derived from columns that
+already live on the AllFieldsRunner+revenue result, so every expectation is an
+exact arithmetic identity, not a tolerance against real data.
+
+This is a *sensitivity*, not an NPV: we assert the opex *band* behaviour
+(NETBACK_HIGH >= NETBACK_LOW), the royalty math, the realized price ratio, and
+the break-even opex.  Missing inputs must produce honest ``NaN`` (never 0).
+"""
+
+import math
+
+import numpy as np
+import pandas as pd
+
+from tests.test_markers import unit
+from worldenergydata.bsee.analysis.field_netback import (
+    OPEX_BAND_HIGH_USD_BBL,
+    OPEX_BAND_LOW_USD_BBL,
+    ROYALTY_RATE_DEFAULT,
+    compute_field_netback,
+)
+
+
+def _base_df():
+    """Two well-formed fields with known oil and revenue."""
+    return pd.DataFrame(
+        {
+            "FIELD_CODE": ["MC807", "GC640"],
+            "CUM_OIL_MMBBL": [1000.0, 100.0],
+            "GROSS_OIL_REVENUE_MM_USD": [55000.0, 4000.0],
+        }
+    )
+
+
+@unit
+def test_realized_price_is_revenue_over_oil():
+    out = compute_field_netback(_base_df())
+    # both in millions -> ratio is $/bbl
+    assert out.loc[0, "REALIZED_OIL_PRICE_USD_BBL"] == 55.0
+    assert out.loc[1, "REALIZED_OIL_PRICE_USD_BBL"] == 40.0
+
+
+@unit
+def test_net_revenue_after_royalty_uses_default_rate():
+    out = compute_field_netback(_base_df())
+    # gross x (1 - 0.1875) == gross x 0.8125
+    assert ROYALTY_RATE_DEFAULT == 0.1875
+    assert out.loc[0, "NET_REVENUE_AFTER_ROYALTY_MM_USD"] == 55000.0 * 0.8125
+    assert out.loc[1, "NET_REVENUE_AFTER_ROYALTY_MM_USD"] == 4000.0 * 0.8125
+
+
+@unit
+def test_opex_band_columns():
+    out = compute_field_netback(_base_df())
+    # MMBBL x $/bbl == $MM
+    assert out.loc[0, "OPEX_LOW_MM_USD"] == OPEX_BAND_LOW_USD_BBL * 1000.0
+    assert out.loc[0, "OPEX_HIGH_MM_USD"] == OPEX_BAND_HIGH_USD_BBL * 1000.0
+
+
+@unit
+def test_netback_high_uses_low_opex_and_is_ge_netback_low():
+    out = compute_field_netback(_base_df())
+    net = 55000.0 * 0.8125
+    assert out.loc[0, "NETBACK_HIGH_MM_USD"] == net - OPEX_BAND_LOW_USD_BBL * 1000.0
+    assert out.loc[0, "NETBACK_LOW_MM_USD"] == net - OPEX_BAND_HIGH_USD_BBL * 1000.0
+    # low opex => high netback; band ordering must hold for every row
+    assert (out["NETBACK_HIGH_MM_USD"] >= out["NETBACK_LOW_MM_USD"]).all()
+
+
+@unit
+def test_breakeven_opex_is_realized_times_one_minus_royalty():
+    out = compute_field_netback(_base_df())
+    # opex $/bbl at which netback == 0
+    assert out.loc[0, "BREAKEVEN_OPEX_USD_BBL"] == 55.0 * (1 - 0.1875)
+    assert out.loc[1, "BREAKEVEN_OPEX_USD_BBL"] == 40.0 * (1 - 0.1875)
+
+
+@unit
+def test_breakeven_zeros_netback_at_that_opex():
+    """The break-even opex really is the opex where netback hits zero."""
+    out = compute_field_netback(_base_df())
+    be = out.loc[0, "BREAKEVEN_OPEX_USD_BBL"]
+    at_be = compute_field_netback(_base_df(), opex_low=be, opex_high=be)
+    assert math.isclose(at_be.loc[0, "NETBACK_HIGH_MM_USD"], 0.0, abs_tol=1e-6)
+    assert math.isclose(at_be.loc[0, "NETBACK_LOW_MM_USD"], 0.0, abs_tol=1e-6)
+
+
+@unit
+def test_missing_revenue_yields_nan_not_zero():
+    df = _base_df()
+    df.loc[1, "GROSS_OIL_REVENUE_MM_USD"] = np.nan
+    out = compute_field_netback(df)
+    for col in (
+        "REALIZED_OIL_PRICE_USD_BBL",
+        "NET_REVENUE_AFTER_ROYALTY_MM_USD",
+        "NETBACK_HIGH_MM_USD",
+        "NETBACK_LOW_MM_USD",
+        "BREAKEVEN_OPEX_USD_BBL",
+    ):
+        assert pd.isna(out.loc[1, col]), f"{col} should be NaN, not fabricated"
+    # row 0 (well-formed) is unaffected
+    assert out.loc[0, "REALIZED_OIL_PRICE_USD_BBL"] == 55.0
+
+
+@unit
+def test_zero_oil_yields_nan_not_zero_or_error():
+    df = _base_df()
+    df.loc[1, "CUM_OIL_MMBBL"] = 0.0
+    out = compute_field_netback(df)
+    assert pd.isna(out.loc[1, "REALIZED_OIL_PRICE_USD_BBL"])
+    assert pd.isna(out.loc[1, "BREAKEVEN_OPEX_USD_BBL"])
+    # opex columns depend only on oil -> 0 oil => 0 opex is correct, not fabricated
+    assert out.loc[1, "OPEX_LOW_MM_USD"] == 0.0
+
+
+@unit
+def test_negative_oil_treated_as_missing():
+    df = _base_df()
+    df.loc[1, "CUM_OIL_MMBBL"] = -5.0
+    out = compute_field_netback(df)
+    assert pd.isna(out.loc[1, "REALIZED_OIL_PRICE_USD_BBL"])
+    assert pd.isna(out.loc[1, "BREAKEVEN_OPEX_USD_BBL"])
+
+
+@unit
+def test_custom_royalty_and_opex_params_honored():
+    out = compute_field_netback(_base_df(), royalty=0.25, opex_low=10.0, opex_high=30.0)
+    assert out.loc[0, "NET_REVENUE_AFTER_ROYALTY_MM_USD"] == 55000.0 * 0.75
+    assert out.loc[0, "OPEX_LOW_MM_USD"] == 10.0 * 1000.0
+    assert out.loc[0, "OPEX_HIGH_MM_USD"] == 30.0 * 1000.0
+    assert out.loc[0, "BREAKEVEN_OPEX_USD_BBL"] == 55.0 * 0.75
+
+
+@unit
+def test_input_not_mutated():
+    df = _base_df()
+    before = df.copy(deep=True)
+    _ = compute_field_netback(df)
+    pd.testing.assert_frame_equal(df, before)
+    # derived columns must not have leaked onto the input
+    assert "NETBACK_HIGH_MM_USD" not in df.columns
+
+
+@unit
+def test_empty_df_handled():
+    df = pd.DataFrame(
+        columns=["FIELD_CODE", "CUM_OIL_MMBBL", "GROSS_OIL_REVENUE_MM_USD"]
+    )
+    out = compute_field_netback(df)
+    assert len(out) == 0
+    # the derived columns are still declared on an empty frame
+    for col in (
+        "REALIZED_OIL_PRICE_USD_BBL",
+        "NET_REVENUE_AFTER_ROYALTY_MM_USD",
+        "OPEX_LOW_MM_USD",
+        "OPEX_HIGH_MM_USD",
+        "NETBACK_HIGH_MM_USD",
+        "NETBACK_LOW_MM_USD",
+        "BREAKEVEN_OPEX_USD_BBL",
+    ):
+        assert col in out.columns
+
+
+@unit
+def test_missing_source_columns_yield_nan_columns():
+    """A result frame lacking the source columns gets honest NaN, not a crash."""
+    df = pd.DataFrame({"FIELD_CODE": ["X", "Y"]})
+    out = compute_field_netback(df)
+    assert out["REALIZED_OIL_PRICE_USD_BBL"].isna().all()
+    assert out["NET_REVENUE_AFTER_ROYALTY_MM_USD"].isna().all()


### PR DESCRIPTION
Rank-3 (final) **economics-tier** deliverable. Explicitly a **sensitivity range, not a point NPV** — NPV cannot generalize (no per-field costs). Pure-derived from already-merged atlas columns (gross oil revenue + cumulative oil) plus **labeled** assumptions; no new data file.

## Adds
- `field_netback.py` (new): `compute_field_netback()` → `REALIZED_OIL_PRICE_USD_BBL`, `NET_REVENUE_AFTER_ROYALTY_MM_USD`, `OPEX_LOW/HIGH_MM_USD`, `NETBACK_HIGH/LOW_MM_USD`, `BREAKEVEN_OPEX_USD_BBL`. All divisions guarded → `NaN` (never fabricated 0). Pure, no I/O, input not mutated.
- Atlas wires it after the decom step; report adds a netback summary line + `Breakeven Opex ($/bbl)` column with explicit assumptions/caveats.
- 13 new unit tests (pure synthetic).

## Labeled assumptions (overridable params)
- Royalty **18.75%** — deepwater statutory default, *not* a per-lease lookup.
- Opex **band $5–$25/bbl** — a transparent sensitivity range, never a single number.
- Oil only; **excludes capex**; decommissioning shown separately (the decom view).

## Verified (real atlas values)
- MC807 (Mars-Ursa): realized **$55.31/bbl**, net-after-royalty **$83.4 B**, break-even opex **$44.94/bbl**, netback band **$37–74 B**.
- Basin net-after-royalty ≈ **$759 B** (= $934.3 B gross × 0.8125).
- 13 tests pass; Black clean; all files ≤500 lines.

This completes the scoped economics tier: gross revenue (#542) + decommissioning liability (#544) + this netback sensitivity — all deterministic and fabrication-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)