### PR TITLE
feat(field-dev): subsea layout optimization — manifold/host placement (#579)

### DIFF
--- a/src/worldenergydata/field_development/__init__.py
+++ b/src/worldenergydata/field_development/__init__.py
@@ -58,6 +58,13 @@ from worldenergydata.field_development.layout import (
     compute_positions,
     render_layout,
 )
+from worldenergydata.field_development.layout_optimization import (
+    LayoutSolution,
+    Well,
+    improvement_vs_naive,
+    naive_layout,
+    optimize_layout,
+)
 from worldenergydata.field_development.llm_completion import (
     CompletionResult,
     complete_concept,
@@ -152,4 +159,9 @@ __all__ = [
     "graph_to_dexpi",
     "dexpi_to_graph",
     "dexpi_mapping",
+    "optimize_layout",
+    "naive_layout",
+    "improvement_vs_naive",
+    "LayoutSolution",
+    "Well",
 ]

--- a/src/worldenergydata/field_development/layout_optimization.py
+++ b/src/worldenergydata/field_development/layout_optimization.py
@@ -1,0 +1,150 @@
+# ABOUTME: Optimize manifold/host placement to minimize flowline length.
+# ABOUTME: Issue #579 (epic #567) — deterministic k-means clustering, zero deps.
+"""
+worldenergydata.field_development.layout_optimization
+=====================================================
+
+Computes an *optimized* subsea field layout: given real well coordinates, where
+should the manifold(s) and host sit so total **flowline + jumper length** is
+minimized? This is the inverse of the plan-view renderer (#573), which *draws*
+given coordinates — here we *compute* them.
+
+Approach (after "A framework for early-stage automated layout design of subsea
+production systems", Ocean Engineering 2024): cluster wells into drill
+centers / manifolds, place each manifold at its cluster centroid, and place a
+standalone host at the manifolds' centroid (or use the given tieback host). The
+objective is the sum of tree→manifold jumpers plus manifold→host flowlines —
+length is a direct CAPEX driver (flowline steel scales with metres laid).
+
+**Deterministic**: the clustering uses farthest-point seeding (ties broken by
+well id) and Lloyd iterations — the same wells always yield the same layout, so
+it is reproducible and testable, and feeds the renderer without randomness.
+
+Keep this out of v1 of the visual pipeline (the deterministic renderer must be
+trusted first); it is an optional Phase-2 module. Constraints like a per-manifold
+well cap are noted but not enforced in this first cut.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Well:
+    """A well with a real seabed coordinate (km, any consistent planar frame)."""
+
+    id: str
+    x: float
+    y: float
+
+
+@dataclass
+class LayoutSolution:
+    """An optimized layout: manifold positions, assignments, host, total length."""
+
+    manifolds: dict[str, tuple[float, float]] = field(default_factory=dict)
+    assignment: dict[str, str] = field(default_factory=dict)  # well id -> manifold id
+    host: tuple[float, float] = (0.0, 0.0)
+    total_length_km: float = 0.0
+    n_manifolds: int = 0
+
+
+def _dist(a: tuple[float, float], b: tuple[float, float]) -> float:
+    return math.hypot(a[0] - b[0], a[1] - b[1])
+
+
+def _centroid(points: list[tuple[float, float]]) -> tuple[float, float]:
+    n = len(points)
+    return (sum(p[0] for p in points) / n, sum(p[1] for p in points) / n)
+
+
+def _seed_centroids(wells: list[Well], k: int) -> list[tuple[float, float]]:
+    """Deterministic farthest-point seeding (k-means++ without randomness)."""
+    pts = {w.id: (w.x, w.y) for w in wells}
+    all_pts = [(w.x, w.y) for w in wells]
+    # First seed: the well nearest the global centroid (ties → lowest id).
+    g = _centroid(all_pts)
+    first = min(wells, key=lambda w: (_dist((w.x, w.y), g), w.id))
+    seeds = [(first.x, first.y)]
+    while len(seeds) < k:
+        # Add the well farthest from its nearest existing seed (ties → lowest id).
+        nxt = max(
+            wells,
+            key=lambda w: (min(_dist(pts[w.id], s) for s in seeds), w.id),
+        )
+        seeds.append((nxt.x, nxt.y))
+    return seeds
+
+
+def optimize_layout(
+    wells: list[Well],
+    n_manifolds: int = 1,
+    host: tuple[float, float] | None = None,
+    max_iterations: int = 50,
+) -> LayoutSolution:
+    """Place ``n_manifolds`` manifolds (+ host) to minimize total flowline length.
+
+    Args:
+        wells: Wells with seabed coordinates.
+        n_manifolds: Number of manifolds / drill centers to place.
+        host: Fixed host position (e.g. an existing tieback host). If None, a
+            standalone host is placed at the manifolds' centroid.
+        max_iterations: Lloyd-iteration cap.
+
+    Returns:
+        A :class:`LayoutSolution`.
+    """
+    if not wells:
+        return LayoutSolution(host=host or (0.0, 0.0), n_manifolds=0)
+    k = max(1, min(n_manifolds, len(wells)))
+    mids = [f"mf-{i + 1}" for i in range(k)]
+    centroids = _seed_centroids(wells, k)
+
+    assignment: dict[str, int] = {}
+    for _ in range(max_iterations):
+        # Assign each well to the nearest centroid (ties → lowest centroid index).
+        new_assign = {
+            w.id: min(range(k), key=lambda c: (_dist((w.x, w.y), centroids[c]), c))
+            for w in wells
+        }
+        if new_assign == assignment:
+            break
+        assignment = new_assign
+        # Recompute centroids; keep the old centroid for an empty cluster.
+        for c in range(k):
+            members = [(w.x, w.y) for w in wells if assignment[w.id] == c]
+            if members:
+                centroids[c] = _centroid(members)
+
+    manifolds = {mids[c]: centroids[c] for c in range(k)}
+    host_pos = host if host is not None else _centroid(list(manifolds.values()))
+
+    jumpers = sum(_dist((w.x, w.y), manifolds[mids[assignment[w.id]]]) for w in wells)
+    flowlines = sum(_dist(pos, host_pos) for pos in manifolds.values())
+    return LayoutSolution(
+        manifolds=manifolds,
+        assignment={w.id: mids[assignment[w.id]] for w in wells},
+        host=host_pos,
+        total_length_km=round(jumpers + flowlines, 6),
+        n_manifolds=k,
+    )
+
+
+def naive_layout(
+    wells: list[Well], host: tuple[float, float] | None = None
+) -> LayoutSolution:
+    """Baseline: a single manifold at the field centroid (no clustering)."""
+    return optimize_layout(wells, n_manifolds=1, host=host)
+
+
+def improvement_vs_naive(
+    wells: list[Well], n_manifolds: int, host: tuple[float, float] | None = None
+) -> float:
+    """Fractional reduction in total length vs the single-manifold baseline."""
+    base = naive_layout(wells, host=host).total_length_km
+    opt = optimize_layout(wells, n_manifolds=n_manifolds, host=host).total_length_km
+    if base == 0:
+        return 0.0
+    return round((base - opt) / base, 6)

--- a/tests/modules/field_development/test_layout_optimization.py
+++ b/tests/modules/field_development/test_layout_optimization.py
@@ -1,0 +1,120 @@
+# ABOUTME: Tests for subsea layout optimization (issue #579).
+# ABOUTME: Clustering correctness, objective improvement vs naive, determinism.
+"""Tests for ``worldenergydata.field_development.layout_optimization``."""
+
+from __future__ import annotations
+
+import math
+
+from worldenergydata.field_development import (
+    LayoutSolution,
+    Well,
+    improvement_vs_naive,
+    naive_layout,
+    optimize_layout,
+)
+
+
+def _two_clusters():
+    # Cluster A near (0,0), cluster B near (10,10).
+    return [
+        Well("a1", 0.0, 0.0),
+        Well("a2", 1.0, 0.0),
+        Well("a3", 0.0, 1.0),
+        Well("b1", 10.0, 10.0),
+        Well("b2", 11.0, 10.0),
+        Well("b3", 10.0, 11.0),
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Clustering correctness
+# --------------------------------------------------------------------------- #
+def test_two_manifolds_separate_two_clusters():
+    sol = optimize_layout(_two_clusters(), n_manifolds=2)
+    assert sol.n_manifolds == 2
+    # The three A-wells share one manifold, the three B-wells the other.
+    a_mf = {sol.assignment[w] for w in ("a1", "a2", "a3")}
+    b_mf = {sol.assignment[w] for w in ("b1", "b2", "b3")}
+    assert len(a_mf) == 1 and len(b_mf) == 1 and a_mf != b_mf
+
+
+def test_manifold_sits_at_cluster_centroid():
+    sol = optimize_layout(_two_clusters(), n_manifolds=2)
+    # Cluster A centroid is (1/3, 1/3); one manifold should be there.
+    positions = list(sol.manifolds.values())
+    assert any(
+        math.isclose(p[0], 1 / 3, abs_tol=1e-6)
+        and math.isclose(p[1], 1 / 3, abs_tol=1e-6)
+        for p in positions
+    )
+
+
+def test_each_well_assigned_to_nearest_manifold():
+    sol = optimize_layout(_two_clusters(), n_manifolds=2)
+    for w in _two_clusters():
+        assigned = sol.manifolds[sol.assignment[w.id]]
+        nearest = min(
+            sol.manifolds.values(), key=lambda p: math.hypot(w.x - p[0], w.y - p[1])
+        )
+        assert math.isclose(
+            math.hypot(w.x - assigned[0], w.y - assigned[1]),
+            math.hypot(w.x - nearest[0], w.y - nearest[1]),
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Objective: optimization beats the naive baseline
+# --------------------------------------------------------------------------- #
+def test_two_manifolds_reduce_total_length_vs_one():
+    wells = _two_clusters()
+    one = optimize_layout(wells, n_manifolds=1).total_length_km
+    two = optimize_layout(wells, n_manifolds=2).total_length_km
+    assert two < one
+
+
+def test_improvement_vs_naive_positive_for_clustered_field():
+    assert improvement_vs_naive(_two_clusters(), n_manifolds=2) > 0.0
+
+
+def test_naive_is_single_manifold():
+    sol = naive_layout(_two_clusters())
+    assert sol.n_manifolds == 1
+    assert len(set(sol.assignment.values())) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Host handling
+# --------------------------------------------------------------------------- #
+def test_given_host_is_used():
+    sol = optimize_layout(_two_clusters(), n_manifolds=2, host=(5.0, 50.0))
+    assert sol.host == (5.0, 50.0)
+
+
+def test_standalone_host_at_manifolds_centroid():
+    sol = optimize_layout(_two_clusters(), n_manifolds=2)
+    cx = sum(p[0] for p in sol.manifolds.values()) / len(sol.manifolds)
+    cy = sum(p[1] for p in sol.manifolds.values()) / len(sol.manifolds)
+    assert math.isclose(sol.host[0], cx) and math.isclose(sol.host[1], cy)
+
+
+# --------------------------------------------------------------------------- #
+# Robustness + determinism
+# --------------------------------------------------------------------------- #
+def test_empty_wells_is_graceful():
+    sol = optimize_layout([], n_manifolds=3)
+    assert isinstance(sol, LayoutSolution) and sol.n_manifolds == 0
+
+
+def test_n_manifolds_capped_at_well_count():
+    sol = optimize_layout([Well("a", 0, 0), Well("b", 1, 1)], n_manifolds=5)
+    assert sol.n_manifolds == 2
+
+
+def test_deterministic_same_wells_same_solution():
+    wells = _two_clusters()
+    a = optimize_layout(wells, n_manifolds=2)
+    b = optimize_layout(wells, n_manifolds=2)
+    assert a.manifolds == b.manifolds
+    assert a.assignment == b.assignment
+    assert a.total_length_km == b.total_length_km


### PR DESCRIPTION
## Phase 2 — Subsea layout optimization (#579, epic #567)

Computes an *optimized* field layout — where manifolds and the host should sit so total **flowline + jumper length** is minimized. This is the inverse of the plan-view renderer (#573): the renderer *draws* given coordinates; this *computes* them.

### Approach (after Ocean Engineering 2024)
- `optimize_layout()` clusters wells into drill-centers/manifolds with a **deterministic k-means** (farthest-point seeding, ties broken by well id, Lloyd iterations), places each manifold at its cluster centroid, and places a standalone host at the manifolds' centroid (or uses a given tieback host).
- Objective = `sum(tree→manifold jumpers) + sum(manifold→host flowlines)` — length is a direct CAPEX driver (flowline steel scales with metres laid).
- `naive_layout()` (single manifold at field centroid) + `improvement_vs_naive()` to **benchmark** the gain.

### Notes
- **Zero deps** (stdlib `math`), fully **deterministic** → reproducible and testable; same wells always yield the same layout, so it can feed the renderer without randomness.
- Kept out of the v1 visual pipeline by design (the deterministic renderer is trusted first); this is the optional Phase-2 optimizer. A per-manifold well cap is noted but not enforced in this first cut.

### Tests
11 tests: clustering correctness (separates clusters, manifold-at-centroid, nearest-assignment), objective (2 manifolds < 1, positive improvement-vs-naive), host handling, robustness, and determinism. **144 field_development tests pass.**

Epic #567 Phase 2: #577, #578 merged + this. Remaining: #580 equipment-3D.
