### PR TITLE
feat(onshore): add Texas RRC source catalog

### DIFF
--- a/docs/data-sources/onshore/texas-rrc/source-catalog.md
+++ b/docs/data-sources/onshore/texas-rrc/source-catalog.md
@@ -1,0 +1,47 @@
+# Texas RRC Source Catalog
+
+This catalog defines the first onshore pilot for `worldenergydata`: Texas RRC
+field-development data stored under `/mnt/ace`. Official Texas RRC datasets are
+the durable source of record. PatchOps and RRC EWA web-form queries are
+validation and query-prototyping surfaces.
+
+## Lifecycle Coverage
+
+| Source family | Coverage | Refresh | Format | Status |
+| --- | --- | --- | --- | --- |
+| `production_pdq` | Lease, field, district, operator, oil, gas, condensate, water, production month, well count | Last Saturday each month | ZIP/CSV | Available |
+| `wellbore_query` | API, district, lease, county, field, operator, permit, schedule, well type, status | Beginning of month | ZIP/ASCII | Available |
+| `drilling_permits` | Permit master/trailer, API, field, lease, depth, location, permit type | Nightly | ASCII | Available |
+| `completion_data` | Completion and recompletion forms, district-organized completion data | Nightly | ZIP/ASCII/PDF | Partial |
+| `directional_surveys` | Directional survey applications | Daily | ZIP/PDF | Partial |
+| `well_gis_layers` | Well GIS layers by county | Twice weekly | Shapefile | Available |
+| `pipeline_gis_layers` | Pipeline GIS layers by county | Twice weekly | Shapefile | Available |
+| `field_lease_operator` | Field, lease, operator, P-4, docket, and organization context | Source-specific | Mixed | Partial |
+| `rrc_ewa_lease_query_validation` | API-to-lease lookup and specific lease production query validation | Service-managed | Web form/CSV | Validation only |
+| `patchops_rrc_validation` | RRC well, production, and pipeline query validation | Service-managed | MCP/PostGIS tools | Validation only |
+
+## Partial-Source Caveats
+
+Completion data is partial for lifecycle reconstruction because structured data
+does not capture every detail available in W-2/G-1 forms. Some lifecycle
+evidence remains in forms or imaged files and will need a separate document
+extraction step if the project needs full form fidelity.
+
+Directional surveys are partial because Texas RRC publishes directional survey
+applications as daily zipped PDF images. The public bulk surface does not provide
+clean station-level MD, inclination, and azimuth tables without PDF extraction.
+
+Field, lease, and operator context is partial because those identifiers appear
+across multiple RRC products. The normalized layer must preserve original keys
+and source names so later joins remain auditable.
+
+PatchOps maps to the same domains as the official catalog for validation:
+`wellbore_query`, `production_pdq`, and `pipeline_gis_layers`. It must not become
+the only durable data source for the public repository.
+
+The RRC EWA lease query endpoints are official web-form surfaces that are useful
+for validating API-to-lease joins and specific lease production output against
+the bulk PDQ and Wellbore Query downloads. The historical `derrickturk/rrc-scraper`
+repository documents that flow, but it has no asserted SPDX license in GitHub
+metadata, so it is reference-only; implementation must use the official endpoint
+behavior and not copy scraper code.

--- a/docs/data-sources/onshore/texas-rrc/storage-contract.md
+++ b/docs/data-sources/onshore/texas-rrc/storage-contract.md
@@ -1,0 +1,64 @@
+# Texas RRC Storage Contract
+
+Texas RRC heavy data belongs outside git under:
+
+`/mnt/ace/worldenergydata/data/modules/texas_rrc`
+
+The repository stores source catalogs, loaders, validators, tests, and report
+builders. Raw downloads, normalized outputs, curated field-atlas outputs, and
+manifests live under `/mnt/ace`.
+
+## Directory Layout
+
+```text
+/mnt/ace/worldenergydata/data/modules/texas_rrc/
+  raw/
+    production/pdq/
+    wellbore/query/
+    permits/drilling/
+    completions/
+    directional_surveys/
+    gis/wells/
+    gis/pipelines/
+    reference/field_lease_operator/
+    validation/rrc_ewa_lease_query/
+    validation/patchops_rrc/
+  normalized/
+    production/pdq/
+    wellbore/query/
+    permits/drilling/
+    completions/
+    directional_surveys/
+    gis/wells/
+    gis/pipelines/
+    reference/field_lease_operator/
+    validation/rrc_ewa_lease_query/
+    validation/patchops_rrc/
+  curated/
+    production/field_atlas/
+    well_lifecycle/spine/
+    well_lifecycle/permits/
+    well_lifecycle/completions/
+    well_lifecycle/directional_surveys/
+    infrastructure/well_layers/
+    infrastructure/pipeline_layers/
+    reference/field_lease_operator/
+    validation/rrc_ewa_lease_query/
+    validation/patchops_rrc/
+```
+
+## Path Rules
+
+All raw, normalized, and curated paths in the machine-readable source catalog
+must be absolute and must remain under
+`/mnt/ace/worldenergydata/data/modules/texas_rrc`.
+
+The source catalog is a contract, not a downloader. Later refresh code will use
+the catalog to decide where source snapshots and manifests are written.
+
+## Source-of-Record Rule
+
+Official Texas RRC public bulk datasets are the durable source of record.
+PatchOps and RRC EWA web-form queries may be used to validate joins, inspect
+nearby pipelines, and prototype geometry or production lookups, but curated
+outputs must be reproducible from official RRC snapshots stored under `/mnt/ace`.

--- a/packages/worldenergydata-texas_rrc/pyproject.toml
+++ b/packages/worldenergydata-texas_rrc/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 dependencies = [
     "worldenergydata-core",
     "pandas>=2.3.3,<3.0",
+    "pyyaml>=6.0,<7.0",
 ]
 
 [project.urls]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/data/source_catalog.yml
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/data/source_catalog.yml
@@ -1,0 +1,118 @@
+sources:
+  production_pdq:
+    source_url: "https://www.rrc.texas.gov/media/ebxnoxbm/pdq-dump.zip"
+    format: "zip_csv"
+    refresh_cadence: "monthly_last_saturday"
+    raw_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/production/pdq"
+    normalized_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/normalized/production/pdq"
+    curated_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/production/field_atlas"
+    availability_status: "available"
+    source_of_record: true
+    caveats: "Production Data Query Dump covers production from 1993 to current at lease/field/operator granularity, not clean per-well allocation."
+
+  wellbore_query:
+    source_url: "https://www.rrc.texas.gov/media/kywh5qsj/wellboredump.zip"
+    format: "zip_ascii"
+    refresh_cadence: "monthly_beginning"
+    raw_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/wellbore/query"
+    normalized_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/normalized/wellbore/query"
+    curated_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/well_lifecycle/spine"
+    availability_status: "available"
+    source_of_record: true
+    caveats: "Wellbore Query Data supports district, lease, county, field, operator, permit, API, schedule, and well type searches."
+
+  drilling_permits:
+    source_url: "https://www.rrc.texas.gov/resource-center/research/data-sets-available-for-download/#drilling-permit-data-table"
+    format: "ascii"
+    refresh_cadence: "nightly"
+    raw_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/permits/drilling"
+    normalized_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/normalized/permits/drilling"
+    curated_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/well_lifecycle/permits"
+    availability_status: "available"
+    source_of_record: true
+    caveats: "Daily drilling permit master/trailer files include latitudes and longitudes, but source schemas vary across daily and month-end products."
+
+  completion_data:
+    source_url: "https://www.rrc.texas.gov/resource-center/research/data-sets-available-for-download/#completion-data-table"
+    format: "zip_ascii_pdf"
+    refresh_cadence: "nightly"
+    raw_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/completions"
+    normalized_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/normalized/completions"
+    curated_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/well_lifecycle/completions"
+    availability_status: "partial"
+    source_of_record: true
+    caveats: "Completion information includes structured submitted/approved forms, but richer W-2/G-1 forms and imaged completion files require form/PDF handling."
+
+  directional_surveys:
+    source_url: "https://www.rrc.texas.gov/resource-center/research/data-sets-available-for-download/#directional-survey-data-table"
+    format: "zip_pdf"
+    refresh_cadence: "daily"
+    raw_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/directional_surveys"
+    normalized_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/normalized/directional_surveys"
+    curated_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/well_lifecycle/directional_surveys"
+    availability_status: "partial"
+    source_of_record: true
+    caveats: "Directional survey applications are daily zipped PDF images; structured MD/inc/azimuth stations are not available from the public bulk dump without PDF extraction."
+
+  well_gis_layers:
+    source_url: "https://www.rrc.texas.gov/resource-center/research/data-sets-available-for-download/#gis-data-table"
+    format: "shapefile"
+    refresh_cadence: "twice_weekly"
+    raw_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/gis/wells"
+    normalized_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/normalized/gis/wells"
+    curated_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/infrastructure/well_layers"
+    availability_status: "available"
+    source_of_record: true
+    caveats: "Well Layers by County are ArcView shapefiles keyed by FIPS code and refreshed twice weekly."
+
+  pipeline_gis_layers:
+    source_url: "https://www.rrc.texas.gov/resource-center/research/data-sets-available-for-download/#gis-data-table"
+    format: "shapefile"
+    refresh_cadence: "twice_weekly"
+    raw_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/gis/pipelines"
+    normalized_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/normalized/gis/pipelines"
+    curated_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/infrastructure/pipeline_layers"
+    availability_status: "available"
+    source_of_record: true
+    caveats: "Pipeline Layers by County are ArcView shapefiles keyed by FIPS code and refreshed twice weekly."
+
+  field_lease_operator:
+    source_url: "https://www.rrc.texas.gov/resource-center/research/data-sets-available-for-download/"
+    format: "mixed_ascii_csv"
+    refresh_cadence: "source_specific"
+    raw_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/reference/field_lease_operator"
+    normalized_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/normalized/reference/field_lease_operator"
+    curated_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/reference/field_lease_operator"
+    availability_status: "partial"
+    source_of_record: true
+    caveats: "Field, lease, operator, P-4, docket, and organization data are spread across several RRC datasets and must be reconciled by source-specific keys."
+
+  rrc_ewa_lease_query_validation:
+    source_url: "https://webapps2.rrc.texas.gov/EWA/specificLeaseQueryAction.do"
+    reference_url: "https://github.com/derrickturk/rrc-scraper/blob/6dce564695df739c43cb257472fbdb455fdd1b2e/RRCScraper.py"
+    format: "web_form_csv"
+    refresh_cadence: "service_managed"
+    raw_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/validation/rrc_ewa_lease_query"
+    normalized_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/normalized/validation/rrc_ewa_lease_query"
+    curated_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/validation/rrc_ewa_lease_query"
+    availability_status: "validation_only"
+    source_of_record: false
+    validates:
+      - "wellbore_query"
+      - "production_pdq"
+    caveats: "Official EWA endpoints can validate API-to-lease lookup and specific lease production query assumptions. The linked rrc-scraper is a historical behavioral reference with no asserted SPDX license; use endpoint clues only and do not copy code."
+
+  patchops_rrc_validation:
+    source_url: "https://patchops.ai/mcpservers/rrc"
+    format: "mcp_postgis_tools"
+    refresh_cadence: "service_managed"
+    raw_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/validation/patchops_rrc"
+    normalized_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/normalized/validation/patchops_rrc"
+    curated_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/validation/patchops_rrc"
+    availability_status: "validation_only"
+    source_of_record: false
+    validates:
+      - "wellbore_query"
+      - "production_pdq"
+      - "pipeline_gis_layers"
+    caveats: "PatchOps exposes RRC wells, well production, area production, and pipeline geometry tools; use it for query validation and prototyping, not as the durable source of record."

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/source_catalog.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/source_catalog.py
@@ -1,0 +1,81 @@
+"""Texas RRC lifecycle source catalog loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SOURCE_CATALOG_ROOT = Path("/mnt/ace/worldenergydata/data/modules/texas_rrc")
+SOURCE_CATALOG_PATH = Path(__file__).parent / "data" / "source_catalog.yml"
+
+REQUIRED_SOURCE_FIELDS = {
+    "source_url",
+    "format",
+    "refresh_cadence",
+    "raw_path",
+    "normalized_path",
+    "curated_path",
+    "availability_status",
+    "source_of_record",
+    "caveats",
+}
+
+VALID_AVAILABILITY_STATUSES = {"available", "partial", "validation_only"}
+
+
+def load_source_catalog(path: Path | None = None) -> dict[str, dict[str, Any]]:
+    """Load and validate the Texas RRC source catalog."""
+    catalog_path = path or SOURCE_CATALOG_PATH
+    with catalog_path.open("r", encoding="utf-8") as stream:
+        payload = yaml.safe_load(stream) or {}
+
+    catalog = payload.get("sources", {})
+    if not isinstance(catalog, dict):
+        raise ValueError("Texas RRC source catalog must contain a 'sources' mapping")
+
+    validate_source_catalog(catalog)
+    return catalog
+
+
+def validate_source_catalog(catalog: dict[str, dict[str, Any]]) -> None:
+    """Validate source catalog shape and storage-path policy."""
+    for source_id, entry in catalog.items():
+        if not isinstance(entry, dict):
+            raise ValueError(f"Catalog entry '{source_id}' must be a mapping")
+
+        missing = REQUIRED_SOURCE_FIELDS.difference(entry)
+        if missing:
+            fields = ", ".join(sorted(missing))
+            raise ValueError(f"Catalog entry '{source_id}' is missing: {fields}")
+
+        status = entry["availability_status"]
+        if status not in VALID_AVAILABILITY_STATUSES:
+            raise ValueError(
+                f"Catalog entry '{source_id}' has invalid availability_status: "
+                f"{status!r}"
+            )
+
+        if not isinstance(entry["source_of_record"], bool):
+            raise ValueError(
+                f"Catalog entry '{source_id}' field 'source_of_record' must be boolean"
+            )
+        if status == "validation_only" and entry["source_of_record"]:
+            raise ValueError(
+                f"Catalog entry '{source_id}' cannot be source_of_record when "
+                "availability_status is validation_only"
+            )
+
+        for field in ("raw_path", "normalized_path", "curated_path"):
+            _validate_catalog_path(source_id, field, Path(entry[field]))
+
+
+def _validate_catalog_path(source_id: str, field: str, path: Path) -> None:
+    if not path.is_absolute():
+        raise ValueError(f"Catalog entry '{source_id}' field '{field}' is not absolute")
+    if not path.is_relative_to(SOURCE_CATALOG_ROOT):
+        raise ValueError(
+            f"Catalog entry '{source_id}' field '{field}' must stay under "
+            f"{SOURCE_CATALOG_ROOT}"
+        )

--- a/tests/unit/texas_rrc/test_source_catalog.py
+++ b/tests/unit/texas_rrc/test_source_catalog.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pytest
 
-
 REQUIRED_SOURCE_IDS = {
     "production_pdq",
     "wellbore_query",

--- a/tests/unit/texas_rrc/test_source_catalog.py
+++ b/tests/unit/texas_rrc/test_source_catalog.py
@@ -1,0 +1,157 @@
+"""Tests for the Texas RRC source catalog and storage contract."""
+
+from pathlib import Path
+
+import pytest
+
+
+REQUIRED_SOURCE_IDS = {
+    "production_pdq",
+    "wellbore_query",
+    "drilling_permits",
+    "completion_data",
+    "directional_surveys",
+    "well_gis_layers",
+    "pipeline_gis_layers",
+    "field_lease_operator",
+    "rrc_ewa_lease_query_validation",
+    "patchops_rrc_validation",
+}
+
+REQUIRED_SOURCE_FIELDS = {
+    "source_url",
+    "format",
+    "refresh_cadence",
+    "raw_path",
+    "normalized_path",
+    "curated_path",
+    "availability_status",
+    "source_of_record",
+    "caveats",
+}
+
+
+def test_source_catalog_declares_required_lifecycle_sources():
+    from worldenergydata.texas_rrc.source_catalog import load_source_catalog
+
+    catalog = load_source_catalog()
+
+    assert REQUIRED_SOURCE_IDS.issubset(catalog)
+
+
+def test_source_catalog_entries_have_required_contract_fields():
+    from worldenergydata.texas_rrc.source_catalog import load_source_catalog
+
+    catalog = load_source_catalog()
+
+    for source_id in REQUIRED_SOURCE_IDS:
+        entry = catalog[source_id]
+        assert REQUIRED_SOURCE_FIELDS.issubset(entry)
+        assert entry["source_url"]
+        assert entry["format"]
+        assert entry["refresh_cadence"]
+        assert entry["availability_status"] in {
+            "available",
+            "partial",
+            "validation_only",
+        }
+        assert isinstance(entry["source_of_record"], bool)
+        assert entry["caveats"]
+
+
+def test_source_catalog_paths_stay_under_texas_rrc_ace_root():
+    from worldenergydata.texas_rrc.source_catalog import (
+        SOURCE_CATALOG_ROOT,
+        load_source_catalog,
+    )
+
+    catalog = load_source_catalog()
+
+    assert SOURCE_CATALOG_ROOT == Path(
+        "/mnt/ace/worldenergydata/data/modules/texas_rrc"
+    )
+    for entry in catalog.values():
+        for field in ("raw_path", "normalized_path", "curated_path"):
+            path = Path(entry[field])
+            assert path.is_absolute()
+            assert path.is_relative_to(SOURCE_CATALOG_ROOT)
+
+
+def test_source_catalog_rejects_paths_outside_texas_rrc_ace_root():
+    from worldenergydata.texas_rrc.source_catalog import validate_source_catalog
+
+    invalid_catalog = {
+        "bad_source": {
+            "source_url": "https://www.rrc.texas.gov/",
+            "format": "csv",
+            "refresh_cadence": "nightly",
+            "raw_path": "/tmp/raw",
+            "normalized_path": "/mnt/ace/worldenergydata/data/modules/texas_rrc/normalized/bad",
+            "curated_path": "/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/bad",
+            "availability_status": "available",
+            "source_of_record": True,
+            "caveats": "test fixture",
+        }
+    }
+
+    with pytest.raises(ValueError, match="must stay under"):
+        validate_source_catalog(invalid_catalog)
+
+
+def test_source_catalog_marks_imaged_and_partial_lifecycle_sources():
+    from worldenergydata.texas_rrc.source_catalog import load_source_catalog
+
+    catalog = load_source_catalog()
+
+    assert catalog["directional_surveys"]["availability_status"] == "partial"
+    assert "PDF" in catalog["directional_surveys"]["caveats"]
+    assert catalog["completion_data"]["availability_status"] == "partial"
+    assert "forms" in catalog["completion_data"]["caveats"].lower()
+
+
+def test_patchops_is_validation_surface_not_source_of_record():
+    from worldenergydata.texas_rrc.source_catalog import load_source_catalog
+
+    catalog = load_source_catalog()
+    patchops = catalog["patchops_rrc_validation"]
+
+    assert patchops["availability_status"] == "validation_only"
+    assert patchops["source_of_record"] is False
+    assert set(patchops["validates"]) == {
+        "wellbore_query",
+        "production_pdq",
+        "pipeline_gis_layers",
+    }
+
+
+def test_rrc_ewa_lease_query_is_validation_surface_not_copied_scraper_code():
+    from worldenergydata.texas_rrc.source_catalog import load_source_catalog
+
+    catalog = load_source_catalog()
+    ewa = catalog["rrc_ewa_lease_query_validation"]
+
+    assert ewa["availability_status"] == "validation_only"
+    assert ewa["source_of_record"] is False
+    assert set(ewa["validates"]) == {
+        "wellbore_query",
+        "production_pdq",
+    }
+    assert "derrickturk/rrc-scraper" in ewa["reference_url"]
+    assert "do not copy code" in ewa["caveats"]
+
+
+def test_source_catalog_docs_exist_and_label_partial_sources():
+    source_doc = Path("docs/data-sources/onshore/texas-rrc/source-catalog.md")
+    storage_doc = Path("docs/data-sources/onshore/texas-rrc/storage-contract.md")
+
+    assert source_doc.exists()
+    assert storage_doc.exists()
+
+    source_text = source_doc.read_text(encoding="utf-8")
+    storage_text = storage_doc.read_text(encoding="utf-8")
+
+    assert "directional surveys" in source_text.lower()
+    assert "PDF" in source_text
+    assert "PatchOps" in source_text
+    assert "RRC EWA" in source_text
+    assert "/mnt/ace/worldenergydata/data/modules/texas_rrc" in storage_text

--- a/uv.lock
+++ b/uv.lock
@@ -7526,12 +7526,14 @@ version = "0.1.0"
 source = { editable = "packages/worldenergydata-texas_rrc" }
 dependencies = [
     { name = "pandas" },
+    { name = "pyyaml" },
     { name = "worldenergydata-core" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "pandas", specifier = ">=2.3.3,<3.0" },
+    { name = "pyyaml", specifier = ">=6.0,<7.0" },
     { name = "worldenergydata-core", editable = "packages/worldenergydata-core" },
 ]
 


### PR DESCRIPTION
## Summary
- Adds a machine-readable Texas RRC lifecycle source catalog for the onshore pilot.
- Defines the /mnt/ace raw, normalized, and curated storage contract.
- Marks PatchOps and RRC EWA lease queries as validation/prototyping surfaces, not durable source-of-record data.
- Adds tests for required lifecycle sources, /mnt/ace path policy, validation-only semantics, and documentation coverage.

Refs #660.

## Validation
- `PYTHONPATH='packages/worldenergydata-texas_rrc/src:packages/worldenergydata-core/src:src' PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 timeout 180 .venv/bin/python -m pytest -o addopts='' --noconftest tests/unit/texas_rrc/test_source_catalog.py -q` -> 8 passed
- `PYTHONPATH='packages/worldenergydata-texas_rrc/src:packages/worldenergydata-core/src:src' PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 timeout 300 .venv/bin/python -m pytest -o addopts='' --noconftest tests/unit/texas_rrc -q` -> 363 passed
- `.venv/bin/ruff check packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/source_catalog.py tests/unit/texas_rrc/test_source_catalog.py` -> passed
- `.venv/bin/ruff format --check packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/source_catalog.py tests/unit/texas_rrc/test_source_catalog.py` -> passed
- `git diff --check` -> passed

## Notes
- The repository-local `scripts/legal/legal-sanity-scan.sh` required by workspace policy is not present in this checkout; no equivalent legal script was found under `scripts/`.
- Coverage-enabled pytest generated reports and then stalled during finalization locally, so final verification used pytest with repository addopts cleared and plugin autoload disabled.