### PR TITLE
feat(field-dev): LLM concept-completion — brief to validated concept (#577)

### DIFF
--- a/src/worldenergydata/field_development/__init__.py
+++ b/src/worldenergydata/field_development/__init__.py
@@ -53,6 +53,10 @@ from worldenergydata.field_development.layout import (
     compute_positions,
     render_layout,
 )
+from worldenergydata.field_development.llm_completion import (
+    CompletionResult,
+    complete_concept,
+)
 from worldenergydata.field_development.loader import (
     load_concept,
     load_concept_json,
@@ -138,4 +142,6 @@ __all__ = [
     "backtest_fields",
     "CalibrationReport",
     "build_fdp_html",
+    "complete_concept",
+    "CompletionResult",
 ]

--- a/src/worldenergydata/field_development/llm_completion.py
+++ b/src/worldenergydata/field_development/llm_completion.py
@@ -1,0 +1,144 @@
+# ABOUTME: LLM concept-completion — loose brief → schema+sanity-gated FieldConcept.
+# ABOUTME: Issue #577 (epic #567) — the ONE place hallucination enters; gated hard.
+"""
+worldenergydata.field_development.llm_completion
+================================================
+
+Turn a loose natural-language brief ("32 MMbbl oil, 1,400 m, 18 km from an FPSO
+with spare capacity") into a validated :class:`FieldConcept`.
+
+This is the only non-deterministic surface in the playbook, so it is gated hard:
+
+1. **Schema gate** — the model is called with structured outputs
+   (``client.messages.parse(output_format=FieldConcept)``), so the API can only
+   return JSON that conforms to the frozen ``field_concept`` schema and the SDK
+   validates it into a :class:`FieldConcept` (Pydantic field validators run here).
+2. **Sanity gate** — :func:`sanity_check` then catches cross-field *engineering*
+   inconsistencies the schema can't express (a tieback with no distance, depth
+   outside a host's envelope). Any violations drive a bounded **repair loop**:
+   the violations are handed back to the model for a corrected concept.
+
+Provider: Claude ``claude-opus-4-8`` with adaptive thinking (the engineering
+reasoning — depth→concept, tieback logic — benefits from it). The Anthropic
+client is injectable so the gate/repair logic is testable without a network or
+API key; in real use it is constructed lazily (requires ``anthropic`` +
+``ANTHROPIC_API_KEY``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from worldenergydata.field_development.enums import ConceptType
+from worldenergydata.field_development.models import FieldConcept
+from worldenergydata.field_development.sanity import SanityViolation, sanity_check
+
+DEFAULT_MODEL = "claude-opus-4-8"
+
+_SYSTEM = (
+    "You are an offshore field-development engineer. Given a short brief about an "
+    "offshore field, produce a structured FieldConcept (concept-select / FEL-1 "
+    "fidelity). Fill only what the brief states or what standard engineering "
+    "inference clearly implies; leave anything unstated as null — do NOT invent "
+    "specific numbers (reserves, rates, depths, distances) that aren't given or "
+    "clearly implied.\n"
+    "concept_type must be one of: "
+    + ", ".join(c.value for c in ConceptType)
+    + ". A field produced via a tieback to an existing host is `subsea_tieback` "
+    "(not the host's own type).\n"
+    "Honour these engineering rules so the concept is internally consistent:\n"
+    "- wet-tree (subsea) fields have one subsea tree per well (num_trees == num_wells);\n"
+    "- a `subsea_tieback` requires a positive tieback_distance_km;\n"
+    "- water depth must suit the concept — fixed_jacket <~450 m; TLP ~300–1500 m; "
+    "spar ~600–2450 m; semisub_fps/fpso to ultra-deep; nui only very shallow;\n"
+    "- tree_type must match the host (TLP/Spar = dry; subsea/FPSO = wet).\n"
+    "Gulf of Mexico fields are hurricane-prone (metocean_regime = hurricane_cyclone)."
+)
+
+
+@dataclass
+class CompletionResult:
+    """Outcome of an LLM concept-completion run."""
+
+    concept: FieldConcept
+    violations: list[SanityViolation] = field(default_factory=list)
+    repairs_used: int = 0
+
+    @property
+    def ok(self) -> bool:
+        """True iff the final concept passed the engineering sanity gate."""
+        return not self.violations
+
+
+def _repair_message(violations: list[SanityViolation]) -> str:
+    lines = "\n".join(f"- [{v.code}] {v.message}" for v in violations)
+    return (
+        "The proposed concept has these engineering sanity violations:\n"
+        f"{lines}\n"
+        "Return a corrected FieldConcept that resolves them while staying faithful "
+        "to the original brief. Do not invent numbers that weren't implied."
+    )
+
+
+def _default_client() -> Any:
+    try:
+        import anthropic
+    except ImportError as exc:  # pragma: no cover - depends on env
+        raise RuntimeError(
+            "complete_concept needs the 'anthropic' package and ANTHROPIC_API_KEY "
+            "(or pass an explicit client=...)."
+        ) from exc
+    return anthropic.Anthropic()
+
+
+def complete_concept(
+    brief: str,
+    client: Optional[Any] = None,
+    model: str = DEFAULT_MODEL,
+    max_repairs: int = 2,
+    max_tokens: int = 4096,
+) -> CompletionResult:
+    """Complete a loose brief into a schema- and sanity-validated FieldConcept.
+
+    Args:
+        brief: Natural-language description of the field.
+        client: An Anthropic client (or compatible). Constructed lazily if None.
+        model: Claude model id (default ``claude-opus-4-8``).
+        max_repairs: Max sanity-driven repair turns after the first attempt.
+        max_tokens: Output token cap.
+
+    Returns:
+        A :class:`CompletionResult`. ``result.ok`` is True when the final concept
+        cleared the sanity gate; otherwise ``result.violations`` lists what
+        remained after exhausting repairs.
+    """
+    client = client or _default_client()
+    messages: list[dict] = [{"role": "user", "content": brief}]
+    concept: Optional[FieldConcept] = None
+    violations: list[SanityViolation] = []
+    attempt = 0
+
+    for attempt in range(max_repairs + 1):
+        resp = client.messages.parse(
+            model=model,
+            max_tokens=max_tokens,
+            system=_SYSTEM,
+            messages=messages,
+            output_format=FieldConcept,
+            thinking={"type": "adaptive"},
+        )
+        concept = resp.parsed_output
+        violations = sanity_check(concept)
+        if not violations:
+            break
+        if attempt < max_repairs:
+            messages = messages + [
+                {"role": "assistant", "content": concept.model_dump_json()},
+                {"role": "user", "content": _repair_message(violations)},
+            ]
+
+    assert concept is not None  # the loop runs at least once
+    return CompletionResult(
+        concept=concept, violations=violations, repairs_used=attempt
+    )

--- a/tests/modules/field_development/test_llm_completion.py
+++ b/tests/modules/field_development/test_llm_completion.py
@@ -1,0 +1,114 @@
+# ABOUTME: Tests for LLM concept-completion gate + repair loop (issue #577).
+# ABOUTME: Uses a fake injected client — no network / API key needed.
+"""Tests for ``worldenergydata.field_development.llm_completion``.
+
+The Anthropic client is dependency-injected, so these exercise the schema/sanity
+gate and the repair loop deterministically with canned FieldConcept outputs.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from worldenergydata.field_development import (
+    CompletionResult,
+    ConceptType,
+    FieldConcept,
+    complete_concept,
+)
+from worldenergydata.field_development.enums import TreeType
+
+
+class _FakeMessages:
+    """Returns the next canned FieldConcept on each .parse() call."""
+
+    def __init__(self, outputs):
+        self._outputs = list(outputs)
+        self.calls = []
+
+    def parse(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(parsed_output=self._outputs.pop(0))
+
+
+class _FakeClient:
+    def __init__(self, outputs):
+        self.messages = _FakeMessages(outputs)
+
+
+def _clean():
+    return FieldConcept(
+        name="Demo",
+        concept_type=ConceptType.SPAR,
+        tree_type=TreeType.DRY,
+        water_depth_m=2000.0,
+    )
+
+
+def _bad_tieback():
+    # subsea_tieback with no distance → tieback_missing_distance violation
+    return FieldConcept(name="Demo", concept_type=ConceptType.SUBSEA_TIEBACK)
+
+
+# --------------------------------------------------------------------------- #
+def test_clean_concept_first_try():
+    client = _FakeClient([_clean()])
+    result = complete_concept("a deepwater spar field", client=client)
+    assert isinstance(result, CompletionResult)
+    assert result.ok is True
+    assert result.repairs_used == 0
+    assert len(client.messages.calls) == 1
+
+
+def test_repairs_then_succeeds():
+    client = _FakeClient([_bad_tieback(), _clean()])
+    result = complete_concept("a tieback", client=client, max_repairs=2)
+    assert result.ok is True
+    assert result.repairs_used == 1
+    assert len(client.messages.calls) == 2
+
+
+def test_repair_message_carries_violation():
+    client = _FakeClient([_bad_tieback(), _clean()])
+    complete_concept("a tieback", client=client)
+    # The 2nd call's last user message should reference the violation.
+    second_msgs = client.messages.calls[1]["messages"]
+    last_user = second_msgs[-1]["content"]
+    assert "tieback_missing_distance" in last_user
+
+
+def test_exhausts_repairs_returns_violations():
+    # Always invalid → never clears the gate.
+    client = _FakeClient([_bad_tieback(), _bad_tieback(), _bad_tieback()])
+    result = complete_concept("a tieback", client=client, max_repairs=2)
+    assert result.ok is False
+    assert any(v.code == "tieback_missing_distance" for v in result.violations)
+    assert result.repairs_used == 2
+    assert len(client.messages.calls) == 3  # initial + 2 repairs
+
+
+def test_uses_structured_output_and_model():
+    client = _FakeClient([_clean()])
+    complete_concept("x", client=client, model="claude-opus-4-8")
+    kw = client.messages.calls[0]
+    assert kw["model"] == "claude-opus-4-8"
+    assert kw["output_format"] is FieldConcept  # schema gate
+    assert kw["thinking"] == {"type": "adaptive"}
+
+
+def test_missing_anthropic_raises_helpful_error(monkeypatch):
+    # With no client and anthropic unimportable, raise a clear error.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name == "anthropic":
+            raise ImportError("no anthropic")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(RuntimeError, match="anthropic"):
+        complete_concept("x")  # client=None → tries to construct default


### PR DESCRIPTION
## Phase 2 — LLM concept-completion (#577, epic #567)

Turns a loose natural-language brief ("32 MMbbl oil, 1,400 m, 18 km from an FPSO with spare capacity") into a validated `FieldConcept`. This is the **only non-deterministic surface** in the playbook, so it's gated hard — the design spine the whole epic was built around.

### Two gates + a repair loop
1. **Schema gate** — `client.messages.parse(output_format=FieldConcept)` on `claude-opus-4-8` with adaptive thinking. Structured outputs make the API return JSON that conforms to the frozen `field_concept` schema; the SDK validates it into a `FieldConcept` (Pydantic field validators run here).
2. **Sanity gate** — `sanity_check()` then catches cross-field *engineering* inconsistencies the schema can't express (a tieback with no distance, depth outside a host's envelope).
3. **Repair loop** — any violations are handed back to the model for a corrected concept (bounded by `max_repairs`); `CompletionResult.ok` reflects the final gate.

### Notes
- Engineering-grounded system prompt: concept vocabulary, the field-vs-host tieback rule, depth envelopes, dry/wet tree consistency, GoM hurricane regime, and an explicit "null for unknowns — don't invent numbers."
- The Anthropic client is **injectable**, so the gate + repair logic is unit-tested with a fake client (no network, no API key). Real use lazily constructs `anthropic.Anthropic()` (needs `anthropic` + `ANTHROPIC_API_KEY`).
- Follows the loaded `claude-api` reference: `claude-opus-4-8`, adaptive thinking, structured outputs via `output_format`.

### Tests
6 new tests (clean-first-try, repairs-then-succeeds, repair-message-carries-violation, exhausts-repairs, structured-output-wiring, missing-anthropic error). **125 field_development tests pass.**

Epic #567: this is the first Phase-2 item. Remaining: #578 DEXPI interop, #579 layout optimization, #580 equipment-3D.
