### PR TITLE
feat(field-dev): 3D multi-bend jumper, mooring spread, manifold assembly

### DIFF
--- a/src/worldenergydata/field_development/assembly_3d.py
+++ b/src/worldenergydata/field_development/assembly_3d.py
@@ -1,0 +1,201 @@
+# ABOUTME: Parametric 3D (STEP/B-rep) subsea ASSEMBLIES via CadQuery (issue #580).
+# ABOUTME: Mooring spreads + manifold/tree skids — companion to equipment_3d.py.
+"""
+worldenergydata.field_development.assembly_3d
+=============================================
+
+Parametric **3D assemblies** (STEP / B-rep) of field-scale subsea hardware via
+CadQuery — a companion to :mod:`worldenergydata.field_development.equipment_3d`
+(which builds individual jumper components). Two builders live here:
+
+* :func:`build_mooring_spread` — N mooring lines radiating evenly from a host's
+  fairlead circle down to seabed anchors.
+* :func:`build_manifold_assembly` — a manifold skid box with N vertical tree
+  stubs on a row.
+
+Like ``equipment_3d``, this module **requires CadQuery** (OCCT) and is
+deliberately **not** re-exported from the package ``__init__`` so the 2D
+pipeline keeps importing without the heavy OCCT stack. Import it explicitly.
+
+Builders return :class:`cadquery.Assembly` objects (each part is a named child),
+which export to a multi-part STEP. Lengths/positions are supplied in **metres**
+and converted to **mm** internally (STEP convention), consistent with v1.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import cadquery as cq
+from cadquery import Solid, Vector
+from cadquery.occ_impl.exporters.assembly import exportAssembly
+
+_M_TO_MM = 1000.0
+
+
+def _save_assembly_step(assy: cq.Assembly, path: str | Path) -> Path:
+    """Export an assembly to a multi-part STEP file and return the path.
+
+    Uses :func:`exportAssembly` (the non-deprecated STEP assembly writer) so the
+    named ``skid``/``tree_<i>``/``line_<i>`` parts survive into the STEP product
+    hierarchy.
+    """
+    out = Path(path)
+    exportAssembly(assy, str(out))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Mooring spread
+# --------------------------------------------------------------------------- #
+def mooring_total_length_m(
+    n_lines: int,
+    radius_m: float,
+    fairlead_z_m: float,
+    anchor_radius_m: float,
+    depth_m: float,
+) -> float:
+    """Total straight-line length (m) of all mooring lines combined.
+
+    Each line runs from a fairlead at ``(radius_m, z=fairlead_z_m)`` to an anchor
+    at ``(anchor_radius_m, z=-depth_m)``; the per-line length is the 2D hypot of
+    the radial offset and the vertical drop (catenary sag is not modelled).
+    """
+    horiz = anchor_radius_m - radius_m
+    vert = fairlead_z_m - (-depth_m)
+    return float(n_lines * math.hypot(horiz, vert))
+
+
+def build_mooring_spread(
+    n_lines: int,
+    radius_m: float,
+    fairlead_z_m: float,
+    anchor_radius_m: float,
+    depth_m: float,
+    line_diameter_m: float = 0.2,
+) -> cq.Assembly:
+    """Build a mooring spread: N lines radiating evenly from fairleads to anchors.
+
+    Lines are equally spaced in azimuth (``360 / n_lines`` degrees). Each is a
+    thin solid cylinder from its fairlead point on the host's fairlead circle
+    (radius ``radius_m``, elevation ``fairlead_z_m``) down to its seabed anchor
+    (radius ``anchor_radius_m``, elevation ``-depth_m``).
+
+    Args:
+        n_lines: Number of mooring lines (≥1).
+        radius_m: Fairlead circle radius (m).
+        fairlead_z_m: Fairlead elevation (m; negative = below waterline).
+        anchor_radius_m: Anchor circle radius (m).
+        depth_m: Water depth (m); anchors sit at ``z = -depth_m``.
+        line_diameter_m: Rendered line diameter (m) for the solid cylinder.
+
+    Returns:
+        A :class:`cadquery.Assembly` with one named ``line_<i>`` child per line.
+
+    Raises:
+        ValueError: if ``n_lines < 1``.
+    """
+    if n_lines < 1:
+        raise ValueError(f"n_lines must be >= 1 (got {n_lines})")
+
+    r_line_mm = (line_diameter_m / 2.0) * _M_TO_MM
+    assy = cq.Assembly(name="mooring_spread")
+    for i in range(n_lines):
+        az = math.radians(360.0 / n_lines * i)
+        fair = Vector(
+            radius_m * math.cos(az) * _M_TO_MM,
+            radius_m * math.sin(az) * _M_TO_MM,
+            fairlead_z_m * _M_TO_MM,
+        )
+        anchor = Vector(
+            anchor_radius_m * math.cos(az) * _M_TO_MM,
+            anchor_radius_m * math.sin(az) * _M_TO_MM,
+            -depth_m * _M_TO_MM,
+        )
+        span = anchor - fair
+        height = span.Length
+        direction = span.normalized()
+        cyl = Solid.makeCylinder(r_line_mm, height, fair, direction)
+        assy.add(cyl, name=f"line_{i}")
+    return assy
+
+
+def mooring_line_count(assy: cq.Assembly) -> int:
+    """Number of mooring-line children in a spread assembly."""
+    return sum(1 for c in assy.children if c.name and c.name.startswith("line_"))
+
+
+def export_mooring_spread_step(assy: cq.Assembly, path: str | Path) -> Path:
+    """Export a mooring-spread assembly to a STEP file. Returns the path."""
+    return _save_assembly_step(assy, path)
+
+
+# --------------------------------------------------------------------------- #
+# Manifold + trees assembly
+# --------------------------------------------------------------------------- #
+def build_manifold_assembly(
+    n_slots: int,
+    spacing_m: float,
+    tree_height_m: float = 3.0,
+    skid_width_m: float = 4.0,
+    skid_height_m: float = 2.0,
+    tree_diameter_m: float = 0.8,
+) -> cq.Assembly:
+    """Build a manifold skid box with N vertical tree stubs on a row.
+
+    The skid is a box of length ``n_slots * spacing_m`` (+ one spacing margin),
+    width ``skid_width_m`` and height ``skid_height_m``, centred on the origin
+    with its base at ``z = 0``. ``n_slots`` tree stubs (vertical cylinders of
+    height ``tree_height_m``) sit on top, evenly spaced along the skid length.
+
+    Args:
+        n_slots: Number of tree slots / stubs (≥1).
+        spacing_m: Centre-to-centre slot spacing (m).
+        tree_height_m: Height of each tree stub (m).
+        skid_width_m: Skid box width (m).
+        skid_height_m: Skid box height (m).
+        tree_diameter_m: Tree stub diameter (m).
+
+    Returns:
+        A :class:`cadquery.Assembly`: a ``skid`` child plus one ``tree_<i>``
+        child per slot.
+
+    Raises:
+        ValueError: if ``n_slots < 1``.
+    """
+    if n_slots < 1:
+        raise ValueError(f"n_slots must be >= 1 (got {n_slots})")
+
+    length_mm = (n_slots * spacing_m + spacing_m) * _M_TO_MM
+    width_mm = skid_width_m * _M_TO_MM
+    height_mm = skid_height_m * _M_TO_MM
+    r_tree_mm = (tree_diameter_m / 2.0) * _M_TO_MM
+    tree_h_mm = tree_height_m * _M_TO_MM
+
+    assy = cq.Assembly(name="manifold")
+    # Skid box centred in X/Y, base on z = 0.
+    box = Solid.makeBox(
+        length_mm, width_mm, height_mm, Vector(-length_mm / 2.0, -width_mm / 2.0, 0.0)
+    )
+    assy.add(box, name="skid")
+
+    # Evenly spaced tree stubs along the skid length, centred about x = 0.
+    span_mm = (n_slots - 1) * spacing_m * _M_TO_MM
+    x0 = -span_mm / 2.0
+    for i in range(n_slots):
+        x = x0 + i * spacing_m * _M_TO_MM
+        base = Vector(x, 0.0, height_mm)
+        tree = Solid.makeCylinder(r_tree_mm, tree_h_mm, base, Vector(0.0, 0.0, 1.0))
+        assy.add(tree, name=f"tree_{i}")
+    return assy
+
+
+def manifold_n_trees(assy: cq.Assembly) -> int:
+    """Number of tree-stub children in a manifold assembly."""
+    return sum(1 for c in assy.children if c.name and c.name.startswith("tree_"))
+
+
+def export_manifold_step(assy: cq.Assembly, path: str | Path) -> Path:
+    """Export a manifold assembly to a STEP file. Returns the path."""
+    return _save_assembly_step(assy, path)

--- a/src/worldenergydata/field_development/equipment_3d.py
+++ b/src/worldenergydata/field_development/equipment_3d.py
@@ -22,9 +22,10 @@ spec (OD, wall thickness, length); multi-bend M/U spool geometry is a follow-on.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Sequence, Tuple
 
 import cadquery as cq
+from cadquery import Edge, Vector, Wire
 
 from worldenergydata.subsea.models.rigid_jumper import (
     RigidJumperSpec,
@@ -33,6 +34,9 @@ from worldenergydata.subsea.models.rigid_jumper import (
 
 _IN_TO_MM = 25.4
 _FT_TO_MM = 304.8
+_M_TO_MM = 1000.0
+
+Waypoint = Tuple[float, float, float]
 
 
 def _curated_jumper_csv() -> Path:
@@ -105,3 +109,91 @@ def build_jumper_from_catalog(
 def jumper_volume_mm3(spec: RigidJumperSpec) -> float:
     """Solid volume (mm³) of a jumper — handy for steel-weight cross-checks."""
     return float(build_jumper_solid(spec).val().Volume())
+
+
+# --------------------------------------------------------------------------- #
+# Multi-bend (M/U-spool) jumper — hollow pipe swept along a 3D polyline
+# --------------------------------------------------------------------------- #
+def _waypoints_mm(waypoints: Sequence[Waypoint]) -> list[Vector]:
+    """Validate ≥2 waypoints and convert (x, y, z) metres → mm vectors."""
+    if waypoints is None or len(waypoints) < 2:
+        raise ValueError(
+            "build_multibend_jumper needs at least 2 waypoints (got "
+            f"{0 if waypoints is None else len(waypoints)})"
+        )
+    return [
+        Vector(p[0] * _M_TO_MM, p[1] * _M_TO_MM, p[2] * _M_TO_MM) for p in waypoints
+    ]
+
+
+def multibend_jumper_bends(waypoints: Sequence[Waypoint]) -> int:
+    """Number of bends = interior vertices of the polyline (``len - 2``)."""
+    if waypoints is None or len(waypoints) < 2:
+        raise ValueError("need at least 2 waypoints to count bends")
+    return len(waypoints) - 2
+
+
+def multibend_jumper_length_mm(waypoints: Sequence[Waypoint]) -> float:
+    """Total centreline length (mm) = sum of polyline segment lengths."""
+    pts = _waypoints_mm(waypoints)
+    return float(sum((pts[i + 1] - pts[i]).Length for i in range(len(pts) - 1)))
+
+
+def build_multibend_jumper(
+    waypoints: Sequence[Waypoint], od_in: float, wall_in: float
+) -> cq.Workplane:
+    """Build a hollow pipe swept along a 3D polyline (multi-bend M/U spool).
+
+    The jumper centreline follows ``waypoints`` (``(x, y, z)`` in **metres**);
+    a circular annulus (OD ``od_in``, bore = OD − 2·``wall_in``) is swept along
+    the assembled wire, yielding a single hollow B-rep tube that turns through
+    every interior vertex.
+
+    Args:
+        waypoints: ≥2 ``(x, y, z)`` points in metres.
+        od_in: Outer diameter (inches).
+        wall_in: Wall thickness (inches).
+
+    Returns:
+        A CadQuery ``Workplane`` holding the swept hollow solid.
+
+    Raises:
+        ValueError: if <2 waypoints, or the wall is ≥ the radius (bore ≤ 0).
+    """
+    pts = _waypoints_mm(waypoints)
+    od = od_in * _IN_TO_MM
+    bore = od - 2 * wall_in * _IN_TO_MM
+    if bore <= 0:
+        raise ValueError(
+            f"wall thickness {wall_in} in >= radius for OD {od_in} in (bore <= 0)"
+        )
+
+    edges = [Edge.makeLine(pts[i], pts[i + 1]) for i in range(len(pts) - 1)]
+    path = Wire.assembleEdges(edges)
+
+    start_dir = (pts[1] - pts[0]).normalized()
+    plane = cq.Plane(
+        origin=pts[0].toTuple(), normal=(start_dir.x, start_dir.y, start_dir.z)
+    )
+    profile = cq.Workplane(plane).circle(od / 2.0).circle(bore / 2.0)
+    return profile.sweep(cq.Workplane(obj=path), isFrenet=True)
+
+
+def multibend_jumper_volume_mm3(
+    waypoints: Sequence[Waypoint], od_in: float, wall_in: float
+) -> float:
+    """Solid (steel) volume (mm³) of a swept multi-bend jumper."""
+    return float(build_multibend_jumper(waypoints, od_in, wall_in).val().Volume())
+
+
+def export_multibend_jumper_step(
+    waypoints: Sequence[Waypoint],
+    path: str | Path,
+    od_in: float,
+    wall_in: float,
+) -> Path:
+    """Build and export a multi-bend jumper to a STEP file. Returns the path."""
+    solid = build_multibend_jumper(waypoints, od_in, wall_in)
+    out = Path(path)
+    cq.exporters.export(solid, str(out))
+    return out

--- a/tests/modules/field_development/test_assembly_3d.py
+++ b/tests/modules/field_development/test_assembly_3d.py
@@ -1,0 +1,165 @@
+# ABOUTME: Tests for multi-bend jumper + mooring/manifold 3D assemblies (issue #580).
+# ABOUTME: Skips cleanly if CadQuery/OCCT is unavailable in the environment.
+"""Tests for the deepened 3D equipment / assembly geometry (epic #567)."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+# Skip the whole module (incl. the cadquery-importing modules under test) if the
+# OCCT stack isn't installed, rather than erroring at collection.
+pytest.importorskip("cadquery")
+
+from worldenergydata.field_development.assembly_3d import (  # noqa: E402
+    build_manifold_assembly,
+    build_mooring_spread,
+    export_manifold_step,
+    export_mooring_spread_step,
+    manifold_n_trees,
+    mooring_line_count,
+    mooring_total_length_m,
+)
+from worldenergydata.field_development.equipment_3d import (  # noqa: E402
+    build_multibend_jumper,
+    export_multibend_jumper_step,
+    multibend_jumper_bends,
+    multibend_jumper_length_mm,
+    multibend_jumper_volume_mm3,
+)
+
+_IN = 25.4
+_M_TO_MM = 1000.0
+
+# An L-bend (1 bend) and a U-spool (2 bends), waypoints in metres.
+_L_BEND = [(0.0, 0.0, 0.0), (10.0, 0.0, 0.0), (10.0, 0.0, 10.0)]
+_U_SPOOL = [(0.0, 0.0, 0.0), (0.0, 0.0, -5.0), (20.0, 0.0, -5.0), (20.0, 0.0, 0.0)]
+
+
+# --------------------------------------------------------------------------- #
+# Multi-bend jumper
+# --------------------------------------------------------------------------- #
+def test_multibend_jumper_valid_and_bend_count():
+    """L-bend and U-spool build valid hollow solids with the right bend counts."""
+    for wp, n_bends in ((_L_BEND, 1), (_U_SPOOL, 2)):
+        solid = build_multibend_jumper(wp, od_in=8.625, wall_in=0.5).val()
+        assert solid.isValid()
+        assert solid.Volume() > 0
+        assert multibend_jumper_bends(wp) == n_bends
+
+
+def test_multibend_jumper_length_and_hollow_volume():
+    """Path length is the polyline length; volume ~= annulus area * length."""
+    wp = _L_BEND
+    expected_len = 20.0 * _M_TO_MM  # 10 m + 10 m
+    assert math.isclose(multibend_jumper_length_mm(wp), expected_len, rel_tol=1e-9)
+
+    od, wall = 8.625 * _IN, 0.5 * _IN
+    bore = od - 2 * wall
+    annulus = math.pi * ((od / 2) ** 2 - (bore / 2) ** 2)
+    vol = multibend_jumper_volume_mm3(wp, od_in=8.625, wall_in=0.5)
+    # ~5% tolerance: mitred corners differ slightly from area*length.
+    assert math.isclose(vol, annulus * expected_len, rel_tol=0.05)
+
+    # A hollow tube has less volume than the equivalent solid sweep.
+    solid_sweep = math.pi * (od / 2) ** 2 * expected_len
+    assert vol < solid_sweep
+
+
+def test_multibend_jumper_requires_two_waypoints():
+    with pytest.raises(ValueError):
+        build_multibend_jumper([(0.0, 0.0, 0.0)], od_in=8.0, wall_in=0.5)
+
+
+def test_multibend_jumper_wall_too_thick_raises():
+    with pytest.raises(ValueError):
+        build_multibend_jumper(_L_BEND, od_in=6.0, wall_in=3.5)  # bore <= 0
+
+
+def test_multibend_jumper_step_export(tmp_path: Path):
+    out = export_multibend_jumper_step(
+        _U_SPOOL, tmp_path / "spool.step", od_in=8.625, wall_in=0.5
+    )
+    assert out.exists() and out.stat().st_size > 0
+    assert "ISO-10303" in out.read_text(encoding="utf-8", errors="ignore")[:200]
+
+
+# --------------------------------------------------------------------------- #
+# Mooring spread
+# --------------------------------------------------------------------------- #
+def test_mooring_spread_line_count_and_extent():
+    assy = build_mooring_spread(
+        n_lines=8,
+        radius_m=40.0,
+        fairlead_z_m=-20.0,
+        anchor_radius_m=1500.0,
+        depth_m=2000.0,
+    )
+    assert mooring_line_count(assy) == 8
+    bb = assy.toCompound().BoundingBox()
+    # Anchors sit on a ~1500 m radius circle -> ~3000 m span across (in mm).
+    assert bb.xlen > 2.9e6
+    # Vertical extent spans fairlead (-20 m) down to seabed (-2000 m).
+    assert bb.zlen > 1.9e6
+
+
+def test_mooring_total_length_matches_geometry():
+    total = mooring_total_length_m(
+        n_lines=4,
+        radius_m=40.0,
+        fairlead_z_m=-20.0,
+        anchor_radius_m=1500.0,
+        depth_m=2000.0,
+    )
+    horiz = 1500.0 - 40.0
+    vert = 2000.0 - 20.0
+    per_line = math.hypot(horiz, vert)
+    assert math.isclose(total, 4 * per_line, rel_tol=1e-9)
+
+
+def test_mooring_invalid_line_count_raises():
+    with pytest.raises(ValueError):
+        build_mooring_spread(
+            n_lines=0,
+            radius_m=40.0,
+            fairlead_z_m=-20.0,
+            anchor_radius_m=1500.0,
+            depth_m=2000.0,
+        )
+
+
+def test_mooring_step_export(tmp_path: Path):
+    assy = build_mooring_spread(
+        n_lines=6,
+        radius_m=40.0,
+        fairlead_z_m=-20.0,
+        anchor_radius_m=1200.0,
+        depth_m=1500.0,
+    )
+    out = export_mooring_spread_step(assy, tmp_path / "mooring.step")
+    assert out.exists() and out.stat().st_size > 0
+    assert "ISO-10303" in out.read_text(encoding="utf-8", errors="ignore")[:200]
+
+
+# --------------------------------------------------------------------------- #
+# Manifold + trees assembly
+# --------------------------------------------------------------------------- #
+def test_manifold_assembly_tree_count_and_validity():
+    assy = build_manifold_assembly(n_slots=4, spacing_m=3.0, tree_height_m=4.0)
+    assert manifold_n_trees(assy) == 4
+    assert assy.toCompound().isValid()
+    assert assy.toCompound().Volume() > 0
+
+
+def test_manifold_invalid_slot_count_raises():
+    with pytest.raises(ValueError):
+        build_manifold_assembly(n_slots=0, spacing_m=3.0)
+
+
+def test_manifold_step_export(tmp_path: Path):
+    assy = build_manifold_assembly(n_slots=6, spacing_m=2.5)
+    out = export_manifold_step(assy, tmp_path / "manifold.step")
+    assert out.exists() and out.stat().st_size > 0
+    assert "ISO-10303" in out.read_text(encoding="utf-8", errors="ignore")[:200]


### PR DESCRIPTION
## What

Deepens the 3D equipment track (epic #567, issue #580) beyond the v1 single straight-pipe jumper into richer parametric subsea hardware, all as parametric B-rep STEP geometry via CadQuery.

### `equipment_3d.py` (extended)
- `build_multibend_jumper(waypoints, od_in, wall_in)` — hollow pipe swept along a 3D polyline (waypoints in metres) using a **real OCCT sweep** of an annular profile (isFrenet). Validates >=2 waypoints and bore>0.
- Helpers: `multibend_jumper_bends`, `multibend_jumper_length_mm`, `multibend_jumper_volume_mm3`, `export_multibend_jumper_step`.

### `assembly_3d.py` (new module)
- `build_mooring_spread(n_lines, radius_m, fairlead_z_m, anchor_radius_m, depth_m)` — N mooring lines radiating evenly (azimuth 360/n) from the fairlead circle down to seabed anchors; returns a named `cq.Assembly`. Helpers `mooring_line_count`, `mooring_total_length_m`, `export_mooring_spread_step`.
- `build_manifold_assembly(n_slots, spacing_m, tree_height_m=...)` — manifold skid box with N vertical tree stubs on a row; returns a named `cq.Assembly`. Helpers `manifold_n_trees`, `export_manifold_step`.
- Assembly STEP export via `exportAssembly` (non-deprecated; preserves named part hierarchy).

### Notes
- `equipment_3d`/`assembly_3d` remain intentionally **not** re-exported from `field_development/__init__` so the 2D pipeline imports without OCCT installed.
- The multi-bend jumper uses a genuine 3D sweep (verified valid for L-bend, U-spool, and 3D zigzag cases; volume matches annulus x path-length within ~5%) — no segment-union fallback was needed.

## Tests
- New `tests/modules/field_development/test_assembly_3d.py` (12 tests), `pytest.importorskip("cadquery")`, consolidated to limit OCCT warmup.
- Asserts solid validity, >=2-waypoint guard, bend counts, hollow volume, mooring line count + bounding box + total length, manifold tree count, and non-empty STEP exports.
- Full suite (existing v1 `test_equipment_3d.py` + new): **19 passed**, no v1 regression. All files <=500 lines; isort/black/ruff clean.