### PR TITLE
feat(data): planned/projected subsea-wells overlay (#587)

### DIFF
--- a/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/intervention/data/planned_subsea_wells.yml
+++ b/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/intervention/data/planned_subsea_wells.yml
@@ -1,0 +1,249 @@
+# Planned / projected US Gulf-of-Mexico new subsea wells (worldenergydata #587, epic #582).
+#
+# on_record_projects: itemised, FID-sanctioned developments from public
+#   announcements. Summed, these are a FLOOR on new subsea wells per year --
+#   later infill phases not yet itemised are deliberately excluded. First-oil
+#   years are best public estimates and may slip.
+# analyst_rate: independent projected GoM subsea tree/well installation rate
+#   used to bracket the floor (P10/P90); confidence = projected.
+#
+# Trion (Chevron) is EXCLUDED: it lies in Mexican waters, not the US GoM.
+# water_depth_ft is the host/field water depth from a cited public source where
+# findable; null + note where not, and such projects fall in deepwater_unknown.
+# water_depth_band keys come from
+#   worldenergydata.bsee.analysis.intervention.well_inventory_by_band
+# NB: "20K" in pressure_class is a 20,000-psi rating, NOT a water depth.
+
+on_record_projects:
+  - name: Anchor
+    operator: Chevron
+    wells: 7
+    first_oil_year: 2024
+    host_type: new_FPS
+    pressure_class: 20K
+    water_depth_ft: 5000
+    water_depth_band: band_5000_10000
+    confidence: on_record
+    source_url: https://www.ogj.com/drilling-production/drilling-operations/article/55233432/chevron-anchor-pioneers-20k-subsea-development
+    note: Green Canyon; first 20K psi subsea development to reach production (~5,000 ft).
+
+  - name: Whale
+    operator: Shell
+    wells: 15
+    first_oil_year: 2025
+    host_type: new_FPS
+    pressure_class: 15K
+    water_depth_ft: 8600
+    water_depth_band: band_5000_10000
+    confidence: on_record
+    source_url: https://www.offshore-mag.com/field-development/article/14207502/shell-sanctions-deepwater-whale-project-in-the-gulf-of-mexico
+    note: Alaminos Canyon 773; host in >8,600 ft; semi-submersible FPU.
+
+  - name: Ballymore
+    operator: Chevron
+    wells: 3
+    first_oil_year: 2025
+    host_type: tieback
+    pressure_class: null
+    water_depth_ft: 6600
+    water_depth_band: band_5000_10000
+    confidence: on_record
+    source_url: https://www.offshore-mag.com/regional-reports/us-gulf-of-mexico/article/14276709/chevron-sanctions-ballymore-project-in-deepwater-us-gom
+    note: Mississippi Canyon (~6,600 ft); tieback to Blind Faith.
+
+  - name: Dover
+    operator: Shell
+    wells: 2
+    first_oil_year: 2025
+    host_type: tieback
+    pressure_class: null
+    water_depth_ft: 7500
+    water_depth_band: band_5000_10000
+    confidence: on_record
+    source_url: https://www.nsenergybusiness.com/projects/dover-deepwater-project/
+    note: Mississippi Canyon 612; tieback to Appomattox; depth ~7,500 ft (regional approx).
+
+  - name: Shenandoah Phase 1
+    operator: Beacon Offshore Energy
+    wells: 4
+    first_oil_year: 2025
+    host_type: new_FPS
+    pressure_class: 20K
+    water_depth_ft: 5800
+    water_depth_band: band_5000_10000
+    confidence: on_record
+    source_url: https://www.nsenergybusiness.com/projects/shenandoah-field-development/
+    note: Walker Ridge 52; 20K psi semi-submersible FPS (~5,800 ft).
+
+  - name: Salamanca (Leon/Castile)
+    operator: LLOG Exploration
+    wells: 4
+    first_oil_year: 2025
+    host_type: new_FPS
+    pressure_class: null
+    water_depth_ft: 6400
+    water_depth_band: band_5000_10000
+    confidence: on_record
+    source_url: https://www.offshore-technology.com/projects/leon-castile-deep-water-project-gulf-of-mexico-us/
+    note: Keathley Canyon 689; redevelopment of Leon and Castile (~6,400 ft); phased.
+
+  - name: Zephyrus
+    operator: Beacon Offshore Energy
+    wells: 2
+    first_oil_year: 2025
+    host_type: tieback
+    pressure_class: null
+    water_depth_ft: 3600
+    water_depth_band: band_3000_5000
+    confidence: on_record
+    source_url: https://www.offshore-technology.com/news/beacon-offshore-energy-begins-production-at-zephyrus-field/
+    note: Mississippi Canyon 759 (sources differ vs Keathley Canyon); ~3,100-3,600 ft, deep end used.
+
+  - name: Sunspear
+    operator: Talos Energy
+    wells: 1
+    first_oil_year: 2025
+    host_type: tieback
+    pressure_class: null
+    water_depth_ft: 1640
+    water_depth_band: band_500_3000
+    confidence: on_record
+    source_url: https://www.ogj.com/exploration-development/article/55017906/talos-energy-lets-subsea-contract-for-sunspear-gom-tieback
+    note: Green Canyon 78 (~500 m / 1,640 ft); tieback to Prince.
+
+  - name: Katmai West
+    operator: Talos Energy
+    wells: 1
+    first_oil_year: 2025
+    host_type: tieback
+    pressure_class: null
+    water_depth_ft: 2100
+    water_depth_band: band_500_3000
+    confidence: on_record
+    source_url: https://www.offshore-technology.com/marketdata/oil-gas-field-profile-katmai-conventional-oil-field-us/
+    note: Green Canyon 40 (~2,100 ft).
+
+  - name: Silvertip Phase 3
+    operator: Shell
+    wells: 2
+    first_oil_year: 2026
+    host_type: tieback
+    pressure_class: null
+    water_depth_ft: 8000
+    water_depth_band: band_5000_10000
+    confidence: on_record
+    source_url: https://www.offshore-mag.com/regional-reports/us-gulf-of-mexico/news/55249632/shell-shell-proceeding-with-phase-3-of-gom-silvertip-subsea-project
+    note: Alaminos Canyon; tieback to Perdido. Depth is the Perdido host (~8,000 ft); Silvertip field likely deeper.
+
+  - name: Longclaw
+    operator: Murphy Oil
+    wells: 1
+    first_oil_year: 2026
+    host_type: tieback
+    pressure_class: null
+    water_depth_ft: null
+    water_depth_band: deepwater_unknown
+    confidence: on_record
+    source_url: https://www.offshore-mag.com/regional-reports/us-gulf-of-mexico/article/14293343/murphy-finds-more-oil-in-green-canyon-area
+    note: Green Canyon (King's Quay area); no published host depth -> not guessed.
+
+  - name: Black Pearl
+    operator: Hess
+    wells: 1
+    first_oil_year: 2026
+    host_type: tieback
+    pressure_class: null
+    water_depth_ft: 3500
+    water_depth_band: band_3000_5000
+    confidence: on_record
+    source_url: https://www.offshore-technology.com/projects/stampede-oil-gas/
+    note: Tieback to Stampede; depth is the Stampede host (~3,500 ft), Black Pearl's own block depth unpublished.
+
+  - name: Monument
+    operator: Beacon Offshore Energy
+    wells: 2
+    first_oil_year: 2026
+    host_type: tieback
+    pressure_class: null
+    water_depth_ft: 6560
+    water_depth_band: band_5000_10000
+    confidence: on_record
+    source_url: https://www.ogj.com/general-interest/article/55249256/beacon-offshore-energy-lets-monument-development-contract
+    note: Walker Ridge (~2,000 m / 6,560 ft); tieback to Shenandoah FPS; partners include Talos.
+
+  - name: String Music / Banjo / Cello
+    operator: Murphy Oil
+    wells: 3
+    first_oil_year: 2027
+    host_type: tieback
+    pressure_class: null
+    water_depth_ft: 6070
+    water_depth_band: band_5000_10000
+    confidence: on_record
+    source_url: https://worldoil.com/news/2026/6/2/murphy-awards-subsea7-contract-for-string-music-subsea-tieback/
+    note: >-
+      Mississippi Canyon; tiebacks to Delta House (not King's Quay/GC). Depth is
+      String Music (~1,850 m / 6,070 ft); Banjo and Cello (MC 385) depths unpublished.
+
+  - name: Sparta
+    operator: Shell
+    wells: 8
+    first_oil_year: 2028
+    host_type: new_FPS
+    pressure_class: 20K
+    water_depth_ft: 5365
+    water_depth_band: band_5000_10000
+    confidence: on_record
+    source_url: https://jpt.spe.org/new-neighborhood-shell-sanctions-sparta-project-in-deepwater-us-gulf-of-mexico
+    note: Garden Banks 959 (up to 5,365 ft); 20K psi development.
+
+  - name: Shenandoah South
+    operator: Beacon Offshore Energy
+    wells: 2
+    first_oil_year: 2028
+    host_type: tieback
+    pressure_class: 20K
+    water_depth_ft: 5800
+    water_depth_band: band_5000_10000
+    confidence: on_record
+    source_url: https://www.offshore-mag.com/production/news/55305650/beacon-starts-oil-and-gas-production-at-offshore-shenandoah-field-in-the-gom
+    note: Walker Ridge 52; expansion tieback to Shenandoah FPS (~5,800-6,000 ft).
+
+  - name: Kaskida
+    operator: bp
+    wells: 6
+    first_oil_year: 2029
+    host_type: new_FPS
+    pressure_class: 20K
+    water_depth_ft: 6000
+    water_depth_band: band_5000_10000
+    confidence: on_record
+    source_url: https://jpt.spe.org/bp-oks-20k-psi-kaskida-project-in-gulf-of-mexico
+    note: Keathley Canyon 292 (~6,000 ft); 20K psi Phase 1.
+
+  - name: Tiber / Guadalupe
+    operator: bp
+    wells: 8
+    first_oil_year: 2030
+    host_type: new_FPS
+    pressure_class: 20K
+    water_depth_ft: 4130
+    water_depth_band: band_3000_5000
+    confidence: on_record
+    source_url: https://en.wikipedia.org/wiki/Tiber_Oil_Field
+    note: Keathley Canyon 102; 20K psi. Depth is Tiber (~4,130 ft); Guadalupe's own depth not separately stated.
+
+analyst_rate:
+  metric: new GoM subsea trees / wells installed per year
+  trees_per_year_low: 12
+  trees_per_year_high: 20
+  central: 16
+  uncertainty_pct: 15
+  confidence: projected
+  horizon: through 2030
+  sources:
+    - Westwood Subsea Tree Tracker (GoM ~16-19 trees/yr)
+    - Rystad Energy subsea market outlook
+  note: >-
+    Independent installation-rate envelope used to bracket the on-record FID
+    floor. Not summed with the itemised counts; it informs P10/P90 only.

--- a/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/intervention/planned_wells_overlay.py
+++ b/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/intervention/planned_wells_overlay.py
@@ -1,0 +1,262 @@
+# ABOUTME: Planned/projected GoM subsea-wells overlay (worldenergydata #587, child of epic #582).
+# ABOUTME: Loads an on-record FID register of announced US GoM subsea developments and triangulates a P10/P50/P90 new-wells-per-year projection against analyst tree-installation rates.
+
+"""Planned / projected Gulf-of-Mexico subsea-wells overlay — the forward axis.
+
+Where ``well_inventory_by_band`` (#583) counts the *installed* subsea-well base,
+this module supplies the *forward* view epic #582 needs: a structured register
+of **announced** US Gulf-of-Mexico developments resolving to new subsea wells by
+*year* and by *water-depth band*, with explicit uncertainty.
+
+Two confidence tiers are carried, and never silently mixed:
+
+* **on_record** — itemised, sanctioned-by-FID projects (operator/wells/first-oil
+  taken from public announcements). Summed, these form a *floor*: a hard lower
+  bound on new wells per year. Later infill phases that are not yet itemised are
+  deliberately *not* counted, so the floor under-states reality.
+* **projected** — an analyst installation rate (~12-20 subsea trees/wells per
+  year for the GoM, ±15%; Westwood Subsea Tree Tracker, Rystad). This brackets
+  the on-record floor to give P10/P50/P90 new-wells-per-year.
+
+The projection is a deliberately simple, transparent **triangulation**, not a
+stochastic model:
+
+    P50[year] = on-record FID floor for that year (itemised, sanctioned)
+    P10[year] = min(P50, analyst_low)    analyst_low  = central * (1 - pct)
+    P90[year] = max(P50, analyst_high)   analyst_high = central * (1 + pct)
+
+The min/max clamps guarantee ``P10 <= P50 <= P90`` for every year even when the
+itemised floor for a year already exceeds the analyst band (i.e. the analyst
+rate is then known to under-state that year).
+
+The water-depth band of each project is placed with the **same** scheme as the
+installed-base inventory — ``classify_modu_band`` from
+``well_inventory_by_band`` — so the forward and installed views are directly
+comparable. Projects whose host water depth could not be sourced are placed in
+a ``deepwater_unknown`` bucket rather than guessed.
+
+Trion (Chevron, Mexican waters) is excluded: this overlay is US GoM only.
+
+Numbers live in a reviewable YAML register
+(``data/planned_subsea_wells.yml``) so downstream consumers read data, not
+hard-coded constants.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from pathlib import Path
+from typing import Iterable, Optional
+
+from worldenergydata.bsee.analysis.intervention.well_inventory_by_band import (
+    BAND_LABELS,
+    classify_modu_band,
+)
+
+# Bucket for projects with no sourced host water depth — kept distinct from the
+# real bands so unknowns are never silently folded into a depth class.
+UNKNOWN_BAND = "deepwater_unknown"
+
+_REGISTER_REL = Path("data") / "planned_subsea_wells.yml"
+
+
+# ---------------------------------------------------------------------------
+# Loaders (thin I/O; aggregation below operates on plain dicts and is testable)
+# ---------------------------------------------------------------------------
+def _default_register_path() -> Path:
+    return Path(__file__).resolve().parent / _REGISTER_REL
+
+
+def load_register(path: Optional[Path] = None) -> dict:
+    """Load the planned-subsea-wells YAML register.
+
+    Returns the parsed mapping with at least ``on_record_projects`` (list) and
+    ``analyst_rate`` (mapping). Raises if the file is missing.
+    """
+    import yaml
+
+    register_path = Path(path) if path is not None else _default_register_path()
+    with open(register_path, "r") as fh:
+        data = yaml.safe_load(fh) or {}
+    data.setdefault("on_record_projects", [])
+    data.setdefault("analyst_rate", {})
+    return data
+
+
+def on_record_projects(register: dict) -> list:
+    """Return the list of on-record (FID) project records."""
+    return list(register.get("on_record_projects", []))
+
+
+# ---------------------------------------------------------------------------
+# Band placement
+# ---------------------------------------------------------------------------
+def project_band(project: dict) -> str:
+    """Return the water-depth band key for a project.
+
+    Uses the project's explicit ``water_depth_band`` if present and non-null;
+    otherwise derives it from ``water_depth_ft`` via the shared
+    ``classify_modu_band``. Falls back to :data:`UNKNOWN_BAND` when depth is
+    unknown, so unknowns are counted explicitly.
+    """
+    band = project.get("water_depth_band")
+    if band:
+        return band
+    derived = classify_modu_band(project.get("water_depth_ft"))
+    return derived if derived is not None else UNKNOWN_BAND
+
+
+# ---------------------------------------------------------------------------
+# Aggregations over on-record projects
+# ---------------------------------------------------------------------------
+def wells_by_year(register: dict) -> "OrderedDict[int, int]":
+    """Sum on-record new subsea wells by first-oil year (ascending)."""
+    totals: dict[int, int] = {}
+    for proj in on_record_projects(register):
+        year = proj.get("first_oil_year")
+        wells = proj.get("wells") or 0
+        if year is None:
+            continue
+        totals[int(year)] = totals.get(int(year), 0) + int(wells)
+    return OrderedDict((y, totals[y]) for y in sorted(totals))
+
+
+def wells_by_band(register: dict) -> "OrderedDict[str, int]":
+    """Sum on-record new subsea wells by water-depth band (display order)."""
+    counts: "OrderedDict[str, int]" = OrderedDict((k, 0) for k in BAND_LABELS)
+    counts[UNKNOWN_BAND] = 0
+    for proj in on_record_projects(register):
+        band = project_band(proj)
+        wells = int(proj.get("wells") or 0)
+        counts[band] = counts.get(band, 0) + wells
+    return counts
+
+
+def total_on_record_wells(register: dict) -> int:
+    """Total itemised on-record new subsea wells across all projects."""
+    return sum(int(p.get("wells") or 0) for p in on_record_projects(register))
+
+
+# ---------------------------------------------------------------------------
+# Projection (triangulation — see module docstring)
+# ---------------------------------------------------------------------------
+def _analyst_band(register: dict) -> tuple[float, float, float]:
+    """Return (low, central, high) analyst wells/yr from the register.
+
+    ``central`` defaults to the midpoint of the low/high tree-per-year range if
+    not given explicitly; the band is widened by ``uncertainty_pct`` (±%).
+    """
+    rate = register.get("analyst_rate", {}) or {}
+    low_in = rate.get("trees_per_year_low")
+    high_in = rate.get("trees_per_year_high")
+    central = rate.get("central")
+    if central is None and low_in is not None and high_in is not None:
+        central = (float(low_in) + float(high_in)) / 2.0
+    if central is None:
+        central = 0.0
+    pct = float(rate.get("uncertainty_pct", 0)) / 100.0
+    low = float(central) * (1.0 - pct)
+    high = float(central) * (1.0 + pct)
+    return low, float(central), high
+
+
+def _forecast_years(register: dict, years: Optional[Iterable[int]]) -> list:
+    if years is not None:
+        return sorted({int(y) for y in years})
+    by_year = wells_by_year(register)
+    return list(by_year.keys())
+
+
+def projection_pxx(
+    register: dict, years: Optional[Iterable[int]] = None
+) -> "OrderedDict[int, dict]":
+    """Triangulate P10/P50/P90 new subsea wells per year.
+
+    ``P50`` is the on-record FID floor for the year; ``P10``/``P90`` bracket it
+    with the analyst ±% band (clamped so ``P10 <= P50 <= P90`` always holds).
+    See the module docstring for the method. All values are integers (wells).
+
+    Pass ``years`` to force a specific forecast horizon; by default the span of
+    on-record first-oil years is used.
+    """
+    analyst_low, _central, analyst_high = _analyst_band(register)
+    floor_by_year = wells_by_year(register)
+    out: "OrderedDict[int, dict]" = OrderedDict()
+    for year in _forecast_years(register, years):
+        p50 = int(floor_by_year.get(year, 0))
+        p10 = int(round(min(p50, analyst_low)))
+        p90 = int(round(max(p50, analyst_high)))
+        out[year] = {
+            "p10": p10,
+            "p50": p50,
+            "p90": p90,
+            "on_record_floor": p50,
+            "confidence": "on_record_floor_with_projected_bracket",
+        }
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------------
+def build_overlay(
+    out_path: Optional[Path] = None,
+    register_path: Optional[Path] = None,
+) -> dict:
+    """Assemble the overlay summary; optionally write it to YAML.
+
+    Returns a dict with ``by_year``, ``by_band``, ``projection`` (per-year
+    P10/P50/P90), totals, the analyst-rate provenance and the standing caveats.
+    """
+    register = load_register(register_path)
+    analyst_low, central, analyst_high = _analyst_band(register)
+
+    by_year = wells_by_year(register)
+    by_band = wells_by_band(register)
+    projection = projection_pxx(register)
+
+    result = {
+        "by_year": {int(y): int(n) for y, n in by_year.items()},
+        "by_band": {k: int(v) for k, v in by_band.items()},
+        "projection_per_year": {int(y): v for y, v in projection.items()},
+        "totals": {
+            "on_record_wells": total_on_record_wells(register),
+            "on_record_projects": len(on_record_projects(register)),
+        },
+        "analyst_rate": {
+            "wells_per_year_low": round(analyst_low, 1),
+            "wells_per_year_central": round(central, 1),
+            "wells_per_year_high": round(analyst_high, 1),
+            "uncertainty_pct": register.get("analyst_rate", {}).get("uncertainty_pct"),
+            "confidence": "projected",
+            "sources": register.get("analyst_rate", {}).get("sources", []),
+        },
+        "band_scheme_ft": dict(BAND_LABELS),
+        "method": (
+            "Triangulation (not stochastic): P50 = on-record FID floor per year; "
+            "P10 = min(P50, analyst_low); P90 = max(P50, analyst_high); "
+            "analyst band = central * (1 +/- uncertainty_pct)."
+        ),
+        "provenance": {
+            "register_source": "data/planned_subsea_wells.yml (author-curated, public announcements)",
+            "band_module": "worldenergydata.bsee.analysis.intervention.well_inventory_by_band",
+            "issue": "worldenergydata#587 (child of epic #582)",
+        },
+        "caveats": [
+            "On-record FID register is a FLOOR: later infill/expansion phases not yet itemised are excluded, so true new-well counts will run higher.",
+            "Installed subsea-well base is derived elsewhere (#583); this overlay is forward-looking only.",
+            "Trion (Chevron) is excluded — it lies in Mexican waters, not the US GoM.",
+            "Host water depths are sourced from public announcements where findable; projects without a sourced depth sit in 'deepwater_unknown', not a guessed band.",
+            "Analyst rate (12-20 wells/yr, +/-15%) is [projected]; itemised project counts are [on_record].",
+        ],
+    }
+
+    if out_path is not None:
+        import yaml
+
+        out_path = Path(out_path)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(out_path, "w") as fh:
+            yaml.safe_dump(result, fh, sort_keys=False, default_flow_style=False)
+
+    return result

--- a/tests/unit/bsee/analysis/intervention/test_planned_wells_overlay.py
+++ b/tests/unit/bsee/analysis/intervention/test_planned_wells_overlay.py
@@ -1,0 +1,137 @@
+# ABOUTME: Unit tests for the planned/projected GoM subsea-wells overlay (worldenergydata #587).
+# ABOUTME: Pure aggregation + triangulation on a small synthetic register plus a sanity load of the committed YAML.
+
+"""Unit tests for worldenergydata.bsee.analysis.intervention.planned_wells_overlay."""
+
+from worldenergydata.bsee.analysis.intervention.planned_wells_overlay import (
+    UNKNOWN_BAND,
+    build_overlay,
+    load_register,
+    project_band,
+    projection_pxx,
+    total_on_record_wells,
+    wells_by_band,
+    wells_by_year,
+)
+
+# Small synthetic register exercised by the pure-function tests so they do not
+# depend on the exact contents of the committed YAML.
+_SYNTH = {
+    "on_record_projects": [
+        {
+            "name": "AlphaFPS",
+            "operator": "OpCo",
+            "wells": 5,
+            "first_oil_year": 2025,
+            "water_depth_ft": 6000,  # -> band_5000_10000
+        },
+        {
+            "name": "BetaTieback",
+            "operator": "OpCo",
+            "wells": 3,
+            "first_oil_year": 2025,
+            "water_depth_ft": 4000,  # -> band_3000_5000
+        },
+        {
+            "name": "GammaDeep",
+            "operator": "OpCo",
+            "wells": 2,
+            "first_oil_year": 2027,
+            "water_depth_ft": None,  # -> deepwater_unknown
+        },
+    ],
+    "analyst_rate": {
+        "trees_per_year_low": 12,
+        "trees_per_year_high": 20,
+        "central": 16,
+        "uncertainty_pct": 15,
+        "sources": ["Westwood Subsea Tree Tracker", "Rystad"],
+    },
+}
+
+
+class TestBandPlacement:
+    def test_explicit_band_wins(self):
+        assert project_band({"water_depth_band": "band_3000_5000"}) == "band_3000_5000"
+
+    def test_derived_from_depth(self):
+        assert project_band({"water_depth_ft": 6000}) == "band_5000_10000"
+
+    def test_unknown_depth_buckets_to_unknown(self):
+        assert project_band({"water_depth_ft": None}) == UNKNOWN_BAND
+        assert project_band({}) == UNKNOWN_BAND
+
+
+class TestAggregations:
+    def test_wells_by_year(self):
+        by_year = wells_by_year(_SYNTH)
+        assert by_year == {2025: 8, 2027: 2}
+        # ascending order preserved
+        assert list(by_year.keys()) == [2025, 2027]
+
+    def test_wells_by_band(self):
+        by_band = wells_by_band(_SYNTH)
+        assert by_band["band_5000_10000"] == 5
+        assert by_band["band_3000_5000"] == 3
+        assert by_band[UNKNOWN_BAND] == 2
+        assert by_band["shelf_lt_500"] == 0  # zero bands still present
+
+    def test_total(self):
+        assert total_on_record_wells(_SYNTH) == 10
+
+
+class TestProjection:
+    def test_ordering_holds_every_year(self):
+        proj = projection_pxx(_SYNTH)
+        for year, vals in proj.items():
+            assert vals["p10"] <= vals["p50"] <= vals["p90"], year
+
+    def test_p50_is_floor(self):
+        proj = projection_pxx(_SYNTH)
+        assert proj[2025]["p50"] == 8  # 5 + 3 on-record wells in 2025
+        assert proj[2027]["p50"] == 2
+
+    def test_analyst_bracket_widens_low_floor(self):
+        # central 16, +/-15% -> low ~13.6, high ~18.4. A year whose floor (2)
+        # is below the analyst band gets p90 lifted to the analyst high.
+        proj = projection_pxx(_SYNTH)
+        assert proj[2027]["p10"] == 2  # min(2, 13.6) -> 2
+        assert proj[2027]["p90"] == 18  # round(18.4)
+
+    def test_forced_horizon(self):
+        proj = projection_pxx(_SYNTH, years=[2030])
+        # no on-record wells in 2030 -> floor 0, bracketed up to analyst high
+        assert proj[2030]["p50"] == 0
+        assert proj[2030]["p10"] == 0
+        assert proj[2030]["p90"] >= proj[2030]["p50"]
+
+
+class TestCommittedRegister:
+    """Sanity-check the YAML that ships in the repo (authored in this worktree)."""
+
+    def test_loads_and_totals_in_expected_range(self):
+        register = load_register()
+        total = total_on_record_wells(register)
+        assert 70 <= total <= 80, total
+
+    def test_known_project_band_placement(self):
+        register = load_register()
+        projects = {p["name"]: p for p in register["on_record_projects"]}
+        assert "Whale" in projects
+        # Whale (Shell, Alaminos Canyon, ~8,600 ft) sits in the 5,000-10,000 band.
+        assert project_band(projects["Whale"]) == "band_5000_10000"
+
+    def test_excludes_trion(self):
+        register = load_register()
+        names = {p["name"] for p in register["on_record_projects"]}
+        assert not any("Trion" in n for n in names)
+
+    def test_build_overlay_shape_and_ordering(self):
+        overlay = build_overlay()
+        assert overlay["totals"]["on_record_wells"] == total_on_record_wells(
+            load_register()
+        )
+        for year, vals in overlay["projection_per_year"].items():
+            assert vals["p10"] <= vals["p50"] <= vals["p90"], year
+        # every project is [on_record]; analyst rate is [projected]
+        assert overlay["analyst_rate"]["confidence"] == "projected"


### PR DESCRIPTION
Closes #587 (child of #582)

## Summary
Adds the **forward axis** to the subsea-intervention database: a structured register of *announced* US Gulf-of-Mexico developments resolving to **new subsea wells by year and by water-depth band**, with explicit uncertainty. Complements the *installed*-base inventory from #583, reusing its exact band scheme (`classify_modu_band` / `BAND_LABELS` from `well_inventory_by_band`).

## What's in it
- **`data/planned_subsea_wells.yml`** — author-curated register:
  - **18 on-record FID projects**, **72 new subsea wells**, first oil **2024-2030**. Each carries operator, wells, first-oil year, host_type (new_FPS/tieback), pressure_class (15K/20K where known), cited host `water_depth_ft` + `source_url`, and band.
  - Host water depths sourced from public announcements (OGJ, Offshore Mag, JPT/SPE, NS Energy, etc.). 3 with no credible published depth (Longclaw, Banjo, Cello) left **null** -> `deepwater_unknown`, not guessed.
  - **Trion excluded** (Mexican waters, not US GoM).
  - **Analyst rate** block: ~12-20 wells/yr, ±15% (Westwood Subsea Tree Tracker, Rystad) — `projected`.
- **`planned_wells_overlay.py`** — `load_register`, `wells_by_year`, `wells_by_band`, `projection_pxx` (P10/P50/P90), `build_overlay`.

## Projection method (documented, deterministic triangulation — not stochastic)
- `P50[year]` = on-record FID **floor** for that year
- `P10[year]` = `min(P50, analyst_low)`, `P90[year]` = `max(P50, analyst_high)`; analyst band = `central * (1 ± pct)`
- min/max clamps guarantee `P10 <= P50 <= P90` every year.

## Confidence labelling
- Itemised project counts: **on_record** (a FLOOR — later infill phases not yet itemised are excluded).
- Analyst installation rate / P10-P90 bracket: **projected**.
- Caveats carried in `build_overlay` output: floor under-states reality; installed base derived in #583; Trion excluded; unknown-depth projects bucketed separately.

## Distribution (on-record)
- By band: shelf_lt_500=0, band_500_3000=2, band_3000_5000=11, band_5000_10000=58, deepwater_unknown=1.
- By year: 2024=7, 2025=32, 2026=6, 2027=3, 2028=10, 2029=6, 2030=8.

## Tests
**14 unit tests** (synthetic register + committed YAML): totals (72 wells), band placement (Whale -> band_5000_10000), year aggregation, projection `p10<=p50<=p90` ordering, Trion exclusion. All pass.

Reuses #583 band scheme; does not edit `__init__.py`.