### PR TITLE
docs(pages): add Engineering Capabilities overview page

### DIFF
--- a/reports/capabilities/index.html
+++ b/reports/capabilities/index.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>worldenergydata — Open Energy-Data Capabilities</title>
+<style>
+  :root{--bg:#0d1117;--panel:#161b22;--line:#30363d;--ink:#e6edf3;--mut:#8b949e;
+        --accent:#3b82f6;--ok:#3fb950;--warn:#d29922}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);
+       font:15px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}
+  .wrap{max-width:1120px;margin:0 auto;padding:0 22px}
+  header{padding:54px 0 30px;border-bottom:1px solid var(--line)}
+  h1{margin:0 0 6px;font-size:30px;letter-spacing:-.4px}
+  .sub{color:var(--mut);font-size:16px;max-width:780px}
+  .tag{display:inline-block;margin-top:14px;padding:3px 10px;border:1px solid var(--line);
+       border-radius:20px;color:var(--mut);font-size:12.5px}
+  h2{font-size:18px;margin:38px 0 14px;letter-spacing:-.2px}
+  .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(330px,1fr));gap:14px}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:16px 18px}
+  .card h3{margin:0 0 4px;font-size:15.5px}
+  .card .std{color:var(--accent);font-size:12.5px;font-weight:600;margin-bottom:8px}
+  .card ul{margin:0;padding-left:18px;color:var(--mut);font-size:13.5px}
+  .card li{margin:2px 0}
+  table{width:100%;border-collapse:collapse;font-size:13.5px;margin-top:6px;
+        background:var(--panel);border:1px solid var(--line);border-radius:10px;overflow:hidden}
+  th,td{padding:9px 12px;text-align:left;border-bottom:1px solid var(--line)}
+  th{background:#1c2330;color:var(--mut);font-weight:600;font-size:12px;text-transform:uppercase;letter-spacing:.4px}
+  tr:last-child td{border-bottom:none}
+  td.val{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;color:var(--ink)}
+  .pub{color:var(--ok);font-weight:600}
+  .der{color:var(--warn);font-weight:600}
+  .note{color:var(--mut);font-size:13px;margin:10px 0 0}
+  footer{margin:46px 0 30px;padding-top:22px;border-top:1px solid var(--line);
+         color:var(--mut);font-size:12.5px}
+  a{color:var(--accent);text-decoration:none}
+  code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;background:#1c2330;
+       padding:1px 5px;border-radius:4px;font-size:12.5px}
+  a.linkcard{text-decoration:none;color:inherit;display:block;transition:border-color .15s,transform .1s}
+  a.linkcard:hover{border-color:var(--accent);transform:translateY(-1px)}
+  a.linkcard h3{color:var(--accent)}
+</style>
+</head>
+<body>
+<header><div class="wrap">
+  <h1>worldenergydata — Open Energy-Data Capabilities</h1>
+  <div class="sub">Deterministic offshore field economics, a field-development playbook, and
+  multi-region production &amp; safety analytics &mdash; each result computed by unit-tested
+  domain code on public regulatory filings, frozen into a report artifact, and rendered to
+  static HTML. No server, no API key: the numbers are identical for everyone, every time.</div>
+  <span class="tag">Public BSEE &amp; multi-region data · sanctioned V30 golden baselines · deterministic static outputs</span>
+</div></header>
+
+<div class="wrap">
+
+  <h2>BSEE production &amp; field economics</h2>
+  <div class="grid">
+    <div class="card"><h3>Sanctioned field economics (V30)</h3><div class="std">BSEE OGOR-A · golden_baseline_v30</div>
+      <ul><li>per-well / per-block / per-field NPV, MIRR, IRR, cashflow</li><li>7 Lower-Tertiary deepwater fields, life-to-date</li><li>frozen golden baseline guarded by a CI regression test</li></ul></div>
+    <div class="card"><h3>Production data &amp; decline</h3><div class="std">BSEE OGOR-A (Sep 2000 &ndash; Jul 2025)</div>
+      <ul><li>monthly oil / gas / water by well, lease, field</li><li>per-well stackup &amp; production forecast</li><li>headerless <code>.bin</code> ingestion with positional schema repair</li></ul></div>
+    <div class="card"><h3>Well benchmarking</h3><div class="std">BSEE Well Activity Reports</div>
+      <ul><li>cross-field per-well performance, 2010 &ndash; latest</li><li>normalized cumulative &amp; rate comparisons</li></ul></div>
+    <div class="card"><h3>3D well paths</h3><div class="std">BSEE directional surveys</div>
+      <ul><li>one frozen JSON data contract &rarr; two renderers</li><li>Plotly + Three.js, north/east-correct geometry</li></ul></div>
+  </div>
+
+  <h2>Offshore field-development playbook</h2>
+  <div class="grid">
+    <div class="card"><h3>Concept-selection engine</h3><div class="std">SubseaIQ catalog · BSEE assets</div>
+      <ul><li>field parameters &rarr; ranked development concept</li><li>Concept-Select / FEL-1 heuristic fidelity</li><li>basin/region prior + depth-band calibration</li></ul></div>
+    <div class="card"><h3>Subsea schematics</h3><div class="std">deterministic pure-Python SVG</div>
+      <ul><li>to-scale plan-view + block diagrams</li><li>zero external dependencies, self-contained HTML</li><li>flow-assurance flags + indicative economics</li></ul></div>
+    <div class="card"><h3>Deepwater portfolio</h3><div class="std">10-field Gulf of Mexico set</div>
+      <ul><li>full field-development plans per field</li><li>DEXPI-style layout + 3D hardware (CadQuery)</li></ul></div>
+    <div class="card"><h3>BSEE-matched concepts</h3><div class="std">BSEE &times; SubseaIQ join (BOEM block key)</div>
+      <ul><li>recommended vs as-built concept</li><li>115 BSEE-cross-referenced GoM fields</li></ul></div>
+  </div>
+
+  <h2>Multi-region data collection &amp; safety</h2>
+  <p class="note">Tier-1 collection surfaces: raw public-source data normalized into a common query layer.
+     Reported as inventories, not sanctioned models.</p>
+  <div class="grid">
+    <div class="card"><h3>Regional production authorities</h3><div class="std">BSEE · Sodir · NSTA · ANP · CNH · AER · RRC · EIA</div>
+      <ul><li>unified cross-regional production &amp; well query</li><li>US GoM, Norway, UK, Brazil, Mexico, Canada, Texas</li></ul></div>
+    <div class="card"><h3>Offshore safety &amp; incidents</h3><div class="std">BSEE HSE · USCG MISLE · NTSB · MAIB</div>
+      <ul><li>incident classification + risk scoring</li><li>marine casualty cause-event analysis</li></ul></div>
+    <div class="card"><h3>Pipeline &amp; marine safety</h3><div class="std">PHMSA · IMO GISIS</div>
+      <ul><li>pipeline safety events; hazmat releases</li><li>IMO GISIS marine-safety executive reporting</li></ul></div>
+    <div class="card"><h3>Infrastructure assets</h3><div class="std">platforms · pipelines · vessels · LNG</div>
+      <ul><li>BSEE structure &amp; pipeline inventories</li><li>vessel fleet specs + OBJ hull geometry</li></ul></div>
+  </div>
+
+  <h2>Sanctioned against frozen baselines</h2>
+  <p class="note"><span class="pub">■ sanctioned-baseline</span> = reproduces the frozen V30 golden baseline within tolerance (CI-guarded);
+     <span class="der">■ data-derived</span> = aggregated directly from public regulatory filings.</p>
+  <table>
+    <thead><tr><th>Surface</th><th>Case</th><th>Result</th><th>Basis</th></tr></thead>
+    <tbody>
+      <tr><td>V30 field economics</td><td>Julia (G20351) terminal NPV @10%</td><td class="val">&minus;$530.6 M</td><td class="pub">sanctioned golden_baseline_v30</td></tr>
+      <tr><td>V30 field economics</td><td>Stones (G17001) terminal NPV @10%</td><td class="val">&minus;$1 479.5 M</td><td class="pub">sanctioned golden_baseline_v30</td></tr>
+      <tr><td>V30 field economics</td><td>Anchor terminal NPV @10%</td><td class="val">&minus;$1 732.8 M</td><td class="pub">sanctioned golden_baseline_v30</td></tr>
+      <tr><td>Julia price sensitivity</td><td>dNPV / d(realized WTI)</td><td class="val">+$16.3 M per $1/bbl</td><td class="pub">V30 model</td></tr>
+      <tr><td>Julia breakeven</td><td>realized-WTI price at NPV = 0</td><td class="val">$99 / bbl</td><td class="pub">V30 model</td></tr>
+      <tr><td>Julia MIRR</td><td>annual, life-to-date</td><td class="val">6.31 %</td><td class="pub">V30 model</td></tr>
+      <tr><td>Portfolio roll-up</td><td>cumulative oil, 6 active LT fields</td><td class="val">685.0 MMbbl</td><td class="der">BSEE OGOR-A</td></tr>
+      <tr><td>Portfolio roll-up</td><td>cumulative gas, 6 active LT fields</td><td class="val">144.1 Bcf</td><td class="der">BSEE OGOR-A</td></tr>
+      <tr><td>Portfolio roll-up</td><td>producing wells / federal leases</td><td class="val">158 / 19</td><td class="der">BSEE OGOR-A (Sep&nbsp;2000&ndash;Jul&nbsp;2025)</td></tr>
+      <tr><td>Playbook coverage</td><td>global offshore fields (GoM subset)</td><td class="val">~2 150 (333)</td><td class="der">SubseaIQ catalog</td></tr>
+      <tr><td>BSEE-matched concepts</td><td>recommended vs as-built fields</td><td class="val">115</td><td class="der">BSEE × SubseaIQ join</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Live dashboards &amp; explorers</h2>
+  <div class="grid">
+    <a class="card linkcard" href="../field-development/showcase.html"><h3>Field-development capability showcase &rarr;</h3>
+      <div class="std">concept &rarr; schematic &rarr; economics</div>
+      <ul><li>what the playbook produces end-to-end, real fields, every offshore region</li></ul></a>
+    <a class="card linkcard" href="../field-development/playbook.html"><h3>Interactive playbook &rarr;</h3>
+      <div class="std">live sliders</div>
+      <ul><li>water depth / reserves / tieback &rarr; recommended concept + schematic, live</li></ul></a>
+    <a class="card linkcard" href="../field-development/portfolio/index.html"><h3>Deepwater portfolio &rarr;</h3>
+      <div class="std">10-field Gulf of Mexico</div>
+      <ul><li>full field-development plans, one page per field</li></ul></a>
+    <a class="card linkcard" href="../field-development/bsee-matched/index.html"><h3>BSEE-matched fields &rarr;</h3>
+      <div class="std">recommended vs as-built</div>
+      <ul><li>concept + schematics across 115 BSEE-cross-referenced GoM fields</li></ul></a>
+    <a class="card linkcard" href="../well-path.html"><h3>Julia well paths (3D) &rarr;</h3>
+      <div class="std">Plotly + Three.js</div>
+      <ul><li>interactive 3D directional surveys from one data contract</li></ul></a>
+    <a class="card linkcard" href="../portfolio.html"><h3>Lower-Tertiary portfolio summary &rarr;</h3>
+      <div class="std">field-by-field roll-up</div>
+      <ul><li>the whole Lower-Tertiary play at a glance</li></ul></a>
+    <a class="card linkcard" href="../benchmark.html"><h3>Well benchmarking &rarr;</h3>
+      <div class="std">2010 &ndash; latest</div>
+      <ul><li>cross-field per-well performance comparison</li></ul></a>
+    <a class="card linkcard" href="../economics-julia.html"><h3>Julia field economics &rarr;</h3>
+      <div class="std">sanctioned V30 NPV</div>
+      <ul><li>per-well stackup, NPV timeline, critical-operations detail</li></ul></a>
+  </div>
+
+  <h2>Provenance</h2>
+  <p class="note">Every figure traces to a public regulatory filing, and the sanctioned economics reproduce a
+  frozen reference held in
+  <a href="https://github.com/vamseeachanta/worldenergydata/blob/main/config/analysis/lower_tertiary/golden_baseline_v30.yml"><code>config/analysis/lower_tertiary/golden_baseline_v30.yml</code></a>
+  &mdash; a CI regression test keeps the published numbers in lock-step with that baseline, so a result can never
+  silently drift from the sanctioned model. Where the underlying data is incomplete, each page says so explicitly
+  rather than filling the gap with a guess.</p>
+
+  <footer>
+    Built by <code>scripts/build_pages.py</code> from frozen report artifacts under <code>reports/**</code>; method
+    code lives under <code>src/worldenergydata/</code>. Lower-Tertiary economics are sanctioned on US Gulf of Mexico
+    BSEE data; the field-development playbook runs over the SubseaIQ field catalog (~2014) at Concept-Select / FEL-1
+    fidelity and is not a sanctioned design.
+  </footer>
+</div>
+</body>
+</html>

--- a/scripts/build_pages.py
+++ b/scripts/build_pages.py
@@ -484,11 +484,30 @@ def build_field_development(available_viz: dict[str, bool]) -> list[tuple]:
     return []
 
 
+def build_capabilities(available_viz: dict[str, bool]) -> list[tuple]:
+    """Publish the self-contained capabilities overview at ``/capabilities/``.
+
+    The page is a hand-authored, fully self-contained HTML file (inline CSS, no
+    external assets) that summarises what the repo can do and links the live
+    dashboards. Like the field-development surfaces it is copied verbatim &mdash; no
+    template wrapping &mdash; so its internal ``../`` links to the sibling dashboards
+    resolve against the site root. Returns ``[]``; the landing index keys off the
+    file existing in ``public/`` (see :func:`build_index`)."""
+    src = REPORTS / "capabilities" / "index.html"
+    if not src.exists():
+        return []
+    dst = PUBLIC / "capabilities"
+    dst.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst / "index.html")
+    return []
+
+
 # Registry of per-domain builders. Add new domains here (key == reports/<domain>/
 # subdir name) as their surfaces come online. ``build(domains=...)`` iterates this.
 DOMAINS = {
     "lower_tertiary": build_lower_tertiary,
     "field_development": build_field_development,
+    "capabilities": build_capabilities,
 }
 
 
@@ -617,11 +636,26 @@ def build_index() -> None:
             + "</tbody></table></div>"
         )
 
+    capabilities_section = ""
+    if (PUBLIC / "capabilities" / "index.html").exists():
+        capabilities_section = (
+            "<h2>Capabilities overview</h2>"
+            "<p>A single-page tour of every analytical surface in this repo &mdash; "
+            "BSEE field economics, the field-development playbook, and multi-region "
+            "production &amp; safety data &mdash; with the sanctioned figures it is "
+            "validated against.</p>"
+            '<div class="cards"><a class="card" href="capabilities/">'
+            "<h3>Engineering Capabilities &rarr;</h3><p>What worldenergydata does, "
+            "the governing data source behind each surface, and the live dashboards "
+            "&mdash; in one page.</p></a></div>"
+        )
+
     landing = page(
         "Open Data Outputs",
         "Deterministic petroleum-engineering analyses + an offshore "
         "field-development playbook on public data.",
-        _field_development_section()
+        capabilities_section
+        + _field_development_section()
         + f'<h2>Lower-Tertiary economics &amp; benchmarking</h2><div class="cards">'
         f'{"".join(cards)}</div>' + econ_table + "<h2>How this works</h2>"
         "<p>Every analysis here is computed by unit-tested domain code, frozen into a "


### PR DESCRIPTION
## What

Adds a self-contained **Engineering Capabilities** page to the GitHub Pages site, modeled on the [digitalmodel capabilities page](https://vamseeachanta.github.io/digitalmodel/capabilities/).

Once merged it publishes to: **https://vamseeachanta.github.io/worldenergydata/capabilities/**

## Contents

- **BSEE production & field economics** — sanctioned V30 economics, OGOR-A production/decline, well benchmarking, 3D well paths
- **Offshore field-development playbook** — concept-selection engine, deterministic subsea schematics, deepwater portfolio, BSEE-matched concepts
- **Multi-region data collection & safety** — 8 regional authorities, incident/risk analytics, pipeline/marine safety, infrastructure assets
- **"Sanctioned against frozen baselines" table** — grounded figures (Julia NPV −$530.6M, Stones −$1,479.5M, portfolio 685.0 MMbbl / 144.1 Bcf / 158 wells, breakeven $99/bbl), split into CI-guarded *sanctioned-baseline* vs *data-derived*
- **Live-dashboard linkcards** to the eight existing published pages + provenance footer linking the V30 golden baseline

## How it's wired

Follows the repo's own `build_field_development()` verbatim-copy pattern:
- new `reports/capabilities/index.html` (self-contained, inline CSS — no external assets)
- `build_capabilities()` copy-builder in `scripts/build_pages.py`, registered in the `DOMAINS` registry
- a guarded landing-page card in `build_index()` (appears only when the page exists on disk)

## Verification

- Full `build_pages.py` run emits `public/capabilities/index.html`; landing page links to `capabilities/`; `--list-domains` lists `capabilities`
- All 8 dashboard `../` links resolve to real published files
- `tests/test_build_pages.py` — **8 passed**
- `black` / `isort` clean on the modified script