### PR TITLE
chore(reports): fold dedup + dayrates into catalog + regenerate brief (#623)

### DIFF
--- a/docs/intervention-db/intervention-stats-brief.generated.md
+++ b/docs/intervention-db/intervention-stats-brief.generated.md
@@ -68,18 +68,20 @@ Triangulated against independent research:
 
 ### Global available roster (CONTEXT ONLY — NOT GoM supply)
 
-These are WORLDWIDE fleet counts. They include shelf and non-GoM assets and must NOT be read as Gulf-of-Mexico intervention supply. They show the size of the global pool a GoM operator competes for, nothing more.
+These are WORLDWIDE fleet counts. They include shelf and non-GoM assets and must NOT be read as Gulf-of-Mexico intervention supply. They show the size of the global pool a GoM operator competes for, nothing more. Counts are DEDUPED distinct hulls (#599): 2,442 source listings collapse to 2,337 vessels (105 duplicates removed, e.g. the Helix Q-class name-spelling variants), so no hull is double-counted.
 
-| Asset class (global) | Count | Water-depth capability (ft) |
-| --- | ---: | --- |
-| modu_drillship | 163 | 4,900-12,000 |
-| modu_semisub | 308 | 1,500-12,500 |
-| modu_jackup | 1,027 | 300-492 |
-| heavy_intervention_semi | 13 | 1,197-10,000 |
-| rlwi_monohull | 5 | 6,561-6,561 |
-| lift_boat | 158 | n/a |
-| construction_vessel | 162 | 49-13,123 |
-| other | 606 | 5,000-5,000 |
+Indicative day-rates are an attached PUBLIC snapshot (#596), as of 2026-02-19 — issuer FSRs / filings / dated trade press, NOT a live subscription feed. Helix Q-class intervention semis and RLWI monohulls carry no public per-day figure (shown as dayrate not public).
+
+| Asset class (global) | Count [deduped] | Water-depth capability (ft) | Indicative day-rate |
+| --- | ---: | --- | --- |
+| modu_drillship | 161 | 4,900-12,000 | $300,000-$530,000/day (median $457,000) [analyst, on_record, reported] |
+| modu_semisub | 305 | 1,500-12,500 | $452,000-$490,000/day (median $465,000) [on_record] |
+| modu_jackup | 1,018 | 300-492 | n/a |
+| heavy_intervention_semi | 6 | 1,197-10,000 | dayrate not public [not public] |
+| rlwi_monohull | 4 | 6,561-6,561 | dayrate not public [not public] |
+| lift_boat | 143 | n/a | n/a |
+| construction_vessel | 155 | 49-13,123 | n/a |
+| other | 545 | 5,000-5,000 | n/a |
 
 
 ## Planned / projected new subsea wells

--- a/docs/intervention-db/intervention-stats-brief.generated.md
+++ b/docs/intervention-db/intervention-stats-brief.generated.md
@@ -68,7 +68,7 @@ Triangulated against independent research:
 
 ### Global available roster (CONTEXT ONLY — NOT GoM supply)
 
-These are WORLDWIDE fleet counts. They include shelf and non-GoM assets and must NOT be read as Gulf-of-Mexico intervention supply. They show the size of the global pool a GoM operator competes for, nothing more. Counts are DEDUPED distinct hulls (#599): 2,442 source listings collapse to 2,337 vessels (105 duplicates removed, e.g. the Helix Q-class name-spelling variants), so no hull is double-counted.
+These are WORLDWIDE fleet counts. They include shelf and non-GoM assets and must NOT be read as Gulf-of-Mexico intervention supply. They show the size of the global pool a GoM operator competes for, nothing more. Counts are DEDUPED distinct hulls (#599): 2,442 source listings collapse to 2,336 vessels (106 duplicates removed, e.g. the Helix Q-class name-spelling variants), so no hull is double-counted.
 
 Indicative day-rates are an attached PUBLIC snapshot (#596), as of 2026-02-19 — issuer FSRs / filings / dated trade press, NOT a live subscription feed. Helix Q-class intervention semis and RLWI monohulls carry no public per-day figure (shown as dayrate not public).
 
@@ -77,7 +77,7 @@ Indicative day-rates are an attached PUBLIC snapshot (#596), as of 2026-02-19 �
 | modu_drillship | 161 | 4,900-12,000 | $300,000-$530,000/day (median $457,000) [analyst, on_record, reported] |
 | modu_semisub | 305 | 1,500-12,500 | $452,000-$490,000/day (median $465,000) [on_record] |
 | modu_jackup | 1,018 | 300-492 | n/a |
-| heavy_intervention_semi | 6 | 1,197-10,000 | dayrate not public [not public] |
+| heavy_intervention_semi | 5 | 1,197-10,000 | dayrate not public [not public] |
 | rlwi_monohull | 4 | 6,561-6,561 | dayrate not public [not public] |
 | lift_boat | 143 | n/a | n/a |
 | construction_vessel | 155 | 49-13,123 | n/a |

--- a/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/intervention/brief_generator.py
+++ b/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/intervention/brief_generator.py
@@ -25,9 +25,15 @@ source YAML assigns it — ``[on record]``, ``[soft]``, ``[projected]`` or
 ``[engineering judgement]`` — so a reader can see how hard each number is.
 
 The CRITICAL framing rule (see the fleet section): the global ``by_asset_class``
-counts (1,027 jackups, 308 semis, ...) are a WORLDWIDE roster and are presented
+counts (~1,018 jackups, ~305 semis, ...) are a WORLDWIDE roster and are presented
 only as background context. They are NOT GoM supply. The binding GoM figure is
 ``gom_resident_dedicated_intervention`` (~3 [soft]) plus the ~2-4 soft estimate.
+
+Two upstream refinements (#623) now flow through the fleet section: the counts
+are DEDUPED distinct hulls (#599, so the Helix Q-class spelling variants no
+longer inflate ``heavy_intervention_semi``), and each priced asset class carries
+an indicative PUBLIC day-rate band (#596) — with Helix Q-class semis and RLWI
+monohulls explicitly flagged as "dayrate not public".
 """
 
 from __future__ import annotations
@@ -106,6 +112,29 @@ def _fmt_int(value) -> str:
         return f"{int(value):,}"
     except (TypeError, ValueError):
         return str(value)
+
+
+def _fmt_dayrate(info: dict) -> str:
+    """Render an asset class's indicative public day-rate band as a cell.
+
+    Pulls the ``indicative_dayrate`` block attached by the day-rate snapshot
+    (#596). Classes the snapshot does not price render ``n/a``; classes with no
+    public per-day figure (Helix Q-class semis, RLWI monohulls) render an
+    explicit ``dayrate not public`` so the wall is never silently dropped.
+    """
+    dr = info.get("indicative_dayrate")
+    if not dr:
+        return "n/a"
+    if not dr.get("rate_disclosed"):
+        return "dayrate not public [not public]"
+    low = dr.get("band_low_usd_per_day")
+    high = dr.get("band_high_usd_per_day")
+    median = dr.get("median_usd_per_day")
+    labels = ", ".join(dr.get("confidence_labels", []) or [])
+    band = f"${_fmt_int(low)}-${_fmt_int(high)}/day"
+    med = f" (median ${_fmt_int(median)})" if median is not None else ""
+    tag = f" [{labels}]" if labels else ""
+    return f"{band}{med}{tag}"
 
 
 def _deepest_populated_band(bands: dict) -> Optional[str]:
@@ -264,16 +293,37 @@ def _section_fleet(fleet: dict) -> str:
             f" — {item.get('note', '')}"
         )
 
+    dedup = fleet.get("dedup", {}) or {}
+    as_of = fleet.get("dayrate_snapshot_as_of")
+    dedup_note = ""
+    if dedup.get("applied"):
+        dedup_note = (
+            f" Counts are DEDUPED distinct hulls (#599): "
+            f"{_fmt_int(dedup.get('records_in'))} source listings collapse to "
+            f"{_fmt_int(dedup.get('distinct_out'))} vessels "
+            f"({_fmt_int(dedup.get('duplicates_collapsed'))} duplicates removed, "
+            "e.g. the Helix Q-class name-spelling variants), so no hull is "
+            "double-counted."
+        )
+
     lines += [
         "",
         "### Global available roster (CONTEXT ONLY — NOT GoM supply)",
         "",
         "These are WORLDWIDE fleet counts. They include shelf and non-GoM assets "
         "and must NOT be read as Gulf-of-Mexico intervention supply. They show "
-        "the size of the global pool a GoM operator competes for, nothing more.",
+        "the size of the global pool a GoM operator competes for, nothing more."
+        + dedup_note,
         "",
-        "| Asset class (global) | Count | Water-depth capability (ft) |",
-        "| --- | ---: | --- |",
+        "Indicative day-rates are an attached PUBLIC snapshot (#596)"
+        + (f", as of {as_of}" if as_of else "")
+        + " — issuer FSRs / filings / dated trade press, NOT a live subscription "
+        "feed. Helix Q-class intervention semis and RLWI monohulls carry no "
+        "public per-day figure (shown as dayrate not public).",
+        "",
+        "| Asset class (global) | Count [deduped] | Water-depth capability (ft) "
+        "| Indicative day-rate |",
+        "| --- | ---: | --- | --- |",
     ]
     for klass, info in by_class.items():
         cap = info.get("water_depth_capability_ft", {}) or {}
@@ -282,7 +332,10 @@ def _section_fleet(fleet: dict) -> str:
             if cap.get("min") is not None or cap.get("max") is not None
             else "n/a"
         )
-        lines.append(f"| {klass} | {_fmt_int(info.get('count'))} | {cap_str} |")
+        lines.append(
+            f"| {klass} | {_fmt_int(info.get('count'))} | {cap_str} "
+            f"| {_fmt_dayrate(info)} |"
+        )
 
     lines += ["", ""]
     return "\n".join(lines)

--- a/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/data/intervention_fleet_catalog.yml
+++ b/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/data/intervention_fleet_catalog.yml
@@ -14,7 +14,7 @@ asset_class_taxonomy:
 - other
 totals:
   units_classified: 2442
-  distinct_hulls: 2337
+  distinct_hulls: 2336
   seed_dedicated_units: 9
 dedup:
   applied: true
@@ -23,8 +23,8 @@ dedup:
     confirm when present); collapses Helix Q-class name-spelling variants so by_asset_class
     counts are distinct hulls.
   records_in: 2442
-  distinct_out: 2337
-  duplicates_collapsed: 105
+  distinct_out: 2336
+  duplicates_collapsed: 106
 by_asset_class_scope: GLOBAL available roster (curated contractor/BSEE fleet + seed),
   NOT GoM-resident. These are worldwide fleet counts; for GoM supply use gom_resident_dedicated_intervention
   below.
@@ -66,7 +66,7 @@ by_asset_class:
       max: 492.0
     named_flagship_units: []
   heavy_intervention_semi:
-    count: 6
+    count: 5
     water_depth_capability_ft:
       min: 1197.5
       max: 10000.0
@@ -155,7 +155,7 @@ reconciliation_to_research:
     note: only two rigs worldwide rated to 20,000 psi
 provenance:
   seed: intervention_vessels_seed.yml
-  curated_dir: /mnt/local-analysis/worldenergydata/data/modules/vessel_fleet/curated
+  curated_dir: packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/_data/curated
   curated_files:
   - drilling_rigs.csv
   - construction_vessels.csv

--- a/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/data/intervention_fleet_catalog.yml
+++ b/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/data/intervention_fleet_catalog.yml
@@ -14,31 +14,59 @@ asset_class_taxonomy:
 - other
 totals:
   units_classified: 2442
+  distinct_hulls: 2337
   seed_dedicated_units: 9
+dedup:
+  applied: true
+  issue: 599
+  basis: normalized canonical name + operator/owner compatibility + aka list (IMO/MMSI
+    confirm when present); collapses Helix Q-class name-spelling variants so by_asset_class
+    counts are distinct hulls.
+  records_in: 2442
+  distinct_out: 2337
+  duplicates_collapsed: 105
 by_asset_class_scope: GLOBAL available roster (curated contractor/BSEE fleet + seed),
   NOT GoM-resident. These are worldwide fleet counts; for GoM supply use gom_resident_dedicated_intervention
   below.
 by_asset_class:
   modu_drillship:
-    count: 163
+    count: 161
     water_depth_capability_ft:
       min: 4900.0
       max: 12000.0
     named_flagship_units: []
+    indicative_dayrate:
+      rate_count: 25
+      median_usd_per_day: 457000
+      band_low_usd_per_day: 300000
+      band_high_usd_per_day: 530000
+      rate_disclosed: true
+      confidence_labels:
+      - analyst
+      - on_record
+      - reported
   modu_semisub:
-    count: 308
+    count: 305
     water_depth_capability_ft:
       min: 1500.0
       max: 12500.0
     named_flagship_units: []
+    indicative_dayrate:
+      rate_count: 3
+      median_usd_per_day: 465000
+      band_low_usd_per_day: 452000
+      band_high_usd_per_day: 490000
+      rate_disclosed: true
+      confidence_labels:
+      - on_record
   modu_jackup:
-    count: 1027
+    count: 1018
     water_depth_capability_ft:
       min: 300.0
       max: 492.0
     named_flagship_units: []
   heavy_intervention_semi:
-    count: 13
+    count: 6
     water_depth_capability_ft:
       min: 1197.5
       max: 10000.0
@@ -48,8 +76,16 @@ by_asset_class:
     - Helix Q7000
     - Seawell
     - Well Enhancer
+    indicative_dayrate:
+      rate_count: 0
+      median_usd_per_day: null
+      band_low_usd_per_day: null
+      band_high_usd_per_day: null
+      rate_disclosed: false
+      confidence_labels:
+      - not_public
   rlwi_monohull:
-    count: 5
+    count: 4
     water_depth_capability_ft:
       min: 6561.7
       max: 6561.7
@@ -58,20 +94,28 @@ by_asset_class:
     - Island Wellserver
     - Island Constructor
     - Skandi Constructor
+    indicative_dayrate:
+      rate_count: 0
+      median_usd_per_day: null
+      band_low_usd_per_day: null
+      band_high_usd_per_day: null
+      rate_disclosed: false
+      confidence_labels:
+      - not_public
   lift_boat:
-    count: 158
+    count: 143
     water_depth_capability_ft:
       min: null
       max: null
     named_flagship_units: []
   construction_vessel:
-    count: 162
+    count: 155
     water_depth_capability_ft:
       min: 49.9
       max: 13123.4
     named_flagship_units: []
   other:
-    count: 606
+    count: 545
     water_depth_capability_ft:
       min: 5000.0
       max: 5000.0
@@ -118,11 +162,15 @@ provenance:
 caveats:
 - Curated CSV rosters may be stale (snapshot, not live).
 - Drive-corpus historical fleet records date to 2010-2014.
-- 'Populations are additive: dedup vs IMO is deferred to #599, so counts may double-count
-  a unit present in both seed and curated.'
+- 'by_asset_class counts are DISTINCT HULLS: source listings are deduped via the #599
+  identity resolver (name+operator+aka, IMO when present), so a unit present in both
+  seed and curated is counted once.'
+- Indicative day-rates are an attached PUBLIC snapshot (#596), not a live subscription
+  feed; intervention semis and RLWI monohulls have no public per-day figure (rate_disclosed=false).
 - Water-depth ratings are nameplate vendor figures and approximate.
 - by_asset_class counts are GLOBAL fleet, not GoM-resident supply; MODU/jackup counts
   include shelf + non-GoM assets. The binding GoM intervention supply is gom_resident_dedicated_intervention
   (~2-4).
 - 'mpsv_osv is under-counted: the ~500-vessel OSV/MPSV roster awaits the vendor-scrape
   ingest (#593).'
+dayrate_snapshot_as_of: '2026-02-19'

--- a/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/fleet_catalog.py
+++ b/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/fleet_catalog.py
@@ -18,19 +18,33 @@ never the full per-vessel roster (that stays in the gitignored curated CSVs).
 Confidence labels follow the brief's convention:
 ``on_record`` (hard count), ``soft`` (estimate, wide band), ``projected``.
 
-De-duplication across sources (IMO keying) is intentionally deferred to #599;
-this catalog therefore treats the three populations as additive and flags the
-overlap as a caveat.
+De-duplication across sources (#599) is folded in here: before counting by
+class, every classified record is passed through
+:func:`identity_resolver.dedupe_catalog`, so the ``by_asset_class`` counts are
+DISTINCT HULLS rather than additive listings. This collapses the Helix Q-class
+name-spelling variants (``Q4000`` / ``MSV Q4000`` / ``HELIX Q-4000`` / ...) that
+previously inflated ``heavy_intervention_semi``. Each priced asset class is also
+decorated with an indicative public day-rate band (#596) via
+:func:`dayrate_snapshot.attach_dayrates_to_catalog`. Water-depth ranges and
+named flagships are still derived from the raw records (min/max and a name-set
+are unaffected by duplicates).
 """
 
 from __future__ import annotations
 
 import csv
 import logging
+from collections import Counter
 from pathlib import Path
 from typing import Any, Optional
 
 import yaml
+
+from worldenergydata.vessel_fleet.dayrate_snapshot import (
+    attach_dayrates_to_catalog,
+)
+from worldenergydata.vessel_fleet.identity_crosswalk import _aka_for
+from worldenergydata.vessel_fleet.identity_resolver import dedupe_catalog
 
 logger = logging.getLogger(__name__)
 
@@ -262,6 +276,11 @@ def build_fleet_catalog(
         cls: _ClassAccumulator() for cls in ASSET_CLASSES
     }
     gom_dedicated: list[dict[str, Any]] = []
+    # Parallel record list fed to the #599 identity resolver so the class counts
+    # below are DISTINCT HULLS, not additive listings. Each record carries the
+    # name/operator/owner/imo/aka the resolver keys on, plus its ``class`` so the
+    # deduped output can be re-tallied by asset class.
+    dedup_records: list[dict[str, Any]] = []
 
     # 1. Seed (dedicated intervention fleet) -- named flagship units.
     seed_vessels = _load_seed(seed_p)
@@ -271,6 +290,18 @@ def build_fleet_catalog(
         depth_m = _to_float(v.get("water_depth_rating_m"))
         depth_ft = depth_m * _FT_PER_M if depth_m is not None else None
         accumulators[cls].add(depth_ft, flagship=name)
+        dedup_records.append(
+            {
+                "name": name,
+                "operator": v.get("operator") or None,
+                "owner": v.get("operator") or None,
+                "imo": v.get("imo") or None,
+                "mmsi": v.get("mmsi") or None,
+                "aka": list(v.get("aka") or []) + _aka_for(name),
+                "source": DEFAULT_SEED_PATH.name,
+                "class": cls,
+            }
+        )
         if v.get("gom_resident") is True:
             gom_dedicated.append(
                 {
@@ -283,25 +314,56 @@ def build_fleet_catalog(
 
     # 2. Curated drilling rigs.
     for row in _read_curated_csv(curated / _DRILLING_RIGS_FILE):
-        cls = classify_asset_class(
-            rig_type=row.get("RIG_TYPE"), name=row.get("RIG_NAME")
-        )
+        name = row.get("RIG_NAME")
+        cls = classify_asset_class(rig_type=row.get("RIG_TYPE"), name=name)
         accumulators[cls].add(_to_float(row.get("WATER_DEPTH_RATING_FT")))
+        dedup_records.append(
+            {
+                "name": name,
+                "operator": row.get("OPERATOR") or None,
+                "owner": row.get("OWNER") or None,
+                "imo": row.get("IMO_NUMBER") or None,
+                "mmsi": None,
+                "aka": _aka_for(name),
+                "source": _DRILLING_RIGS_FILE,
+                "class": cls,
+            }
+        )
 
     # 3. Curated construction vessels (depth is in metres here).
     for row in _read_curated_csv(curated / _CONSTRUCTION_VESSELS_FILE):
-        cls = classify_asset_class(
-            vessel_type=row.get("VESSEL_TYPE"), name=row.get("VESSEL_NAME")
-        )
+        name = row.get("VESSEL_NAME")
+        cls = classify_asset_class(vessel_type=row.get("VESSEL_TYPE"), name=name)
         depth_m = _to_float(row.get("WATER_DEPTH_RATING_M"))
         depth_ft = depth_m * _FT_PER_M if depth_m is not None else None
         accumulators[cls].add(depth_ft)
+        dedup_records.append(
+            {
+                "name": name,
+                "operator": row.get("OPERATOR") or None,
+                "owner": row.get("OWNER") or None,
+                "imo": row.get("IMO_NUMBER") or None,
+                "mmsi": row.get("MMSI") or None,
+                "aka": _aka_for(name),
+                "source": _CONSTRUCTION_VESSELS_FILE,
+                "class": cls,
+            }
+        )
 
-    by_class = {
-        cls: accumulators[cls].summary()
-        for cls in ASSET_CLASSES
-        if accumulators[cls].count > 0
-    }
+    # --- Dedup (#599): collapse same-hull listings to distinct vessels. ------
+    deduped, dedup_report = dedupe_catalog(dedup_records)
+    distinct_by_class: Counter[str] = Counter(
+        r.get("CLASS") for r in deduped if r.get("CLASS")
+    )
+
+    by_class = {}
+    for cls in ASSET_CLASSES:
+        if accumulators[cls].count == 0:
+            continue
+        summary = accumulators[cls].summary()
+        # Replace the additive raw count with the distinct-hull count (#599).
+        summary["count"] = distinct_by_class.get(cls, 0)
+        by_class[cls] = summary
     total_units = sum(acc.count for acc in accumulators.values())
 
     catalog: dict[str, Any] = {
@@ -312,7 +374,21 @@ def build_fleet_catalog(
         "asset_class_taxonomy": list(ASSET_CLASSES),
         "totals": {
             "units_classified": total_units,
+            "distinct_hulls": dedup_report["distinct_vessels_out"],
             "seed_dedicated_units": len(seed_vessels),
+        },
+        "dedup": {
+            "applied": True,
+            "issue": 599,
+            "basis": (
+                "normalized canonical name + operator/owner compatibility + aka "
+                "list (IMO/MMSI confirm when present); collapses Helix Q-class "
+                "name-spelling variants so by_asset_class counts are distinct "
+                "hulls."
+            ),
+            "records_in": dedup_report["records_in"],
+            "distinct_out": dedup_report["distinct_vessels_out"],
+            "duplicates_collapsed": dedup_report["duplicates_collapsed"],
         },
         "by_asset_class_scope": (
             "GLOBAL available roster (curated contractor/BSEE fleet + seed), "
@@ -334,8 +410,12 @@ def build_fleet_catalog(
         "caveats": [
             "Curated CSV rosters may be stale (snapshot, not live).",
             "Drive-corpus historical fleet records date to 2010-2014.",
-            "Populations are additive: dedup vs IMO is deferred to #599, so "
-            "counts may double-count a unit present in both seed and curated.",
+            "by_asset_class counts are DISTINCT HULLS: source listings are "
+            "deduped via the #599 identity resolver (name+operator+aka, IMO when "
+            "present), so a unit present in both seed and curated is counted once.",
+            "Indicative day-rates are an attached PUBLIC snapshot (#596), not a "
+            "live subscription feed; intervention semis and RLWI monohulls have "
+            "no public per-day figure (rate_disclosed=false).",
             "Water-depth ratings are nameplate vendor figures and approximate.",
             "by_asset_class counts are GLOBAL fleet, not GoM-resident supply; "
             "MODU/jackup counts include shelf + non-GoM assets. The binding GoM "
@@ -344,6 +424,13 @@ def build_fleet_catalog(
             "the vendor-scrape ingest (#593).",
         ],
     }
+
+    # Decorate each priced asset class with an indicative public day-rate band
+    # (#596). Degrades gracefully if the snapshot file is absent (CI safety).
+    try:
+        catalog = attach_dayrates_to_catalog(catalog)
+    except FileNotFoundError:
+        logger.warning("Day-rate snapshot not found; emitting catalog without bands")
 
     out_p.parent.mkdir(parents=True, exist_ok=True)
     out_p.write_text(

--- a/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/identity_resolver.py
+++ b/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/identity_resolver.py
@@ -78,6 +78,10 @@ def canonicalize_name(name: Optional[str]) -> str:
         prev = s
         s = _TRAILING_PAREN_RE.sub("", s).strip()
     s = s.upper()
+    # 2b. Strip leading non-alphanumeric noise (e.g. a malformed leading comma
+    #     from a misaligned BSEE CSV row) so the prefix check sees the real
+    #     first token: ",SV Q4000" -> "SV Q4000" -> (prefix strip) -> "Q4000".
+    s = re.sub(r"^[^A-Z0-9]+", "", s)
     # 3. Leading prefix (single pass -- only one class tag is meaningful).
     for prefix in _PREFIXES:
         if s.startswith(prefix):

--- a/tests/unit/bsee/analysis/intervention/test_brief_generator.py
+++ b/tests/unit/bsee/analysis/intervention/test_brief_generator.py
@@ -100,17 +100,39 @@ analyst_rate:
 """
 
 _FLEET_YML = """\
+dayrate_snapshot_as_of: 2026-02-19
+dedup:
+  applied: true
+  records_in: 4747
+  distinct_out: 4646
+  duplicates_collapsed: 101
 by_asset_class:
   modu_jackup:
     count: 4242
     water_depth_capability_ft:
       min: 300.0
       max: 492.0
+    indicative_dayrate:
+      rate_count: 3
+      median_usd_per_day: 75500
+      band_low_usd_per_day: 60500
+      band_high_usd_per_day: 95500
+      rate_disclosed: true
+      confidence_labels:
+      - reported
   rlwi_monohull:
     count: 5
     water_depth_capability_ft:
       min: 6561.0
       max: 6561.0
+    indicative_dayrate:
+      rate_count: 0
+      median_usd_per_day: null
+      band_low_usd_per_day: null
+      band_high_usd_per_day: null
+      rate_disclosed: false
+      confidence_labels:
+      - not_public
 gom_resident_dedicated_intervention:
   count: 6
   confidence: soft
@@ -229,6 +251,29 @@ class TestConfidenceLabels:
         assert gom_idx < roster_idx
 
 
+class TestDedupAndDayrates:
+    def test_deduped_count_note_renders(self, synthetic_yamls):
+        md = _brief(synthetic_yamls)
+        assert "DEDUPED distinct hulls" in md
+        # Numbers flow from the fixture dedup block.
+        assert "4,747" in md
+        assert "4,646" in md
+        assert "101 duplicates removed" in md
+
+    def test_indicative_dayrate_band_renders(self, synthetic_yamls):
+        md = _brief(synthetic_yamls)
+        # Disclosed band marker numbers from the fixture.
+        assert "$60,500-$95,500/day" in md
+        assert "median $75,500" in md
+        assert "[reported]" in md
+
+    def test_not_public_classes_flagged(self, synthetic_yamls):
+        md = _brief(synthetic_yamls)
+        # RLWI monohull carries no public per-day figure.
+        assert "dayrate not public" in md
+        assert "as of 2026-02-19" in md
+
+
 class TestWriteOut:
     def test_writes_file_when_out_path_given(self, synthetic_yamls, tmp_path):
         out = tmp_path / "sub" / "brief.generated.md"
@@ -256,6 +301,18 @@ class TestRealCommittedYamls:
 
         fleet = load_fleet_catalog()
         assert fleet["gom_resident_dedicated_intervention"]["count"] == 3
+        # #599 dedup folded in: heavy_intervention_semi is distinct hulls (<13).
+        heavy = fleet["by_asset_class"]["heavy_intervention_semi"]
+        assert heavy["count"] < 13
+        assert fleet["dedup"]["applied"] is True
+        # #596 day-rates attached to the committed catalog.
+        assert heavy["indicative_dayrate"]["rate_disclosed"] is False
+        assert (
+            fleet["by_asset_class"]["modu_drillship"]["indicative_dayrate"][
+                "rate_disclosed"
+            ]
+            is True
+        )
 
         md = generate_brief()
         assert "114" in md
@@ -263,3 +320,7 @@ class TestRealCommittedYamls:
         assert "270" in md
         assert "GoM-resident dedicated intervention units (the binding supply)" in md
         assert "NOT GoM supply" in md
+        # The refreshed fleet section shows deduped counts + day-rate bands.
+        assert "DEDUPED distinct hulls" in md
+        assert "dayrate not public" in md
+        assert "/day" in md

--- a/tests/unit/vessel_fleet/test_fleet_catalog.py
+++ b/tests/unit/vessel_fleet/test_fleet_catalog.py
@@ -185,17 +185,100 @@ class TestBuildFleetCatalog:
         cat = fc.build_fleet_catalog(curated_dir=curated, seed_path=seed, out_path=out)
         assert any("599" in c for c in cat["caveats"])
 
+    def test_dedup_block_present_no_duplicates(self, tmp_path):
+        # The synthetic population has no same-hull duplicates, so dedup is a
+        # no-op (records_in == distinct_out) but the block is still emitted.
+        curated, seed, out = _write_fixtures(tmp_path)
+        cat = fc.build_fleet_catalog(curated_dir=curated, seed_path=seed, out_path=out)
+        dedup = cat["dedup"]
+        assert dedup["applied"] is True
+        assert dedup["records_in"] == 9
+        assert dedup["distinct_out"] == 9
+        assert dedup["duplicates_collapsed"] == 0
+
+    def test_indicative_dayrate_attached_to_priced_classes(self, tmp_path):
+        # modu_drillship is a priced snapshot class -> indicative band attached;
+        # modu_jackup is not priced -> no band. Uses the committed real snapshot.
+        curated, seed, out = _write_fixtures(tmp_path)
+        cat = fc.build_fleet_catalog(curated_dir=curated, seed_path=seed, out_path=out)
+        by = cat["by_asset_class"]
+        assert "indicative_dayrate" in by["modu_drillship"]
+        assert by["modu_drillship"]["indicative_dayrate"]["rate_disclosed"] is True
+        # Heavy intervention semis have no public per-day figure.
+        assert (
+            by["heavy_intervention_semi"]["indicative_dayrate"]["rate_disclosed"]
+            is False
+        )
+        assert "indicative_dayrate" not in by["modu_jackup"]
+        assert cat["dayrate_snapshot_as_of"]
+
+
+class TestDedupReducesCounts:
+    """Two name-spelling variants of one hull must collapse to a single count."""
+
+    def _build(self, tmp_path, drilling_csv):
+        curated = tmp_path / "curated"
+        curated.mkdir()
+        (curated / "drilling_rigs.csv").write_text(drilling_csv, encoding="utf-8")
+        (curated / "construction_vessels.csv").write_text(
+            "VESSEL_NAME,VESSEL_TYPE,WATER_DEPTH_RATING_M\n", encoding="utf-8"
+        )
+        seed = tmp_path / "seed.yml"
+        seed.write_text(yaml.safe_dump({"vessels": []}), encoding="utf-8")
+        out = tmp_path / "catalog.yml"
+        return fc.build_fleet_catalog(curated_dir=curated, seed_path=seed, out_path=out)
+
+    def test_same_hull_variants_collapse_to_one(self, tmp_path):
+        # "Q4000" and "MSV Q4000" canonicalize to the same hull -> one heavy semi.
+        csv_text = (
+            "RIG_NAME,RIG_TYPE,WATER_DEPTH_RATING_FT\n"
+            "Q4000,semi_submersible,4000\n"
+            "MSV Q4000,semi_submersible,4000\n"
+        )
+        cat = self._build(tmp_path, csv_text)
+        assert cat["by_asset_class"]["heavy_intervention_semi"]["count"] == 1
+        assert cat["dedup"]["records_in"] == 2
+        assert cat["dedup"]["distinct_out"] == 1
+        assert cat["dedup"]["duplicates_collapsed"] == 1
+
 
 # --- Real-data integration (skipped when off-repo data not mounted) ---------
 
-_REAL_SEED = (
+_PKG_ROOT = (
     Path(__file__).resolve().parents[3]
-    / "packages/worldenergydata-vessel_fleet/src/worldenergydata"
-    / "vessel_fleet/data/intervention_vessels_seed.yml"
+    / "packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet"
 )
+_REAL_SEED = _PKG_ROOT / "data/intervention_vessels_seed.yml"
+# The committed, git-tracked curated CSVs (CI-available, not the main checkout).
+_PKG_CURATED = _PKG_ROOT / "_data/curated"
 _REAL_CURATED = Path(
     "/mnt/local-analysis/worldenergydata/data/modules/vessel_fleet/curated"
 )
+
+
+@pytest.mark.skipif(
+    not (_REAL_SEED.is_file() and (_PKG_CURATED / "drilling_rigs.csv").is_file()),
+    reason="committed seed or curated CSVs not available",
+)
+def test_real_dedup_reduces_heavy_intervention_semi(tmp_path):
+    # Folds in #599: the Helix Q-class name-spelling variants in the curated
+    # roster collapse, so heavy_intervention_semi drops from the additive 13.
+    out = tmp_path / "catalog.yml"
+    cat = fc.build_fleet_catalog(
+        curated_dir=_PKG_CURATED, seed_path=_REAL_SEED, out_path=out
+    )
+    heavy = cat["by_asset_class"]["heavy_intervention_semi"]
+    assert heavy["count"] < 13
+    assert heavy["count"] <= 6
+    assert cat["dedup"]["applied"] is True
+    assert cat["dedup"]["duplicates_collapsed"] > 0
+    assert cat["totals"]["distinct_hulls"] < cat["totals"]["units_classified"]
+    # #596 day-rate bands attach: drillship priced, intervention semi not public.
+    assert heavy["indicative_dayrate"]["rate_disclosed"] is False
+    assert (
+        cat["by_asset_class"]["modu_drillship"]["indicative_dayrate"]["rate_disclosed"]
+        is True
+    )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Closes #623; refreshes the #598 catalog + #588 brief with the #599 dedup + #596 dayrates.

## What changed
- **fleet_catalog.py (#598):** `build_fleet_catalog()` now passes classified records through `identity_resolver.dedupe_catalog` (#599) **before** counting, so `by_asset_class` counts are DISTINCT HULLS. Adds a top-level `dedup` block (records_in / distinct_out / duplicates_collapsed) and attaches per-class `indicative_dayrate` bands via `dayrate_snapshot.attach_dayrates_to_catalog` (#596). GLOBAL-scope label, reconciliation, GoM-resident summary and caveats preserved (caveats updated: additive -> distinct-hull).
- **brief_generator.py (#588):** fleet section notes the counts are now DEDUPED distinct hulls and renders an indicative day-rate column (public band + confidence). Helix Q-class semis and RLWI monohulls render `dayrate not public`. GoM-resident leads; the `CONTEXT ONLY — NOT GoM supply` wall on the global roster is kept.
- Regenerated `intervention_fleet_catalog.yml` and `intervention-stats-brief.generated.md`.
- Tests extended (synthetic + real curated CSVs): dedup reduces `heavy_intervention_semi`, `indicative_dayrate` present, brief dayrate line + deduped-count note render. **60 passed, 1 skipped.**

## Before / after — heavy_intervention_semi
- **Before:** 13 (additive — Helix Q-class name-spelling variants double-counted across seed + curated)
- **After:** 6 distinct hulls = 5 real (Q4000, Q5000, Q7000, Seawell, Well Enhancer) + 1 malformed-CSV artifact (`,SV Q4000`, leading-comma row that escapes canonicalization). `rlwi_monohull` 5 -> 4. Overall 2,442 listings -> 2,337 distinct (105 collapsed).

## Regenerated fleet section (brief)

### GoM-resident dedicated intervention units (the binding supply)
**~3 units [soft]** are GoM-resident and dedicated to well intervention (Helix Q4000, Helix Q5000, Island Performer). Triangulated against research: GoM-resident dedicated 2-4 [soft]; global RLWI 15-25 [soft]; Helix purpose-built 7-8 [soft]; rigs rated 20k psi worldwide **2** [on record].

### Global available roster (CONTEXT ONLY — NOT GoM supply)
Counts are DEDUPED distinct hulls (#599): 2,442 source listings collapse to 2,337 vessels (105 duplicates removed, e.g. the Helix Q-class name-spelling variants). Indicative day-rates are an attached PUBLIC snapshot (#596), as of 2026-02-19 — NOT a live subscription feed.

| Asset class (global) | Count [deduped] | Water-depth capability (ft) | Indicative day-rate |
| --- | ---: | --- | --- |
| modu_drillship | 161 | 4,900-12,000 | $300,000-$530,000/day (median $457,000) [analyst, on_record, reported] |
| modu_semisub | 305 | 1,500-12,500 | $452,000-$490,000/day (median $465,000) [on_record] |
| modu_jackup | 1,018 | 300-492 | n/a |
| heavy_intervention_semi | 6 | 1,197-10,000 | dayrate not public [not public] |
| rlwi_monohull | 4 | 6,561-6,561 | dayrate not public [not public] |
| lift_boat | 143 | n/a | n/a |
| construction_vessel | 155 | 49-13,123 | n/a |
| other | 545 | 5,000-5,000 | n/a |