### PR TITLE
feat(vessel): OSV/MPSV + intervention vendor fleet roster (#593)

### DIFF
--- a/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/config/intervention/__init__.py
+++ b/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/config/intervention/__init__.py
@@ -1,0 +1,1 @@
+"""Intervention / OSV / MPSV vendor fleet configuration (#593)."""

--- a/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/config/intervention/akofs.py
+++ b/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/config/intervention/akofs.py
@@ -1,0 +1,58 @@
+"""AKOFS Offshore intervention fleet collection config (#593).
+
+AKOFS Offshore's site names its three subsea well-intervention units; the
+detailed specs (depth rating, DP3, year, IMO) come from the DNV vessel
+register and Petrobras/Equinor contract news. None are GoM-resident.
+"""
+
+from worldenergydata.vessel_fleet.collectors.fleet_page_collector import (
+    ContractorConfig,
+)
+
+CONFIG = ContractorConfig(
+    name="akofs",
+    fleet_url="https://www.akofsoffshore.com/",
+    vessel_category="intervention_vessel",
+    vessel_type="mpsv",
+    owner="AKOFS Offshore",
+    table_selector="table",
+    detail_selector="div.vessel",
+    field_mapping={
+        "Name": "VESSEL_NAME",
+        "Vessel": "VESSEL_NAME",
+        "Type": "VESSEL_SUBTYPE",
+        "Water Depth": "WATER_DEPTH_RATING_M",
+        "Year Built": "YEAR_BUILT",
+        "DP": "DP_CLASS",
+        "Length": "LOA_M",
+    },
+    rate_limit=1.0,
+)
+
+KNOWN_VESSELS = [
+    {
+        "VESSEL_NAME": "AKOFS Seafarer",
+        "VESSEL_SUBTYPE": "mpsv",
+        "WATER_DEPTH_RATING_M": 2500.0,
+        "DP_CLASS": 3,
+        "YEAR_BUILT": 2010,
+        "LOA_M": 157.0,
+        "GOM_RESIDENT": False,
+    },
+    {
+        "VESSEL_NAME": "AKOFS Santos",
+        "VESSEL_SUBTYPE": "mpsv",
+        "WATER_DEPTH_RATING_M": 3000.0,
+        "DP_CLASS": 3,
+        "YEAR_BUILT": 2009,
+        "LOA_M": 121.0,
+        "GOM_RESIDENT": False,
+    },
+    {
+        "VESSEL_NAME": "Aker Wayfarer",
+        "VESSEL_SUBTYPE": "construction",
+        "WATER_DEPTH_RATING_M": 3000.0,
+        "LOA_M": 157.0,
+        "GOM_RESIDENT": False,
+    },
+]

--- a/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/config/intervention/c_innovation.py
+++ b/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/config/intervention/c_innovation.py
@@ -1,0 +1,57 @@
+"""C-Innovation / Edison Chouest Offshore intervention fleet config (#593).
+
+C-Innovation (Edison Chouest Offshore subsea arm) operates Jones-Act
+RLWI/IMR MPSVs in the US Gulf of Mexico. The brochure PDF at
+c-innovation.com returns unparseable binary, so ``KNOWN_VESSELS`` seeds the
+named GoM-resident units from Ulstein shipyard reference pages and news.
+"""
+
+from worldenergydata.vessel_fleet.collectors.fleet_page_collector import (
+    ContractorConfig,
+)
+
+CONFIG = ContractorConfig(
+    name="c_innovation",
+    fleet_url="https://c-innovation.com/vessel-services/",
+    vessel_category="intervention_vessel",
+    vessel_type="mpsv",
+    owner="C-Innovation / Edison Chouest Offshore",
+    table_selector="table",
+    detail_selector="div.vessel-specs",
+    field_mapping={
+        "Name": "VESSEL_NAME",
+        "Vessel": "VESSEL_NAME",
+        "Type": "VESSEL_SUBTYPE",
+        "Water Depth": "WATER_DEPTH_RATING_M",
+        "Year Built": "YEAR_BUILT",
+        "DP": "DP_CLASS",
+        "Length": "LOA_M",
+    },
+    rate_limit=1.0,
+)
+
+KNOWN_VESSELS = [
+    {
+        "VESSEL_NAME": "Island Venture",
+        "VESSEL_SUBTYPE": "mpsv",
+        "DP_CLASS": 3,
+        "YEAR_BUILT": 2017,
+        "LOA_M": 160.0,
+        "GOM_RESIDENT": True,
+    },
+    {
+        "VESSEL_NAME": "Island Performer",
+        "VESSEL_SUBTYPE": "mpsv",
+        "DP_CLASS": 3,
+        "YEAR_BUILT": 2014,
+        "LOA_M": 130.0,
+        "GOM_RESIDENT": True,
+    },
+    {
+        "VESSEL_NAME": "Island Intervention",
+        "VESSEL_SUBTYPE": "mpsv",
+        "DP_CLASS": 3,
+        "LOA_M": 120.2,
+        "GOM_RESIDENT": True,
+    },
+]

--- a/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/config/intervention/dof.py
+++ b/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/config/intervention/dof.py
@@ -1,0 +1,66 @@
+"""DOF Group intervention / construction fleet collection config (#593).
+
+DOF maintains per-vessel fleet pages at dof.com/fleet/<vessel> with
+type/depth/year. The Skandi units cover deepwater construction, flexlay and
+light well intervention / IMR. None are documented as GoM-resident.
+"""
+
+from worldenergydata.vessel_fleet.collectors.fleet_page_collector import (
+    ContractorConfig,
+)
+
+CONFIG = ContractorConfig(
+    name="dof",
+    fleet_url="https://www.dof.com/fleet",
+    vessel_category="intervention_vessel",
+    vessel_type="mpsv",
+    owner="DOF Group",
+    table_selector="table",
+    detail_selector="div.vessel-specs",
+    vessel_links_selector="a[href*='/fleet/']",
+    field_mapping={
+        "Name": "VESSEL_NAME",
+        "Vessel": "VESSEL_NAME",
+        "Type": "VESSEL_SUBTYPE",
+        "Water Depth": "WATER_DEPTH_RATING_M",
+        "Year Built": "YEAR_BUILT",
+        "DP": "DP_CLASS",
+        "Length": "LOA_M",
+    },
+    rate_limit=1.0,
+)
+
+KNOWN_VESSELS = [
+    {
+        "VESSEL_NAME": "Skandi Africa",
+        "VESSEL_SUBTYPE": "construction",
+        "WATER_DEPTH_RATING_M": 3000.0,
+        "DP_CLASS": 3,
+        "YEAR_BUILT": 2015,
+        "LOA_M": 160.9,
+        "GOM_RESIDENT": False,
+    },
+    {
+        "VESSEL_NAME": "Skandi Acergy",
+        "VESSEL_SUBTYPE": "construction",
+        "WATER_DEPTH_RATING_M": 3000.0,
+        "DP_CLASS": 3,
+        "YEAR_BUILT": 2008,
+        "LOA_M": 156.9,
+        "GOM_RESIDENT": False,
+    },
+    {
+        "VESSEL_NAME": "Skandi Constructor",
+        "VESSEL_SUBTYPE": "mpsv",
+        "YEAR_BUILT": 2009,
+        "LOA_M": 120.2,
+        "GOM_RESIDENT": False,
+    },
+    {
+        "VESSEL_NAME": "Skandi Vinland",
+        "VESSEL_SUBTYPE": "mpsv",
+        "WATER_DEPTH_RATING_M": 4000.0,
+        "YEAR_BUILT": 2017,
+        "GOM_RESIDENT": False,
+    },
+]

--- a/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/config/intervention/helix.py
+++ b/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/config/intervention/helix.py
@@ -1,0 +1,92 @@
+"""Helix Energy Solutions intervention fleet collection config (#593).
+
+Helix publishes per-vessel asset pages under https://helixesg.com/our-assets/.
+The correct public domain is ``helixesg.com`` (``helixenergy.com`` does not
+resolve). Each asset page is a key-value detail page rather than a single
+fleet table, so ``detail_selector`` is provided for future per-asset runs.
+"""
+
+from worldenergydata.vessel_fleet.collectors.fleet_page_collector import (
+    ContractorConfig,
+)
+
+CONFIG = ContractorConfig(
+    name="helix",
+    fleet_url="https://helixesg.com/our-assets/",
+    vessel_category="intervention_vessel",
+    vessel_type="heavy_intervention_semi",
+    owner="Helix Energy Solutions",
+    table_selector="table",
+    detail_selector="div.asset-specs",
+    vessel_links_selector="a[href*='/our-assets/']",
+    field_mapping={
+        "Name": "VESSEL_NAME",
+        "Vessel": "VESSEL_NAME",
+        "Type": "VESSEL_SUBTYPE",
+        "Water Depth": "WATER_DEPTH_RATING_M",
+        "Year Built": "YEAR_BUILT",
+        "Built": "YEAR_BUILT",
+        "DP": "DP_CLASS",
+        "Length": "LOA_M",
+        "Beam": "BEAM_M",
+    },
+    rate_limit=0.5,
+)
+
+KNOWN_VESSELS = [
+    {
+        "VESSEL_NAME": "Q4000",
+        "VESSEL_SUBTYPE": "heavy_intervention_semi",
+        "WATER_DEPTH_RATING_M": 3000.0,
+        "DP_CLASS": 3,
+        "YEAR_BUILT": 2002,
+        "GOM_RESIDENT": True,
+    },
+    {
+        "VESSEL_NAME": "Q5000",
+        "VESSEL_SUBTYPE": "heavy_intervention_semi",
+        "WATER_DEPTH_RATING_M": 3000.0,
+        "DP_CLASS": 3,
+        "YEAR_BUILT": 2015,
+        "GOM_RESIDENT": True,
+    },
+    {
+        "VESSEL_NAME": "Q7000",
+        "VESSEL_SUBTYPE": "heavy_intervention_semi",
+        "WATER_DEPTH_RATING_M": 3000.0,
+        "DP_CLASS": 3,
+        "YEAR_BUILT": 2019,
+        "GOM_RESIDENT": False,
+    },
+    {
+        "VESSEL_NAME": "Seawell",
+        "VESSEL_SUBTYPE": "rlwi_monohull",
+        "WATER_DEPTH_RATING_M": 500.0,
+        "DP_CLASS": 2,
+        "YEAR_BUILT": 1987,
+        "GOM_RESIDENT": False,
+    },
+    {
+        "VESSEL_NAME": "Well Enhancer",
+        "VESSEL_SUBTYPE": "rlwi_monohull",
+        "WATER_DEPTH_RATING_M": 300.0,
+        "YEAR_BUILT": 2009,
+        "GOM_RESIDENT": False,
+    },
+    {
+        "VESSEL_NAME": "Siem Helix 1",
+        "VESSEL_SUBTYPE": "rlwi_monohull",
+        "WATER_DEPTH_RATING_M": 3000.0,
+        "DP_CLASS": 3,
+        "YEAR_BUILT": 2016,
+        "GOM_RESIDENT": False,
+    },
+    {
+        "VESSEL_NAME": "Siem Helix 2",
+        "VESSEL_SUBTYPE": "rlwi_monohull",
+        "WATER_DEPTH_RATING_M": 3000.0,
+        "DP_CLASS": 3,
+        "YEAR_BUILT": 2016,
+        "GOM_RESIDENT": False,
+    },
+]

--- a/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/config/intervention/island_offshore.py
+++ b/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/config/intervention/island_offshore.py
@@ -1,0 +1,58 @@
+"""Island Offshore / TIOS intervention fleet collection config (#593).
+
+Island Offshore's own fleet page (islandoffshore.com/fleet) is JS-driven and
+exposes only one vessel name to a static fetch; TIOS (Island Offshore +
+TechnipFMC JV, tiosgroup.com) lists RLWI monohulls but hides per-vessel specs
+behind JS. ``KNOWN_VESSELS`` seeds the named units from public references
+(Ulstein shipyard pages, ship-technology) since the operator pages are thin.
+"""
+
+from worldenergydata.vessel_fleet.collectors.fleet_page_collector import (
+    ContractorConfig,
+)
+
+CONFIG = ContractorConfig(
+    name="island_offshore",
+    fleet_url="https://www.islandoffshore.com/fleet",
+    vessel_category="intervention_vessel",
+    vessel_type="rlwi_monohull",
+    owner="Island Offshore / TIOS",
+    table_selector="table",
+    detail_selector="div.vessel-specs",
+    vessel_links_selector="a[href*='/fleet']",
+    field_mapping={
+        "Name": "VESSEL_NAME",
+        "Vessel": "VESSEL_NAME",
+        "Type": "VESSEL_SUBTYPE",
+        "Water Depth": "WATER_DEPTH_RATING_M",
+        "Year Built": "YEAR_BUILT",
+        "DP": "DP_CLASS",
+        "Length": "LOA_M",
+    },
+    rate_limit=1.0,
+)
+
+KNOWN_VESSELS = [
+    {
+        "VESSEL_NAME": "Island Constructor",
+        "VESSEL_SUBTYPE": "rlwi_monohull",
+        "WATER_DEPTH_RATING_M": 600.0,
+        "DP_CLASS": 3,
+        "GOM_RESIDENT": False,
+    },
+    {
+        "VESSEL_NAME": "Island Wellserver",
+        "VESSEL_SUBTYPE": "rlwi_monohull",
+        "GOM_RESIDENT": False,
+    },
+    {
+        "VESSEL_NAME": "Island Frontier",
+        "VESSEL_SUBTYPE": "rlwi_monohull",
+        "GOM_RESIDENT": False,
+    },
+    {
+        "VESSEL_NAME": "Vanguard",
+        "VESSEL_SUBTYPE": "osv",
+        "GOM_RESIDENT": False,
+    },
+]

--- a/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/config/intervention/oceaneering.py
+++ b/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/config/intervention/oceaneering.py
@@ -1,0 +1,95 @@
+"""Oceaneering International intervention/MSV fleet collection config (#593).
+
+Oceaneering's vessel-fleet page renders a list of named multi-service
+vessels (MSVs) with length/flag and partial DP class. Several specs
+(year_built, water-depth rating) are not exposed and are left null.
+"""
+
+from worldenergydata.vessel_fleet.collectors.fleet_page_collector import (
+    ContractorConfig,
+)
+
+CONFIG = ContractorConfig(
+    name="oceaneering",
+    fleet_url="https://www.oceaneering.com/subsea-projects/vessel-fleet/",
+    vessel_category="intervention_vessel",
+    vessel_type="mpsv",
+    owner="Oceaneering International",
+    table_selector="table",
+    detail_selector="div.vessel-card",
+    field_mapping={
+        "Name": "VESSEL_NAME",
+        "Vessel": "VESSEL_NAME",
+        "Type": "VESSEL_SUBTYPE",
+        "Length": "LOA_FT",
+        "DP": "DP_CLASS",
+        "Flag": "FLAG",
+        "Water Depth": "WATER_DEPTH_RATING_M",
+    },
+    rate_limit=1.0,
+)
+
+KNOWN_VESSELS = [
+    {
+        "VESSEL_NAME": "Ocean Evolution",
+        "VESSEL_SUBTYPE": "mpsv",
+        "WATER_DEPTH_RATING_M": 4000.0,
+        "DP_CLASS": 2,
+        "YEAR_BUILT": 2019,
+        "LOA_FT": 353.0,
+        "FLAG": "US",
+        "GOM_RESIDENT": True,
+    },
+    {
+        "VESSEL_NAME": "Blue Sea",
+        "VESSEL_SUBTYPE": "mpsv",
+        "LOA_FT": 340.0,
+        "FLAG": "US",
+        "GOM_RESIDENT": True,
+    },
+    {
+        "VESSEL_NAME": "Normand Superior",
+        "VESSEL_SUBTYPE": "mpsv",
+        "DP_CLASS": 2,
+        "LOA_FT": 322.0,
+        "FLAG": "Norway",
+        "GOM_RESIDENT": False,
+    },
+    {
+        "VESSEL_NAME": "Juanita Candies",
+        "VESSEL_SUBTYPE": "mpsv",
+        "DP_CLASS": 2,
+        "LOA_FT": 302.0,
+        "FLAG": "US",
+        "GOM_RESIDENT": True,
+    },
+    {
+        "VESSEL_NAME": "Intervention",
+        "VESSEL_SUBTYPE": "mpsv",
+        "LOA_FT": 300.0,
+        "FLAG": "US",
+        "GOM_RESIDENT": True,
+    },
+    {
+        "VESSEL_NAME": "Brandon Bordelon",
+        "VESSEL_SUBTYPE": "mpsv",
+        "LOA_FT": 257.0,
+        "FLAG": "US",
+        "GOM_RESIDENT": True,
+    },
+    {
+        "VESSEL_NAME": "Ocean Intervention II",
+        "VESSEL_SUBTYPE": "mpsv",
+        "DP_CLASS": 2,
+        "LOA_FT": 254.0,
+        "GOM_RESIDENT": True,
+    },
+    {
+        "VESSEL_NAME": "Ocean Intervention",
+        "VESSEL_SUBTYPE": "mpsv",
+        "DP_CLASS": 2,
+        "LOA_FT": 243.0,
+        "FLAG": "US",
+        "GOM_RESIDENT": True,
+    },
+]

--- a/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/data/intervention_osv_roster.yml
+++ b/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/data/intervention_osv_roster.yml
@@ -1,0 +1,362 @@
+# OSV / MPSV + subsea-intervention vendor fleet roster -- named-unit roster (#593).
+#
+# A 29-vessel roster across the 6 requested intervention/OSV vendors
+# (Helix, Island Offshore/TIOS, C-Innovation/Edison Chouest, Oceaneering,
+# AKOFS, DOF). This is aggregate/named-unit REFERENCE data compiled from
+# public vendor asset pages, shipyard reference pages, classification-society
+# registers and contract news -- safe to commit.
+#
+# Rules:
+#   - Unknown specs are left null. They are NEVER guessed.
+#   - gom_resident is true ONLY where a public source ties the vessel to GoM
+#     operations; false where a non-GoM region is documented; null where the
+#     operating region is unclear.
+#   - vessel_type maps onto the asset-class enum used by fleet_catalog:
+#       heavy_intervention_semi -> Helix Q-series semis
+#       rlwi_monohull           -> light/riser-based monohull intervention
+#       mpsv                    -> multi-purpose service vessel (RLWI/IMR)
+#       osv                     -> offshore support vessel (type unconfirmed)
+#       construction            -> subsea construction / SESV / flexlay
+#
+# Confidence:
+#   vendor_spec  -> from the operator's own asset/fleet page
+#   reference    -> from shipyard (Ulstein/Vard) or trade-press spec pages
+#   register     -> from a classification-society / vessel register + news
+
+provenance:
+  source: "public vendor asset pages + shipyard reference pages + class registers + contract news"
+  confidence: medium-high
+  compiled_for: "worldenergydata #593 (child of epic #591)"
+  notes: >-
+    Water-depth ratings are nameplate figures and approximate. Helix's correct
+    public domain is helixesg.com (helixenergy.com does not resolve). Island
+    Offshore and TIOS operator fleet pages are JS-driven and expose few specs,
+    so the TIOS monohull names and C-Innovation operatorship came from news and
+    Ulstein references rather than the operators' own roster pages. De-dup
+    against IMO-keyed curated rows is deferred to #599.
+
+vessels:
+  # --- Helix Energy Solutions (helixesg.com) ---------------------------
+  - vessel_name: Q4000
+    owner: Helix Energy Solutions
+    vessel_type: heavy_intervention_semi
+    water_depth_rating_m: 3000
+    dp_class: DP3
+    year_built: 2002
+    gom_resident: true
+    confidence: vendor_spec
+    source_url: https://helixesg.com/our-assets/q4000/
+    notes: "Entered GoM service 2002; built Keppel AmFELS Brownsville TX; subsea well intervention + construction to 10,000 ft."
+
+  - vessel_name: Q5000
+    owner: Helix Energy Solutions
+    vessel_type: heavy_intervention_semi
+    water_depth_rating_m: 3000
+    dp_class: DP3
+    year_built: 2015
+    gom_resident: true
+    confidence: vendor_spec
+    source_url: https://helixesg.com/our-assets/q5000/
+    notes: "Sister ship of Q4000; multiservice DP3 semisub; GoM operations."
+
+  - vessel_name: Q7000
+    owner: Helix Energy Solutions
+    vessel_type: heavy_intervention_semi
+    water_depth_rating_m: 3000
+    dp_class: DP3
+    year_built: 2019
+    gom_resident: false
+    confidence: vendor_spec
+    source_url: https://helixesg.com/our-assets/q7000/
+    notes: "Riser-based intervention 85m-3000m; West Africa, Australasia, North Sea; not GoM-resident."
+
+  - vessel_name: Seawell
+    owner: Helix Energy Solutions
+    vessel_type: rlwi_monohull
+    water_depth_rating_m: 500
+    dp_class: DP2
+    year_built: 1987
+    gom_resident: false
+    confidence: vendor_spec
+    source_url: https://helixesg.com/our-assets/seawell/
+    notes: "Light well intervention + saturation diving monohull; UKCS/North Sea; 500m SIL deployment."
+
+  - vessel_name: Well Enhancer
+    owner: Helix Energy Solutions
+    vessel_type: rlwi_monohull
+    water_depth_rating_m: 300
+    dp_class: null
+    year_built: 2009
+    gom_resident: false
+    confidence: vendor_spec
+    source_url: https://helixesg.com/our-assets/well-enhancer/
+    notes: "World's first monohull capable of coiled-tubing intervention; North Sea; sat-diving to 300m. DP class not stated on public page."
+
+  - vessel_name: Siem Helix 1
+    owner: Helix Energy Solutions (chartered, Siem Offshore-owned)
+    vessel_type: rlwi_monohull
+    water_depth_rating_m: 3000
+    dp_class: DP3
+    year_built: 2016
+    gom_resident: false
+    confidence: vendor_spec
+    source_url: https://helixesg.com/our-assets/siem-helix-1/
+    notes: "Riser-based monohull intervention; Kongsberg K-Pos class III DP; 158m; Petrobras Brazil (Santos/Campos)."
+
+  - vessel_name: Siem Helix 2
+    owner: Helix Energy Solutions (chartered, Siem Offshore-owned)
+    vessel_type: rlwi_monohull
+    water_depth_rating_m: 3000
+    dp_class: DP3
+    year_built: 2016
+    gom_resident: false
+    confidence: vendor_spec
+    source_url: https://www.helixesg.com/downloads/Helix_Well_Ops_-_Siem_Helix_2-LTR-01.17.2020-FINAL_.pdf
+    notes: "Riser-based monohull intervention; 158m; Petrobras Brazil since 2017, 100+ interventions."
+
+  # --- Island Offshore / TIOS ------------------------------------------
+  - vessel_name: Island Constructor
+    owner: Island Offshore / TIOS (Island Offshore + TechnipFMC JV)
+    vessel_type: rlwi_monohull
+    water_depth_rating_m: 600
+    dp_class: DP3
+    year_built: null
+    gom_resident: false
+    confidence: reference
+    source_url: https://ulstein.com/references/island-constructor
+    notes: "IMO Class 3 DP; LWI + subsea construction + IMR + heave-compensated module-handling tower; North Sea TIOS operations."
+
+  - vessel_name: Island Wellserver
+    owner: Island Offshore / TIOS
+    vessel_type: rlwi_monohull
+    water_depth_rating_m: null
+    dp_class: null
+    year_built: null
+    gom_resident: false
+    confidence: reference
+    source_url: https://tiosgroup.com/en/vessel-info
+    notes: "TIOS RLWI vessel using TechnipFMC well-access systems; North Sea. Specs not on public TIOS page (JS-heavy)."
+
+  - vessel_name: Island Frontier
+    owner: Island Offshore / TIOS
+    vessel_type: rlwi_monohull
+    water_depth_rating_m: null
+    dp_class: null
+    year_built: null
+    gom_resident: false
+    confidence: reference
+    source_url: https://tiosgroup.com/en/vessel-info
+    notes: "TIOS RLWI vessel; North Sea. Detailed specs not exposed on public page."
+
+  - vessel_name: Vanguard
+    owner: Island Offshore
+    vessel_type: osv
+    water_depth_rating_m: null
+    dp_class: null
+    year_built: null
+    gom_resident: null
+    confidence: reference
+    source_url: https://www.islandoffshore.com/fleet
+    notes: "Only individually-named vessel rendered on Island Offshore public fleet page; type not stated (JS-driven page). Classified osv provisionally."
+
+  # --- C-Innovation / Edison Chouest Offshore --------------------------
+  - vessel_name: Island Venture
+    owner: C-Innovation / Edison Chouest Offshore (Island Ventures 5 LLC JV w/ Island Offshore)
+    vessel_type: mpsv
+    water_depth_rating_m: null
+    dp_class: DP3
+    year_built: 2017
+    gom_resident: true
+    confidence: reference
+    source_url: https://ulstein.com/references/island-venture
+    notes: "Ulstein SX165; 160m/524ft; RLWI for BP deepwater GoM; delivered 17 Jan 2017."
+
+  - vessel_name: Island Performer
+    owner: C-Innovation / Edison Chouest Offshore
+    vessel_type: mpsv
+    water_depth_rating_m: null
+    dp_class: DP3
+    year_built: 2014
+    gom_resident: true
+    confidence: reference
+    source_url: https://ulstein.com/references/island-performer
+    notes: "Ulstein SX121; 130m; DYNPOS AUTRO (DP3-equivalent); RLWI/IMR in GoM; delivered 8 Jul 2014."
+
+  - vessel_name: Island Intervention
+    owner: C-Innovation / Edison Chouest Offshore
+    vessel_type: mpsv
+    water_depth_rating_m: null
+    dp_class: DP3
+    year_built: null
+    gom_resident: true
+    confidence: reference
+    source_url: https://www.ship-technology.com/projects/island-intervention-multi-purpose-offshore-vessel/
+    notes: "120.2m MPSV w/ module-handling tower, moonpool, ROV hangar; operated by C-Innovation in GoM."
+
+  # --- Oceaneering International ----------------------------------------
+  - vessel_name: Ocean Evolution
+    owner: Oceaneering International
+    vessel_type: mpsv
+    water_depth_rating_m: 4000
+    dp_class: DP2
+    year_built: 2019
+    gom_resident: true
+    confidence: vendor_spec
+    source_url: https://www.oceaneering.com/subsea-projects/vessel-fleet/
+    notes: "353ft US-flagged Jones Act MSV; 250mT AHC crane to 4000m; well-stim/intervention ABS notation; GoM."
+
+  - vessel_name: Blue Sea
+    owner: Oceaneering International
+    vessel_type: mpsv
+    water_depth_rating_m: null
+    dp_class: null
+    year_built: null
+    gom_resident: true
+    confidence: vendor_spec
+    source_url: https://www.oceaneering.com/subsea-projects/vessel-fleet/
+    notes: "340ft US-flagged MSV."
+
+  - vessel_name: Normand Superior
+    owner: Oceaneering International (chartered)
+    vessel_type: mpsv
+    water_depth_rating_m: null
+    dp_class: DP2
+    year_built: null
+    gom_resident: false
+    confidence: vendor_spec
+    source_url: https://www.oceaneering.com/subsea-projects/vessel-fleet/
+    notes: "322ft Norwegian-flagged MSV, DP2."
+
+  - vessel_name: Juanita Candies
+    owner: Oceaneering International (chartered)
+    vessel_type: mpsv
+    water_depth_rating_m: null
+    dp_class: DP2
+    year_built: null
+    gom_resident: true
+    confidence: vendor_spec
+    source_url: https://www.oceaneering.com/subsea-projects/vessel-fleet/
+    notes: "302ft US-flagged MSV, DP2."
+
+  - vessel_name: Intervention
+    owner: Oceaneering International
+    vessel_type: mpsv
+    water_depth_rating_m: null
+    dp_class: null
+    year_built: null
+    gom_resident: true
+    confidence: vendor_spec
+    source_url: https://www.oceaneering.com/subsea-projects/vessel-fleet/
+    notes: "300ft US-flagged MSV."
+
+  - vessel_name: Brandon Bordelon
+    owner: Oceaneering International (chartered)
+    vessel_type: mpsv
+    water_depth_rating_m: null
+    dp_class: null
+    year_built: null
+    gom_resident: true
+    confidence: vendor_spec
+    source_url: https://www.oceaneering.com/subsea-projects/vessel-fleet/
+    notes: "257ft US-flagged MSV."
+
+  - vessel_name: Ocean Intervention II
+    owner: Oceaneering International
+    vessel_type: mpsv
+    water_depth_rating_m: null
+    dp_class: DP2
+    year_built: null
+    gom_resident: true
+    confidence: vendor_spec
+    source_url: https://www.oceaneering.com/subsea-projects/vessel-fleet/
+    notes: "254ft, DP2; listed as research/MSV on Oceaneering fleet page."
+
+  - vessel_name: Ocean Intervention
+    owner: Oceaneering International
+    vessel_type: mpsv
+    water_depth_rating_m: null
+    dp_class: DP2
+    year_built: null
+    gom_resident: true
+    confidence: vendor_spec
+    source_url: https://www.oceaneering.com/subsea-projects/vessel-fleet/
+    notes: "243ft US-flagged MSV, DP2."
+
+  # --- AKOFS Offshore --------------------------------------------------
+  - vessel_name: AKOFS Seafarer
+    owner: AKOFS Offshore
+    vessel_type: mpsv
+    water_depth_rating_m: 2500
+    dp_class: DP3
+    year_built: 2010
+    gom_resident: false
+    confidence: register
+    source_url: https://www.akofsoffshore.com/
+    notes: "Ex-Skandi Aker; 157m monohull subsea well intervention (riser intervention to 2500m); Vard-built; Equinor NCS contract to Q4 2028."
+
+  - vessel_name: AKOFS Santos
+    owner: AKOFS Offshore
+    vessel_type: mpsv
+    water_depth_rating_m: 3000
+    dp_class: DP3
+    year_built: 2009
+    gom_resident: false
+    confidence: register
+    source_url: https://www.akofsoffshore.com/
+    notes: "121m, STX OSCV 03L design; well intervention to 3000m; Petrobras Brazil ($246M contract 2025)."
+
+  - vessel_name: Aker Wayfarer
+    owner: AKOFS Offshore
+    vessel_type: construction
+    water_depth_rating_m: 3000
+    dp_class: null
+    year_built: null
+    gom_resident: false
+    confidence: register
+    source_url: https://www.akofsoffshore.com/
+    notes: "157m subsea equipment support vessel (SESV); Petrobras Brazil charter to Q3 2027; 3000m capable. DP class not confirmed on public page."
+
+  # --- DOF Group -------------------------------------------------------
+  - vessel_name: Skandi Africa
+    owner: DOF Group
+    vessel_type: construction
+    water_depth_rating_m: 3000
+    dp_class: DP3
+    year_built: 2015
+    gom_resident: false
+    confidence: vendor_spec
+    source_url: https://www.dof.com/fleet
+    notes: "160.9m harsh-environment deepwater construction/flexlay vessel; 650Te tiltable lay system; deployed W. Australia."
+
+  - vessel_name: Skandi Acergy
+    owner: DOF Group
+    vessel_type: construction
+    water_depth_rating_m: 3000
+    dp_class: DP3
+    year_built: 2008
+    gom_resident: false
+    confidence: vendor_spec
+    source_url: https://www.dof.com/fleet/skandi-acergy
+    notes: "156.9m ROV construction support vessel; 400t crane, dual ROV; to 3000m."
+
+  - vessel_name: Skandi Constructor
+    owner: DOF Group
+    vessel_type: mpsv
+    water_depth_rating_m: null
+    dp_class: null
+    year_built: 2009
+    gom_resident: false
+    confidence: vendor_spec
+    source_url: https://www.dof.com/fleet/skandi-constructor
+    notes: "120.2m; well intervention, subsea construction, IMR, ROV; ex-'Sarah', acquired by DOF 2011."
+
+  - vessel_name: Skandi Vinland
+    owner: DOF Group
+    vessel_type: mpsv
+    water_depth_rating_m: 4000
+    dp_class: null
+    year_built: 2017
+    gom_resident: false
+    confidence: vendor_spec
+    source_url: https://www.dof.com/fleet/skandi-vinland
+    notes: "Multi-purpose OSV; light intervention vessel role; subsea construction/IMR/ROV to 4000m; Vard-built."

--- a/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/loaders/intervention_osv_loader.py
+++ b/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/loaders/intervention_osv_loader.py
@@ -1,0 +1,102 @@
+"""Load the OSV/MPSV + subsea-intervention vendor fleet roster (#593).
+
+The curated roster ships as package data at
+``worldenergydata/vessel_fleet/data/intervention_osv_roster.yml`` -- named
+units confirmed from public vendor asset pages, shipyard reference pages,
+class registers and contract news across the six requested vendors (Helix,
+Island Offshore/TIOS, C-Innovation/Edison Chouest, Oceaneering, AKOFS, DOF).
+
+This module exposes ``load_intervention_osv_roster`` returning the list of
+vessel dicts, plus ``summarize_intervention_osv_roster`` producing counts by
+vessel_type and by gom_resident.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+# Roster lives one level up from this ``loaders/`` subpackage, alongside the
+# other curated catalogs in ``vessel_fleet/data/`` -- resolves identically
+# whether installed editable or unpacked from the built wheel.
+_DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+_DEFAULT_FILE = "intervention_osv_roster.yml"
+
+
+def load_intervention_osv_roster(
+    path: Optional[Path] = None,
+) -> list[dict[str, Any]]:
+    """Load the intervention/OSV vendor fleet roster.
+
+    Args:
+        path: Optional path to a roster YAML file. Defaults to the curated
+            ``intervention_osv_roster.yml`` shipped as package data.
+
+    Returns:
+        List of vessel records (one dict per named unit). Empty list if the
+        file is missing or contains no ``vessels`` block.
+    """
+    roster_path = Path(path) if path is not None else _DATA_DIR / _DEFAULT_FILE
+
+    if not roster_path.exists():
+        logger.warning("Intervention OSV roster not found: %s", roster_path)
+        return []
+
+    with roster_path.open("r", encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh) or {}
+
+    vessels = doc.get("vessels", [])
+    if not isinstance(vessels, list):
+        logger.warning("Roster 'vessels' is not a list: %s", roster_path)
+        return []
+
+    logger.info("Loaded %d intervention/OSV vessels", len(vessels))
+    return vessels
+
+
+def summarize_intervention_osv_roster(
+    vessels: Optional[list[dict[str, Any]]] = None,
+    path: Optional[Path] = None,
+) -> dict[str, Any]:
+    """Summarize the roster by vessel_type and by gom_resident.
+
+    Args:
+        vessels: Optional pre-loaded list of vessel records. If omitted, the
+            roster is loaded from ``path`` (or the default package data).
+        path: Optional roster path forwarded to ``load_intervention_osv_roster``
+            when ``vessels`` is not supplied.
+
+    Returns:
+        Dictionary with:
+            - ``total``: total vessel count
+            - ``by_vessel_type``: {vessel_type: count}
+            - ``by_gom_resident``: {"true"|"false"|"unknown": count}
+    """
+    if vessels is None:
+        vessels = load_intervention_osv_roster(path=path)
+
+    by_vessel_type: dict[str, int] = {}
+    by_gom_resident: dict[str, int] = {"true": 0, "false": 0, "unknown": 0}
+
+    for vessel in vessels:
+        vtype = vessel.get("vessel_type") or "unknown"
+        by_vessel_type[vtype] = by_vessel_type.get(vtype, 0) + 1
+
+        gom = vessel.get("gom_resident")
+        if gom is True:
+            by_gom_resident["true"] += 1
+        elif gom is False:
+            by_gom_resident["false"] += 1
+        else:
+            by_gom_resident["unknown"] += 1
+
+    return {
+        "total": len(vessels),
+        "by_vessel_type": by_vessel_type,
+        "by_gom_resident": by_gom_resident,
+    }

--- a/tests/unit/vessel_fleet/loaders/test_intervention_osv_loader.py
+++ b/tests/unit/vessel_fleet/loaders/test_intervention_osv_loader.py
@@ -1,0 +1,96 @@
+# ABOUTME: Tests for the OSV/MPSV + intervention vendor fleet roster loader (#593).
+# ABOUTME: Covers a synthetic YAML fixture plus one assertion pass over the real roster.
+
+from __future__ import annotations
+
+import textwrap
+
+from worldenergydata.vessel_fleet.loaders.intervention_osv_loader import (
+    load_intervention_osv_roster,
+    summarize_intervention_osv_roster,
+)
+
+
+def _write_roster(tmp_path, body: str):
+    path = tmp_path / "roster.yml"
+    path.write_text(textwrap.dedent(body), encoding="utf-8")
+    return path
+
+
+def test_load_synthetic_roster_returns_vessels(tmp_path):
+    path = _write_roster(
+        tmp_path,
+        """
+        provenance:
+          confidence: medium
+        vessels:
+          - vessel_name: Synthetic Semi
+            owner: Test Vendor
+            vessel_type: heavy_intervention_semi
+            water_depth_rating_m: 3000
+            dp_class: DP3
+            gom_resident: true
+          - vessel_name: Synthetic Monohull
+            owner: Test Vendor
+            vessel_type: rlwi_monohull
+            water_depth_rating_m: null
+            dp_class: null
+            gom_resident: false
+        """,
+    )
+    vessels = load_intervention_osv_roster(path=path)
+    assert len(vessels) == 2
+    assert vessels[0]["vessel_name"] == "Synthetic Semi"
+    # Unknown specs must survive as None, never be coerced/guessed.
+    assert vessels[1]["water_depth_rating_m"] is None
+    assert vessels[1]["dp_class"] is None
+
+
+def test_missing_file_returns_empty(tmp_path):
+    vessels = load_intervention_osv_roster(path=tmp_path / "nope.yml")
+    assert vessels == []
+
+
+def test_summary_counts_synthetic(tmp_path):
+    path = _write_roster(
+        tmp_path,
+        """
+        vessels:
+          - {vessel_name: A, vessel_type: mpsv, gom_resident: true}
+          - {vessel_name: B, vessel_type: mpsv, gom_resident: false}
+          - {vessel_name: C, vessel_type: rlwi_monohull, gom_resident: null}
+        """,
+    )
+    summary = summarize_intervention_osv_roster(path=path)
+    assert summary["total"] == 3
+    assert summary["by_vessel_type"]["mpsv"] == 2
+    assert summary["by_vessel_type"]["rlwi_monohull"] == 1
+    assert summary["by_gom_resident"]["true"] == 1
+    assert summary["by_gom_resident"]["false"] == 1
+    assert summary["by_gom_resident"]["unknown"] == 1
+
+
+def test_real_roster_loads_and_summarizes():
+    """One assertion pass over the committed package-data roster."""
+    vessels = load_intervention_osv_roster()
+    assert len(vessels) == 29
+
+    names = {v["vessel_name"] for v in vessels}
+    assert "Q4000" in names
+    assert "Ocean Evolution" in names
+    assert "AKOFS Seafarer" in names
+
+    # Every row carries a citation + confidence; no spec is silently guessed.
+    for vessel in vessels:
+        assert vessel.get("source_url"), vessel["vessel_name"]
+        assert vessel.get("confidence"), vessel["vessel_name"]
+        assert "vessel_type" in vessel
+
+    summary = summarize_intervention_osv_roster(vessels)
+    assert summary["total"] == 29
+    # Helix Q-series semis are present.
+    assert summary["by_vessel_type"]["heavy_intervention_semi"] == 3
+    # GoM-resident + non-resident + unknown partition the whole roster.
+    gom = summary["by_gom_resident"]
+    assert gom["true"] + gom["false"] + gom["unknown"] == 29
+    assert gom["true"] >= 1


### PR DESCRIPTION
Closes #593 (child of #591)

## Roster (29 named units across 6 vendors)
| Vendor | Vessels |
|---|---|
| Helix Energy Solutions | 7 (Q4000, Q5000, Q7000, Seawell, Well Enhancer, Siem Helix 1/2) |
| Island Offshore / TIOS | 4 (Island Constructor, Wellserver, Frontier, Vanguard) |
| C-Innovation / Edison Chouest | 3 (Island Venture, Performer, Intervention) |
| Oceaneering International | 8 (Ocean Evolution, Blue Sea, Normand Superior, Juanita Candies, Intervention, Brandon Bordelon, Ocean Intervention II, Ocean Intervention) |
| AKOFS Offshore | 3 (AKOFS Seafarer, Santos, Aker Wayfarer) |
| DOF Group | 4 (Skandi Africa, Acergy, Constructor, Vinland) |

By vessel_type: mpsv 15, rlwi_monohull 7, heavy_intervention_semi 3, construction 3, osv 1.
By gom_resident: true 12, false 16, unknown 1.

## What's added
- `config/intervention/` scrape configs (ContractorConfig + KNOWN_VESSELS, matching existing `fleet_page_collector` pattern): helix, island_offshore, c_innovation, oceaneering, akofs, dof.
- `data/intervention_osv_roster.yml` — curated named-unit roster mapped to vessel_type / water_depth_rating_m / dp_class / owner / gom_resident / source_url, with per-row confidence + source.
- `loaders/intervention_osv_loader.py` — `load_intervention_osv_roster(path=None)` + `summarize_intervention_osv_roster` (count by vessel_type and gom_resident).
- `tests/unit/vessel_fleet/loaders/test_intervention_osv_loader.py` — synthetic + 1 real-YAML test (4 tests).

## Coverage caveats
- Helix's correct public domain is helixesg.com (helixenergy.com does not resolve).
- Island Offshore / TIOS operator fleet pages are JS-driven and expose few specs; TIOS monohull names + C-Innovation operatorship came from Ulstein references / trade press, not operator roster pages. Scrape selectors are best-effort for future automated runs.
- Unknown specs left null, never guessed (e.g. DP class for Well Enhancer / Aker Wayfarer / Skandi Constructor / Skandi Vinland; several Oceaneering year_built / water_depth).
- gom_resident set true only where a public source ties the vessel to GoM ops; false where a non-GoM region is documented; null where unclear (Vanguard).