### PR TITLE
feat(data): ingest other /mnt/ace fleet data (heavy-lift CSVs + B1535 MSIV) (#595)

### DIFF
--- a/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/loaders/mnt_ace_fleet_loader.py
+++ b/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/loaders/mnt_ace_fleet_loader.py
@@ -1,0 +1,367 @@
+"""Loader for additional off-repo ``/mnt/ace`` fleet sources (#595).
+
+Ingests two further off-repo fleet datasets into the vessel-fleet schema by
+explicit path (no environment variables -- the caller passes the directory):
+
+1. **Heavy-lift CSVs** -- brochure-digitised heavy-lift / crane-vessel
+   particulars captured in two snapshots:
+
+   - ``heavy-lift-vessels-2010.csv``    (original 2010 snapshot)
+   - ``heavy-lift-vessels-current.csv`` (current snapshot, enriched with
+     IMO, current owner / status, and a ``source_url``)
+
+   :func:`load_heavy_lift_csvs` maps both snapshots into the construction /
+   heavy-lift schema, reconciles them by vessel name (current snapshot is
+   authoritative; missing spec fields are filled forward from 2010), and
+   stamps ``DATA_SOURCE`` + ``COLLECTION_DATE`` on every record.
+
+2. **MSIV markdown DB** -- a Multi-Service Intervention Vessel database held
+   as markdown tables. :func:`parse_msiv_markdown` extracts the vessel
+   comparison matrix (name + particulars) and tags rows as
+   ``intervention`` / ``msiv``.
+
+Data policy (client-derived source): only public vessel *particulars* are
+mapped. Cost / day-rate / mobilisation / scoring / recommendation tables, and
+any client or project identifiers in the source text, are **never** read into
+the output. The raw source folders are never copied into the repository --
+both readers operate on a path supplied at call time.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any, Optional
+
+from worldenergydata.vessel_fleet.collectors.acma_msiv_collector import (
+    _find_spec_table,
+    _parse_crane,
+    _parse_draft,
+    _parse_dp,
+    _split_md_row,
+    _SPEC_TABLE_HEADERS,
+)
+from worldenergydata.vessel_fleet.collectors.frontier_csv_collector import (
+    _map_heavy_lift_row,
+    _read_csv,
+)
+from worldenergydata.vessel_fleet.parsers.numeric import parse_numeric
+
+logger = logging.getLogger(__name__)
+
+# --- Source file names ------------------------------------------------------
+
+HEAVY_LIFT_2010_FILE = "heavy-lift-vessels-2010.csv"
+HEAVY_LIFT_CURRENT_FILE = "heavy-lift-vessels-current.csv"
+
+# --- Provenance tags --------------------------------------------------------
+
+DATA_SOURCE_HEAVY_LIFT_2010 = "mnt_ace_heavy_lift_csv_2010"
+DATA_SOURCE_HEAVY_LIFT_CURRENT = "mnt_ace_heavy_lift_csv_current"
+DATA_SOURCE_MSIV = "mnt_ace_msiv_md"
+
+# --- Tagging ----------------------------------------------------------------
+
+_HEAVY_LIFT_CATEGORY = "construction"
+_HEAVY_LIFT_TYPE = "heavy_lift"
+_MSIV_CATEGORY = "intervention"
+_MSIV_TYPE = "msiv"
+
+_COLLECTION_DATE_2010 = "2010"
+
+# Numeric / categorical spec fields that may be filled forward from the 2010
+# snapshot into a current record when the current value is missing.
+_RECONCILE_SPEC_FIELDS = (
+    "LOA_M",
+    "BEAM_M",
+    "DRAFT_M",
+    "DP_CLASS",
+    "MAIN_CRANE_CAPACITY_T",
+    "MAIN_CRANE_REACH_M",
+    "AUX_CRANE_CAPACITY_T",
+    "AUX_CRANE_REACH_M",
+    "DECK_LOAD_CAPACITY_T",
+    "CLASSIFICATION_SOCIETY",
+    "VESSEL_SUBTYPE",
+)
+
+# "> Created: 2025-08-07" provenance line in the MSIV markdown headers.
+_CREATED_RE = re.compile(r"created:\s*(\d{4}-\d{2}-\d{2})", re.IGNORECASE)
+
+
+# --- Heavy-lift CSV loader --------------------------------------------------
+
+
+def _map_heavy_lift_snapshot(
+    row: dict[str, str],
+    *,
+    data_source: str,
+    collection_date: Optional[str],
+) -> Optional[dict[str, Any]]:
+    """Map one heavy-lift CSV row, stamping snapshot provenance.
+
+    Reuses the shared Frontier row mapper for the spec columns, then overrides
+    ``DATA_SOURCE`` and ``COLLECTION_DATE`` for this snapshot. Returns ``None``
+    for rows without a vessel name.
+    """
+    mapped = _map_heavy_lift_row(row)
+    if mapped is None:
+        return None
+    mapped["DATA_SOURCE"] = data_source
+    mapped["COLLECTION_DATE"] = collection_date
+    return mapped
+
+
+def _current_collection_date(row: dict[str, str]) -> Optional[str]:
+    """Derive a COLLECTION_DATE for a current-snapshot row.
+
+    Prefers the per-row ``status_year`` (e.g. ``2024``); falls back to the
+    literal ``"current"`` when absent.
+    """
+    year = (row.get("status_year") or "").strip()
+    return year or "current"
+
+
+def _reconcile(
+    current: list[dict[str, Any]],
+    legacy: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Reconcile current and 2010 heavy-lift snapshots into one record set.
+
+    The current snapshot is authoritative. For a vessel present in both
+    snapshots, any missing spec field on the current record is filled forward
+    from its 2010 counterpart. Vessels present only in 2010 are appended with
+    their original provenance.
+    """
+    by_name: dict[str, dict[str, Any]] = {}
+    order: list[str] = []
+    for rec in current:
+        key = rec["VESSEL_NAME"].upper()
+        by_name[key] = rec
+        order.append(key)
+
+    legacy_by_name: dict[str, dict[str, Any]] = {}
+    for rec in legacy:
+        legacy_by_name.setdefault(rec["VESSEL_NAME"].upper(), rec)
+
+    # Fill-forward missing specs onto matched current records.
+    for key, cur in by_name.items():
+        old = legacy_by_name.get(key)
+        if old is None:
+            continue
+        for field in _RECONCILE_SPEC_FIELDS:
+            if cur.get(field) is None and old.get(field) is not None:
+                cur[field] = old[field]
+
+    # Append vessels that only appear in the 2010 snapshot.
+    for key, old in legacy_by_name.items():
+        if key not in by_name:
+            by_name[key] = old
+            order.append(key)
+
+    return [by_name[key] for key in order]
+
+
+def load_heavy_lift_csvs(source_dir: str | Path) -> list[dict[str, Any]]:
+    """Load and reconcile the 2010 + current heavy-lift CSV snapshots.
+
+    Args:
+        source_dir: Directory containing ``heavy-lift-vessels-2010.csv`` and
+            ``heavy-lift-vessels-current.csv``.
+
+    Returns:
+        Reconciled construction / heavy-lift records (one per vessel). Each
+        record carries ``DATA_SOURCE`` and ``COLLECTION_DATE``. Returns an
+        empty list (with a warning) when the directory is missing, so callers
+        and CI degrade gracefully without the off-repo share mounted.
+    """
+    base = Path(source_dir)
+    if not base.is_dir():
+        logger.warning("Heavy-lift source dir not found: %s; skipping", base)
+        return []
+
+    current: list[dict[str, Any]] = []
+    cur_path = base / HEAVY_LIFT_CURRENT_FILE
+    if cur_path.is_file():
+        for row in _read_csv(cur_path):
+            mapped = _map_heavy_lift_snapshot(
+                row,
+                data_source=DATA_SOURCE_HEAVY_LIFT_CURRENT,
+                collection_date=_current_collection_date(row),
+            )
+            if mapped is not None:
+                current.append(mapped)
+    else:
+        logger.warning("Current heavy-lift file missing: %s", cur_path)
+
+    legacy: list[dict[str, Any]] = []
+    legacy_path = base / HEAVY_LIFT_2010_FILE
+    if legacy_path.is_file():
+        for row in _read_csv(legacy_path):
+            mapped = _map_heavy_lift_snapshot(
+                row,
+                data_source=DATA_SOURCE_HEAVY_LIFT_2010,
+                collection_date=_COLLECTION_DATE_2010,
+            )
+            if mapped is not None:
+                legacy.append(mapped)
+    else:
+        logger.warning("2010 heavy-lift file missing: %s", legacy_path)
+
+    records = _reconcile(current, legacy)
+    logger.info(
+        "Loaded %d reconciled heavy-lift vessels (%d current, %d legacy-2010)",
+        len(records),
+        len(current),
+        len(legacy),
+    )
+    return records
+
+
+# --- MSIV markdown parser ---------------------------------------------------
+
+
+def _extract_created_date(text: str) -> Optional[str]:
+    """Return the ``Created:`` ISO date from the markdown header, if present."""
+    match = _CREATED_RE.search(text)
+    return match.group(1) if match else None
+
+
+def _map_msiv_row(
+    header: list[str],
+    cells: list[str],
+    collection_date: Optional[str],
+) -> Optional[dict[str, Any]]:
+    """Map one vessel-comparison-matrix row to an intervention/MSIV record.
+
+    Only vessel particulars are mapped; no cost / scoring / mobilisation or
+    project-identifier content is read.
+    """
+    row = dict(zip(header, cells))
+    name = (row.get("vessel name") or "").strip()
+    if not name:
+        return None
+
+    accommodation = parse_numeric(row.get("accommodation"))
+
+    return {
+        "VESSEL_NAME": name,
+        "VESSEL_CATEGORY": _MSIV_CATEGORY,
+        "VESSEL_TYPE": _MSIV_TYPE,
+        "VESSEL_SUBTYPE": (row.get("type") or "").strip() or None,
+        "DATA_SOURCE": DATA_SOURCE_MSIV,
+        "DATA_SOURCE_URL": None,
+        "COLLECTION_DATE": collection_date,
+        "LOA_M": parse_numeric(row.get("loa (m)")),
+        "BEAM_M": parse_numeric(row.get("beam (m)")),
+        "DRAFT_M": _parse_draft(row.get("draft (m)", "")),
+        "MAIN_CRANE_CAPACITY_T": _parse_crane(row.get("main crane (mt)", "")),
+        "AUX_CRANE_CAPACITY_T": _parse_crane(row.get("aux crane (mt)", "")),
+        "DP_CLASS": _parse_dp(row.get("dp class", "")),
+        "QUARTERS_CAPACITY": (
+            int(accommodation) if accommodation is not None else None
+        ),
+    }
+
+
+def parse_msiv_markdown(path: str | Path) -> list[dict[str, Any]]:
+    """Parse a single MSIV markdown file into intervention/MSIV records.
+
+    Locates the vessel comparison matrix (the only particulars table) and maps
+    each data row. Files without that table (e.g. prose-only documents or the
+    cost/recommendation reports) yield an empty list.
+
+    Args:
+        path: Path to a ``.md`` file from the MSIV database.
+
+    Returns:
+        A list of intervention/MSIV record dicts (vessel particulars only).
+    """
+    md_path = Path(path)
+    if not md_path.is_file():
+        logger.warning("MSIV markdown file not found: %s; skipping", md_path)
+        return []
+
+    text = md_path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    collection_date = _extract_created_date(text)
+
+    header: list[str] = []
+    for line in lines:
+        if "|" not in line:
+            continue
+        candidate = [c.lower() for c in _split_md_row(line)]
+        if all(h in " ".join(candidate) for h in _SPEC_TABLE_HEADERS):
+            header = candidate
+            break
+
+    if not header:
+        return []
+
+    records: list[dict[str, Any]] = []
+    for cells in _find_spec_table(lines):
+        if len(cells) != len(header):
+            continue
+        mapped = _map_msiv_row(header, cells, collection_date)
+        if mapped is not None:
+            records.append(mapped)
+    return records
+
+
+def parse_msiv_dir(source_dir: str | Path) -> list[dict[str, Any]]:
+    """Parse every ``*.md`` file in an MSIV directory into vessel records.
+
+    De-duplicates by vessel name across files (first occurrence wins), so the
+    comparison matrix and any spec-sheet tables collapse to one record each.
+
+    Args:
+        source_dir: Directory holding the MSIV markdown database files.
+
+    Returns:
+        Combined, de-duplicated intervention/MSIV records.
+    """
+    base = Path(source_dir)
+    if not base.is_dir():
+        logger.warning("MSIV source dir not found: %s; skipping", base)
+        return []
+
+    seen: set[str] = set()
+    records: list[dict[str, Any]] = []
+    for md_path in sorted(base.glob("*.md")):
+        for rec in parse_msiv_markdown(md_path):
+            key = rec["VESSEL_NAME"].upper()
+            if key in seen:
+                continue
+            seen.add(key)
+            records.append(rec)
+    logger.info("Parsed %d MSIV vessels from %s", len(records), base)
+    return records
+
+
+# --- Combine ----------------------------------------------------------------
+
+
+def combine(
+    heavy_lift_dir: Optional[str | Path] = None,
+    msiv_dir: Optional[str | Path] = None,
+) -> list[dict[str, Any]]:
+    """Combine heavy-lift CSV and MSIV markdown records into one record set.
+
+    Args:
+        heavy_lift_dir: Directory with the heavy-lift CSV snapshots. Skipped
+            when ``None``.
+        msiv_dir: Directory with the MSIV markdown database. Skipped when
+            ``None``.
+
+    Returns:
+        A single list of schema-mapped vessel records from both sources.
+        Heavy-lift records come first, followed by MSIV records.
+    """
+    records: list[dict[str, Any]] = []
+    if heavy_lift_dir is not None:
+        records.extend(load_heavy_lift_csvs(heavy_lift_dir))
+    if msiv_dir is not None:
+        records.extend(parse_msiv_dir(msiv_dir))
+    logger.info("Combined %d /mnt/ace fleet records", len(records))
+    return records

--- a/tests/unit/vessel_fleet/loaders/test_mnt_ace_fleet_loader.py
+++ b/tests/unit/vessel_fleet/loaders/test_mnt_ace_fleet_loader.py
@@ -1,0 +1,263 @@
+# ABOUTME: Tests for the /mnt/ace fleet loader (heavy-lift CSV snapshots +
+# ABOUTME: MSIV markdown DB ingestion into the vessel-fleet schema, issue #595.
+"""Tests for ``mnt_ace_fleet_loader``.
+
+CI-safe: synthetic CSV/markdown fixtures written to ``tmp_path`` exercise the
+normalisation, reconciliation, and markdown-table parsing. One skip-if-missing
+test runs against the real off-repo data under ``/mnt/ace``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from worldenergydata.vessel_fleet.loaders import mnt_ace_fleet_loader as ld
+
+_HEAVY_LIFT_HEADER = (
+    "contractor,vessel_name,vessel_type,operating_region,loa_ft,beam_ft,"
+    "draft_ft,deck_capacity_t,classification,crane_model,"
+    "primary_lift_capacity_t,primary_lift_radius_ft,secondary_lift_capacity_t,"
+    "secondary_lift_radius_ft,max_hook_height_ft,mooring_system,dp_class,"
+    "notes,needs_review,imo_number,current_owner,current_status,status_year,"
+    "renamed_to,source_url,archival_year"
+)
+
+# 2010 snapshot has only the original (pre-enrichment) columns.
+_HEAVY_LIFT_2010_HEADER = (
+    "contractor,vessel_name,vessel_type,operating_region,loa_ft,beam_ft,"
+    "draft_ft,deck_capacity_t,classification,crane_model,"
+    "primary_lift_capacity_t,primary_lift_radius_ft,secondary_lift_capacity_t,"
+    "secondary_lift_radius_ft,max_hook_height_ft,mooring_system,dp_class,"
+    "notes,needs_review"
+)
+
+_MSIV_MARKDOWN = """# MSIV Vessel Specifications Matrix
+
+> Created: 2025-08-07
+> Project: REDACTED - Confidential Client Research
+
+## Vessel Comparison Matrix
+
+| Vessel Name | Type | LOA (m) | Beam (m) | Draft (m) | Main Crane (MT) | \
+Aux Crane (MT) | DP Class | Accommodation | Shallow Water Rating |
+|---|---|---|---|---|---|---|---|---|---|
+| Sleipnir | Semi-sub | 220 | 102 | 10.5/26 | 2x10,000 | - | DP3 | 400 | \
+Excellent |
+| Seven Borealis | Pipelay | 180 | 32 | 6.5 | 400 | 100 | DP2 | 140 | \
+Excellent |
+| DB-30 | Derrick Barge | 126 | 37 | 3.7 | 1,200 | - | Anchored | 150 | \
+Excellent |
+
+## Regional Availability & Mobilization
+
+| Vessel Name | Primary Region | Estimated Mob Cost (USD) |
+|---|---|---|
+| Sleipnir | North Sea | $1M-4M |
+"""
+
+
+def _write(tmp_path: Path, name: str, header: str, rows: list[str]) -> None:
+    (tmp_path / name).write_text("\n".join([header, *rows]) + "\n", encoding="utf-8")
+
+
+class TestLoadHeavyLiftCsvs:
+    def test_missing_dir_returns_empty(self, tmp_path):
+        assert ld.load_heavy_lift_csvs(tmp_path / "nope") == []
+
+    def test_current_snapshot_normalised(self, tmp_path):
+        _write(
+            tmp_path,
+            ld.HEAVY_LIFT_CURRENT_FILE,
+            _HEAVY_LIFT_HEADER,
+            [
+                "BIGLIFT,HAPPY BUCCANEER,Heavylift,WW,479,93,,,DNV,,675.0,,"
+                "2755.0,,300.0,8 Point,DP2,,False,8300389,BigLift,scrapped,"
+                "2024,,https://x,2010"
+            ],
+        )
+        out = ld.load_heavy_lift_csvs(tmp_path)
+        assert len(out) == 1
+        rec = out[0]
+        assert rec["VESSEL_NAME"] == "HAPPY BUCCANEER"
+        assert rec["VESSEL_CATEGORY"] == "construction"
+        assert rec["VESSEL_TYPE"] == "heavy_lift"
+        assert rec["IMO_NUMBER"] == "8300389"
+        assert rec["DATA_SOURCE"] == ld.DATA_SOURCE_HEAVY_LIFT_CURRENT
+        # COLLECTION_DATE comes from status_year
+        assert rec["COLLECTION_DATE"] == "2024"
+        # ft -> m conversion
+        assert rec["LOA_M"] == round(479 * 0.3048, 1)
+        assert rec["DP_CLASS"] == 2
+        assert rec["MAIN_CRANE_CAPACITY_T"] == 675.0
+
+    def test_current_collection_date_falls_back(self, tmp_path):
+        # status_year blank -> "current"
+        _write(
+            tmp_path,
+            ld.HEAVY_LIFT_CURRENT_FILE,
+            _HEAVY_LIFT_HEADER,
+            [
+                "C,VESSEL X,Heavylift,WW,100,30,,,,,500.0,,,,,,,,False,,Owner,"
+                "active,,,https://z,2010"
+            ],
+        )
+        out = ld.load_heavy_lift_csvs(tmp_path)
+        assert out[0]["COLLECTION_DATE"] == "current"
+
+    def test_legacy_only_vessel_kept_with_2010_provenance(self, tmp_path):
+        _write(
+            tmp_path,
+            ld.HEAVY_LIFT_CURRENT_FILE,
+            _HEAVY_LIFT_HEADER,
+            [
+                "C,CURRENT ONLY,Heavylift,WW,100,30,,,,,500.0,,,,,,,,False,,O,"
+                "active,2024,,https://z,2010"
+            ],
+        )
+        _write(
+            tmp_path,
+            ld.HEAVY_LIFT_2010_FILE,
+            _HEAVY_LIFT_2010_HEADER,
+            ["C,LEGACY ONLY,Stiff Leg,GOM,200,70,14,,ABS,,700.0,,,,,,,,False"],
+        )
+        out = ld.load_heavy_lift_csvs(tmp_path)
+        by_name = {r["VESSEL_NAME"]: r for r in out}
+        assert set(by_name) == {"CURRENT ONLY", "LEGACY ONLY"}
+        assert by_name["LEGACY ONLY"]["DATA_SOURCE"] == (ld.DATA_SOURCE_HEAVY_LIFT_2010)
+        assert by_name["LEGACY ONLY"]["COLLECTION_DATE"] == "2010"
+
+    def test_reconcile_fills_missing_spec_from_2010(self, tmp_path):
+        # Current row has no draft; 2010 row supplies it. Match on name.
+        _write(
+            tmp_path,
+            ld.HEAVY_LIFT_CURRENT_FILE,
+            _HEAVY_LIFT_HEADER,
+            [
+                "C,SHARED,Heavylift,WW,479,93,,,,,675.0,,,,,,,,False,8300389,"
+                "Owner,active,2024,,https://x,2010"
+            ],
+        )
+        _write(
+            tmp_path,
+            ld.HEAVY_LIFT_2010_FILE,
+            _HEAVY_LIFT_2010_HEADER,
+            ["C,SHARED,Heavylift,WW,479,93,20,,ABS,,675.0,,,,,,,,False"],
+        )
+        out = ld.load_heavy_lift_csvs(tmp_path)
+        assert len(out) == 1
+        rec = out[0]
+        # current is authoritative for provenance
+        assert rec["DATA_SOURCE"] == ld.DATA_SOURCE_HEAVY_LIFT_CURRENT
+        # draft filled forward from the 2010 snapshot
+        assert rec["DRAFT_M"] == round(20 * 0.3048, 1)
+        # classification filled forward too
+        assert rec["CLASSIFICATION_SOCIETY"] == "ABS"
+
+
+class TestParseMsivMarkdown:
+    def test_parses_only_spec_matrix(self, tmp_path):
+        path = tmp_path / "vessel-specifications-matrix.md"
+        path.write_text(_MSIV_MARKDOWN, encoding="utf-8")
+        out = ld.parse_msiv_markdown(path)
+        names = {r["VESSEL_NAME"] for r in out}
+        assert names == {"Sleipnir", "Seven Borealis", "DB-30"}
+
+    def test_tags_intervention_msiv(self, tmp_path):
+        path = tmp_path / "matrix.md"
+        path.write_text(_MSIV_MARKDOWN, encoding="utf-8")
+        rec = next(
+            r for r in ld.parse_msiv_markdown(path) if r["VESSEL_NAME"] == "DB-30"
+        )
+        assert rec["VESSEL_CATEGORY"] == "intervention"
+        assert rec["VESSEL_TYPE"] == "msiv"
+
+    def test_specs_and_collection_date(self, tmp_path):
+        path = tmp_path / "matrix.md"
+        path.write_text(_MSIV_MARKDOWN, encoding="utf-8")
+        rec = next(
+            r for r in ld.parse_msiv_markdown(path) if r["VESSEL_NAME"] == "Sleipnir"
+        )
+        assert rec["LOA_M"] == 220.0
+        assert rec["BEAM_M"] == 102.0
+        # "2x10,000" -> per-crane SWL 10000
+        assert rec["MAIN_CRANE_CAPACITY_T"] == 10000.0
+        # draft "10.5/26" -> transit (first)
+        assert rec["DRAFT_M"] == 10.5
+        assert rec["DP_CLASS"] == 3
+        assert rec["QUARTERS_CAPACITY"] == 400
+        # provenance date from the "Created:" header line
+        assert rec["COLLECTION_DATE"] == "2025-08-07"
+
+    def test_no_client_or_project_identifiers_in_output(self, tmp_path):
+        path = tmp_path / "matrix.md"
+        path.write_text(_MSIV_MARKDOWN, encoding="utf-8")
+        blob = repr(ld.parse_msiv_markdown(path)).upper()
+        assert "REDACTED" not in blob
+        assert "CONFIDENTIAL" not in blob
+        assert "PROJECT" not in blob
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert ld.parse_msiv_markdown(tmp_path / "nope.md") == []
+
+    def test_prose_only_markdown_yields_empty(self, tmp_path):
+        path = tmp_path / "prose.md"
+        path.write_text("# Notes\n\nNo tables here.\n", encoding="utf-8")
+        assert ld.parse_msiv_markdown(path) == []
+
+
+class TestParseMsivDir:
+    def test_dedups_across_files(self, tmp_path):
+        (tmp_path / "a.md").write_text(_MSIV_MARKDOWN, encoding="utf-8")
+        (tmp_path / "b.md").write_text(_MSIV_MARKDOWN, encoding="utf-8")
+        out = ld.parse_msiv_dir(tmp_path)
+        names = [r["VESSEL_NAME"] for r in out]
+        assert sorted(names) == ["DB-30", "Seven Borealis", "Sleipnir"]
+
+
+class TestCombine:
+    def test_combines_both_sources(self, tmp_path):
+        hl_dir = tmp_path / "hl"
+        msiv_dir = tmp_path / "msiv"
+        hl_dir.mkdir()
+        msiv_dir.mkdir()
+        _write(
+            hl_dir,
+            ld.HEAVY_LIFT_CURRENT_FILE,
+            _HEAVY_LIFT_HEADER,
+            [
+                "C,VESSEL X,Heavylift,WW,100,30,,,,,500.0,,,,,,,,False,,O,"
+                "active,2024,,https://z,2010"
+            ],
+        )
+        (msiv_dir / "matrix.md").write_text(_MSIV_MARKDOWN, encoding="utf-8")
+        out = ld.combine(heavy_lift_dir=hl_dir, msiv_dir=msiv_dir)
+        cats = {r["VESSEL_CATEGORY"] for r in out}
+        assert cats == {"construction", "intervention"}
+        assert len(out) == 4  # 1 heavy-lift + 3 MSIV
+
+    def test_all_none_returns_empty(self):
+        assert ld.combine() == []
+
+
+# --- Real-data integration (skipped when /mnt/ace is not mounted) -----------
+
+_REAL_HL_DIR = Path("/mnt/ace/frontierdeepwater/data/processed/vessel-fleet")
+_REAL_MSIV_DIR = Path("/mnt/ace/acma-projects/B1535/data/vessels/msiv")
+
+
+@pytest.mark.skipif(
+    not (_REAL_HL_DIR.is_dir() and _REAL_MSIV_DIR.is_dir()),
+    reason="off-repo /mnt/ace fleet data not mounted",
+)
+def test_real_mnt_ace_data_combines():
+    out = ld.combine(heavy_lift_dir=_REAL_HL_DIR, msiv_dir=_REAL_MSIV_DIR)
+    assert out, "expected records from real /mnt/ace fleet data"
+    # every record has the required name + provenance
+    for rec in out:
+        assert rec["VESSEL_NAME"]
+        assert rec["DATA_SOURCE"]
+    cats = {r["VESSEL_CATEGORY"] for r in out}
+    assert "construction" in cats
+    assert "intervention" in cats


### PR DESCRIPTION
Closes #595 (child of epic #591).

## What this does
Adds a new loader `vessel_fleet/loaders/mnt_ace_fleet_loader.py` that ingests two further off-repo `/mnt/ace` fleet datasets into the vessel-fleet schema, by explicit path (no env vars).

### Heavy-lift CSVs (`frontierdeepwater/.../vessel-fleet/`)
- `load_heavy_lift_csvs(dir)` maps `heavy-lift-vessels-2010.csv` and `heavy-lift-vessels-current.csv` into the **construction / heavy_lift** schema.
- Reconciles the two snapshots by vessel name: the **current** snapshot is authoritative; missing spec fields (LOA/beam/draft/crane/class/DP/subtype) are **filled forward** from the 2010 snapshot; vessels present only in 2010 are kept with their 2010 provenance.
- Stamps `DATA_SOURCE` (`mnt_ace_heavy_lift_csv_current` / `_2010`) and `COLLECTION_DATE` (per-row `status_year`, else `"current"`; `"2010"` for the legacy snapshot) on every record.

### MSIV markdown DB (`acma-projects/B1535/.../msiv/*.md`)
- `parse_msiv_markdown(path)` extracts the **vessel comparison matrix** (name + particulars) and tags rows as **intervention / msiv**. `COLLECTION_DATE` is taken from the `Created:` header line.
- `parse_msiv_dir(dir)` globs `*.md` and de-dups by name.
- **Data policy (client-derived source):** only public vessel *particulars* are read. Cost / day-rate / mobilisation / scoring / recommendation tables are never parsed, and no client or project identifiers (e.g. the project code) reach the output — covered by an explicit leakage test.

### combine()
- `combine(heavy_lift_dir=..., msiv_dir=...)` returns one unified record list.

## Row counts (run against `/mnt/ace`)
- `heavy-lift-vessels-2010.csv`: 72 named rows
- `heavy-lift-vessels-current.csv`: 72 named rows
- Reconciled heavy-lift: **72** vessels (all 2010 vessels also present in current)
- MSIV markdown DB: **10** vessels
- Combined: **82** records; no project/client identifier leakage verified

## Tests
- 15 tests in `tests/unit/vessel_fleet/loaders/test_mnt_ace_fleet_loader.py` — all CI-safe synthetic-input (CSV normalize/reconcile, markdown-table parse, no-leak), plus **1 skip-if-missing** real-data test against `/mnt/ace`. All 15 pass locally (real-data test runs here since the share is mounted).

Reuses shared helpers from the existing `frontier_csv_collector` / `acma_msiv_collector` and `parsers.numeric`; no `__init__.py` edits.