### PR TITLE
ci: fix docs.yml startup_failure (workspace-hub#3293)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,6 @@ on:
 jobs:
   docs:
     runs-on: ubuntu-latest
-    if: hashFiles('mkdocs.yml') != ''
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Implements workspace-hub#3293.

Removes the invalid job-level `if: hashFiles('mkdocs.yml') != ''` (line 20) in `.github/workflows/docs.yml`. `hashFiles()` requires a checked-out workspace that does not exist at job-load time, so the workflow loader rejects the `docs` job and every run is a 0-minute `startup_failure` (run name surfaces as the raw path `.github/workflows/docs.yml` instead of `Build API Docs`). `mkdocs.yml` is both committed and already in the `on.*.paths` filter, so the guard is doubly redundant.

**Success signal (narrow):** the workflow LOADS and its job EXECUTES — i.e. NOT a `startup_failure` / 0-minute parse failure, with run `name` resolving to `Build API Docs`. It is **NOT** a green `mkdocs build --strict`: `--strict` may still fail on pre-existing doc warnings, which is a normal non-zero-minute `failure` and is explicitly out of scope for #3293 (track separately under epic #3290).

**Verification:** YAML parses (`yaml.safe_load`); `grep hashFiles` → no match; `git diff` is the single-line deletion only. Empirical confirmation is via `gh workflow run docs.yml` (`workflow_dispatch`) — a `docs.yml`-only change matches none of the `on.*.paths` entries (`src/**`, `docs/api/**`, `mkdocs.yml`), so no organic push/PR triggers the workflow. **Not self-triggered by this PR.** GitHub only accepts `workflow_dispatch` once the trigger is on the default branch, so the dispatch verification runs post-merge (operator-gated).