### PR TITLE
feat(data): subsea-vs-dry-tree completion classifier (#584)

### DIFF
--- a/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/intervention/subsea_classifier.py
+++ b/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/intervention/subsea_classifier.py
@@ -1,0 +1,351 @@
+# ABOUTME: Subsea-vs-dry-tree completion classifier from BSEE data (worldenergydata #584).
+# ABOUTME: Flags wells subsea/surface from the SUBSEA_TREE_HEIGHT_AML signal and cross-checks against the authoritative subsea-borehole registry.
+
+"""Subsea-vs-dry-tree completion classifier.
+
+Part of the subsea-intervention/maintenance database (epic #582). A well's
+*completion type* — subsea (wet tree, on the seabed) vs. surface/dry-tree
+(on a platform) — decides which asset can service it, so it is a key axis of
+the maintenance-demand model alongside the water-depth bands of #583.
+
+The primary signal is BSEE's ``SUBSEA_TREE_HEIGHT_AML`` (above-mud-line height
+of a subsea tree). The classification rule is:
+
+* a present (non-null, parseable) tree height  -> ``"subsea"`` (a subsea tree
+  exists, so the well is a wet-tree completion);
+* an empty / null / NaN value                  -> ``"surface"`` (no subsea tree
+  recorded -> treated as a dry-tree completion);
+* a non-empty but un-parseable value           -> ``"unknown"``.
+
+⚠ Coverage caveat. The only carrier of this flag here,
+``current/operations/ST_BP_and_tree_height.csv``, is a **~100-row sample**, not
+the full Gulf-of-Mexico well set. The "surface" inference from an empty value
+is therefore weak: an absent tree height usually means *not recorded in this
+sample*, not a proven dry-tree completion. Counts are reported as such.
+
+Two further BSEE sources give context but **cannot be row-joined** to the
+sample:
+
+* **Subsea-borehole registry** (``permstruc/mv_subsea_boreholes.bin``) — 593
+  authoritative subsea wells. It has no ``API_WELL_NUMBER`` and the sample CSV
+  has no ``WELL_NAME`` string, so :func:`cross_validate` reports a *population*
+  overlap (how many subsea wells each source asserts), not a row-level match.
+* **Platform-structure registry** (``platstruc/mv_platstruc_structures.bin``) —
+  floating hosts (``SPAR``/``TLP``/``SEMI``) are dry-tree-capable; fixed hosts
+  (``FIXED``/``CAIS``/``WP``) are not. Used only to tag host-type context.
+
+All numbers are externalised to a reviewable YAML so downstream consumers read
+data, not hard-coded constants.
+"""
+
+from __future__ import annotations
+
+import math
+import pickle
+from collections import OrderedDict
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+try:  # data-root resolution is best-effort; callers may pass an explicit dir
+    from worldenergydata.common.data_resolver import get_module_data_safe
+except Exception:  # pragma: no cover - core package may be absent in isolation
+    get_module_data_safe = None  # type: ignore[assignment]
+
+# Completion-type labels.
+SUBSEA = "subsea"
+SURFACE = "surface"
+UNKNOWN = "unknown"
+COMPLETION_TYPES: tuple[str, ...] = (SUBSEA, SURFACE, UNKNOWN)
+
+TREE_HEIGHT_COL = "SUBSEA_TREE_HEIGHT_AML"
+COMPLETION_COL = "completion_type"
+
+# Host structure types that can carry dry-tree completions (floating) vs. the
+# fixed/bottom-founded structures. Used purely for host-context tagging.
+FLOATING_HOST_TYPES: tuple[str, ...] = ("SPAR", "TLP", "SEMI", "MTLP", "FPSO")
+FIXED_HOST_TYPES: tuple[str, ...] = ("FIXED", "CAIS", "WP", "MOPU", "CT")
+
+_CSV_REL = Path("current") / "operations" / "ST_BP_and_tree_height.csv"
+_REGISTRY_REL = Path("bin") / "permstruc" / "mv_subsea_boreholes.bin"
+_STRUCTURES_REL = Path("bin") / "platstruc" / "mv_platstruc_structures.bin"
+
+
+# ---------------------------------------------------------------------------
+# Classification (pure)
+# ---------------------------------------------------------------------------
+def classify_completion(subsea_tree_height) -> str:
+    """Classify a single well's completion from its subsea-tree height.
+
+    Returns one of ``"subsea"`` / ``"surface"`` / ``"unknown"``:
+
+    * a present, parseable numeric height -> ``"subsea"``;
+    * ``None`` / NaN / empty-or-whitespace -> ``"surface"`` (no subsea tree
+      recorded; see the module-level caveat about this being a weak signal in a
+      sample);
+    * a non-empty value that is not a number -> ``"unknown"``.
+    """
+    if subsea_tree_height is None:
+        return SURFACE
+    # float NaN (and other non-comparable floats handled below)
+    if isinstance(subsea_tree_height, float) and math.isnan(subsea_tree_height):
+        return SURFACE
+    try:
+        if pd.isna(subsea_tree_height):
+            return SURFACE
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        pass
+    if isinstance(subsea_tree_height, str):
+        stripped = subsea_tree_height.strip()
+        if stripped == "":
+            return SURFACE
+        try:
+            value = float(stripped)
+        except ValueError:
+            return UNKNOWN
+    else:
+        try:
+            value = float(subsea_tree_height)
+        except (TypeError, ValueError):
+            return UNKNOWN
+    if math.isnan(value):
+        return SURFACE
+    return SUBSEA
+
+
+def _zeroed_summary() -> "OrderedDict[str, int]":
+    return OrderedDict((t, 0) for t in COMPLETION_TYPES)
+
+
+# ---------------------------------------------------------------------------
+# Table classification + summary (pure — operate on loaded frames)
+# ---------------------------------------------------------------------------
+def classify_tree_height_table(
+    df: pd.DataFrame, tree_height_col: str = TREE_HEIGHT_COL
+) -> pd.DataFrame:
+    """Return a copy of ``df`` with a ``completion_type`` column appended."""
+    if tree_height_col not in df.columns:
+        raise KeyError(f"{tree_height_col!r} not in frame (cols={list(df.columns)})")
+    out = df.copy()
+    out[COMPLETION_COL] = out[tree_height_col].map(classify_completion)
+    return out
+
+
+def summarize_completions(classified: pd.DataFrame) -> "OrderedDict[str, int]":
+    """Count rows per completion type; always returns all keys (zero-filled)."""
+    counts = _zeroed_summary()
+    if COMPLETION_COL not in classified.columns:
+        raise KeyError(
+            f"{COMPLETION_COL!r} missing; run classify_tree_height_table first."
+        )
+    observed = classified[COMPLETION_COL].value_counts().to_dict()
+    for key, value in observed.items():
+        counts[key] = counts.get(key, 0) + int(value)
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Cross-validation against the authoritative subsea registry
+# ---------------------------------------------------------------------------
+def cross_validate(classified: pd.DataFrame, truth_registry: pd.DataFrame) -> dict:
+    """Compare the sample's subsea count to the registry's subsea population.
+
+    The sample CSV carries no ``WELL_NAME`` string and the registry carries no
+    ``API_WELL_NUMBER``, so the two cannot be row-joined. This is therefore an
+    honest *population* comparison, not a corroboration of individual wells.
+    """
+    sample_subsea = int(
+        (classified.get(COMPLETION_COL) == SUBSEA).sum()
+        if COMPLETION_COL in classified.columns
+        else 0
+    )
+    registry_subsea = int(len(truth_registry))
+    return {
+        "sample_subsea_wells": sample_subsea,
+        "sample_total_wells": int(len(classified)),
+        "registry_subsea_wells": registry_subsea,
+        "row_level_join_possible": False,
+        "join_limitation": (
+            "Sample CSV has no WELL_NAME and the registry has no "
+            "API_WELL_NUMBER; no shared key exists, so wells cannot be matched "
+            "one-to-one. Counts are population totals, not corroborated rows."
+        ),
+        "coverage_gap": (
+            "Sample carries the subsea flag for "
+            f"{sample_subsea} well(s); the registry lists {registry_subsea} "
+            "subsea wells. The sample covers only a small fraction of the "
+            "authoritative subsea population."
+        ),
+    }
+
+
+def host_type_context(structures: pd.DataFrame) -> "OrderedDict[str, object]":
+    """Summarise platform host types into floating (dry-tree-capable) vs fixed."""
+    col = "STRUC_TYPE_CODE"
+    by_code: "OrderedDict[str, int]" = OrderedDict()
+    floating = fixed = other = 0
+    if col in structures.columns:
+        counts = structures[col].value_counts()
+        for code, n in counts.items():
+            by_code[str(code)] = int(n)
+            if code in FLOATING_HOST_TYPES:
+                floating += int(n)
+            elif code in FIXED_HOST_TYPES:
+                fixed += int(n)
+            else:
+                other += int(n)
+    return OrderedDict(
+        [
+            ("floating_dry_tree_capable", floating),
+            ("fixed_bottom_founded", fixed),
+            ("other", other),
+            ("by_struc_type_code", dict(by_code)),
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Loaders (I/O — thin, so the logic above stays unit-testable)
+# ---------------------------------------------------------------------------
+def _resolve_data_dir(data_dir: Optional[Path]) -> Path:
+    if data_dir is not None:
+        return Path(data_dir)
+    if get_module_data_safe is not None:
+        return Path(get_module_data_safe("bsee"))
+    raise RuntimeError(
+        "No data_dir given and worldenergydata.common.data_resolver is unavailable."
+    )
+
+
+def _read_pickle_df(path: Path) -> pd.DataFrame:
+    with open(path, "rb") as fh:
+        obj = pickle.load(fh)
+    return obj if isinstance(obj, pd.DataFrame) else pd.DataFrame(obj)
+
+
+def load_tree_height_table(
+    data_dir: Optional[Path] = None, csv_path: Optional[Path] = None
+) -> pd.DataFrame:
+    """Load the subsea-tree-height sample CSV (the completion-flag carrier)."""
+    path = (
+        Path(csv_path)
+        if csv_path is not None
+        else _resolve_data_dir(data_dir) / _CSV_REL
+    )
+    df = pd.read_csv(path)
+    if TREE_HEIGHT_COL not in df.columns:
+        raise KeyError(f"{TREE_HEIGHT_COL} not in {path} (cols={list(df.columns)})")
+    return df
+
+
+def load_subsea_registry(
+    data_dir: Optional[Path] = None, registry_path: Optional[Path] = None
+) -> pd.DataFrame:
+    """Load the authoritative subsea-borehole registry (one row per subsea well)."""
+    path = (
+        Path(registry_path)
+        if registry_path is not None
+        else _resolve_data_dir(data_dir) / _REGISTRY_REL
+    )
+    return _read_pickle_df(path)
+
+
+def load_structures(
+    data_dir: Optional[Path] = None, structures_path: Optional[Path] = None
+) -> pd.DataFrame:
+    """Load the platform-structure registry (host-type context)."""
+    path = (
+        Path(structures_path)
+        if structures_path is not None
+        else _resolve_data_dir(data_dir) / _STRUCTURES_REL
+    )
+    return _read_pickle_df(path)
+
+
+# ---------------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------------
+def build_classification(
+    data_dir: Optional[Path] = None,
+    out_path: Optional[Path] = None,
+    csv_path: Optional[Path] = None,
+    registry_path: Optional[Path] = None,
+    structures_path: Optional[Path] = None,
+) -> dict:
+    """Classify the sample, cross-check it, and (optionally) write a YAML summary.
+
+    The tree-height CSV is required. The subsea registry and platform
+    structures are best-effort context: if either file is missing the build
+    still succeeds and records the gap in ``caveats``.
+
+    Returns a dict with ``summary`` (completion counts), ``sample_total``,
+    ``cross_validation``, ``host_context``, ``provenance`` and ``caveats``.
+    """
+    table = load_tree_height_table(data_dir=data_dir, csv_path=csv_path)
+    classified = classify_tree_height_table(table)
+    summary = summarize_completions(classified)
+    sample_total = int(len(classified))
+
+    caveats = [
+        "SUBSEA_TREE_HEIGHT_AML lives only in ST_BP_and_tree_height.csv, a "
+        "~100-row SAMPLE — coverage is limited; this is NOT the full well set.",
+        "'surface' is inferred from an empty/absent tree height; absence usually "
+        "means 'not recorded in this sample', not a proven dry-tree completion.",
+        "Subsea registry has no API_WELL_NUMBER and the sample has no WELL_NAME, "
+        "so cross-validation is a population comparison, not a row-level join.",
+        "Confidence: subsea flag where present is [on record]; 'surface' counts "
+        "are [low-confidence inference]; cross-validation is [population-level].",
+    ]
+
+    cross = None
+    registry_total = None
+    try:
+        registry = load_subsea_registry(data_dir=data_dir, registry_path=registry_path)
+        cross = cross_validate(classified, registry)
+        registry_total = int(len(registry))
+    except (FileNotFoundError, OSError, pickle.UnpicklingError) as exc:
+        caveats.append(
+            f"Subsea registry unavailable; cross-validation skipped ({exc})."
+        )
+
+    host_context = None
+    try:
+        structures = load_structures(data_dir=data_dir, structures_path=structures_path)
+        host_context = dict(host_type_context(structures))
+    except (FileNotFoundError, OSError, pickle.UnpicklingError) as exc:
+        caveats.append(
+            f"Platform structures unavailable; host context skipped ({exc})."
+        )
+
+    result = {
+        "summary": dict(summary),
+        "sample_total": sample_total,
+        "cross_validation": cross,
+        "registry_subsea_total": registry_total,
+        "host_context": host_context,
+        "provenance": {
+            "completion_source": (
+                "BSEE current/operations/ST_BP_and_tree_height.csv "
+                "(SUBSEA_TREE_HEIGHT_AML; ~100-row sample)"
+            ),
+            "registry_source": "BSEE permstruc/mv_subsea_boreholes.bin (subsea registry)",
+            "structures_source": "BSEE platstruc/mv_platstruc_structures.bin (host types)",
+            "rule": (
+                "present tree height -> subsea; empty/null -> surface; "
+                "non-numeric -> unknown"
+            ),
+            "issue": "worldenergydata#584 (epic #582)",
+        },
+        "caveats": caveats,
+    }
+
+    if out_path is not None:
+        import yaml
+
+        out_path = Path(out_path)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(out_path, "w") as fh:
+            yaml.safe_dump(result, fh, sort_keys=False, default_flow_style=False)
+
+    return result

--- a/tests/unit/bsee/analysis/intervention/test_subsea_classifier.py
+++ b/tests/unit/bsee/analysis/intervention/test_subsea_classifier.py
@@ -1,0 +1,154 @@
+# ABOUTME: Unit tests for the subsea-vs-dry-tree completion classifier (worldenergydata #584).
+# ABOUTME: Pure-function classification + table summary on synthetic frames; real-data run is skip-if-missing.
+
+"""Unit tests for worldenergydata.bsee.analysis.intervention.subsea_classifier."""
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from worldenergydata.bsee.analysis.intervention.subsea_classifier import (
+    COMPLETION_COL,
+    COMPLETION_TYPES,
+    SUBSEA,
+    SURFACE,
+    UNKNOWN,
+    build_classification,
+    classify_completion,
+    classify_tree_height_table,
+    cross_validate,
+    host_type_context,
+    summarize_completions,
+)
+
+# The sample CSV is committed in-repo; the registry/structures pickles live on
+# the external mount. Resolve both for the skip-if-missing real-data test.
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_REAL_CSV = (
+    _REPO_ROOT
+    / "data"
+    / "modules"
+    / "bsee"
+    / "current"
+    / "operations"
+    / "ST_BP_and_tree_height.csv"
+)
+_REAL_REGISTRY = Path(
+    "/mnt/ace/worldenergydata/data/modules/bsee/bin/permstruc/mv_subsea_boreholes.bin"
+)
+_REAL_STRUCTURES = Path(
+    "/mnt/ace/worldenergydata/data/modules/bsee/bin/platstruc/mv_platstruc_structures.bin"
+)
+
+
+class TestClassifyCompletion:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (15.0, SUBSEA),
+            (22, SUBSEA),
+            (0.0, SUBSEA),  # a present (zero) height is still "on record"
+            ("17", SUBSEA),
+            (None, SURFACE),
+            (float("nan"), SURFACE),
+            ("", SURFACE),
+            ("   ", SURFACE),
+            ("not-a-number", UNKNOWN),
+            ("12ft", UNKNOWN),
+        ],
+    )
+    def test_cases(self, value, expected):
+        assert classify_completion(value) == expected
+
+    def test_returns_only_known_labels(self):
+        for v in [10.0, None, "x"]:
+            assert classify_completion(v) in COMPLETION_TYPES
+
+
+class TestClassifyTable:
+    def _frame(self):
+        return pd.DataFrame(
+            {
+                "API_WELL_NUMBER": [1, 2, 3, 4, 5],
+                "SUBSEA_TREE_HEIGHT_AML": [15.0, None, 22.0, float("nan"), "junk"],
+            }
+        )
+
+    def test_adds_completion_column(self):
+        out = classify_tree_height_table(self._frame())
+        assert COMPLETION_COL in out.columns
+        assert list(out[COMPLETION_COL]) == [
+            SUBSEA,
+            SURFACE,
+            SUBSEA,
+            SURFACE,
+            UNKNOWN,
+        ]
+        # original frame untouched (copy semantics)
+        assert COMPLETION_COL not in self._frame().columns
+
+    def test_missing_column_raises(self):
+        with pytest.raises(KeyError):
+            classify_tree_height_table(pd.DataFrame({"x": [1]}))
+
+    def test_summary_counts_all_keys(self):
+        summary = summarize_completions(classify_tree_height_table(self._frame()))
+        assert summary[SUBSEA] == 2
+        assert summary[SURFACE] == 2
+        assert summary[UNKNOWN] == 1
+        assert set(summary.keys()) == set(COMPLETION_TYPES)
+        assert sum(summary.values()) == 5
+
+    def test_summary_requires_classified_frame(self):
+        with pytest.raises(KeyError):
+            summarize_completions(pd.DataFrame({"x": [1]}))
+
+
+class TestCrossValidate:
+    def test_population_counts_and_honesty(self):
+        classified = classify_tree_height_table(
+            pd.DataFrame({"SUBSEA_TREE_HEIGHT_AML": [15.0, None, 22.0]})
+        )
+        registry = pd.DataFrame({"WELL_NAME": ["006", "P011", "UI005", "A1"]})
+        cv = cross_validate(classified, registry)
+        assert cv["sample_subsea_wells"] == 2
+        assert cv["sample_total_wells"] == 3
+        assert cv["registry_subsea_wells"] == 4
+        assert cv["row_level_join_possible"] is False
+        assert "no shared key" in cv["join_limitation"].lower()
+
+
+class TestHostContext:
+    def test_floating_vs_fixed_split(self):
+        structures = pd.DataFrame(
+            {"STRUC_TYPE_CODE": ["FIXED", "FIXED", "SPAR", "TLP", "CAIS", "ZZZ"]}
+        )
+        ctx = host_type_context(structures)
+        assert ctx["floating_dry_tree_capable"] == 2  # SPAR + TLP
+        assert ctx["fixed_bottom_founded"] == 3  # FIXED, FIXED, CAIS
+        assert ctx["other"] == 1  # ZZZ
+        assert ctx["by_struc_type_code"]["FIXED"] == 2
+
+
+@pytest.mark.skipif(
+    not _REAL_CSV.exists(),
+    reason="BSEE tree-height sample CSV not available",
+)
+class TestRealData:
+    def test_build_classification_sane_structure(self):
+        result = build_classification(
+            csv_path=_REAL_CSV,
+            registry_path=_REAL_REGISTRY if _REAL_REGISTRY.exists() else None,
+            structures_path=_REAL_STRUCTURES if _REAL_STRUCTURES.exists() else None,
+        )
+        summary = result["summary"]
+        # counts partition the sample exactly and are non-negative
+        assert set(summary.keys()) == set(COMPLETION_TYPES)
+        assert all(v >= 0 for v in summary.values())
+        assert (
+            summary[SUBSEA] + summary[SURFACE] + summary[UNKNOWN]
+            == result["sample_total"]
+        )
+        assert result["sample_total"] > 0
+        assert isinstance(result["caveats"], list) and result["caveats"]


### PR DESCRIPTION
Closes #584 (child of #582).

## What it does
Adds `bsee/analysis/intervention/subsea_classifier.py` — classifies Gulf-of-Mexico wells as **subsea (wet-tree)** vs **surface/dry-tree** from BSEE's `SUBSEA_TREE_HEIGHT_AML` signal, the completion axis of the subsea-intervention/maintenance database (epic #582).

- `classify_completion(value)` — pure function → `subsea` / `surface` / `unknown` (present height → subsea; empty/null/NaN → surface; non-numeric → unknown). Handles None/empty/NaN explicitly.
- `classify_tree_height_table(df)` + `summarize_completions(df)` — append a `completion_type` column and count per type.
- Loaders (`load_tree_height_table`, `load_subsea_registry`, `load_structures`) accept explicit `data_dir`/path, default via `get_module_data_safe("bsee")` like the sibling `well_inventory_by_band` module.
- `cross_validate(classified, registry)` — honest **population-level** comparison (sample subsea count vs the 593-well authoritative registry). No shared join key exists (sample CSV has no `WELL_NAME`, registry has no `API_WELL_NUMBER`), so no row-level match is claimed.
- `host_type_context(structures)` — tags floating dry-tree-capable hosts (SPAR/TLP/SEMI) vs fixed (FIXED/CAIS/WP).
- `build_classification(data_dir, out_path)` — writes a reviewable YAML with counts, cross-validation, host context, provenance, caveats and confidence labels (mirrors `well_inventory_by_band.py`).

Real-data run: 7 subsea / 93 surface / 0 unknown of the 100-row sample; registry 593 subsea wells; 61 floating vs 7030 fixed hosts.

## Caveats (documented in code + YAML)
- `SUBSEA_TREE_HEIGHT_AML` lives only in `ST_BP_and_tree_height.csv`, a **~100-row SAMPLE** — coverage is limited, NOT the full well set.
- `surface` is a **weak inference** from an absent tree height (usually "not recorded in this sample", not proven dry-tree).
- Cross-validation is population-level only — no shared key for a row join.

## Tests
18 tests (17 synthetic, CI-safe; 1 skip-if-missing real-data run asserting the counts partition the sample). All pass.

Does not edit `__init__.py` (avoids conflicts with parallel work).