### PR TITLE
feat(field-dev): parametric per-concept CAPEX/OPEX cost estimator

### DIFF
--- a/src/worldenergydata/field_development/__init__.py
+++ b/src/worldenergydata/field_development/__init__.py
@@ -25,6 +25,13 @@ from worldenergydata.field_development.calibration import (
     compare_enrichment,
     concept_recall,
 )
+from worldenergydata.field_development.cost_estimator import (
+    PerConceptCostEstimate,
+    capex_adjustment_for,
+    estimate_field_cost_portfolio,
+    estimate_per_concept_costs,
+    opex_factor_for,
+)
 from worldenergydata.field_development.dexpi import (
     dexpi_mapping,
     dexpi_to_graph,
@@ -192,4 +199,9 @@ __all__ = [
     "improvement_vs_naive",
     "LayoutSolution",
     "Well",
+    "PerConceptCostEstimate",
+    "estimate_per_concept_costs",
+    "estimate_field_cost_portfolio",
+    "capex_adjustment_for",
+    "opex_factor_for",
 ]

--- a/src/worldenergydata/field_development/cost_estimator.py
+++ b/src/worldenergydata/field_development/cost_estimator.py
@@ -1,0 +1,318 @@
+# ABOUTME: Parametric per-concept CAPEX/OPEX estimator (issue #643, epic #567).
+# ABOUTME: Layers concept-specific adjustments onto the field-level FDAS economics.
+"""
+worldenergydata.field_development.cost_estimator
+================================================
+
+The FDAS economics in :mod:`worldenergydata.field_development.integrations` are
+**depth-driven and field-level**: at a given water depth every concept inherits
+the same dev-system CAPEX (``dry`` / ``subsea15`` / ``subsea20``). That is the
+right altitude for a sanity-check NPV, but a Concept-Select comparison needs to
+*separate* the candidates — a subsea tieback to a host is not the same cost as a
+dedicated FPSO at the same depth.
+
+This module adds that separation **by reuse, not re-derivation**:
+
+* the **base CAPEX** is :func:`integrations.estimate_economics` (FDAS host +
+  per-well assumptions) — never recomputed here;
+* the **base annual OPEX** is the FDAS ``FIXED_OPEX_MM_PER_YEAR`` assumption for
+  the same depth-classified dev system;
+* the **per-concept multipliers** are derived from the same priors the
+  recommendation engine already scores on — :data:`recommendation._CONCEPT_PROFILES`
+  (relative CAPEX/OPEX), :func:`recommendation._depth_fit` /
+  :data:`recommendation.DEPTH_SWEET_M` (the depth-fit penalty), and
+  :class:`recommendation.Thresholds` (the flow-assurance tieback threshold, the
+  single source of truth for the long-offset penalty).
+
+Every multiplier is a **qualitative engineering prior** (Concept-Select / AACE
+Class 5 fidelity), documented inline with its rationale — not an empirically
+calibrated cost model. Costs round to 0.1 MM. If FDAS cannot classify a dev
+system (e.g. unknown water depth) the estimator **degrades gracefully**: it
+returns an estimate carrying a ``note`` rather than raising.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Optional
+
+from worldenergydata.field_development.enums import ConceptType
+from worldenergydata.field_development.integrations import (
+    dev_system_for,
+    estimate_economics,
+)
+from worldenergydata.field_development.models import FieldConcept
+from worldenergydata.field_development.recommendation import (
+    _CONCEPT_PROFILES,
+    ScoredConcept,
+    Thresholds,
+    _depth_fit,
+)
+
+# --------------------------------------------------------------------------- #
+# Tunable priors (all qualitative Concept-Select-fidelity factors)
+# --------------------------------------------------------------------------- #
+# The concept CAPEX prior in ``_CONCEPT_PROFILES`` is in [0, 1] where 1.0 =
+# *most favourable* (cheapest). We map it to a multiplier centred on the median
+# prior (0.5): a cheaper-than-median concept pulls CAPEX below the field base, a
+# costlier one pushes it above. The span is tuned so the spread of the real
+# priors yields the acceptance-criterion gap — a subsea tieback (prior 0.95)
+# lands ~10% below an FPSO (prior 0.40) at the same depth (within the 5–15% band).
+_CAPEX_PRIOR_SPAN = 0.20
+_CAPEX_PRIOR_MID = 0.5
+
+# Depth-fit penalty: a concept used outside its sweet-spot band (per
+# ``DEPTH_SWEET_M``, surfaced via ``_depth_fit`` in [0, 1]) costs more — hull
+# size, mooring, or riser design must stretch beyond the type's comfortable
+# envelope. A total miss (fit 0.0) adds up to +30% CAPEX.
+_DEPTH_PENALTY_SPAN = 0.30
+
+# Long-tieback flow-assurance penalty: beyond the ``Thresholds`` flow-assurance
+# warning distance (~32 km / 20 mi) insulation, heating, and boosting drive
+# subsea CAPEX up. Modelled as +0.5%/km past the threshold, capped at +25% so a
+# very long offset cannot run away. The threshold itself is *not* duplicated —
+# it is read from ``Thresholds`` (the source of truth).
+_TIEBACK_PENALTY_PER_KM = 0.005
+_TIEBACK_PENALTY_CAP = 0.25
+
+# Final CAPEX adjustment is clamped to this defensive envelope.
+_CAPEX_ADJ_MIN = 0.80
+_CAPEX_ADJ_MAX = 1.50
+
+# OPEX concept prior maps the same way (1.0 = cheapest to operate). A wider span
+# than CAPEX reflects how much intervention/manning philosophy varies by concept
+# (e.g. a subsea-to-shore tieback vs an FLNG).
+_OPEX_PRIOR_SPAN = 0.40
+_OPEX_PRIOR_MID = 0.5
+
+# OPEX scales with field size: more reserves means more wells, throughput, and
+# intervention exposure. Scaled by sqrt of reserves vs a 100-MMboe reference so
+# the factor grows sub-linearly, clamped to keep marginal/giant fields sane.
+_OPEX_REF_RESERVES_MMBOE = 100.0
+_OPEX_RESERVES_MIN = 0.60
+_OPEX_RESERVES_MAX = 1.70
+
+# Final OPEX factor envelope (issue acceptance: ~[0.5, 2.0]).
+_OPEX_FACTOR_MIN = 0.50
+_OPEX_FACTOR_MAX = 2.00
+
+# Default field life (years) used only to rank a portfolio by lifecycle cost when
+# the field life is not supplied.
+_DEFAULT_FIELD_LIFE_YEARS = 20.0
+
+# Concepts whose CAPEX carries the long-offset flow-assurance penalty — i.e. the
+# ones that actually flow back to a remote host/shore.
+_TIEBACK_CONCEPTS = {ConceptType.SUBSEA_TIEBACK, ConceptType.SUBSEA_TO_SHORE}
+
+
+@dataclass
+class PerConceptCostEstimate:
+    """A transparent per-concept CAPEX/OPEX estimate at Concept-Select fidelity.
+
+    ``capex_mm`` / ``annual_opex_mm`` are ``None`` when the underlying FDAS
+    economics could not be classified (graceful degrade); ``note`` then explains
+    why. ``capex_adjustment`` and ``opex_factor`` are the multipliers applied to
+    the FDAS field-level base; ``depth_fit_penalty`` and ``tieback_penalty_pct``
+    expose the two CAPEX penalty components so they can be audited.
+    """
+
+    concept_type: ConceptType
+    capex_mm: Optional[float] = None
+    annual_opex_mm: Optional[float] = None
+    capex_adjustment: float = 1.0
+    opex_factor: float = 1.0
+    depth_fit_penalty: float = 0.0  # fractional CAPEX increase from depth misfit
+    tieback_penalty_pct: float = 0.0  # CAPEX increase (%) from long-offset
+    dev_system: Optional[str] = None
+    rationale: list[str] = field(default_factory=list)
+    note: str = ""
+
+
+# --------------------------------------------------------------------------- #
+# CAPEX adjustment
+# --------------------------------------------------------------------------- #
+def _concept_capex_mult(concept: ConceptType) -> float:
+    """Multiplier from the concept's relative-CAPEX prior (1.0 = field median)."""
+    score = _CONCEPT_PROFILES[concept]["capex"]
+    return 1.0 + _CAPEX_PRIOR_SPAN * (_CAPEX_PRIOR_MID - score)
+
+
+def _depth_capex_penalty(depth_fit: float) -> float:
+    """Fractional CAPEX increase for using a concept outside its depth band."""
+    clamped = max(0.0, min(1.0, depth_fit))
+    return _DEPTH_PENALTY_SPAN * (1.0 - clamped)
+
+
+def _tieback_capex_penalty(tieback_km: Optional[float]) -> float:
+    """Fractional CAPEX increase for a tieback beyond the flow-assurance limit.
+
+    The threshold is read from :class:`Thresholds` so this stays consistent with
+    the recommendation engine's flow-assurance warning rather than duplicating
+    the 32 km constant.
+    """
+    if tieback_km is None:
+        return 0.0
+    warn_km = Thresholds().flow_assurance_warn_km
+    if tieback_km <= warn_km:
+        return 0.0
+    return min(_TIEBACK_PENALTY_CAP, _TIEBACK_PENALTY_PER_KM * (tieback_km - warn_km))
+
+
+def capex_adjustment_for(
+    concept: ConceptType,
+    depth_fit: float = 1.0,
+    tieback_km: Optional[float] = None,
+) -> float:
+    """Per-concept CAPEX multiplier on the FDAS field-level base (~[0.8, 1.5]).
+
+    Combines three documented priors multiplicatively: the concept's relative
+    CAPEX prior, the depth-fit penalty, and the long-tieback flow-assurance
+    penalty. The result is clamped to a defensive envelope.
+
+    Args:
+        concept: The development concept being priced.
+        depth_fit: Depth-fit score in [0, 1] from ``recommendation._depth_fit``.
+        tieback_km: Host offset for tieback concepts; ``None`` to skip.
+    """
+    mult = _concept_capex_mult(concept)
+    mult *= 1.0 + _depth_capex_penalty(depth_fit)
+    mult *= 1.0 + _tieback_capex_penalty(tieback_km)
+    return round(max(_CAPEX_ADJ_MIN, min(_CAPEX_ADJ_MAX, mult)), 4)
+
+
+# --------------------------------------------------------------------------- #
+# OPEX factor
+# --------------------------------------------------------------------------- #
+def _reserves_opex_scale(reserves_mmboe: Optional[float]) -> float:
+    """Sub-linear (sqrt) OPEX scaling vs a reference field size."""
+    if not reserves_mmboe or reserves_mmboe <= 0:
+        return 1.0
+    raw = math.sqrt(reserves_mmboe / _OPEX_REF_RESERVES_MMBOE)
+    return max(_OPEX_RESERVES_MIN, min(_OPEX_RESERVES_MAX, raw))
+
+
+def opex_factor_for(
+    concept: ConceptType, reserves_mmboe: Optional[float] = None
+) -> float:
+    """Per-concept annual-OPEX multiplier on the FDAS fixed-OPEX base (~[0.5, 2]).
+
+    Combines the concept's relative-OPEX prior with a reserves-based size scale,
+    clamped to a defensive envelope.
+    """
+    score = _CONCEPT_PROFILES[concept]["opex"]
+    concept_mult = 1.0 + _OPEX_PRIOR_SPAN * (_OPEX_PRIOR_MID - score)
+    factor = concept_mult * _reserves_opex_scale(reserves_mmboe)
+    return round(max(_OPEX_FACTOR_MIN, min(_OPEX_FACTOR_MAX, factor)), 4)
+
+
+def _base_annual_opex_mm(concept: FieldConcept) -> Optional[float]:
+    """FDAS fixed annual OPEX for the depth-classified dev system; None if N/A."""
+    sysname = dev_system_for(concept)
+    if sysname in (None, "unknown"):
+        return None
+    try:
+        from worldenergydata.fdas.core.config import AssumptionsManager
+    except Exception:  # pragma: no cover - defensive, FDAS optional
+        return None
+    return AssumptionsManager().get(sysname, "FIXED_OPEX_MM_PER_YEAR", 0.0)
+
+
+# --------------------------------------------------------------------------- #
+# Top-level estimate
+# --------------------------------------------------------------------------- #
+def estimate_per_concept_costs(
+    concept: FieldConcept, scored: ScoredConcept
+) -> PerConceptCostEstimate:
+    """Estimate CAPEX/OPEX for one scored concept against a field's parameters.
+
+    Reuses :func:`integrations.estimate_economics` for the field-level CAPEX base
+    and the FDAS fixed-OPEX assumption for the base annual OPEX, then applies the
+    per-concept :func:`capex_adjustment_for` and :func:`opex_factor_for`
+    multipliers. Degrades gracefully (capex/opex ``None`` + ``note``) when FDAS
+    cannot classify a dev system.
+    """
+    ct = scored.concept_type
+    eco = estimate_economics(concept)
+
+    depth_fit = _depth_fit(ct, concept.water_depth_m)
+    tieback_km = concept.distance_to_host_km if ct in _TIEBACK_CONCEPTS else None
+    capex_adj = capex_adjustment_for(ct, depth_fit, tieback_km)
+    opex_factor = opex_factor_for(ct, concept.recoverable_reserves_mmboe)
+
+    depth_pen = _depth_capex_penalty(depth_fit)
+    tieback_pen_pct = round(_tieback_capex_penalty(tieback_km) * 100.0, 1)
+
+    est = PerConceptCostEstimate(
+        concept_type=ct,
+        capex_adjustment=capex_adj,
+        opex_factor=opex_factor,
+        depth_fit_penalty=round(depth_pen, 4),
+        tieback_penalty_pct=tieback_pen_pct,
+        dev_system=eco.dev_system,
+    )
+
+    # --- CAPEX (graceful degrade if FDAS yielded no field-level CAPEX) ---
+    if eco.capex_mm is None:
+        est.note = (
+            eco.note or "field-level CAPEX unavailable — per-concept CAPEX skipped"
+        )
+    else:
+        est.capex_mm = round(eco.capex_mm * capex_adj, 1)
+        est.rationale.append(
+            f"base CAPEX {eco.capex_mm:g} $MM ({eco.dev_system}) "
+            f"× {capex_adj:g} concept adjustment = {est.capex_mm:g} $MM"
+        )
+        if depth_pen > 0:
+            est.rationale.append(
+                f"depth fit {depth_fit:.2f} adds {depth_pen * 100:.1f}% CAPEX "
+                f"(outside the {ct.value} sweet-spot band)"
+            )
+        if tieback_pen_pct > 0:
+            est.rationale.append(
+                f"tieback {tieback_km:g} km exceeds the "
+                f"{Thresholds().flow_assurance_warn_km:g} km flow-assurance "
+                f"threshold, adding {tieback_pen_pct:.1f}% CAPEX"
+            )
+
+    # --- OPEX (independent graceful degrade) ---
+    base_opex = _base_annual_opex_mm(concept)
+    if base_opex is None:
+        if not est.note:
+            est.note = "dev system unclassified — annual OPEX skipped"
+    else:
+        est.annual_opex_mm = round(base_opex * opex_factor, 1)
+        res = concept.recoverable_reserves_mmboe
+        est.rationale.append(
+            f"base OPEX {base_opex:g} $MM/yr × {opex_factor:g} factor"
+            + (f" (reserves {res:g} MMboe)" if res else "")
+            + f" = {est.annual_opex_mm:g} $MM/yr"
+        )
+
+    return est
+
+
+def _lifecycle_cost(est: PerConceptCostEstimate, field_life_years: float) -> float:
+    """Rough lifecycle cost (CAPEX + OPEX×life) for portfolio ranking; inf if N/A."""
+    if est.capex_mm is None:
+        return float("inf")
+    life = field_life_years or _DEFAULT_FIELD_LIFE_YEARS
+    return est.capex_mm + (est.annual_opex_mm or 0.0) * life
+
+
+def estimate_field_cost_portfolio(
+    concept: FieldConcept, scored_concepts: list[ScoredConcept]
+) -> dict[ConceptType, PerConceptCostEstimate]:
+    """Cost every scored concept for a field, ordered by ascending lifecycle cost.
+
+    Concepts whose economics could not be estimated (no CAPEX) sort last. The
+    result is keyed by :class:`ConceptType` for O(1) lookup while preserving the
+    cheapest-first ordering (Python dicts are insertion-ordered).
+    """
+    life = concept.field_life_years or _DEFAULT_FIELD_LIFE_YEARS
+    estimates = {
+        sc.concept_type: estimate_per_concept_costs(concept, sc)
+        for sc in scored_concepts
+    }
+    ordered = sorted(estimates.items(), key=lambda kv: _lifecycle_cost(kv[1], life))
+    return dict(ordered)

--- a/src/worldenergydata/field_development/fdp_report.py
+++ b/src/worldenergydata/field_development/fdp_report.py
@@ -24,6 +24,9 @@ from __future__ import annotations
 from typing import Optional
 
 from worldenergydata.field_development.block import render_block_diagram
+from worldenergydata.field_development.cost_estimator import (
+    estimate_field_cost_portfolio,
+)
 from worldenergydata.field_development.enums import ConceptType
 from worldenergydata.field_development.integrations import enrich
 from worldenergydata.field_development.layout import render_layout
@@ -146,6 +149,34 @@ def _economics_block(economics, enriched, actuals: Optional[dict]) -> str:
     return "".join(out)
 
 
+def _cost_comparison_table(concept: FieldConcept, ranked) -> str:
+    """Per-concept CAPEX/OPEX comparison (issue #643), cheapest lifecycle first."""
+    portfolio = estimate_field_cost_portfolio(concept, ranked)
+    rows = []
+    for ct, est in portfolio.items():
+        is_actual = concept.concept_type is not None and ct == concept.concept_type
+        cls = ' class="pick"' if is_actual else ""
+        rows.append(
+            f"<tr{cls}><td>{_esc(ct.value)}{' ★' if is_actual else ''}</td>"
+            f"<td>{_fmt(est.capex_mm, ' $MM')}</td>"
+            f"<td>{_fmt(est.annual_opex_mm, ' $MM/yr')}</td>"
+            f"<td>{est.capex_adjustment:g}×</td>"
+            f"<td>{est.opex_factor:g}×</td>"
+            f"<td>{_esc(est.note) if est.note else ''}</td></tr>"
+        )
+    return (
+        "<h2>Per-concept cost comparison (Concept-Select fidelity)</h2>"
+        "<table><tr><th>Concept</th><th>Est. CAPEX</th><th>Annual OPEX</th>"
+        "<th>CAPEX adj.</th><th>OPEX factor</th><th>Note</th></tr>"
+        + "".join(rows)
+        + "</table>"
+        '<p class="sub" style="font-size:12px">CAPEX layers a concept adjustment '
+        "onto the field-level FDAS estimate; OPEX scales the FDAS fixed-OPEX "
+        "assumption by concept and reserves. Qualitative priors, not a calibrated "
+        "cost model.</p>"
+    )
+
+
 def build_fdp_html(
     concept: FieldConcept,
     top_n: int = 5,
@@ -203,6 +234,7 @@ not a sanctioned design.</p>
 this field (where known).</p></div>
 </div>
 {_economics_block(economics, enriched, actuals)}
+{_cost_comparison_table(concept, ranked)}
 <h2>Architecture &amp; layout ({_esc(arch.concept_type.value if arch.concept_type else "—")})</h2>
 <div class="viz">
 <figure>{block_svg}<figcaption>Subsea architecture block diagram</figcaption></figure>

--- a/tests/modules/field_development/test_cost_estimator.py
+++ b/tests/modules/field_development/test_cost_estimator.py
@@ -1,0 +1,195 @@
+# ABOUTME: Tests for the parametric per-concept CAPEX/OPEX estimator (issue #643).
+# ABOUTME: Verifies reuse of FDAS economics + recommendation priors, not new factors.
+"""Tests for ``worldenergydata.field_development.cost_estimator``.
+
+The estimator layers a *per-concept* adjustment on top of the field-level,
+depth-driven FDAS CAPEX (``integrations.estimate_economics``) and scales OPEX by
+the FDAS fixed-OPEX assumption. Tests assert the documented behaviours from the
+issue acceptance criteria: tieback cheaper than FPSO, measurable depth-fit and
+long-tieback penalties, reserves-scaled OPEX, bounded factors, graceful degrade,
+and ordered portfolios with costs rounded to 0.1 MM.
+"""
+
+from __future__ import annotations
+
+from worldenergydata.field_development import (
+    ConceptType,
+    FieldConcept,
+    PerConceptCostEstimate,
+    capex_adjustment_for,
+    estimate_field_cost_portfolio,
+    estimate_per_concept_costs,
+    opex_factor_for,
+    recommend,
+)
+from worldenergydata.field_development.enums import TreeType
+from worldenergydata.field_development.recommendation import (
+    ScoredConcept,
+    Thresholds,
+)
+
+
+def _scored(concept_type: ConceptType, tree: TreeType = TreeType.WET) -> ScoredConcept:
+    return ScoredConcept(concept_type=concept_type, tree_type=tree)
+
+
+# --------------------------------------------------------------------------- #
+# capex_adjustment_for — bounds and the documented penalties
+# --------------------------------------------------------------------------- #
+def test_capex_adjustment_in_band_range():
+    # Across every concept at a perfect depth fit and no tieback, the multiplier
+    # stays inside the documented ~[0.8, 1.5] envelope.
+    for ct in ConceptType:
+        adj = capex_adjustment_for(ct, depth_fit=1.0)
+        assert 0.8 <= adj <= 1.5
+
+
+def test_depth_misfit_raises_capex_adjustment():
+    # A poor depth fit must add a measurable CAPEX penalty.
+    good = capex_adjustment_for(ConceptType.FPSO, depth_fit=1.0)
+    bad = capex_adjustment_for(ConceptType.FPSO, depth_fit=0.0)
+    assert bad > good
+
+
+def test_tieback_beyond_threshold_is_penalised():
+    warn = Thresholds().flow_assurance_warn_km
+    near = capex_adjustment_for(ConceptType.SUBSEA_TIEBACK, tieback_km=warn)
+    far = capex_adjustment_for(ConceptType.SUBSEA_TIEBACK, tieback_km=warn + 40)
+    assert far > near
+
+
+def test_tieback_within_threshold_no_penalty():
+    warn = Thresholds().flow_assurance_warn_km
+    base = capex_adjustment_for(ConceptType.SUBSEA_TIEBACK)
+    within = capex_adjustment_for(ConceptType.SUBSEA_TIEBACK, tieback_km=warn - 5)
+    assert within == base
+
+
+# --------------------------------------------------------------------------- #
+# opex_factor_for — reserves scaling and bounds
+# --------------------------------------------------------------------------- #
+def test_opex_factor_scales_with_reserves():
+    small = opex_factor_for(ConceptType.FPSO, reserves_mmboe=25.0)
+    large = opex_factor_for(ConceptType.FPSO, reserves_mmboe=400.0)
+    assert large > small
+
+
+def test_opex_factor_in_range():
+    for ct in ConceptType:
+        for res in (None, 10.0, 100.0, 1000.0):
+            assert 0.5 <= opex_factor_for(ct, reserves_mmboe=res) <= 2.0
+
+
+# --------------------------------------------------------------------------- #
+# estimate_per_concept_costs — structure, relative CAPEX, rounding
+# --------------------------------------------------------------------------- #
+def test_per_concept_returns_populated_struct():
+    c = FieldConcept(name="X", water_depth_m=1500.0, num_wells=6)
+    est = estimate_per_concept_costs(c, _scored(ConceptType.FPSO))
+    assert isinstance(est, PerConceptCostEstimate)
+    assert est.concept_type == ConceptType.FPSO
+    assert est.capex_mm is not None and est.capex_mm > 0
+    assert est.annual_opex_mm is not None and est.annual_opex_mm > 0
+    assert 0.8 <= est.capex_adjustment <= 1.5
+    assert 0.5 <= est.opex_factor <= 2.0
+    assert est.rationale
+
+
+def test_subsea_tieback_cheaper_than_fpso_same_depth():
+    # Same field/depth; the tieback's favourable CAPEX prior should make it
+    # 5–15% cheaper than a dedicated FPSO host (issue acceptance).
+    c = FieldConcept(
+        name="X",
+        water_depth_m=1500.0,
+        num_wells=6,
+        distance_to_host_km=15.0,
+        host_spare_capacity=True,
+    )
+    tb = estimate_per_concept_costs(c, _scored(ConceptType.SUBSEA_TIEBACK))
+    fpso = estimate_per_concept_costs(c, _scored(ConceptType.FPSO))
+    assert tb.capex_mm < fpso.capex_mm
+    ratio = tb.capex_mm / fpso.capex_mm
+    assert 0.85 <= ratio <= 0.95
+
+
+def test_opex_scales_with_reserves_in_estimate():
+    base = dict(name="X", water_depth_m=1500.0, num_wells=6)
+    small = estimate_per_concept_costs(
+        FieldConcept(recoverable_reserves_mmboe=25.0, **base),
+        _scored(ConceptType.FPSO),
+    )
+    large = estimate_per_concept_costs(
+        FieldConcept(recoverable_reserves_mmboe=400.0, **base),
+        _scored(ConceptType.FPSO),
+    )
+    assert large.annual_opex_mm > small.annual_opex_mm
+
+
+def test_long_tieback_records_penalty():
+    c = FieldConcept(
+        name="X",
+        water_depth_m=1500.0,
+        num_wells=4,
+        distance_to_host_km=80.0,
+        host_spare_capacity=True,
+    )
+    est = estimate_per_concept_costs(c, _scored(ConceptType.SUBSEA_TIEBACK))
+    assert est.tieback_penalty_pct > 0
+
+
+def test_costs_rounded_to_point_one():
+    c = FieldConcept(name="X", water_depth_m=1500.0, num_wells=7)
+    est = estimate_per_concept_costs(c, _scored(ConceptType.FPSO))
+    assert est.capex_mm == round(est.capex_mm, 1)
+    assert est.annual_opex_mm == round(est.annual_opex_mm, 1)
+
+
+# --------------------------------------------------------------------------- #
+# Graceful degradation
+# --------------------------------------------------------------------------- #
+def test_graceful_degrade_unknown_depth():
+    # No water depth → FDAS cannot classify a dev system → no CAPEX, but the
+    # estimator must return a noted struct rather than raise.
+    est = estimate_per_concept_costs(FieldConcept(name="X"), _scored(ConceptType.FPSO))
+    assert est.capex_mm is None
+    assert est.annual_opex_mm is None
+    assert est.note
+
+
+# --------------------------------------------------------------------------- #
+# Portfolio
+# --------------------------------------------------------------------------- #
+def test_portfolio_keys_match_concepts_and_ordered():
+    c = FieldConcept(
+        name="X",
+        water_depth_m=1500.0,
+        num_wells=6,
+        recoverable_reserves_mmboe=120.0,
+        distance_to_host_km=20.0,
+        host_spare_capacity=True,
+    )
+    ranked = recommend(c)
+    portfolio = estimate_field_cost_portfolio(c, ranked)
+    assert set(portfolio.keys()) == {sc.concept_type for sc in ranked}
+    # Ordered by ascending lifecycle cost (CAPEX + OPEX×life; None last).
+    life = c.field_life_years or 20.0
+
+    def lifecycle(e):
+        if e.capex_mm is None:
+            return float("inf")
+        return e.capex_mm + (e.annual_opex_mm or 0.0) * life
+
+    costs = [lifecycle(e) for e in portfolio.values()]
+    assert costs == sorted(costs)
+
+
+# --------------------------------------------------------------------------- #
+# Optional report wiring
+# --------------------------------------------------------------------------- #
+def test_fdp_report_includes_cost_comparison():
+    from worldenergydata.field_development import build_fdp_html
+
+    html = build_fdp_html(FieldConcept(name="X", water_depth_m=1500.0, num_wells=6))
+    assert "Per-concept cost comparison" in html
+    # Existing render is intact.
+    assert "<!doctype html>" in html and "Architecture" in html


### PR DESCRIPTION
## Summary
Adds `cost_estimator.py` (issue #643, epic #567): per-concept CAPEX/OPEX breakdowns from `concept_type + water_depth_m + recoverable_reserves_mmboe + num_wells + distance_to_host_km`.

**Reuse, not duplication** — the cost factors are *not* re-derived:
- **Base CAPEX** = `integrations.estimate_economics` (FDAS host + per-well assumptions), never recomputed.
- **Base annual OPEX** = FDAS `FIXED_OPEX_MM_PER_YEAR` for the depth-classified dev system (via `dev_system_for` + `AssumptionsManager`).
- **Per-concept multipliers** derive from the same priors the engine already scores on: `recommendation._CONCEPT_PROFILES` (relative CAPEX/OPEX), `_depth_fit`/`DEPTH_SWEET_M` (depth-fit penalty), and `Thresholds.flow_assurance_warn_km` (tieback >32 km penalty — single source of truth, not duplicated).

## API
- `estimate_per_concept_costs(concept, scored) -> PerConceptCostEstimate`
- `estimate_field_cost_portfolio(concept, scored_concepts) -> dict[ConceptType, PerConceptCostEstimate]` (ordered by ascending lifecycle cost)
- `capex_adjustment_for(concept, depth_fit=1.0, tieback_km=None) -> float` (clamped ~[0.8, 1.5])
- `opex_factor_for(concept, reserves_mmboe=None) -> float` (clamped ~[0.5, 2.0])

## Acceptance
- `PerConceptCostEstimate` carries concept_type, capex_mm, annual_opex_mm, capex_adjustment, opex_factor, depth_fit_penalty, tieback_penalty_pct, rationale (+ dev_system, note).
- SUBSEA_TIEBACK CAPEX ~11% < FPSO at same depth (within 5-15%); depth-fit & tieback>32km penalties measurable; OPEX scales with reserves.
- Graceful degrade: returns a noted estimate (no raise) when FDAS can't classify a dev system.
- Costs rounded to 0.1 MM; no new deps; file ~330 lines.
- Optional cost-comparison section wired into `fdp_report` without breaking existing render.

## Tests
14 new tests in `tests/modules/field_development/test_cost_estimator.py`; full `tests/modules/field_development/` suite green (207 passed), no regression. isort/black/ruff clean.

## Caveats
The per-concept multipliers are **qualitative engineering priors** (Concept-Select / AACE Class 5 fidelity), not empirically calibrated cost models. The tieback-vs-FPSO gap, depth-fit span, and +0.5%/km flow-assurance penalty are tuned to be directionally sensible and to meet the acceptance bands, not fitted to project cost data.

Closes #643