### PR TITLE
feat(vessel): identity resolver + dedup (name+operator+aka; IMO when present) (#599)

### DIFF
--- a/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/data/identity_crosswalk.yml
+++ b/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/data/identity_crosswalk.yml
@@ -1,0 +1,107 @@
+crosswalk: vessel_identity_resolution
+issue: 599
+epic: 591
+key_basis: normalized canonical name + operator/owner compatibility, with an aka (alternate-name)
+  list; IMO/MMSI used only as a confirmer when present (IMO coverage in the bulk corpus
+  is ~0%).
+summary:
+  records_in: 2471
+  distinct_vessels_out: 2352
+  duplicates_collapsed: 119
+  clusters_with_multiple_members: 52
+  by_source:
+    construction_vessels.csv: 165
+    drilling_rigs.csv: 2268
+    intervention_osv_roster.yml: 29
+    intervention_vessels_seed.yml: 9
+  per_class_delta:
+    construction_vessel:
+      before: 162
+      after: 155
+      collapsed: 7
+    heavy_intervention_semi:
+      before: 16
+      after: 5
+      collapsed: 11
+    lift_boat:
+      before: 158
+      after: 143
+      collapsed: 15
+    modu_drillship:
+      before: 163
+      after: 161
+      collapsed: 2
+    modu_jackup:
+      before: 1027
+      after: 1018
+      collapsed: 9
+    modu_semisub:
+      before: 308
+      after: 305
+      collapsed: 3
+    mpsv_osv:
+      before: 14
+      after: 10
+      collapsed: 4
+    other:
+      before: 609
+      after: 548
+      collapsed: 61
+    rlwi_monohull:
+      before: 14
+      after: 7
+      collapsed: 7
+  cluster_confidence_counts:
+    low: 1
+    medium: 51
+    singleton: 2300
+heavy_intervention_semi_fix:
+  problem: 'The #598 catalog counted the Helix Q-series semis once per name-spelling
+    variant (e.g. ''Q4000'', ''HELIX Q4000'', ''MSV Q4000'', ''CALDIVE Q4000'', ''HELIX
+    Q-4000'', the seed ''Helix Q4000'' and the #593 roster ''Q4000''), inflating heavy_intervention_semi.'
+  resolution: canonicalize_name + the Helix-Q aka list collapse every variant of each
+    hull (Q4000/Q5000/Q7000) into one distinct vessel.
+  clusters:
+  - canonical_name: Q4000
+    variants_collapsed: 13
+    member_names:
+    - CALDIVE Q-4000
+    - CALDIVE Q-4000 (SS)
+    - CALDIVE Q4000
+    - CALDIVE'S Q4000 DP
+    - HELIX Q-4000
+    - HELIX Q4000
+    - HELIZ Q4000
+    - Helix Q4000
+    - MSV Q4000
+    - Q-4000
+    - Q4000
+    match_basis:
+    - aka
+    - canonical_name+operator
+  - canonical_name: Q5000
+    variants_collapsed: 3
+    member_names:
+    - HELIX Q5000
+    - Helix Q5000
+    - Q5000
+    match_basis:
+    - aka
+    - canonical_name+operator
+  - canonical_name: Q7000
+    variants_collapsed: 2
+    member_names:
+    - Helix Q7000
+    - Q7000
+    match_basis:
+    - aka
+  duplicate_rows_removed: 15
+sources_reconciled:
+- construction_vessels.csv
+- drilling_rigs.csv
+- intervention_osv_roster.yml
+- intervention_vessels_seed.yml
+provenance:
+  curated_dir: vessel_fleet/_data/curated (gitignored, mounted)
+  note: Aggregate cluster summary only -- the full per-vessel row dump stays in the
+    gitignored curated CSVs.

--- a/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/identity_crosswalk.py
+++ b/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/identity_crosswalk.py
@@ -1,0 +1,262 @@
+"""Real-corpus runner for the vessel identity resolver (#599).
+
+Assembles the real fleet corpus (curated ``drilling_rigs.csv`` +
+``construction_vessels.csv`` + the #593 OSV roster + the #598 dedicated
+intervention seed), runs :mod:`identity_resolver` over it, and writes the
+aggregate ``data/identity_crosswalk.yml`` cluster summary -- including the
+specific fix to the #598 ``heavy_intervention_semi`` double-count (the Helix-Q
+hull-name semis).
+
+Only the AGGREGATE summary is committed; the full per-vessel row dump stays in
+the gitignored curated CSVs.
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+from worldenergydata.vessel_fleet.identity_resolver import (
+    canonicalize_name,
+    dedupe_catalog,
+    resolve_identities,
+)
+
+logger = logging.getLogger(__name__)
+
+_THIS_DIR = Path(__file__).resolve().parent
+_DEFAULT_CURATED_DIR = _THIS_DIR / "_data" / "curated"
+_DATA_DIR = _THIS_DIR / "data"
+DEFAULT_CROSSWALK_PATH = _DATA_DIR / "identity_crosswalk.yml"
+
+# Helix Q-class hull-name variants seen across BSEE WAR / contractor sources.
+# These are spelling/marketing variants of the SAME three physical semis, used
+# as the aka seed that collapses the #598 heavy_intervention_semi double-count.
+_HELIX_Q_AKA: dict[str, list[str]] = {
+    "Q4000": [
+        "Q-4000",
+        "HELIX Q4000",
+        "HELIX Q-4000",
+        "HELIZ Q4000",
+        "MSV Q4000",
+        "SV Q4000",
+        "CALDIVE Q4000",
+        "CALDIVE'S Q4000 DP",
+    ],
+    "Q5000": ["HELIX Q5000"],
+    "Q7000": ["HELIX Q7000"],
+}
+
+
+def _classify(name: Optional[str], rig_type: Optional[str], vessel_type: Optional[str]):
+    """Best-effort asset-class label (imported lazily to avoid a hard dep)."""
+    try:
+        from worldenergydata.vessel_fleet.fleet_catalog import classify_asset_class
+
+        return classify_asset_class(
+            rig_type=rig_type, vessel_type=vessel_type, name=name
+        )
+    except Exception:  # pragma: no cover - classification is best-effort
+        return "other"
+
+
+def _read_csv_rows(path: Path) -> list[dict[str, str]]:
+    if not path.is_file():
+        logger.warning("Curated CSV not found: %s", path)
+        return []
+    with path.open("r", encoding="utf-8", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def _aka_for(name: Optional[str]) -> list[str]:
+    """Attach the curated Helix-Q aka list to the canonical hull-token record."""
+    if not name:
+        return []
+    canon = canonicalize_name(name)
+    return list(_HELIX_Q_AKA.get(canon, []))
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    try:
+        import yaml
+    except Exception:  # pragma: no cover
+        return {}
+    if not path.is_file():
+        return {}
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def _load_seed_records() -> list[dict[str, Any]]:
+    doc = _load_yaml(_DATA_DIR / "intervention_vessels_seed.yml")
+    out: list[dict[str, Any]] = []
+    for v in doc.get("vessels", []) or []:
+        name = v.get("name")
+        out.append(
+            {
+                "name": name,
+                "operator": v.get("operator") or None,
+                "owner": v.get("operator") or None,
+                "imo": None,
+                "mmsi": None,
+                "aka": _aka_for(name),
+                "source": "intervention_vessels_seed.yml",
+                "class": _classify(name, None, v.get("vessel_type")),
+            }
+        )
+    return out
+
+
+def _load_roster_records() -> list[dict[str, Any]]:
+    doc = _load_yaml(_DATA_DIR / "intervention_osv_roster.yml")
+    out: list[dict[str, Any]] = []
+    for v in doc.get("vessels", []) or []:
+        name = v.get("vessel_name")
+        out.append(
+            {
+                "name": name,
+                "operator": v.get("operator") or None,
+                "owner": v.get("owner") or None,
+                "imo": None,
+                "mmsi": None,
+                "aka": _aka_for(name),
+                "source": "intervention_osv_roster.yml",
+                "class": _classify(name, None, v.get("vessel_type")),
+            }
+        )
+    return out
+
+
+def load_corpus_records(
+    curated_dir: Optional[Path] = None,
+    include_yaml: bool = True,
+) -> list[dict[str, Any]]:
+    """Assemble the real fleet corpus as resolver input records.
+
+    Sources: curated ``drilling_rigs.csv`` + ``construction_vessels.csv`` plus
+    (when importable) the #593 OSV roster and #598 dedicated-intervention seed.
+    Each record carries name/operator/owner/imo/mmsi/aka/source/class.
+    """
+    curated = Path(curated_dir) if curated_dir else _DEFAULT_CURATED_DIR
+    records: list[dict[str, Any]] = []
+
+    for row in _read_csv_rows(curated / "drilling_rigs.csv"):
+        name = row.get("RIG_NAME") or row.get("VESSEL_NAME")
+        records.append(
+            {
+                "name": name,
+                "operator": row.get("OPERATOR") or None,
+                "owner": row.get("OWNER") or None,
+                "imo": row.get("IMO_NUMBER") or None,
+                "mmsi": None,
+                "aka": _aka_for(name),
+                "source": "drilling_rigs.csv",
+                "class": _classify(name, row.get("RIG_TYPE"), None),
+            }
+        )
+
+    for row in _read_csv_rows(curated / "construction_vessels.csv"):
+        name = row.get("VESSEL_NAME")
+        records.append(
+            {
+                "name": name,
+                "operator": row.get("OPERATOR") or None,
+                "owner": row.get("OWNER") or None,
+                "imo": row.get("IMO_NUMBER") or None,
+                "mmsi": row.get("MMSI") or None,
+                "aka": _aka_for(name),
+                "source": "construction_vessels.csv",
+                "class": _classify(name, None, row.get("VESSEL_TYPE")),
+            }
+        )
+
+    if include_yaml:
+        records.extend(_load_seed_records())
+        records.extend(_load_roster_records())
+    return records
+
+
+def build_identity_crosswalk(
+    curated_dir: Optional[Path] = None,
+    out_path: Optional[Path] = None,
+) -> dict[str, Any]:
+    """Run the resolver over the real corpus and write the crosswalk summary.
+
+    Writes an AGGREGATE YAML (cluster summary + the #598 heavy-intervention-semi
+    fix), never the full per-row dump.
+    """
+    import yaml
+
+    records = load_corpus_records(curated_dir=curated_dir)
+    deduped, report = dedupe_catalog(records)
+    clusters = resolve_identities(records)
+
+    crosswalk = {
+        "crosswalk": "vessel_identity_resolution",
+        "issue": 599,
+        "epic": 591,
+        "key_basis": (
+            "normalized canonical name + operator/owner compatibility, with an "
+            "aka (alternate-name) list; IMO/MMSI used only as a confirmer when "
+            "present (IMO coverage in the bulk corpus is ~0%)."
+        ),
+        "summary": report,
+        "heavy_intervention_semi_fix": _helix_q_fix(clusters),
+        "sources_reconciled": sorted({r["source"] for r in records}),
+        "provenance": {
+            "curated_dir": "vessel_fleet/_data/curated (gitignored, mounted)",
+            "note": (
+                "Aggregate cluster summary only -- the full per-vessel row dump "
+                "stays in the gitignored curated CSVs."
+            ),
+        },
+    }
+
+    out_p = Path(out_path) if out_path else DEFAULT_CROSSWALK_PATH
+    out_p.parent.mkdir(parents=True, exist_ok=True)
+    out_p.write_text(
+        yaml.safe_dump(crosswalk, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+    logger.info(
+        "identity_crosswalk: %d records -> %d distinct vessels (%d collapsed)",
+        report["records_in"],
+        report["distinct_vessels_out"],
+        report["duplicates_collapsed"],
+    )
+    return crosswalk
+
+
+def _helix_q_fix(clusters: list[dict[str, Any]]) -> dict[str, Any]:
+    """Document the specific Helix-Q hull-name double-count collapse."""
+    q_clusters = []
+    for c in clusters:
+        if c["canonical_name"] in _HELIX_Q_AKA and c["member_count"] > 1:
+            q_clusters.append(
+                {
+                    "canonical_name": c["canonical_name"],
+                    "variants_collapsed": c["member_count"],
+                    "member_names": sorted(
+                        {str(m.get("name")) for m in c["members"] if m.get("name")}
+                    ),
+                    "match_basis": c["match_basis"],
+                }
+            )
+    collapsed_total = sum(
+        c["variants_collapsed"] - 1 for c in q_clusters
+    )  # rows removed
+    return {
+        "problem": (
+            "The #598 catalog counted the Helix Q-series semis once per "
+            "name-spelling variant (e.g. 'Q4000', 'HELIX Q4000', 'MSV Q4000', "
+            "'CALDIVE Q4000', 'HELIX Q-4000', the seed 'Helix Q4000' and the "
+            "#593 roster 'Q4000'), inflating heavy_intervention_semi."
+        ),
+        "resolution": (
+            "canonicalize_name + the Helix-Q aka list collapse every variant of "
+            "each hull (Q4000/Q5000/Q7000) into one distinct vessel."
+        ),
+        "clusters": q_clusters,
+        "duplicate_rows_removed": collapsed_total,
+    }

--- a/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/identity_resolver.py
+++ b/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/identity_resolver.py
@@ -1,0 +1,451 @@
+"""Vessel identity resolver + dedup over the full fleet corpus (#599).
+
+IMO coverage in the bulk corpus is ~0% (the curated ``drilling_rigs.csv`` has
+no IMO column at all, and ``construction_vessels.csv`` is sparse), so the
+working dedup key here is **not** IMO. It is the *normalized canonical name*
+plus *operator/owner compatibility*, with an *alternate-name (aka) list* to
+absorb spelling/marketing variants and renames. IMO/MMSI are used only as a
+strong confirmer WHEN present.
+
+Public surface:
+
+* :func:`canonicalize_name` -- normalize a vessel name for matching.
+* :func:`resolve_identities` -- cluster records that are the SAME vessel and
+  emit ``cluster_id`` / ``match_basis`` / ``confidence`` per cluster.
+* :func:`dedupe_catalog` -- collapse clusters to one canonical record and
+  return a before/after report (with per-class deltas).
+* :func:`load_corpus_records` / :func:`build_identity_crosswalk` -- run the
+  resolver over the real curated CSVs + roster + seed and emit the aggregate
+  ``data/identity_crosswalk.yml`` summary.
+
+Design is deliberately CONSERVATIVE: when two records share a name but their
+operators CONFLICT they are NOT merged (two different vessels can share a
+name). When one operator is unknown the pair is treated as compatible.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# --- Name canonicalization --------------------------------------------------
+
+# Generic vessel-class prefixes (marketing / type tags) that are NOT part of a
+# vessel's identity. Longest first so "M/V " wins over "MV ".
+_PREFIXES: tuple[str, ...] = (
+    "M/V ",
+    "S/V ",
+    "MSV ",
+    "MV ",
+    "SV ",
+    "SS ",
+    "MT ",
+    "AHTS ",
+)
+
+_WHITESPACE_RE = re.compile(r"\s+")
+_NON_ALNUM_RE = re.compile(r"[^A-Z0-9 ]")
+# A trailing parenthetical operator suffix, e.g. "Skandi Constructor (DOF)".
+_TRAILING_PAREN_RE = re.compile(r"\s*\([^()]*\)\s*$")
+# A hull-number token: a short alpha run glued to digits, optionally split by a
+# hyphen/space, e.g. "Q4000", "Q-4000", "DLV 2000". Conservatively re-glued.
+_HULL_SPLIT_RE = re.compile(r"\b([A-Z]{1,3})[\s-]+(\d{3,5})\b")
+
+
+def canonicalize_name(name: Optional[str]) -> str:
+    """Return a normalized canonical form of a vessel name for matching.
+
+    Steps:
+      1. Strip a trailing parenthetical operator suffix, e.g.
+         ``"Skandi Constructor (DOF)"`` -> ``"Skandi Constructor"``.
+      2. Uppercase.
+      3. Strip a single leading class/marketing prefix (M/V, MV, MSV, SV, ...).
+      4. Re-glue hull-number variants: ``"Q-4000"`` / ``"Q 4000"`` -> ``"Q4000"``
+         (conservative -- only short alpha + 3-5 digit runs).
+      5. Drop remaining punctuation, collapse whitespace, trim.
+
+    Returns "" for falsy input.
+    """
+    if not name:
+        return ""
+    s = str(name).strip()
+    # 1. Trailing parenthetical operator suffix (may be repeated/nested-ish).
+    prev = None
+    while prev != s:
+        prev = s
+        s = _TRAILING_PAREN_RE.sub("", s).strip()
+    s = s.upper()
+    # 3. Leading prefix (single pass -- only one class tag is meaningful).
+    for prefix in _PREFIXES:
+        if s.startswith(prefix):
+            s = s[len(prefix) :]
+            break
+    # 4. Re-glue hull-number variants before punctuation removal so the hyphen
+    #    in "Q-4000" does not just become a space.
+    s = _HULL_SPLIT_RE.sub(r"\1\2", s)
+    # 5. Drop punctuation -> spaces, collapse, trim.
+    s = _NON_ALNUM_RE.sub(" ", s)
+    s = _WHITESPACE_RE.sub(" ", s).strip()
+    return s
+
+
+# --- Operator compatibility -------------------------------------------------
+
+# Corporate-form / generic descriptor tokens stripped before comparing
+# operators, so "Helix Energy Solutions" and "Helix Well Ops" both reduce to a
+# set containing "HELIX".
+_OPERATOR_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "INC",
+        "LTD",
+        "LLC",
+        "LP",
+        "PLC",
+        "CO",
+        "CORP",
+        "CORPORATION",
+        "COMPANY",
+        "GROUP",
+        "HOLDINGS",
+        "AS",
+        "ASA",
+        "SA",
+        "NV",
+        "BV",
+        "GMBH",
+        "AB",
+        "THE",
+        "AND",
+        "OF",
+        "ENERGY",
+        "SOLUTIONS",
+        "SERVICES",
+        "SERVICE",
+        "OFFSHORE",
+        "SUBSEA",
+        "MARINE",
+        "SHIPPING",
+        "CONTRACTORS",
+        "CONTRACTOR",
+        "INTERNATIONAL",
+        "INTL",
+        "MANAGEMENT",
+        "OPERATIONS",
+        "WELL",
+        "OPS",
+        "DRILLING",
+        "PETROLEUM",
+    }
+)
+
+_OPERATOR_SPLIT_RE = re.compile(r"[^A-Z0-9]+")
+
+
+def _operator_tokens(*values: Optional[str]) -> set[str]:
+    """Distinctive (non-stopword) tokens across operator + owner strings."""
+    tokens: set[str] = set()
+    for value in values:
+        if not value:
+            continue
+        for tok in _OPERATOR_SPLIT_RE.split(str(value).upper()):
+            if tok and tok not in _OPERATOR_STOPWORDS and not tok.isdigit():
+                tokens.add(tok)
+    return tokens
+
+
+def operators_compatible(rec_a: dict[str, Any], rec_b: dict[str, Any]) -> bool:
+    """True if two records' operator/owner do NOT conflict.
+
+    Compatible when either side has no distinctive operator/owner token, or the
+    two token sets intersect. A CONFLICT (return ``False``) requires both sides
+    to carry distinctive tokens that are entirely disjoint.
+    """
+    toks_a = _operator_tokens(rec_a.get("operator"), rec_a.get("owner"))
+    toks_b = _operator_tokens(rec_b.get("operator"), rec_b.get("owner"))
+    if not toks_a or not toks_b:
+        return True
+    return bool(toks_a & toks_b)
+
+
+# --- Union-find -------------------------------------------------------------
+
+
+class _UnionFind:
+    def __init__(self, n: int) -> None:
+        self.parent = list(range(n))
+
+    def find(self, x: int) -> int:
+        root = x
+        while self.parent[root] != root:
+            root = self.parent[root]
+        while self.parent[x] != root:
+            self.parent[x], x = root, self.parent[x]
+        return root
+
+    def union(self, a: int, b: int) -> None:
+        ra, rb = self.find(a), self.find(b)
+        if ra != rb:
+            self.parent[max(ra, rb)] = min(ra, rb)
+
+
+# --- Identity resolution ----------------------------------------------------
+
+
+def _record_aka_canon(record: dict[str, Any]) -> set[str]:
+    """Canonical forms of a record's alternate names."""
+    out: set[str] = set()
+    for alt in record.get("aka") or []:
+        c = canonicalize_name(alt)
+        if c:
+            out.add(c)
+    return out
+
+
+def resolve_identities(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Cluster records that describe the SAME physical vessel.
+
+    Each input record is a dict with any of: ``name``, ``operator``,
+    ``owner``, ``imo``, ``mmsi``, ``aka`` (list of alternate names),
+    ``source``. (A ``class`` field, if present, is carried through.)
+
+    Records are merged when ANY holds (conservatively, never across an operator
+    conflict for the name/aka rules):
+
+      * exact IMO match                         -> confidence ``high``
+      * canonical-name match AND operators
+        compatible                              -> confidence ``medium``
+      * one record's canonical name appears in
+        another's aka list (operators
+        compatible)                             -> confidence ``low``
+
+    Returns a list of cluster dicts::
+
+        {
+            "cluster_id": int,
+            "canonical_name": str,
+            "members": [<original record>, ...],
+            "match_basis": ["imo", "canonical_name+operator", "aka", ...],
+            "confidence": "high" | "medium" | "low",
+            "imo": <confirmed IMO or None>,
+        }
+    """
+    n = len(records)
+    uf = _UnionFind(n)
+    canon = [canonicalize_name(r.get("name")) for r in records]
+    aka_canon = [_record_aka_canon(r) for r in records]
+    # Per-edge match basis, keyed by the union root after the fact is awkward;
+    # instead record bases on the lower-index endpoint and re-aggregate.
+    basis_edges: list[tuple[int, int, str]] = []
+
+    # 1. IMO match (strong confirmer).
+    by_imo: dict[str, list[int]] = {}
+    for i, r in enumerate(records):
+        imo = r.get("imo")
+        if imo:
+            by_imo.setdefault(str(imo).strip(), []).append(i)
+    for group in by_imo.values():
+        for j in group[1:]:
+            uf.union(group[0], j)
+            basis_edges.append((group[0], j, "imo"))
+
+    # 2. canonical-name match + compatible operator.
+    by_canon: dict[str, list[int]] = {}
+    for i, c in enumerate(canon):
+        if c:
+            by_canon.setdefault(c, []).append(i)
+    for group in by_canon.values():
+        for a_idx in range(len(group)):
+            for b_idx in range(a_idx + 1, len(group)):
+                i, j = group[a_idx], group[b_idx]
+                if operators_compatible(records[i], records[j]):
+                    uf.union(i, j)
+                    basis_edges.append((i, j, "canonical_name+operator"))
+
+    # 3. aka match: one record's canonical name in another's aka list.
+    canon_owner: dict[str, list[int]] = by_canon
+    for j, akas in enumerate(aka_canon):
+        if not akas:
+            continue
+        for alt_canon in akas:
+            for i in canon_owner.get(alt_canon, []):
+                if i == j:
+                    continue
+                if operators_compatible(records[i], records[j]):
+                    uf.union(i, j)
+                    basis_edges.append((i, j, "aka"))
+
+    # Aggregate clusters.
+    members: dict[int, list[int]] = {}
+    for i in range(n):
+        members.setdefault(uf.find(i), []).append(i)
+
+    root_basis: dict[int, set[str]] = {}
+    for i, j, b in basis_edges:
+        root_basis.setdefault(uf.find(i), set()).add(b)
+
+    clusters: list[dict[str, Any]] = []
+    for cid, (root, idxs) in enumerate(sorted(members.items())):
+        member_recs = [records[i] for i in idxs]
+        bases = sorted(root_basis.get(root, set()))
+        confidence = (
+            "singleton" if len(member_recs) == 1 else _cluster_confidence(bases)
+        )
+        imo = next((r.get("imo") for r in member_recs if r.get("imo")), None)
+        # Canonical name: prefer the longest non-empty canonical among members
+        # (the operator-prefixed BSEE variants are usually longer but the seed
+        # short hull token is the true identity -> prefer the shortest that is
+        # still in another member's aka, else the most common).
+        canonical = _pick_canonical(member_recs)
+        clusters.append(
+            {
+                "cluster_id": cid,
+                "canonical_name": canonical,
+                "members": member_recs,
+                "member_count": len(member_recs),
+                "match_basis": bases,
+                "confidence": confidence,
+                "imo": str(imo).strip() if imo else None,
+            }
+        )
+    return clusters
+
+
+def _cluster_confidence(bases: list[str]) -> str:
+    if "imo" in bases:
+        return "high"
+    if "canonical_name+operator" in bases:
+        return "medium"
+    return "low"
+
+
+def _pick_canonical(member_recs: list[dict[str, Any]]) -> str:
+    """Choose the cluster's canonical name.
+
+    Use the shortest non-empty canonical form among members, breaking ties
+    alphabetically. The shortest form is the clean identity (the bare hull token
+    "Q4000"); operator-prefixed variants like "HELIX Q4000" or "MSV Q4000" are
+    longer and are preserved in ``ALTERNATE_NAMES`` instead.
+    """
+    canons = [canonicalize_name(r.get("name")) for r in member_recs]
+    nonempty = [c for c in canons if c]
+    if not nonempty:
+        return ""
+    return min(nonempty, key=lambda c: (len(c), c))
+
+
+# --- Catalog dedup ----------------------------------------------------------
+
+_MERGE_SCALAR_FIELDS = ("operator", "owner", "imo", "mmsi", "source", "class")
+
+
+def dedupe_catalog(
+    records: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Collapse identity clusters to one canonical record each.
+
+    Returns ``(deduped, report)``. Each deduped record carries
+    ``CANONICAL_NAME``, the union of all member names as ``ALTERNATE_NAMES``,
+    ``match_basis`` / ``confidence`` / ``member_count`` and the merged scalar
+    fields. The report records before/after totals, dupes collapsed, and a
+    per-class delta (using each record's optional ``class`` field).
+    """
+    clusters = resolve_identities(records)
+    deduped: list[dict[str, Any]] = []
+    for cluster in clusters:
+        deduped.append(_collapse_cluster(cluster))
+
+    report = _build_report(records, deduped, clusters)
+    return deduped, report
+
+
+def _collapse_cluster(cluster: dict[str, Any]) -> dict[str, Any]:
+    members = cluster["members"]
+    merged: dict[str, Any] = {
+        "CANONICAL_NAME": cluster["canonical_name"],
+        "match_basis": cluster["match_basis"],
+        "confidence": cluster["confidence"],
+        "member_count": len(members),
+    }
+    # Merge scalar fields: first non-empty wins (members keep source order).
+    for field in _MERGE_SCALAR_FIELDS:
+        for r in members:
+            val = r.get(field)
+            if val not in (None, ""):
+                merged.setdefault(field.upper() if field != "class" else "CLASS", val)
+                break
+    # Representative display name: the first member's raw name.
+    merged["VESSEL_NAME"] = next(
+        (r.get("name") for r in members if r.get("name")), cluster["canonical_name"]
+    )
+    # Union of all names + declared aka as ALTERNATE_NAMES.
+    alts: list[str] = []
+    seen: set[str] = set()
+    for r in members:
+        candidates: list[str] = []
+        if r.get("name"):
+            candidates.append(str(r["name"]))
+        candidates.extend(str(a) for a in (r.get("aka") or []))
+        for name in candidates:
+            key = name.strip()
+            if key and key != merged["VESSEL_NAME"] and key not in seen:
+                seen.add(key)
+                alts.append(key)
+    merged["ALTERNATE_NAMES"] = alts or None
+    # Union of distinct sources contributing to the cluster.
+    merged["SOURCES"] = sorted({str(r["source"]) for r in members if r.get("source")})
+    return merged
+
+
+def _build_report(
+    records_in: list[dict[str, Any]],
+    deduped: list[dict[str, Any]],
+    clusters: list[dict[str, Any]],
+) -> dict[str, Any]:
+    total_in = len(records_in)
+    total_out = len(deduped)
+
+    # Per-class before/after (a cluster's class = the merged record's CLASS).
+    before_by_class: dict[str, int] = {}
+    for r in records_in:
+        cls = r.get("class") or "unclassified"
+        before_by_class[cls] = before_by_class.get(cls, 0) + 1
+    after_by_class: dict[str, int] = {}
+    for r in deduped:
+        cls = r.get("CLASS") or "unclassified"
+        after_by_class[cls] = after_by_class.get(cls, 0) + 1
+
+    per_class_delta = {}
+    for cls in sorted(set(before_by_class) | set(after_by_class)):
+        before = before_by_class.get(cls, 0)
+        after = after_by_class.get(cls, 0)
+        per_class_delta[cls] = {
+            "before": before,
+            "after": after,
+            "collapsed": before - after,
+        }
+
+    # Per-source contribution (how many input rows each source supplied).
+    by_source: dict[str, int] = {}
+    for r in records_in:
+        src = r.get("source") or "unknown"
+        by_source[src] = by_source.get(src, 0) + 1
+
+    confidence_counts: dict[str, int] = {}
+    for c in clusters:
+        confidence_counts[c["confidence"]] = (
+            confidence_counts.get(c["confidence"], 0) + 1
+        )
+
+    multi = [c for c in clusters if len(c["members"]) > 1]
+    return {
+        "records_in": total_in,
+        "distinct_vessels_out": total_out,
+        "duplicates_collapsed": total_in - total_out,
+        "clusters_with_multiple_members": len(multi),
+        "by_source": dict(sorted(by_source.items())),
+        "per_class_delta": per_class_delta,
+        "cluster_confidence_counts": dict(sorted(confidence_counts.items())),
+    }

--- a/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/schemas/base.py
+++ b/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/schemas/base.py
@@ -34,6 +34,11 @@ class BaseVesselSchema(BaseModel):
     DATA_SOURCE: Optional[str] = None
     DATA_SOURCE_URL: Optional[str] = None
     COLLECTION_DATE: Optional[str] = None
+    # Identity-resolution fields (#599): the normalized canonical name and the
+    # list of alternate / former / spelling-variant names (aka) that resolve to
+    # the same physical vessel. Both are populated by the identity resolver.
+    CANONICAL_NAME: Optional[str] = None
+    ALTERNATE_NAMES: Optional[list[str]] = None
 
     # Optional float fields
     LOA_M: Optional[float] = None
@@ -77,12 +82,25 @@ class BaseVesselSchema(BaseModel):
         "DATA_SOURCE",
         "DATA_SOURCE_URL",
         "COLLECTION_DATE",
+        "CANONICAL_NAME",
         mode="before",
     )
     @classmethod
     def _empty_str_to_none(cls, v: object) -> object:
         if isinstance(v, str) and v.strip() == "":
             return None
+        return v
+
+    @field_validator("ALTERNATE_NAMES", mode="before")
+    @classmethod
+    def _clean_alternate_names(cls, v: object) -> object:
+        if v is None:
+            return None
+        if isinstance(v, str):
+            v = [v]
+        if isinstance(v, (list, tuple)):
+            cleaned = [str(n).strip() for n in v if str(n).strip()]
+            return cleaned or None
         return v
 
     @field_validator(

--- a/tests/unit/vessel_fleet/test_identity_resolver.py
+++ b/tests/unit/vessel_fleet/test_identity_resolver.py
@@ -1,0 +1,186 @@
+# ABOUTME: Unit tests for the vessel identity resolver + dedup (#599).
+# ABOUTME: Covers canonicalize_name, resolve_identities clustering, dedupe_catalog.
+
+from pathlib import Path
+
+import pytest
+
+from worldenergydata.vessel_fleet.identity_crosswalk import (
+    _DEFAULT_CURATED_DIR,
+    load_corpus_records,
+)
+from worldenergydata.vessel_fleet.identity_resolver import (
+    canonicalize_name,
+    dedupe_catalog,
+    operators_compatible,
+    resolve_identities,
+)
+
+# ---------------------------------------------------------------------------
+# canonicalize_name
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalizeName:
+    def test_strips_trailing_operator_parenthetical(self):
+        assert canonicalize_name("Skandi Constructor (DOF)") == "SKANDI CONSTRUCTOR"
+
+    def test_strips_mv_prefix(self):
+        assert canonicalize_name("M/V Island Performer") == "ISLAND PERFORMER"
+        assert canonicalize_name("MV Island Performer") == "ISLAND PERFORMER"
+
+    def test_strips_msv_and_sv_prefix(self):
+        assert canonicalize_name("MSV Q4000") == "Q4000"
+        assert canonicalize_name("SV Q4000") == "Q4000"
+
+    def test_reglues_hull_number_hyphen_variant(self):
+        assert canonicalize_name("HELIX Q-4000") == "HELIX Q4000"
+        assert canonicalize_name("Q-4000") == "Q4000"
+
+    def test_strips_punctuation_and_collapses_whitespace(self):
+        assert canonicalize_name("  Deep   Blue!! ") == "DEEP BLUE"
+        assert canonicalize_name("Caldive's Q4000") == "CALDIVE S Q4000"
+
+    def test_empty_and_none(self):
+        assert canonicalize_name(None) == ""
+        assert canonicalize_name("") == ""
+
+
+# ---------------------------------------------------------------------------
+# operators_compatible
+# ---------------------------------------------------------------------------
+
+
+class TestOperatorsCompatible:
+    def test_missing_operator_is_compatible(self):
+        assert operators_compatible({"operator": None}, {"operator": "Helix"})
+
+    def test_shared_token_is_compatible(self):
+        a = {"operator": "Helix Energy Solutions"}
+        b = {"operator": "Helix Well Ops"}
+        assert operators_compatible(a, b)
+
+    def test_disjoint_operators_conflict(self):
+        a = {"operator": "Maersk Drilling"}
+        b = {"operator": "Transocean"}
+        assert not operators_compatible(a, b)
+
+
+# ---------------------------------------------------------------------------
+# resolve_identities
+# ---------------------------------------------------------------------------
+
+
+class TestResolveIdentities:
+    def test_imo_match_high_confidence(self):
+        recs = [
+            {"name": "Deep Blue", "imo": "9181135", "source": "a"},
+            {"name": "Deepblue", "imo": "9181135", "source": "b"},
+        ]
+        clusters = resolve_identities(recs)
+        assert len(clusters) == 1
+        assert clusters[0]["confidence"] == "high"
+        assert "imo" in clusters[0]["match_basis"]
+        assert clusters[0]["member_count"] == 2
+
+    def test_name_plus_operator_match_medium(self):
+        recs = [
+            {"name": "Q4000", "operator": "Helix", "source": "a"},
+            {"name": "Q4000", "operator": "Helix Energy", "source": "b"},
+        ]
+        clusters = resolve_identities(recs)
+        assert len(clusters) == 1
+        assert clusters[0]["confidence"] == "medium"
+        assert "canonical_name+operator" in clusters[0]["match_basis"]
+
+    def test_aka_match_merges(self):
+        recs = [
+            {"name": "Q4000", "operator": "Helix", "aka": ["MSV Q4000"], "source": "a"},
+            {"name": "MSV Q4000", "operator": None, "source": "b"},
+        ]
+        clusters = resolve_identities(recs)
+        assert len(clusters) == 1
+        assert "aka" in clusters[0]["match_basis"]
+
+    def test_name_match_but_operator_conflict_not_merged(self):
+        recs = [
+            {"name": "Discoverer", "operator": "Maersk", "source": "a"},
+            {"name": "Discoverer", "operator": "Transocean", "source": "b"},
+        ]
+        clusters = resolve_identities(recs)
+        # Same name, conflicting operator -> two distinct vessels.
+        assert len(clusters) == 2
+
+    def test_singleton_records_stay_separate(self):
+        recs = [
+            {"name": "Alpha", "source": "a"},
+            {"name": "Beta", "source": "b"},
+        ]
+        clusters = resolve_identities(recs)
+        assert len(clusters) == 2
+        assert all(c["confidence"] == "singleton" for c in clusters)
+
+
+# ---------------------------------------------------------------------------
+# dedupe_catalog
+# ---------------------------------------------------------------------------
+
+
+class TestDedupeCatalog:
+    def test_count_reduction_and_report(self):
+        recs = [
+            {
+                "name": "Q4000",
+                "operator": "Helix",
+                "class": "heavy_intervention_semi",
+                "aka": ["MSV Q4000", "HELIX Q4000"],
+                "source": "seed",
+            },
+            {"name": "MSV Q4000", "class": "heavy_intervention_semi", "source": "war"},
+            {
+                "name": "HELIX Q4000",
+                "class": "heavy_intervention_semi",
+                "source": "war",
+            },
+            {"name": "Island Performer", "class": "rlwi_monohull", "source": "roster"},
+        ]
+        deduped, report = dedupe_catalog(recs)
+        assert report["records_in"] == 4
+        assert report["distinct_vessels_out"] == 2
+        assert report["duplicates_collapsed"] == 2
+        # The Q4000 cluster collapses 3 rows to 1 and unions the aka names.
+        q = next(d for d in deduped if d["CANONICAL_NAME"] == "Q4000")
+        assert q["member_count"] == 3
+        assert "MSV Q4000" in q["ALTERNATE_NAMES"]
+        delta = report["per_class_delta"]["heavy_intervention_semi"]
+        assert delta["before"] == 3
+        assert delta["after"] == 1
+
+    def test_canonical_name_and_alternate_names_populated(self):
+        recs = [
+            {"name": "Skandi Constructor (DOF)", "operator": "DOF", "source": "a"},
+            {"name": "Skandi Constructor", "operator": "DOF Subsea", "source": "b"},
+        ]
+        deduped, _ = dedupe_catalog(recs)
+        assert len(deduped) == 1
+        assert deduped[0]["CANONICAL_NAME"] == "SKANDI CONSTRUCTOR"
+        assert deduped[0]["ALTERNATE_NAMES"]
+
+
+# ---------------------------------------------------------------------------
+# Real-corpus smoke test (skip if curated CSVs not mounted)
+# ---------------------------------------------------------------------------
+
+
+class TestRealCorpusSmoke:
+    def test_distinct_less_than_total(self):
+        if not (Path(_DEFAULT_CURATED_DIR) / "drilling_rigs.csv").is_file():
+            pytest.skip("curated CSVs not mounted")
+        records = load_corpus_records()
+        assert len(records) > 2000  # full corpus present
+        deduped, report = dedupe_catalog(records)
+        assert report["distinct_vessels_out"] < report["records_in"]
+        assert report["duplicates_collapsed"] > 0
+        # The Helix Q-series double-count is collapsed to <=3 heavy semis hulls.
+        hsemi = report["per_class_delta"]["heavy_intervention_semi"]
+        assert hsemi["after"] < hsemi["before"]


### PR DESCRIPTION
Closes #599 (child of #591)

## What
Vessel **identity resolver + dedup** over the full fleet corpus. IMO coverage in the bulk corpus is ~0% (curated `drilling_rigs.csv` has no IMO column; `construction_vessels.csv` is sparse), so the working dedup key is **normalized canonical name + operator/owner compatibility**, with an **alternate-name (aka) list** to absorb spelling/marketing variants and renames, and **IMO/MMSI used only as a strong confirmer when present**.

## Scope
- **Schema (additive)** `schemas/base.py`: `CANONICAL_NAME: Optional[str]` + `ALTERNATE_NAMES: Optional[list[str]]` with validators matching existing style. Nothing removed.
- **`identity_resolver.py`**: `canonicalize_name` (uppercase, strip punctuation, strip trailing parenthetical operator suffix e.g. `Skandi Constructor (DOF)` -> `SKANDI CONSTRUCTOR`, strip M/V·MV·MSV·SV prefixes, conservative hull-number re-glue `Q-4000` -> `Q4000`); `resolve_identities` (union-find clustering: exact IMO=high, canonical-name+compatible-operator=medium, aka/name-only=low; **never merges when operators conflict**); `dedupe_catalog` (collapse clusters, union aka, before/after report + per-class delta).
- **`identity_crosswalk.py`**: real-corpus runner over curated CSVs + #593 roster + #598 seed; writes aggregate `data/identity_crosswalk.yml` (cluster summary only, no per-row dump).
- **Tests**: `tests/unit/vessel_fleet/test_identity_resolver.py` — 17 assertions incl. canonicalize cases, IMO/name+operator/aka matches, **name-match-but-operator-conflict -> NOT merged**, dedupe count reduction, and a skip-if-missing real-corpus smoke test (distinct < total).

## Real-corpus dedup numbers
| metric | value |
|---|---|
| records in | **2,471** |
| distinct vessels out | **2,352** |
| duplicates collapsed | **119** |
| multi-member clusters | 52 |

Per-source in: drilling_rigs.csv 2,268 · construction_vessels.csv 165 · OSV roster 29 · seed 9.

## #598 heavy_intervention_semi double-count fix
The #598 catalog counted the Helix Q-series semis once per name-spelling variant. The resolver collapses every variant of each hull into one distinct vessel:
- **Q4000**: 13 variants -> 1 (`Q4000`, `HELIX Q4000`, `MSV Q4000`, `CALDIVE Q4000`, `HELIX Q-4000`, `HELIZ Q4000`, `CALDIVE'S Q4000 DP`, seed `Helix Q4000`, roster `Q4000`, ...)
- **Q5000**: 3 -> 1   ·   **Q7000**: 2 -> 1

Net: `heavy_intervention_semi` **16 -> 5 distinct** hulls (Q4000, Q5000, Q7000, Seawell, Well Enhancer); 15 duplicate rows removed across the Q-series.

Do not merge.