### PR TITLE
feat(field-dev): calibration v3 — recalibrate moored-floater depth bands

### DIFF
--- a/docs/domains/field-development/calibration-v2.md
+++ b/docs/domains/field-development/calibration-v2.md
@@ -59,13 +59,35 @@ on covered fields*, not a generalizing heuristic, and is reported separately.
 | **v2 (both)**                | **52.4%** | **62.7%** |
 
 FPSO recall 0 → 82 / 226; subsea_tieback 0 → 19 / 135; fixed_jacket held at
-309 / 334. Regression tests pin top-1 ≥ 0.48 (un-enriched) / ≥ 0.50 (enriched),
-FPSO ≥ 50, subsea_tieback ≥ 15.
+309 / 334.
+
+## v3 — moored-floater depth recalibration
+
+v2's residual gap was the **moored-floater family** (TLP / spar / semisub): their
+`DEPTH_SWEET_M` bands were nearly identical, so `depth_fit` could not separate
+them and spar/TLP picks lost to the semisub's flatter, higher base profile (spar
+sat at **0** recall). The observed GoM medians are distinct — TLP ≈ 1036 m, spar
+≈ 1265 m, semisub ≈ 1958 m — so the bands were tightened to **tile by depth**:
+TLP `(400, 1400)`, spar `(700, 1600)`, semisub `(1700, 2800)`. Water depth is a
+pure input, so this carries no leakage.
+
+| metric           | v2        | v3        |
+|------------------|-----------|-----------|
+| top-1 (base)     | 50.5%     | 52.6%     |
+| top-1 (enriched) | 52.4%     | 54.6%     |
+| spar recall      | 0 / 28    | 7 / 28    |
+| TLP recall       | 15 / 46   | 30 / 46   |
+
+Top-3 dips ~1 pt (a band-edge reshuffle) but stays well above the pinned floor.
+Regression tests pin top-1 ≥ 0.50 (un-enriched) / ≥ 0.52 (enriched), FPSO ≥ 50,
+subsea_tieback ≥ 15, spar ≥ 4, TLP ≥ 25.
 
 ## Honest residual gaps
 
-- **spar vs semisub** (still 0 recall) — near-identical profiles; needs a
-  dry-tree/intervention signal not cleanly available upstream.
+- **spar vs semisub** remains the weakest pair — depth now separates the bulk,
+  but the overlap band (≈1600–1800 m) still mixes them; a clean split needs a
+  dry-tree/intervention signal that is *downstream* of the concept choice (so it
+  would leak), hence not used.
 - **Per-tieback offset** is approximated by a basin median (og_host records none),
   so tieback distance is feasibility-grade, not metric-grade.
 - The basin table is coarse by design; per-operator/era signatures are out of

--- a/src/worldenergydata/field_development/recommendation.py
+++ b/src/worldenergydata/field_development/recommendation.py
@@ -78,13 +78,21 @@ class CriteriaWeights:
 # Per-concept preferred (sweet-spot) water-depth band in m — tighter than the
 # feasibility envelope; drives the ``depth_fit`` score. Calibrated to the real
 # depth→concept distribution of the enriched SubseaIQ catalog.
+#
+# Calibration v3: the moored-floater bands (TLP / spar / semisub) were nearly
+# identical, so depth_fit could not separate them and the spar/TLP picks lost to
+# the semisub's flatter, higher base profile. They are now tightened to the
+# observed GoM medians — TLP ≈ 1036 m, spar ≈ 1265 m, semisub ≈ 1958 m — so the
+# bands tile by depth (TLP shallowest, then spar, then semisub). This recovered
+# spar (0→7) and roughly doubled TLP recall (15→30) with no leakage: water depth
+# is a pure input. See ``docs/domains/field-development/calibration-v2.md``.
 DEPTH_SWEET_M: dict[ConceptType, tuple[float, float]] = {
     ConceptType.NUI: (0.0, 120.0),
     ConceptType.FIXED_JACKET: (0.0, 300.0),
     ConceptType.COMPLIANT_TOWER: (400.0, 900.0),
     ConceptType.TLP: (400.0, 1400.0),
-    ConceptType.SPAR: (900.0, 2450.0),
-    ConceptType.SEMISUB_FPS: (1000.0, 2600.0),
+    ConceptType.SPAR: (700.0, 1600.0),
+    ConceptType.SEMISUB_FPS: (1700.0, 2800.0),
     ConceptType.FPSO: (700.0, 3000.0),
     ConceptType.FLNG: (700.0, 3000.0),
     ConceptType.SUBSEA_TIEBACK: (0.0, 3000.0),  # flat — depends on host

--- a/tests/modules/field_development/test_calibration.py
+++ b/tests/modules/field_development/test_calibration.py
@@ -25,9 +25,9 @@ def test_backtest_runs_over_a_large_real_sample():
 
 def test_top1_accuracy_meets_calibrated_floor():
     rep = backtest_fields()
-    # depth_fit + NUI fix took top-1 ~10%→43%; the basin prior (calibration v2)
-    # took it to ~50% on the un-enriched set. Pin a floor with margin.
-    assert rep.top1_acc >= 0.48, f"top-1 regressed to {rep.top1_acc:.0%}"
+    # depth_fit + NUI fix took top-1 ~10%→43%; the basin prior (v2) → ~50% and
+    # the v3 moored-floater depth recalibration → ~52% on the un-enriched set.
+    assert rep.top1_acc >= 0.50, f"top-1 regressed to {rep.top1_acc:.0%}"
 
 
 def test_top3_accuracy_meets_floor():
@@ -39,9 +39,17 @@ def test_host_enrichment_lifts_top1_above_baseline():
     cmp = compare_enrichment()
     base, enr = cmp["baseline"], cmp["enriched"]
     # The SubseaIQ host layer (label fix + host-proximity) must not regress, and
-    # lifts top-1 to ~52% on the enriched catalog.
+    # lifts top-1 to ~55% on the enriched catalog (with the v3 depth bands).
     assert enr.top1_acc >= base.top1_acc
-    assert enr.top1_acc >= 0.50, f"enriched top-1 regressed to {enr.top1_acc:.0%}"
+    assert enr.top1_acc >= 0.52, f"enriched top-1 regressed to {enr.top1_acc:.0%}"
+
+
+def test_v3_depth_bands_recover_spar_and_tlp():
+    # v2 left spar at 0 recall and TLP under-predicted because the moored-floater
+    # depth bands overlapped. The v3 recalibration must recover both.
+    recall = concept_recall(backtest_fields(enrich=True))
+    assert recall.get("spar", (0, 0))[0] >= 4, "spar still zero-recall"
+    assert recall.get("tlp", (0, 0))[0] >= 25, "TLP recall not recovered"
 
 
 def test_enrichment_recovers_subsea_tieback_recall():


### PR DESCRIPTION
## Calibration v3 — moored-floater depth recalibration

Follow-up to #625. v2 cracked FPSO and subsea_tieback but left the **moored-floater
family** (TLP / spar / semisub) confused: their `DEPTH_SWEET_M` sweet-spot bands
were nearly identical, so `depth_fit` couldn't separate them and spar/TLP picks
lost to the semisub's flatter, higher base profile. **Spar sat at 0 recall.**

### Fix
The observed GoM depth medians are distinct — TLP ≈ 1036 m, spar ≈ 1265 m,
semisub ≈ 1958 m — so the bands are tightened to **tile by depth**:
`TLP (400,1400)`, `spar (700,1600)`, `semisub (1700,2800)`. Water depth is a pure
input, so this is honest depth calibration with **no leakage** (unlike a
dry-tree signal, which is downstream of the concept choice).

### Effect (867-field back-test)
| metric           | v2        | v3        |
|------------------|-----------|-----------|
| top-1 (base)     | 50.5%     | **52.6%** |
| top-1 (enriched) | 52.4%     | **54.6%** |
| spar recall      | 0 / 28    | 7 / 28    |
| TLP recall       | 15 / 46   | 30 / 46   |

FPSO (82/226), subsea_tieback (19/135), fixed_jacket (309/334) all held. Top-3
dips ~1 pt (band-edge reshuffle) but stays well above the pinned floor.

### Tests
171 field_development tests green. Regression floors raised: top-1 ≥ 0.50 (base)
/ ≥ 0.52 (enriched), spar ≥ 4, TLP ≥ 25 (plus existing FPSO ≥ 50, tieback ≥ 15).
Surgical change: `DEPTH_SWEET_M` constants + tests + docs. Files ≤ 500 lines.

Residual gap documented honestly: the spar/semisub overlap band (~1600–1800 m)
still mixes them; a clean split would need a downstream dry-tree signal (would
leak), so it's left out. See `docs/domains/field-development/calibration-v2.md`.

Epic #567.
