### PR TITLE
chore(precommit): add legal-sanity-scan hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,6 +124,13 @@ repos:
         stages: [pre-commit]
         additional_dependencies:
           - PyYAML
+      - id: legal-sanity-scan
+        name: Legal sanity scan (deny list)
+        language: script
+        entry: ../scripts/legal/legal-sanity-scan.sh
+        args: [--repo=worldenergydata]
+        pass_filenames: false
+        stages: [pre-commit]
 
 # CI configuration
 ci:


### PR DESCRIPTION
Adds the legal-sanity-scan pre-commit hook (mirroring digitalmodel) so workspace-hub nightly readiness check R-PRECOMMIT passes. Config-only change.