### PR TITLE
feat(onshore): refresh Texas RRC raw snapshots

### DIFF
--- a/docs/data-sources/onshore/texas-rrc/raw-refresh.md
+++ b/docs/data-sources/onshore/texas-rrc/raw-refresh.md
@@ -1,0 +1,67 @@
+# Texas RRC Raw Refresh
+
+Raw Texas RRC snapshots are refreshed from official RRC source URLs only. The
+current refresh implementation supports official GoDrive single-file datasets.
+Official GoDrive directory datasets remain in the catalog, but are skipped until
+directory fanout and pagination handling are implemented. The default storage
+root is:
+
+`/mnt/ace/worldenergydata/data/modules/texas_rrc`
+
+Validation surfaces such as PatchOps and RRC EWA lease-query pages are excluded
+from raw refresh. They remain useful for query validation, but curated outputs
+must be reproducible from official RRC snapshots.
+
+## Commands
+
+List configured sources and refresh status:
+
+```bash
+uv run worldenergydata texas-rrc refresh --list-sources
+```
+
+Dry-run one source without network writes:
+
+```bash
+uv run worldenergydata texas-rrc refresh --dry-run --source production_pdq
+```
+
+Refresh one direct-source snapshot:
+
+```bash
+uv run worldenergydata texas-rrc refresh --source production_pdq
+```
+
+Refresh every currently supported direct-source catalog entry:
+
+```bash
+uv run worldenergydata texas-rrc refresh --all
+```
+
+For test or staging environments, override the output root:
+
+```bash
+uv run worldenergydata texas-rrc refresh --dry-run --source production_pdq --output-root /tmp/texas_rrc
+```
+
+## Manifest Schema
+
+Each refresh attempt writes a JSON manifest under `manifests/` with:
+
+- `source_id`
+- `source_url`
+- `download_url`
+- `effective_url`
+- `retrieved_at`
+- `refresh_cadence`
+- `raw_path`
+- `checksum_sha256`
+- `byte_size`
+- `status`
+- `error`
+
+Downloads are written to `*.part` files and atomically renamed after the byte
+size, SHA256 checksum, expected GoDrive filename, and `Content-Length` are
+validated. Transient download failures are retried up to three times with
+partial-file cleanup before each retry. If a source returns HTML instead of a
+data artifact, refresh fails closed and writes an error manifest.

--- a/docs/data-sources/onshore/texas-rrc/source-catalog.md
+++ b/docs/data-sources/onshore/texas-rrc/source-catalog.md
@@ -22,6 +22,13 @@ validation and query-prototyping surfaces.
 
 ## Partial-Source Caveats
 
+Raw refresh uses official Texas RRC download links only. Entries with
+`download_strategy: official_godrive_file` or `download_strategy: direct_http`
+are eligible for `worldenergydata texas-rrc refresh`; validation-only,
+index-required, and `official_godrive_directory` entries are skipped by default.
+Directory entries are still official RRC sources, but need fanout/pagination
+handling before they can be safely refreshed as a bulk operation.
+
 Completion data is partial for lifecycle reconstruction because structured data
 does not capture every detail available in W-2/G-1 forms. Some lifecycle
 evidence remains in forms or imaged files and will need a separate document

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/data/source_catalog.yml
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/data/source_catalog.yml
@@ -1,6 +1,9 @@
 sources:
   production_pdq:
     source_url: "https://www.rrc.texas.gov/media/ebxnoxbm/pdq-dump.zip"
+    download_url: "https://mft.rrc.texas.gov/link/1f5ddb8d-329a-4459-b7f8-177b4f5ee60d"
+    download_strategy: "official_godrive_file"
+    snapshot_filename: "PDQ_DSV.zip"
     format: "zip_csv"
     refresh_cadence: "monthly_last_saturday"
     raw_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/production/pdq"
@@ -12,6 +15,9 @@ sources:
 
   wellbore_query:
     source_url: "https://www.rrc.texas.gov/media/kywh5qsj/wellboredump.zip"
+    download_url: "https://mft.rrc.texas.gov/link/650649b7-e019-4d77-a8e0-d118d6455381"
+    download_strategy: "official_godrive_file"
+    snapshot_filename: "OG_WELLBORE_EWA_Report.csv"
     format: "zip_ascii"
     refresh_cadence: "monthly_beginning"
     raw_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/wellbore/query"
@@ -23,6 +29,9 @@ sources:
 
   drilling_permits:
     source_url: "https://www.rrc.texas.gov/resource-center/research/data-sets-available-for-download/#drilling-permit-data-table"
+    download_url: "https://mft.rrc.texas.gov/link/5f07cc72-2e79-4df8-ade1-9aeb792e03fc"
+    download_strategy: "official_godrive_file"
+    snapshot_filename: "daf420.dat"
     format: "ascii"
     refresh_cadence: "nightly"
     raw_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/permits/drilling"
@@ -34,6 +43,8 @@ sources:
 
   completion_data:
     source_url: "https://www.rrc.texas.gov/resource-center/research/data-sets-available-for-download/#completion-data-table"
+    download_url: "https://mft.rrc.texas.gov/link/ed7ab066-879f-40b6-8144-2ae4b6810c04"
+    download_strategy: "official_godrive_directory"
     format: "zip_ascii_pdf"
     refresh_cadence: "nightly"
     raw_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/completions"
@@ -45,6 +56,8 @@ sources:
 
   directional_surveys:
     source_url: "https://www.rrc.texas.gov/resource-center/research/data-sets-available-for-download/#directional-survey-data-table"
+    download_url: "https://mft.rrc.texas.gov/link/01769aa7-dee8-4121-bb25-e7557307f6bd"
+    download_strategy: "official_godrive_directory"
     format: "zip_pdf"
     refresh_cadence: "daily"
     raw_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/directional_surveys"
@@ -56,6 +69,8 @@ sources:
 
   well_gis_layers:
     source_url: "https://www.rrc.texas.gov/resource-center/research/data-sets-available-for-download/#gis-data-table"
+    download_url: "https://mft.rrc.texas.gov/link/d551fb20-442e-4b67-84fa-ac3f23ecabb4"
+    download_strategy: "official_godrive_directory"
     format: "shapefile"
     refresh_cadence: "twice_weekly"
     raw_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/gis/wells"
@@ -67,6 +82,8 @@ sources:
 
   pipeline_gis_layers:
     source_url: "https://www.rrc.texas.gov/resource-center/research/data-sets-available-for-download/#gis-data-table"
+    download_url: "https://mft.rrc.texas.gov/link/c7cbab0c-afe2-4f6f-91ae-e6ed7d3a7ab6"
+    download_strategy: "official_godrive_directory"
     format: "shapefile"
     refresh_cadence: "twice_weekly"
     raw_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/gis/pipelines"
@@ -78,6 +95,7 @@ sources:
 
   field_lease_operator:
     source_url: "https://www.rrc.texas.gov/resource-center/research/data-sets-available-for-download/"
+    download_strategy: "official_index_required"
     format: "mixed_ascii_csv"
     refresh_cadence: "source_specific"
     raw_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/reference/field_lease_operator"
@@ -90,6 +108,7 @@ sources:
   rrc_ewa_lease_query_validation:
     source_url: "https://webapps2.rrc.texas.gov/EWA/specificLeaseQueryAction.do"
     reference_url: "https://github.com/derrickturk/rrc-scraper/blob/6dce564695df739c43cb257472fbdb455fdd1b2e/RRCScraper.py"
+    download_strategy: "validation_only"
     format: "web_form_csv"
     refresh_cadence: "service_managed"
     raw_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/validation/rrc_ewa_lease_query"
@@ -104,6 +123,7 @@ sources:
 
   patchops_rrc_validation:
     source_url: "https://patchops.ai/mcpservers/rrc"
+    download_strategy: "validation_only"
     format: "mcp_postgis_tools"
     refresh_cadence: "service_managed"
     raw_path: "/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/validation/patchops_rrc"

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/godrive.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/godrive.py
@@ -1,0 +1,76 @@
+"""Helpers for official Texas RRC GoDrive public download pages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from html.parser import HTMLParser
+
+
+@dataclass(frozen=True)
+class GoDriveFileForm:
+    """JSF form values required to request one public GoDrive file."""
+
+    command_id: str
+    view_state: str
+
+
+class GoDrivePublicPageParser(HTMLParser):
+    """Extract the file command id and JSF view state from a GoDrive page."""
+
+    def __init__(self, expected_filename: str):
+        super().__init__()
+        self.expected_filename = expected_filename
+        self.view_states: list[str] = []
+        self.command_id: str | None = None
+        self._active_link_id: str | None = None
+        self._active_link_text: list[str] = []
+
+    def handle_starttag(
+        self,
+        tag: str,
+        attrs: list[tuple[str, str | None]],
+    ) -> None:
+        attr_map = dict(attrs)
+        if tag == "input" and attr_map.get("name") == "javax.faces.ViewState":
+            value = attr_map.get("value")
+            if value:
+                self.view_states.append(value)
+        if tag == "a" and attr_map.get("id", "").startswith("fileTable:"):
+            self._active_link_id = attr_map["id"]
+            self._active_link_text = []
+
+    def handle_data(self, data: str) -> None:
+        if self._active_link_id:
+            self._active_link_text.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag != "a" or not self._active_link_id:
+            return
+
+        link_text = "".join(self._active_link_text).strip()
+        if link_text == self.expected_filename:
+            self.command_id = self._active_link_id
+        self._active_link_id = None
+        self._active_link_text = []
+
+
+def parse_godrive_file_form(
+    html_text: str,
+    expected_filename: str,
+) -> GoDriveFileForm:
+    """Return the JSF form values for a named public GoDrive file."""
+    parser = GoDrivePublicPageParser(expected_filename)
+    parser.feed(html_text)
+    if not parser.view_states:
+        raise ValueError("Official GoDrive page did not include a JSF view state")
+    if not parser.command_id:
+        raise ValueError(
+            f"Official GoDrive page did not list expected file {expected_filename!r}"
+        )
+    return GoDriveFileForm(
+        command_id=parser.command_id,
+        view_state=parser.view_states[-1],
+    )
+
+
+__all__ = ["GoDriveFileForm", "GoDrivePublicPageParser", "parse_godrive_file_form"]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/raw_refresh.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/raw_refresh.py
@@ -1,0 +1,316 @@
+"""Raw snapshot refresh for Texas RRC official source data."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+from worldenergydata.texas_rrc.raw_transport import (
+    DownloadedArtifact,
+    RawRefreshTransport,
+    RetryableDownloadError,
+    TransportResponse,
+    UrlLibTransport,
+)
+from worldenergydata.texas_rrc.source_catalog import (
+    SOURCE_CATALOG_ROOT,
+    load_source_catalog,
+    validate_source_catalog,
+)
+
+
+@dataclass(frozen=True)
+class RefreshPlan:
+    """Planned refresh action for one source catalog entry."""
+
+    source_id: str
+    refreshable: bool
+    download_strategy: str
+    source_url: str
+    download_url: str | None
+    target_path: Path
+    refresh_cadence: str
+    skip_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class SnapshotManifest:
+    """Manifest record for one attempted raw snapshot refresh."""
+
+    source_id: str
+    source_url: str
+    download_url: str | None
+    effective_url: str | None
+    retrieved_at: str
+    refresh_cadence: str
+    raw_path: str
+    checksum_sha256: str | None
+    byte_size: int
+    status: str
+    error: str | None = None
+
+
+class RawSnapshotRefresher:
+    """Plan and execute official Texas RRC raw snapshot refreshes."""
+
+    def __init__(
+        self,
+        catalog: dict[str, dict[str, Any]] | None = None,
+        output_root: Path | str = SOURCE_CATALOG_ROOT,
+        transport: RawRefreshTransport | None = None,
+        clock: Callable[[], datetime] | None = None,
+        max_attempts: int = 3,
+    ):
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be at least 1")
+        self.catalog = catalog or load_source_catalog()
+        validate_source_catalog(self.catalog)
+        self.output_root = Path(output_root)
+        self._reject_repo_output_root()
+        self.transport = transport or UrlLibTransport()
+        self.clock = clock or (lambda: datetime.now(timezone.utc))
+        self.max_attempts = max_attempts
+
+    def plan_sources(
+        self, source_ids: Iterable[str] | None = None
+    ) -> list[RefreshPlan]:
+        """Return refresh plans without touching the network."""
+        ids = list(source_ids) if source_ids else sorted(self.catalog)
+        return [self._plan_source(source_id) for source_id in ids]
+
+    def refresh_source(self, source_id: str) -> SnapshotManifest:
+        """Download one refreshable official-source snapshot and write a manifest."""
+        plan = self._refreshable_plan(source_id)
+        part_path = plan.target_path.with_suffix(plan.target_path.suffix + ".part")
+        retrieved_at = self._timestamp()
+
+        try:
+            artifact = self._download_with_retries(plan, part_path)
+            part_path.replace(plan.target_path)
+            return self._write_success_manifest(plan, artifact, retrieved_at)
+        except Exception as exc:
+            self._write_error_manifest(plan, retrieved_at, part_path, exc)
+            raise
+
+    def _refreshable_plan(self, source_id: str) -> RefreshPlan:
+        plan = self._plan_source(source_id)
+        if not plan.refreshable:
+            raise ValueError(
+                f"Source '{source_id}' is not refreshable: {plan.skip_reason}"
+            )
+        return plan
+
+    def _download_with_retries(
+        self,
+        plan: RefreshPlan,
+        part_path: Path,
+    ) -> DownloadedArtifact:
+        for attempt in range(1, self.max_attempts + 1):
+            self._remove_partial(part_path)
+            try:
+                return self._download_artifact(plan, part_path)
+            except RetryableDownloadError:
+                if attempt == self.max_attempts:
+                    raise
+            except ValueError:
+                raise
+            except Exception:
+                if attempt == self.max_attempts:
+                    raise
+        raise RuntimeError("download retry loop exited without a result")
+
+    def _download_artifact(
+        self,
+        plan: RefreshPlan,
+        part_path: Path,
+    ) -> DownloadedArtifact:
+        assert plan.download_url is not None
+        if plan.download_strategy == "official_godrive_file":
+            download_godrive_file_to = getattr(
+                self.transport,
+                "download_godrive_file_to",
+                None,
+            )
+            if not download_godrive_file_to:
+                raise ValueError("Transport does not support official GoDrive files")
+            artifact = download_godrive_file_to(
+                plan.download_url,
+                part_path,
+                plan.target_path.name,
+            )
+            self._validate_artifact(artifact)
+            return artifact
+
+        download_to = getattr(self.transport, "download_to", None)
+        if download_to:
+            artifact = download_to(plan.download_url, part_path)
+            self._validate_artifact(artifact)
+            return artifact
+
+        response = self._download_response(plan)
+        part_path.parent.mkdir(parents=True, exist_ok=True)
+        part_path.write_bytes(response.content)
+        return DownloadedArtifact(
+            headers=response.headers,
+            effective_url=response.effective_url,
+            checksum_sha256=hashlib.sha256(response.content).hexdigest(),
+            byte_size=len(response.content),
+        )
+
+    def _download_response(self, plan: RefreshPlan) -> TransportResponse:
+        assert plan.download_url is not None
+        response = self.transport.get(plan.download_url)
+        UrlLibTransport._validate_artifact_response(
+            response.status_code,
+            response.headers,
+        )
+        UrlLibTransport._validate_content_length(
+            response.headers, len(response.content)
+        )
+        return response
+
+    def _validate_artifact(self, artifact: DownloadedArtifact) -> None:
+        UrlLibTransport._validate_content_length(artifact.headers, artifact.byte_size)
+
+    def _write_success_manifest(
+        self,
+        plan: RefreshPlan,
+        artifact: DownloadedArtifact,
+        retrieved_at: str,
+    ) -> SnapshotManifest:
+        manifest = SnapshotManifest(
+            source_id=plan.source_id,
+            source_url=plan.source_url,
+            download_url=plan.download_url,
+            effective_url=artifact.effective_url,
+            retrieved_at=retrieved_at,
+            refresh_cadence=plan.refresh_cadence,
+            raw_path=str(plan.target_path),
+            checksum_sha256=artifact.checksum_sha256,
+            byte_size=artifact.byte_size,
+            status="downloaded",
+        )
+        self._write_manifest(manifest)
+        return manifest
+
+    def _write_error_manifest(
+        self,
+        plan: RefreshPlan,
+        retrieved_at: str,
+        part_path: Path,
+        exc: Exception,
+    ) -> SnapshotManifest:
+        self._remove_partial(part_path)
+        manifest = SnapshotManifest(
+            source_id=plan.source_id,
+            source_url=plan.source_url,
+            download_url=plan.download_url,
+            effective_url=None,
+            retrieved_at=retrieved_at,
+            refresh_cadence=plan.refresh_cadence,
+            raw_path=str(plan.target_path),
+            checksum_sha256=None,
+            byte_size=0,
+            status="error",
+            error=str(exc),
+        )
+        self._write_manifest(manifest)
+        return manifest
+
+    def _remove_partial(self, part_path: Path) -> None:
+        if part_path.exists():
+            part_path.unlink()
+
+    def _plan_source(self, source_id: str) -> RefreshPlan:
+        if source_id not in self.catalog:
+            raise KeyError(f"Unknown Texas RRC source: {source_id}")
+
+        entry = self.catalog[source_id]
+        strategy = entry["download_strategy"]
+        target_path = self._target_path(entry)
+        skip_reason = self._skip_reason(entry)
+
+        return RefreshPlan(
+            source_id=source_id,
+            refreshable=skip_reason is None,
+            download_strategy=strategy,
+            source_url=entry["source_url"],
+            download_url=entry.get("download_url"),
+            target_path=target_path,
+            refresh_cadence=entry["refresh_cadence"],
+            skip_reason=skip_reason,
+        )
+
+    def _target_path(self, entry: dict[str, Any]) -> Path:
+        raw_path = Path(entry["raw_path"])
+        relative_raw = raw_path.relative_to(SOURCE_CATALOG_ROOT)
+        target_dir = self.output_root / relative_raw
+        filename = entry.get("snapshot_filename")
+        if not filename:
+            filename = Path(entry.get("download_url") or entry["source_url"]).name
+        return target_dir / filename
+
+    def _skip_reason(self, entry: dict[str, Any]) -> str | None:
+        if entry["availability_status"] == "validation_only":
+            return "validation_only"
+        if not entry["source_of_record"]:
+            return "not_source_of_record"
+        if entry["download_strategy"] not in {"direct_http", "official_godrive_file"}:
+            return entry["download_strategy"]
+        return None
+
+    def _timestamp(self) -> str:
+        timestamp = self.clock()
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
+        return timestamp.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    def _manifest_path(self, manifest: SnapshotManifest) -> Path:
+        stamp = manifest.retrieved_at.replace("-", "").replace(":", "")
+        manifest_dir = self.output_root / "manifests"
+        base_path = manifest_dir / f"{manifest.source_id}-{stamp}.json"
+        if not base_path.exists():
+            return base_path
+        for index in range(2, 10_000):
+            candidate = manifest_dir / f"{manifest.source_id}-{stamp}-{index}.json"
+            if not candidate.exists():
+                return candidate
+        raise RuntimeError("Unable to allocate unique snapshot manifest path")
+
+    def _write_manifest(self, manifest: SnapshotManifest) -> Path:
+        manifest_path = self._manifest_path(manifest)
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = asdict(manifest)
+        manifest_path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return manifest_path
+
+    def _reject_repo_output_root(self) -> None:
+        repo_root = self._find_repo_root(Path(__file__).resolve())
+        if repo_root and self.output_root.resolve().is_relative_to(repo_root):
+            raise ValueError("Raw refresh output_root must not be inside git worktree")
+
+    @staticmethod
+    def _find_repo_root(start: Path) -> Path | None:
+        current = start.resolve()
+        for path in (current, *current.parents):
+            if (path / ".git").exists():
+                return path
+        return None
+
+
+__all__ = [
+    "RawSnapshotRefresher",
+    "DownloadedArtifact",
+    "RefreshPlan",
+    "SnapshotManifest",
+    "TransportResponse",
+    "RetryableDownloadError",
+    "UrlLibTransport",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/raw_transport.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/raw_transport.py
@@ -1,0 +1,175 @@
+"""Transport layer for Texas RRC raw snapshot downloads."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from http.cookiejar import CookieJar
+from pathlib import Path
+from typing import Protocol
+from urllib.parse import urlencode, urljoin
+from urllib.request import HTTPCookieProcessor, Request, build_opener, urlopen
+
+from worldenergydata.texas_rrc.godrive import parse_godrive_file_form
+
+
+@dataclass(frozen=True)
+class TransportResponse:
+    """HTTP response payload used by raw snapshot refresh."""
+
+    status_code: int
+    headers: dict[str, str]
+    content: bytes
+    effective_url: str
+
+
+@dataclass(frozen=True)
+class DownloadedArtifact:
+    """Metadata for a streamed artifact written to disk."""
+
+    headers: dict[str, str]
+    effective_url: str
+    checksum_sha256: str
+    byte_size: int
+
+
+class RetryableDownloadError(ValueError):
+    """Download error that may succeed on a later attempt."""
+
+
+class RawRefreshTransport(Protocol):
+    """Transport contract for fakeable official-source downloads."""
+
+    def get(self, url: str) -> TransportResponse:
+        """Fetch a URL and return response bytes plus metadata."""
+
+
+class UrlLibTransport:
+    """Small urllib-based transport to avoid adding a package dependency."""
+
+    def get(self, url: str) -> TransportResponse:
+        request = Request(url, headers={"User-Agent": "worldenergydata-texas-rrc/1.0"})
+        with urlopen(request, timeout=60) as response:
+            headers = {key.lower(): value for key, value in response.headers.items()}
+            return TransportResponse(
+                status_code=response.status,
+                headers=headers,
+                content=response.read(),
+                effective_url=response.geturl(),
+            )
+
+    def download_to(self, url: str, output_path: Path) -> DownloadedArtifact:
+        request = Request(url, headers={"User-Agent": "worldenergydata-texas-rrc/1.0"})
+        with urlopen(request, timeout=60) as response:
+            return self._stream_response_to_artifact(response, output_path)
+
+    def download_godrive_file_to(
+        self,
+        url: str,
+        output_path: Path,
+        expected_filename: str,
+    ) -> DownloadedArtifact:
+        opener = build_opener(HTTPCookieProcessor(CookieJar()))
+        landing_request = Request(
+            url,
+            headers={"User-Agent": "worldenergydata-texas-rrc/1.0"},
+        )
+        with opener.open(landing_request, timeout=60) as landing_response:
+            html_text = landing_response.read().decode("utf-8", errors="replace")
+
+        form = parse_godrive_file_form(html_text, expected_filename)
+        post_data = urlencode(
+            {
+                "fileList_SUBMIT": "1",
+                form.command_id: form.command_id,
+                "javax.faces.ViewState": form.view_state,
+            }
+        ).encode("utf-8")
+        download_request = Request(
+            urljoin(url, "/webclient/godrive/PublicGoDrive.xhtml"),
+            data=post_data,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "User-Agent": "worldenergydata-texas-rrc/1.0",
+            },
+        )
+        with opener.open(download_request, timeout=60) as response:
+            return self._stream_response_to_artifact(
+                response,
+                output_path,
+                expected_filename=expected_filename,
+            )
+
+    @staticmethod
+    def _stream_response_to_artifact(
+        response,
+        output_path: Path,
+        expected_filename: str | None = None,
+    ) -> DownloadedArtifact:
+        headers = {key.lower(): value for key, value in response.headers.items()}
+        UrlLibTransport._validate_artifact_response(
+            response.status,
+            headers,
+            expected_filename=expected_filename,
+        )
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        sha256 = hashlib.sha256()
+        byte_size = 0
+        with output_path.open("wb") as stream:
+            while chunk := response.read(1024 * 1024):
+                sha256.update(chunk)
+                byte_size += len(chunk)
+                stream.write(chunk)
+        UrlLibTransport._validate_content_length(headers, byte_size)
+        return DownloadedArtifact(
+            headers=headers,
+            effective_url=response.geturl(),
+            checksum_sha256=sha256.hexdigest(),
+            byte_size=byte_size,
+        )
+
+    @staticmethod
+    def _validate_artifact_response(
+        status_code: int,
+        headers: dict[str, str],
+        expected_filename: str | None = None,
+    ) -> None:
+        if status_code >= 500:
+            raise RetryableDownloadError(
+                f"Download failed with HTTP status {status_code}"
+            )
+        if status_code >= 400:
+            raise ValueError(f"Download failed with HTTP status {status_code}")
+        content_type = headers.get("content-type", "").lower()
+        if "text/html" in content_type:
+            raise ValueError(
+                "Direct-source refresh received HTML instead of a data artifact"
+            )
+        if expected_filename:
+            disposition = headers.get("content-disposition", "")
+            if expected_filename not in disposition:
+                raise ValueError(
+                    "Official GoDrive download did not return expected file "
+                    f"{expected_filename!r}"
+                )
+
+    @staticmethod
+    def _validate_content_length(headers: dict[str, str], byte_size: int) -> None:
+        raw_content_length = headers.get("content-length")
+        if not raw_content_length:
+            return
+        expected_size = int(raw_content_length)
+        if expected_size != byte_size:
+            raise RetryableDownloadError(
+                f"Content-Length mismatch: expected {expected_size} bytes, "
+                f"received {byte_size} bytes"
+            )
+
+
+__all__ = [
+    "DownloadedArtifact",
+    "RawRefreshTransport",
+    "RetryableDownloadError",
+    "TransportResponse",
+    "UrlLibTransport",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/source_catalog.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/source_catalog.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import yaml
 
@@ -18,11 +19,22 @@ REQUIRED_SOURCE_FIELDS = {
     "normalized_path",
     "curated_path",
     "availability_status",
+    "download_strategy",
     "source_of_record",
     "caveats",
 }
 
 VALID_AVAILABILITY_STATUSES = {"available", "partial", "validation_only"}
+VALID_DOWNLOAD_STRATEGIES = {
+    "direct_http",
+    "official_godrive_file",
+    "official_godrive_directory",
+    "official_index_required",
+    "unsupported_live_refresh",
+    "validation_only",
+}
+OFFICIAL_RRC_DOWNLOAD_HOSTS = {"mft.rrc.texas.gov", "www.rrc.texas.gov"}
+OFFICIAL_RRC_GODRIVE_HOST = "mft.rrc.texas.gov"
 
 
 def load_source_catalog(path: Path | None = None) -> dict[str, dict[str, Any]]:
@@ -57,6 +69,22 @@ def validate_source_catalog(catalog: dict[str, dict[str, Any]]) -> None:
                 f"{status!r}"
             )
 
+        strategy = entry["download_strategy"]
+        if strategy not in VALID_DOWNLOAD_STRATEGIES:
+            raise ValueError(
+                f"Catalog entry '{source_id}' has invalid download_strategy: "
+                f"{strategy!r}"
+            )
+        if strategy in {"direct_http", "official_godrive_file"}:
+            _validate_download_url(source_id, strategy, entry.get("download_url"))
+        if strategy == "official_godrive_file" and not entry.get("snapshot_filename"):
+            raise ValueError(
+                f"Catalog entry '{source_id}' must define snapshot_filename for "
+                "official_godrive_file"
+            )
+        if strategy == "official_godrive_directory":
+            _validate_download_url(source_id, strategy, entry.get("download_url"))
+
         if not isinstance(entry["source_of_record"], bool):
             raise ValueError(
                 f"Catalog entry '{source_id}' field 'source_of_record' must be boolean"
@@ -78,4 +106,23 @@ def _validate_catalog_path(source_id: str, field: str, path: Path) -> None:
         raise ValueError(
             f"Catalog entry '{source_id}' field '{field}' must stay under "
             f"{SOURCE_CATALOG_ROOT}"
+        )
+
+
+def _validate_download_url(source_id: str, strategy: str, url: str | None) -> None:
+    if not url:
+        raise ValueError(f"Catalog entry '{source_id}' must define download_url")
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise ValueError(f"Catalog entry '{source_id}' download_url must use https")
+    if strategy.startswith("official_godrive"):
+        if parsed.netloc != OFFICIAL_RRC_GODRIVE_HOST:
+            raise ValueError(
+                f"Catalog entry '{source_id}' download_url must use an official "
+                "RRC host for GoDrive"
+            )
+        return
+    if parsed.netloc not in OFFICIAL_RRC_DOWNLOAD_HOSTS:
+        raise ValueError(
+            f"Catalog entry '{source_id}' download_url must use an official RRC host"
         )

--- a/src/worldenergydata/cli/commands/texas_rrc.py
+++ b/src/worldenergydata/cli/commands/texas_rrc.py
@@ -261,6 +261,115 @@ def collect(
         raise typer.Exit(1)
 
 
+def _print_refresh_plans(plans) -> None:
+    table = Table(
+        title="Texas RRC Raw Refresh Sources",
+        show_header=True,
+        header_style="bold cyan",
+    )
+    table.add_column("Source", style="dim", no_wrap=True)
+    table.add_column("Strategy", no_wrap=True)
+    table.add_column("Status")
+    table.add_column("Target", overflow="fold")
+
+    for plan in plans:
+        status = "planned" if plan.refreshable else plan.skip_reason or "skipped"
+        table.add_row(
+            plan.source_id,
+            plan.download_strategy,
+            status,
+            str(plan.target_path),
+        )
+
+    console.print(table)
+
+
+def _validate_refresh_selection(
+    source: Optional[List[str]],
+    all_sources: bool,
+) -> None:
+    if source and all_sources:
+        console.print("[red]Error:[/red] Use either --source or --all, not both")
+        raise typer.Exit(1)
+    if not source and not all_sources:
+        console.print("[red]Error:[/red] Use --source, --all, or --list-sources")
+        raise typer.Exit(1)
+
+
+def _execute_refresh_plans(refresher, plans, explicit_sources: bool) -> None:
+    refreshed = []
+    for plan in plans:
+        if not plan.refreshable:
+            if explicit_sources:
+                console.print(
+                    f"[red]Error:[/red] {plan.source_id} is not refreshable: "
+                    f"{plan.skip_reason}"
+                )
+                raise typer.Exit(1)
+            continue
+        refreshed.append(refresher.refresh_source(plan.source_id))
+
+    if not refreshed:
+        console.print(
+            "[yellow]No refreshable direct-source snapshots selected[/yellow]"
+        )
+        return
+
+    for manifest in refreshed:
+        console.print(
+            f"[green]Downloaded[/green] {manifest.source_id}: "
+            f"{manifest.byte_size} bytes -> {manifest.raw_path}"
+        )
+
+
+@app.command()
+def refresh(
+    source: Optional[List[str]] = typer.Option(
+        None,
+        "--source",
+        "-s",
+        help="Source ID to refresh; repeat for multiple sources",
+    ),
+    all_sources: bool = typer.Option(
+        False,
+        "--all",
+        help="Refresh every direct-source catalog entry",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Plan refresh actions without downloading data",
+    ),
+    list_sources: bool = typer.Option(
+        False,
+        "--list-sources",
+        help="List configured Texas RRC refresh sources",
+    ),
+    output_root: Path = typer.Option(
+        Path("/mnt/ace/worldenergydata/data/modules/texas_rrc"),
+        "--output-root",
+        help="Raw data output root",
+    ),
+) -> None:
+    """Refresh official Texas RRC raw snapshots into the /mnt/ace contract."""
+    from worldenergydata.texas_rrc.raw_refresh import RawSnapshotRefresher
+
+    refresher = RawSnapshotRefresher(output_root=output_root)
+
+    if list_sources:
+        _print_refresh_plans(refresher.plan_sources())
+        return
+
+    _validate_refresh_selection(source, all_sources)
+
+    plans = refresher.plan_sources(source if source else None)
+    if dry_run:
+        _print_refresh_plans(plans)
+        return
+
+    _execute_refresh_plans(refresher, plans, explicit_sources=bool(source))
+
+
 @app.command()
 def analyze(
     district: Optional[str] = typer.Option(

--- a/tests/unit/texas_rrc/test_raw_refresh.py
+++ b/tests/unit/texas_rrc/test_raw_refresh.py
@@ -1,0 +1,377 @@
+"""Tests for Texas RRC raw snapshot refresh."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+class FakeTransport:
+    def __init__(
+        self,
+        payload: bytes = b"source-bytes",
+        content_type: str = "application/zip",
+        status_code: int = 200,
+        error: Exception | None = None,
+        errors: list[Exception | None] | None = None,
+        content_length: int | None = None,
+    ):
+        self.payload = payload
+        self.content_type = content_type
+        self.status_code = status_code
+        self.error = error
+        self.errors = errors or []
+        self.content_length = content_length
+        self.urls: list[str] = []
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"content-type": self.content_type}
+        if self.content_length is not None:
+            headers["content-length"] = str(self.content_length)
+        return headers
+
+    def _raise_next_error(self) -> None:
+        if self.errors:
+            error = self.errors.pop(0)
+            if error:
+                raise error
+            return
+        if self.error:
+            raise self.error
+
+    def get(self, url: str):
+        from worldenergydata.texas_rrc.raw_refresh import TransportResponse
+
+        self.urls.append(url)
+        self._raise_next_error()
+        return TransportResponse(
+            status_code=self.status_code,
+            headers=self._headers(),
+            content=self.payload,
+            effective_url=url,
+        )
+
+    def download_to(self, url: str, output_path: Path):
+        from worldenergydata.texas_rrc.raw_refresh import DownloadedArtifact
+
+        self.urls.append(url)
+        self._raise_next_error()
+        if self.status_code >= 400:
+            raise ValueError(f"Download failed with HTTP status {self.status_code}")
+        if "text/html" in self.content_type.lower():
+            raise ValueError(
+                "Direct-source refresh received HTML instead of a data artifact"
+            )
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(self.payload)
+        return DownloadedArtifact(
+            headers=self._headers(),
+            effective_url=url,
+            checksum_sha256=hashlib.sha256(self.payload).hexdigest(),
+            byte_size=len(self.payload),
+        )
+
+    def download_godrive_file_to(
+        self,
+        url: str,
+        output_path: Path,
+        expected_filename: str,
+    ):
+        return self.download_to(url, output_path)
+
+
+class GetOnlyTransport:
+    def __init__(self, *responses: FakeTransport):
+        self.responses = list(responses)
+        self.urls: list[str] = []
+
+    def get(self, url: str):
+        if not self.responses:
+            raise AssertionError("No fake response configured")
+        response = self.responses.pop(0).get(url)
+        self.urls.append(url)
+        return response
+
+
+def fixed_clock() -> datetime:
+    return datetime(2026, 6, 29, 20, 0, 0, tzinfo=timezone.utc)
+
+
+def test_godrive_parser_extracts_expected_file_form():
+    from worldenergydata.texas_rrc.godrive import parse_godrive_file_form
+
+    form = parse_godrive_file_form(
+        """
+        <form id="fileList">
+          <input type="hidden" name="javax.faces.ViewState" value="older" />
+          <input type="hidden" name="javax.faces.ViewState" value="state-123" />
+          <a id="fileTable:0:j_id_2f" href="#">PDQ_DSV.zip</a>
+        </form>
+        """,
+        "PDQ_DSV.zip",
+    )
+
+    assert form.command_id == "fileTable:0:j_id_2f"
+    assert form.view_state == "state-123"
+
+
+def test_raw_refresh_plan_uses_direct_official_rrc_sources_only(tmp_path):
+    from worldenergydata.texas_rrc.raw_refresh import RawSnapshotRefresher
+    from worldenergydata.texas_rrc.source_catalog import load_source_catalog
+
+    refresher = RawSnapshotRefresher(
+        catalog=load_source_catalog(),
+        output_root=tmp_path,
+        clock=fixed_clock,
+    )
+
+    plans = {
+        plan.source_id: plan
+        for plan in refresher.plan_sources(
+            [
+                "production_pdq",
+                "completion_data",
+                "patchops_rrc_validation",
+                "rrc_ewa_lease_query_validation",
+            ]
+        )
+    }
+
+    assert plans["production_pdq"].refreshable is True
+    assert plans["production_pdq"].download_strategy == "official_godrive_file"
+    assert plans["production_pdq"].download_url.startswith(
+        "https://mft.rrc.texas.gov/link/"
+    )
+    assert plans["production_pdq"].target_path.is_relative_to(tmp_path)
+    assert plans["completion_data"].refreshable is False
+    assert plans["completion_data"].skip_reason == "official_godrive_directory"
+    assert plans["patchops_rrc_validation"].refreshable is False
+    assert plans["patchops_rrc_validation"].skip_reason == "validation_only"
+    assert plans["rrc_ewa_lease_query_validation"].refreshable is False
+    assert plans["rrc_ewa_lease_query_validation"].skip_reason == "validation_only"
+
+
+def test_raw_refresh_writes_snapshot_and_manifest_with_fake_transport(tmp_path):
+    from worldenergydata.texas_rrc.raw_refresh import RawSnapshotRefresher
+    from worldenergydata.texas_rrc.source_catalog import load_source_catalog
+
+    transport = FakeTransport(payload=b"abc123")
+    refresher = RawSnapshotRefresher(
+        catalog=load_source_catalog(),
+        output_root=tmp_path,
+        transport=transport,
+        clock=fixed_clock,
+    )
+
+    manifest = refresher.refresh_source("production_pdq")
+
+    assert transport.urls == [
+        "https://mft.rrc.texas.gov/link/1f5ddb8d-329a-4459-b7f8-177b4f5ee60d"
+    ]
+    assert manifest.status == "downloaded"
+    assert manifest.byte_size == 6
+    assert (
+        manifest.checksum_sha256
+        == "6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"
+    )
+    assert Path(manifest.raw_path).read_bytes() == b"abc123"
+
+    manifest_path = tmp_path / "manifests" / "production_pdq-20260629T200000Z.json"
+    assert manifest_path.exists()
+    assert "production_pdq" in manifest_path.read_text(encoding="utf-8")
+
+
+def test_raw_refresh_manifest_names_do_not_collide_with_same_second_attempts(
+    tmp_path,
+):
+    from worldenergydata.texas_rrc.raw_refresh import RawSnapshotRefresher
+    from worldenergydata.texas_rrc.source_catalog import load_source_catalog
+
+    refresher = RawSnapshotRefresher(
+        catalog=load_source_catalog(),
+        output_root=tmp_path,
+        transport=FakeTransport(payload=b"abc123"),
+        clock=fixed_clock,
+    )
+
+    refresher.refresh_source("production_pdq")
+    refresher.refresh_source("production_pdq")
+
+    manifests = sorted((tmp_path / "manifests").glob("production_pdq-*.json"))
+    assert len(manifests) == 2
+
+
+def test_raw_refresh_rejects_html_response_and_removes_partial_file(tmp_path):
+    from worldenergydata.texas_rrc.raw_refresh import RawSnapshotRefresher
+    from worldenergydata.texas_rrc.source_catalog import load_source_catalog
+
+    refresher = RawSnapshotRefresher(
+        catalog=load_source_catalog(),
+        output_root=tmp_path,
+        transport=FakeTransport(payload=b"<html></html>", content_type="text/html"),
+        clock=fixed_clock,
+    )
+
+    with pytest.raises(ValueError, match="HTML"):
+        refresher.refresh_source("production_pdq")
+
+    assert not list(tmp_path.rglob("*.part"))
+    failure_manifest = tmp_path / "manifests" / "production_pdq-20260629T200000Z.json"
+    assert failure_manifest.exists()
+    assert '"status": "error"' in failure_manifest.read_text(encoding="utf-8")
+
+
+def test_raw_refresh_rejects_content_length_mismatch(tmp_path):
+    from worldenergydata.texas_rrc.raw_refresh import RawSnapshotRefresher
+    from worldenergydata.texas_rrc.source_catalog import load_source_catalog
+
+    refresher = RawSnapshotRefresher(
+        catalog=load_source_catalog(),
+        output_root=tmp_path,
+        transport=FakeTransport(payload=b"short", content_length=12),
+        clock=fixed_clock,
+    )
+
+    with pytest.raises(ValueError, match="Content-Length"):
+        refresher.refresh_source("production_pdq")
+
+    assert not list(tmp_path.rglob("*.part"))
+    assert not list((tmp_path / "raw").rglob("PDQ_DSV.zip"))
+    failure_manifest = tmp_path / "manifests" / "production_pdq-20260629T200000Z.json"
+    assert failure_manifest.exists()
+    assert '"status": "error"' in failure_manifest.read_text(encoding="utf-8")
+
+
+def test_raw_refresh_retries_transient_download_failure(tmp_path):
+    from worldenergydata.texas_rrc.raw_refresh import RawSnapshotRefresher
+    from worldenergydata.texas_rrc.source_catalog import load_source_catalog
+
+    transport = FakeTransport(
+        payload=b"retry-success",
+        errors=[OSError("temporary network failure"), None],
+    )
+    refresher = RawSnapshotRefresher(
+        catalog=load_source_catalog(),
+        output_root=tmp_path,
+        transport=transport,
+        clock=fixed_clock,
+    )
+
+    manifest = refresher.refresh_source("production_pdq")
+
+    assert len(transport.urls) == 2
+    assert manifest.status == "downloaded"
+    assert Path(manifest.raw_path).read_bytes() == b"retry-success"
+    assert not list(tmp_path.rglob("*.part"))
+
+
+def test_raw_refresh_rejects_repo_output_root():
+    from worldenergydata.texas_rrc.raw_refresh import RawSnapshotRefresher
+    from worldenergydata.texas_rrc.source_catalog import load_source_catalog
+
+    with pytest.raises(ValueError, match="git worktree"):
+        RawSnapshotRefresher(
+            catalog=load_source_catalog(),
+            output_root=Path.cwd() / "data" / "texas_rrc",
+            transport=FakeTransport(),
+            clock=fixed_clock,
+        )
+
+
+def test_raw_refresh_rejects_repo_output_root_when_launched_elsewhere(
+    tmp_path,
+):
+    import os
+
+    from worldenergydata.texas_rrc.raw_refresh import RawSnapshotRefresher
+    from worldenergydata.texas_rrc.source_catalog import load_source_catalog
+
+    original_cwd = Path.cwd()
+    repo_output = original_cwd / "data" / "texas_rrc"
+    os.chdir(tmp_path)
+
+    try:
+        with pytest.raises(ValueError, match="git worktree"):
+            RawSnapshotRefresher(
+                catalog=load_source_catalog(),
+                output_root=repo_output,
+                transport=FakeTransport(),
+                clock=fixed_clock,
+            )
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_raw_refresh_retries_get_transport_http_status_failure(tmp_path):
+    from worldenergydata.texas_rrc.raw_refresh import RawSnapshotRefresher
+    from worldenergydata.texas_rrc.source_catalog import load_source_catalog
+
+    catalog = load_source_catalog()
+    catalog["production_pdq"] = {
+        **catalog["production_pdq"],
+        "download_strategy": "direct_http",
+    }
+    transport = GetOnlyTransport(
+        FakeTransport(status_code=503),
+        FakeTransport(payload=b"get-success"),
+    )
+    refresher = RawSnapshotRefresher(
+        catalog=catalog,
+        output_root=tmp_path,
+        transport=transport,
+        clock=fixed_clock,
+    )
+
+    manifest = refresher.refresh_source("production_pdq")
+
+    assert len(transport.urls) == 2
+    assert manifest.status == "downloaded"
+    assert Path(manifest.raw_path).read_bytes() == b"get-success"
+
+
+def test_raw_refresh_validates_injected_catalog_direct_urls(tmp_path):
+    from worldenergydata.texas_rrc.raw_refresh import RawSnapshotRefresher
+    from worldenergydata.texas_rrc.source_catalog import load_source_catalog
+
+    catalog = load_source_catalog()
+    catalog["production_pdq"] = {
+        **catalog["production_pdq"],
+        "download_url": "https://example.com/not-rrc.zip",
+    }
+
+    with pytest.raises(ValueError, match="official RRC host"):
+        RawSnapshotRefresher(catalog=catalog, output_root=tmp_path)
+
+
+def test_raw_refresh_cli_lists_and_dry_runs_without_network(tmp_path):
+    from typer.testing import CliRunner
+
+    from worldenergydata.cli.commands.texas_rrc import app
+
+    runner = CliRunner()
+
+    list_result = runner.invoke(app, ["refresh", "--list-sources"])
+    assert list_result.exit_code == 0
+    assert "production_pdq" in list_result.output
+    assert "patchops_rrc_validation" in list_result.output
+    assert "validation_only" in list_result.output
+
+    dry_run_result = runner.invoke(
+        app,
+        [
+            "refresh",
+            "--dry-run",
+            "--source",
+            "production_pdq",
+            "--output-root",
+            str(tmp_path),
+        ],
+    )
+    assert dry_run_result.exit_code == 0
+    assert "production_pdq" in dry_run_result.output
+    assert "planned" in dry_run_result.output
+    assert not any(tmp_path.rglob("*"))

--- a/tests/unit/texas_rrc/test_source_catalog.py
+++ b/tests/unit/texas_rrc/test_source_catalog.py
@@ -25,8 +25,22 @@ REQUIRED_SOURCE_FIELDS = {
     "normalized_path",
     "curated_path",
     "availability_status",
+    "download_strategy",
     "source_of_record",
     "caveats",
+}
+
+REFRESH_SOURCE_IDS = {
+    "production_pdq",
+    "wellbore_query",
+    "drilling_permits",
+}
+
+OFFICIAL_GODRIVE_DIRECTORY_SOURCE_IDS = {
+    "completion_data",
+    "directional_surveys",
+    "well_gis_layers",
+    "pipeline_gis_layers",
 }
 
 
@@ -56,6 +70,36 @@ def test_source_catalog_entries_have_required_contract_fields():
         }
         assert isinstance(entry["source_of_record"], bool)
         assert entry["caveats"]
+
+
+def test_refresh_catalog_entries_use_official_rrc_direct_sources_only():
+    from urllib.parse import urlparse
+
+    from worldenergydata.texas_rrc.source_catalog import load_source_catalog
+
+    catalog = load_source_catalog()
+
+    for source_id in REFRESH_SOURCE_IDS:
+        entry = catalog[source_id]
+        assert entry["download_strategy"] == "official_godrive_file"
+        assert entry["download_url"]
+        assert entry["snapshot_filename"]
+        host = urlparse(entry["download_url"]).netloc
+        assert host == "mft.rrc.texas.gov"
+        assert "patchops" not in entry["download_url"].lower()
+        assert "github" not in entry["download_url"].lower()
+
+
+def test_directory_catalog_entries_require_official_godrive_fanout():
+    from worldenergydata.texas_rrc.source_catalog import load_source_catalog
+
+    catalog = load_source_catalog()
+
+    for source_id in OFFICIAL_GODRIVE_DIRECTORY_SOURCE_IDS:
+        entry = catalog[source_id]
+        assert entry["download_strategy"] == "official_godrive_directory"
+        assert entry["download_url"].startswith("https://mft.rrc.texas.gov/link/")
+        assert "snapshot_filename" not in entry
 
 
 def test_source_catalog_paths_stay_under_texas_rrc_ace_root():
@@ -88,6 +132,7 @@ def test_source_catalog_rejects_paths_outside_texas_rrc_ace_root():
             "normalized_path": "/mnt/ace/worldenergydata/data/modules/texas_rrc/normalized/bad",
             "curated_path": "/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/bad",
             "availability_status": "available",
+            "download_strategy": "unsupported_live_refresh",
             "source_of_record": True,
             "caveats": "test fixture",
         }


### PR DESCRIPTION
## Summary

- Adds official Texas RRC raw snapshot refresh planning/execution for GoDrive single-file datasets.
- Uses official RRC GoDrive source links only for refreshable raw downloads; PatchOps, EWA, and scraper references remain validation-only.
- Adds manifest writing, `.part` atomic writes, SHA256/byte-size metadata, content-length validation, retryable transient failures, HTML fail-closed behavior, and repo-local output rejection.
- Adds `worldenergydata texas-rrc refresh` with `--list-sources`, `--dry-run`, `--source`, `--all`, and `/mnt/ace/worldenergydata/data/modules/texas_rrc` default output root.

## Direct-source scope

Supported in this PR:
- `production_pdq` -> official GoDrive attachment `PDQ_DSV.zip`
- `wellbore_query` -> official GoDrive attachment `OG_WELLBORE_EWA_Report.csv`
- `drilling_permits` -> official GoDrive attachment `daf420.dat`

Official GoDrive directory datasets are cataloged but skipped until fanout/pagination handling is implemented in #669:
- `completion_data`
- `directional_surveys`
- `well_gis_layers`
- `pipeline_gis_layers`

## Verification

- RED: review-regression tests failed before fixes for content-length mismatch, HTTP 503 retry, injected non-RRC catalog URLs, repo-output-root bypass, and same-second manifest collision.
- `PYTHONPATH='packages/worldenergydata-texas_rrc/src:packages/worldenergydata-core/src:src' PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 timeout 360 .venv/bin/python -m pytest -o addopts='' --noconftest tests/unit/texas_rrc -q` -> `377 passed in 5.10s`
- `.venv/bin/ruff check ...` -> `All checks passed!`
- `.venv/bin/ruff format --check ...` -> `7 files already formatted`
- `git diff --check` -> clean
- Live official GoDrive header probe resolved all three supported sources to attachment responses with expected filenames and `Content-Length`; no payloads downloaded.

## Notes

- This PR is stacked on #667 / #660.
- `scripts/legal/legal-sanity-scan.sh` is not present/executable in this checkout; could not run that required repository gate locally.

Fixes #661
Related: #669
