### PR TITLE
feat(vessel): well-intervention vessel schema + class (#592)

### DIFF
--- a/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/constants.py
+++ b/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/constants.py
@@ -12,6 +12,7 @@ class VesselCategory(str, Enum):
     DRILLING_RIG = "drilling_rig"
     CONSTRUCTION_VESSEL = "construction_vessel"
     SERVICE_VESSEL = "service_vessel"
+    INTERVENTION_VESSEL = "intervention_vessel"
 
 
 @unique
@@ -43,6 +44,9 @@ class VesselType(str, Enum):
     PSV = "psv"
     DIVE_SUPPORT = "dive_support"
     FPSO = "fpso"
+    RLWI_MONOHULL = "rlwi_monohull"
+    HEAVY_INTERVENTION_SEMI = "heavy_intervention_semi"
+    MPSV = "mpsv"
 
 
 @unique

--- a/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/schemas/intervention_vessel.py
+++ b/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/schemas/intervention_vessel.py
@@ -1,0 +1,73 @@
+"""Pydantic schema for well-intervention vessel records."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import field_validator
+
+from worldenergydata.vessel_fleet.schemas.base import BaseVesselSchema
+
+
+class InterventionVesselSchema(BaseVesselSchema):
+    """Schema for a well-intervention vessel record.
+
+    Extends BaseVesselSchema with fields specific to riser-based and
+    riserless light well-intervention (RLWI) units, heavy intervention
+    semi-submersibles, and multipurpose support vessels (MPSV).
+    """
+
+    # Riser / intervention capability
+    RISER_CAPABLE: Optional[bool] = None
+    INTERVENTION_CLASS: Optional[str] = None  # "light" / "heavy"
+    SUBSEA_LUBRICATOR: Optional[bool] = None
+    IRS_SYSTEM: Optional[str] = None
+    WELL_CONTROL_PACKAGE: Optional[str] = None
+    CT_CAPABLE: Optional[bool] = None
+    GOM_RESIDENT: Optional[bool] = None
+
+    # Operational
+    WATER_DEPTH_RATING_M: Optional[float] = None
+
+    # --- Validators ---
+
+    @field_validator(
+        "INTERVENTION_CLASS",
+        "IRS_SYSTEM",
+        "WELL_CONTROL_PACKAGE",
+        mode="before",
+    )
+    @classmethod
+    def _empty_str_to_none_iv(cls, v: object) -> object:
+        if isinstance(v, str) and v.strip() == "":
+            return None
+        return v
+
+    @field_validator("INTERVENTION_CLASS")
+    @classmethod
+    def _validate_intervention_class(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and v.lower() not in {"light", "heavy"}:
+            raise ValueError("INTERVENTION_CLASS must be 'light' or 'heavy'")
+        return v
+
+    @field_validator("WATER_DEPTH_RATING_M", mode="before")
+    @classmethod
+    def _coerce_iv_float_fields(cls, v: object) -> object:
+        if v is None:
+            return None
+        if isinstance(v, str):
+            v = v.strip()
+            if v == "":
+                return None
+            return float(v)
+        return v
+
+    @field_validator("WATER_DEPTH_RATING_M")
+    @classmethod
+    def _validate_non_negative_iv_floats(
+        cls,
+        v: Optional[float],
+    ) -> Optional[float]:
+        if v is not None and v < 0:
+            raise ValueError("Value must be >= 0")
+        return v

--- a/tests/unit/vessel_fleet/schemas/test_intervention.py
+++ b/tests/unit/vessel_fleet/schemas/test_intervention.py
@@ -1,0 +1,144 @@
+# ABOUTME: Tests for the well-intervention vessel schema and new enum members.
+# ABOUTME: Covers real units (Helix Q4000/Q5000/Q7000, Island Performer) round-trip.
+
+"""Tests for the intervention vessel schema."""
+
+from __future__ import annotations
+
+import pytest
+
+from worldenergydata.vessel_fleet.constants import VesselCategory, VesselType
+from worldenergydata.vessel_fleet.schemas.intervention_vessel import (
+    InterventionVesselSchema,
+)
+
+
+class TestNewEnumMembers:
+    def test_intervention_vessel_category_exists(self):
+        assert VesselCategory.INTERVENTION_VESSEL.value == "intervention_vessel"
+
+    def test_new_vessel_types_exist(self):
+        assert VesselType.RLWI_MONOHULL.value == "rlwi_monohull"
+        assert VesselType.HEAVY_INTERVENTION_SEMI.value == "heavy_intervention_semi"
+        assert VesselType.MPSV.value == "mpsv"
+
+
+class TestInterventionVesselSchemaInheritance:
+    def test_inherits_base_fields(self):
+        schema = InterventionVesselSchema(VESSEL_NAME="Q4000")
+        assert schema.VESSEL_NAME == "Q4000"
+        assert schema.OWNER is None
+
+    def test_base_field_validation_still_applies(self):
+        schema = InterventionVesselSchema(
+            VESSEL_NAME="Q4000",
+            YEAR_BUILT="2002",
+            LOA_M="156.0",
+        )
+        assert schema.YEAR_BUILT == 2002
+        assert schema.LOA_M == 156.0
+
+    def test_base_validation_rejects_bad_year(self):
+        with pytest.raises(Exception):
+            InterventionVesselSchema(VESSEL_NAME="Q4000", YEAR_BUILT=1800)
+
+
+class TestRealUnits:
+    def test_helix_q4000(self):
+        schema = InterventionVesselSchema(
+            VESSEL_NAME="Q4000",
+            VESSEL_CATEGORY=VesselCategory.INTERVENTION_VESSEL.value,
+            VESSEL_TYPE=VesselType.HEAVY_INTERVENTION_SEMI.value,
+            WATER_DEPTH_RATING_M=3048.0,
+            RISER_CAPABLE=True,
+            INTERVENTION_CLASS="heavy",
+            CT_CAPABLE=True,
+            GOM_RESIDENT=True,
+        )
+        assert schema.VESSEL_NAME == "Q4000"
+        assert schema.WATER_DEPTH_RATING_M == 3048.0
+        assert schema.RISER_CAPABLE is True
+        assert schema.INTERVENTION_CLASS == "heavy"
+        assert schema.CT_CAPABLE is True
+        assert schema.GOM_RESIDENT is True
+        assert schema.VESSEL_TYPE == "heavy_intervention_semi"
+
+    def test_helix_q5000(self):
+        schema = InterventionVesselSchema(
+            VESSEL_NAME="Q5000",
+            WATER_DEPTH_RATING_M=3048.0,
+            RISER_CAPABLE=True,
+            INTERVENTION_CLASS="heavy",
+            WELL_CONTROL_PACKAGE="15K IRS",
+        )
+        assert schema.WATER_DEPTH_RATING_M == 3048.0
+        assert schema.INTERVENTION_CLASS == "heavy"
+        assert schema.WELL_CONTROL_PACKAGE == "15K IRS"
+
+    def test_helix_q7000(self):
+        schema = InterventionVesselSchema(
+            VESSEL_NAME="Q7000",
+            WATER_DEPTH_RATING_M=3000.0,
+            RISER_CAPABLE=True,
+            INTERVENTION_CLASS="heavy",
+            IRS_SYSTEM="Helix IRS-3",
+        )
+        assert schema.WATER_DEPTH_RATING_M == 3000.0
+        assert schema.RISER_CAPABLE is True
+        assert schema.IRS_SYSTEM == "Helix IRS-3"
+
+    def test_island_performer_rlwi(self):
+        schema = InterventionVesselSchema(
+            VESSEL_NAME="Island Performer",
+            VESSEL_TYPE=VesselType.RLWI_MONOHULL.value,
+            WATER_DEPTH_RATING_M=2000.0,
+            RISER_CAPABLE=False,
+            INTERVENTION_CLASS="light",
+            SUBSEA_LUBRICATOR=True,
+        )
+        assert schema.WATER_DEPTH_RATING_M == 2000.0
+        assert schema.RISER_CAPABLE is False
+        assert schema.INTERVENTION_CLASS == "light"
+        assert schema.SUBSEA_LUBRICATOR is True
+        assert schema.VESSEL_TYPE == "rlwi_monohull"
+
+
+class TestInterventionVesselSchemaCoercion:
+    def test_float_from_string(self):
+        schema = InterventionVesselSchema(
+            VESSEL_NAME="T",
+            WATER_DEPTH_RATING_M="3048",
+        )
+        assert schema.WATER_DEPTH_RATING_M == 3048.0
+
+    def test_float_empty_to_none(self):
+        schema = InterventionVesselSchema(
+            VESSEL_NAME="T",
+            WATER_DEPTH_RATING_M="",
+        )
+        assert schema.WATER_DEPTH_RATING_M is None
+
+    def test_string_empty_to_none(self):
+        schema = InterventionVesselSchema(
+            VESSEL_NAME="T",
+            INTERVENTION_CLASS="",
+            IRS_SYSTEM="",
+        )
+        assert schema.INTERVENTION_CLASS is None
+        assert schema.IRS_SYSTEM is None
+
+
+class TestInterventionVesselSchemaValidation:
+    def test_negative_water_depth_raises(self):
+        with pytest.raises(Exception):
+            InterventionVesselSchema(
+                VESSEL_NAME="T",
+                WATER_DEPTH_RATING_M=-1,
+            )
+
+    def test_invalid_intervention_class_raises(self):
+        with pytest.raises(Exception):
+            InterventionVesselSchema(
+                VESSEL_NAME="T",
+                INTERVENTION_CLASS="medium",
+            )

--- a/tests/unit/vessel_fleet/test_constants.py
+++ b/tests/unit/vessel_fleet/test_constants.py
@@ -18,7 +18,12 @@ from worldenergydata.vessel_fleet.constants import (
 
 class TestVesselCategory:
     def test_all_members(self):
-        expected = {"DRILLING_RIG", "CONSTRUCTION_VESSEL", "SERVICE_VESSEL"}
+        expected = {
+            "DRILLING_RIG",
+            "CONSTRUCTION_VESSEL",
+            "SERVICE_VESSEL",
+            "INTERVENTION_VESSEL",
+        }
         assert {m.name for m in VesselCategory} == expected
 
     def test_string_enum(self):
@@ -55,6 +60,9 @@ class TestVesselType:
             "PSV",
             "DIVE_SUPPORT",
             "FPSO",
+            "RLWI_MONOHULL",
+            "HEAVY_INTERVENTION_SEMI",
+            "MPSV",
         }
         assert {m.name for m in VesselType} == expected
 


### PR DESCRIPTION
Closes #592 (child of #591)

Adds a dedicated well-intervention vessel schema and supporting enum members to the `vessel_fleet` package.

## What it adds
- **constants.py**: `VesselCategory.INTERVENTION_VESSEL`; `VesselType.RLWI_MONOHULL`, `VesselType.HEAVY_INTERVENTION_SEMI`, `VesselType.MPSV`
- **schemas/intervention_vessel.py**: `InterventionVesselSchema(BaseVesselSchema)` with intervention-specific fields:
  - `RISER_CAPABLE`, `INTERVENTION_CLASS` ("light"/"heavy"), `SUBSEA_LUBRICATOR`, `IRS_SYSTEM`, `WELL_CONTROL_PACKAGE`, `WATER_DEPTH_RATING_M`, `CT_CAPABLE`, `GOM_RESIDENT`
  - Follows the existing `construction_vessel.py` validator idiom (empty-string-to-none, float coercion, non-negative floats); `INTERVENTION_CLASS` constrained to light/heavy
- **tests**: `tests/unit/vessel_fleet/schemas/test_intervention.py` — 14 new cases covering real units (Helix Q4000/Q5000/Q7000 heavy, Island Performer RLWI light), field round-trip, coercion, validation, base-field inheritance, and new enum members; updates the existing enum-membership assertions in `test_constants.py`

## Tests
- New file: **14 passed**
- vessel_fleet schemas + constants suite: **152 passed**