### PR TITLE
feat: add Texas RRC lifecycle spine

### DIFF
--- a/docs/data-sources/onshore/texas-rrc/well-lifecycle-spine.md
+++ b/docs/data-sources/onshore/texas-rrc/well-lifecycle-spine.md
@@ -38,7 +38,9 @@ The lifecycle command writes curated outputs under:
 ```
 
 Writes are staged under `.staging-well-lifecycle-spine-*` and then promoted into
-the final curated directory.
+the final curated directory. By default, lifecycle writes are rejected outside
+`/mnt/ace/worldenergydata/data/modules/texas_rrc`; the test/sandbox override is
+explicit so local runs do not weaken the durable storage contract.
 
 ## Command
 
@@ -63,7 +65,8 @@ For test or sandbox runs, override both roots:
 ```bash
 uv run worldenergydata texas-rrc normalize-lifecycle \
   --raw-root /tmp/texas_rrc \
-  --output-root /tmp/texas_rrc_out
+  --output-root /tmp/texas_rrc_out \
+  --allow-non-ace-output
 ```
 
 ## Spine Grain
@@ -78,6 +81,11 @@ Current join priority is:
 1. Wellbore Query for durable well identifiers and status.
 2. Drilling permits for intent, permit dates, spud date, and surface location.
 3. Completion data for completion milestones and completion-form evidence.
+
+Official Texas RRC drilling permits use the `daf420.dat` fixed-record product,
+not only delimited files. The lifecycle loader reads type-02 permit master
+records and the following type-14 surface-location record, then normalizes the
+official eight-digit RRC API number into the Texas API14 shape for joins.
 
 ## Quality Report
 

--- a/docs/data-sources/onshore/texas-rrc/well-lifecycle-spine.md
+++ b/docs/data-sources/onshore/texas-rrc/well-lifecycle-spine.md
@@ -1,0 +1,108 @@
+# Texas RRC Well Lifecycle Spine
+
+The Texas RRC well lifecycle spine is the first onshore analog to the BSEE
+field-development workflow. It centers official Texas RRC raw snapshots on the
+API14/API10 well identity, then writes a curated spine under `/mnt/ace` for
+production analysis, lease/field rollups, and later field architecture work.
+
+## Source Of Record
+
+The lifecycle spine uses direct Texas RRC sources only:
+
+| Lifecycle stage | Catalog source | Refresh cycle | Current role |
+| --- | --- | --- | --- |
+| Production and lease history | `production_pdq` | Monthly, after the last Saturday | Downstream production and field/lease rollups |
+| Well identity and status | `wellbore_query` | Monthly, beginning of month | API, district, field, lease, operator, well status |
+| Development intent | `drilling_permits` | Nightly | Permit number, permit dates, depth, location, spud date |
+| Completion milestone | `completion_data` | Nightly | W-2/G-1 completion date and completion evidence |
+| Trajectory evidence | `directional_surveys` | Daily | Source-gap flag until PDF extraction is implemented |
+
+PatchOps and RRC EWA query flows remain validation surfaces. They are useful for
+spot-checking official joins but are not durable storage inputs for this repo.
+
+## Storage Contract
+
+Raw refreshes land under:
+
+```text
+/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/
+```
+
+The lifecycle command writes curated outputs under:
+
+```text
+/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/well_lifecycle/spine/
++-- well_lifecycle_spine.csv
++-- well_lifecycle_quality.json
++-- manifest.json
+```
+
+Writes are staged under `.staging-well-lifecycle-spine-*` and then promoted into
+the final curated directory.
+
+## Command
+
+Refresh the official raw sources first, then normalize the lifecycle spine:
+
+```bash
+uv run worldenergydata texas-rrc refresh --source wellbore_query
+uv run worldenergydata texas-rrc refresh --source drilling_permits
+uv run worldenergydata texas-rrc refresh --source completion_data
+uv run worldenergydata texas-rrc normalize-lifecycle --require-sources
+```
+
+Use `--dry-run` to load and assess local raw snapshots without writing curated
+outputs:
+
+```bash
+uv run worldenergydata texas-rrc normalize-lifecycle --dry-run
+```
+
+For test or sandbox runs, override both roots:
+
+```bash
+uv run worldenergydata texas-rrc normalize-lifecycle \
+  --raw-root /tmp/texas_rrc \
+  --output-root /tmp/texas_rrc_out
+```
+
+## Spine Grain
+
+The spine is one row per API10/API14 well identity. It preserves the normalized
+API14, derived API10, county code, well unique number, sidetrack code,
+completion code, district, field, lease, operator, permit, well status,
+milestone dates, coordinates, and source-presence flags.
+
+Current join priority is:
+
+1. Wellbore Query for durable well identifiers and status.
+2. Drilling permits for intent, permit dates, spud date, and surface location.
+3. Completion data for completion milestones and completion-form evidence.
+
+## Quality Report
+
+`well_lifecycle_quality.json` counts high-signal quality defects:
+
+- duplicate API14 values
+- missing field, lease, or operator identifiers
+- invalid Texas coordinate bounds
+- impossible milestone ordering
+- permits or completions without a wellbore row
+- wellbores without completion evidence
+- missing lifecycle source directories
+
+The CSV also carries row-level `quality_flags` so downstream production and field
+development analysis can filter or inspect suspect joins.
+
+## Field Development Use
+
+This spine is the onshore lifecycle anchor for later work:
+
+- production decline and lease/field allocation from `production_pdq`
+- drilling-to-completion cycle time and permit aging analysis
+- active, shut-in, plugged, and orphaned well status rollups
+- operator, lease, field, and district field-development comparisons
+- pipeline and surface-infrastructure overlays once official GIS layers are
+  normalized
+- architecture analysis that links well pads, pipelines, leases, and production
+  facilities from official RRC sources

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/data/lifecycle_column_aliases.yml
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/data/lifecycle_column_aliases.yml
@@ -1,0 +1,117 @@
+sources:
+  wellbore_query:
+    api_number:
+      - API_NO
+      - API_NUMBER
+      - API
+    district:
+      - DISTRICT_NO
+      - DISTRICT
+    field_number:
+      - FIELD_NO
+      - FIELD_NUMBER
+    field_name:
+      - FIELD_NAME
+    lease_number:
+      - LEASE_NO
+      - LEASE_NUMBER
+    lease_name:
+      - LEASE_NAME
+    operator_number:
+      - OPERATOR_NO
+      - OPERATOR_NUMBER
+    operator_name:
+      - OPERATOR_NAME
+    well_status:
+      - WELL_STATUS
+      - STATUS
+    well_type:
+      - WELL_TYPE
+      - TYPE
+    total_depth:
+      - TOTAL_DEPTH
+      - TD
+    completion_date:
+      - COMPLETION_DATE
+      - COMPL_DATE
+    plug_date:
+      - PLUG_DATE
+
+  drilling_permits:
+    api_number:
+      - API_NO
+      - API_NUMBER
+      - API
+    permit_number:
+      - PERMIT_NO
+      - PERMIT_NUMBER
+    permit_status:
+      - PERMIT_STATUS
+      - STATUS
+    permit_type:
+      - PERMIT_TYPE
+      - TYPE
+    district:
+      - DISTRICT_NO
+      - DISTRICT
+    field_number:
+      - FIELD_NO
+      - FIELD_NUMBER
+    field_name:
+      - FIELD_NAME
+    lease_number:
+      - LEASE_NO
+      - LEASE_NUMBER
+    lease_name:
+      - LEASE_NAME
+    operator_number:
+      - OPERATOR_NO
+      - OPERATOR_NUMBER
+    operator_name:
+      - OPERATOR_NAME
+    permit_issued_date:
+      - APPROVED_DATE
+      - APPROVAL_DATE
+      - ISSUED_DATE
+    permit_amended_date:
+      - AMENDED_DATE
+      - AMEND_DATE
+    permit_extended_date:
+      - EXTENDED_DATE
+      - EXTENSION_DATE
+    spud_date:
+      - SPUD_DATE
+    latitude:
+      - LATITUDE
+      - LAT
+    longitude:
+      - LONGITUDE
+      - LON
+      - LONG
+
+  completion_data:
+    api_number:
+      - API_NO
+      - API_NUMBER
+      - API
+    completion_date:
+      - COMPLETION_DATE
+      - COMPL_DATE
+    form_type:
+      - FORM_TYPE
+      - FORM
+    field_number:
+      - FIELD_NO
+      - FIELD_NUMBER
+    field_name:
+      - FIELD_NAME
+    lease_number:
+      - LEASE_NO
+      - LEASE_NUMBER
+    lease_name:
+      - LEASE_NAME
+    operator_number:
+      - OPERATOR_NO
+      - OPERATOR_NUMBER
+    operator_name:
+      - OPERATOR_NAME

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/data/lifecycle_column_aliases.yml
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/data/lifecycle_column_aliases.yml
@@ -97,6 +97,7 @@ sources:
     completion_date:
       - COMPLETION_DATE
       - COMPL_DATE
+      - CMPL_OR_RECMPL_DATE
     form_type:
       - FORM_TYPE
       - FORM

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/__init__.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/__init__.py
@@ -1,0 +1,9 @@
+"""Lifecycle normalization tools for Texas RRC well data."""
+
+from worldenergydata.texas_rrc.lifecycle.keys import (
+    derive_api10,
+    normalize_api14,
+    split_api14,
+)
+
+__all__ = ["derive_api10", "normalize_api14", "split_api14"]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/__init__.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/__init__.py
@@ -5,5 +5,6 @@ from worldenergydata.texas_rrc.lifecycle.keys import (
     normalize_api14,
     split_api14,
 )
+from worldenergydata.texas_rrc.lifecycle.spine import build_lifecycle_spine
 
-__all__ = ["derive_api10", "normalize_api14", "split_api14"]
+__all__ = ["build_lifecycle_spine", "derive_api10", "normalize_api14", "split_api14"]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/io.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/io.py
@@ -47,9 +47,11 @@ def write_lifecycle_outputs(
     output_root: Path | str = SOURCE_CATALOG_ROOT,
     generated_at: datetime | None = None,
     input_paths: Iterable[str | Path] = (),
+    allow_non_ace_root: bool = False,
 ) -> LifecycleOutputManifest:
     """Write lifecycle spine artifacts under the Texas RRC curated data layout."""
     root = Path(output_root)
+    _validate_output_root(root, allow_non_ace_root)
     target_dir = root / LIFECYCLE_SPINE_DIR
     stamp = _timestamp(generated_at)
     final_spine = target_dir / SPINE_FILENAME
@@ -83,6 +85,17 @@ def write_lifecycle_outputs(
 def load_lifecycle_spine(path: Path | str) -> pd.DataFrame:
     """Load a persisted lifecycle spine while preserving API key strings."""
     return pd.read_csv(path, dtype=API_KEY_DTYPES)
+
+
+def _validate_output_root(root: Path, allow_non_ace_root: bool) -> None:
+    if allow_non_ace_root:
+        return
+    if not root.resolve().is_relative_to(SOURCE_CATALOG_ROOT.resolve()):
+        raise ValueError(
+            "Lifecycle output_root must stay under "
+            f"{SOURCE_CATALOG_ROOT}; pass allow_non_ace_root=True only for "
+            "isolated tests or sandbox runs"
+        )
 
 
 def _quality_payload(quality: LifecycleQualityReport) -> dict[str, object]:

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/io.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/io.py
@@ -1,0 +1,131 @@
+"""Persist Texas RRC lifecycle spine outputs."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import shutil
+from typing import Iterable
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.lifecycle.quality import LifecycleQualityReport
+from worldenergydata.texas_rrc.source_catalog import SOURCE_CATALOG_ROOT
+
+LIFECYCLE_SPINE_DIR = Path("curated") / "well_lifecycle" / "spine"
+SPINE_FILENAME = "well_lifecycle_spine.csv"
+QUALITY_FILENAME = "well_lifecycle_quality.json"
+MANIFEST_FILENAME = "manifest.json"
+API_KEY_DTYPES = {
+    "api14": "string",
+    "api10": "string",
+    "county_code": "string",
+    "well_unique_number": "string",
+    "sidetrack_code": "string",
+    "completion_code": "string",
+}
+
+
+@dataclass(frozen=True)
+class LifecycleOutputManifest:
+    """Paths and summary metadata for one lifecycle spine output batch."""
+
+    generated_at: str
+    output_root: Path
+    spine_path: Path
+    quality_path: Path
+    manifest_path: Path
+    row_count: int
+    input_paths: tuple[str, ...]
+
+
+def write_lifecycle_outputs(
+    spine: pd.DataFrame,
+    quality: LifecycleQualityReport,
+    output_root: Path | str = SOURCE_CATALOG_ROOT,
+    generated_at: datetime | None = None,
+    input_paths: Iterable[str | Path] = (),
+) -> LifecycleOutputManifest:
+    """Write lifecycle spine artifacts under the Texas RRC curated data layout."""
+    root = Path(output_root)
+    target_dir = root / LIFECYCLE_SPINE_DIR
+    stamp = _timestamp(generated_at)
+    final_spine = target_dir / SPINE_FILENAME
+    final_quality = target_dir / QUALITY_FILENAME
+    final_manifest = target_dir / MANIFEST_FILENAME
+    manifest = LifecycleOutputManifest(
+        generated_at=stamp,
+        output_root=root,
+        spine_path=final_spine,
+        quality_path=final_quality,
+        manifest_path=final_manifest,
+        row_count=len(spine),
+        input_paths=tuple(str(path) for path in input_paths),
+    )
+    staging = target_dir / f".staging-well-lifecycle-spine-{_compact_stamp(stamp)}"
+    shutil.rmtree(staging, ignore_errors=True)
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+        spine.to_csv(staging / SPINE_FILENAME, index=False)
+        _write_json(staging / QUALITY_FILENAME, _quality_payload(quality))
+        _write_json(staging / MANIFEST_FILENAME, _manifest_payload(manifest, quality))
+        target_dir.mkdir(parents=True, exist_ok=True)
+        (staging / SPINE_FILENAME).replace(final_spine)
+        (staging / QUALITY_FILENAME).replace(final_quality)
+        (staging / MANIFEST_FILENAME).replace(final_manifest)
+        return manifest
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def load_lifecycle_spine(path: Path | str) -> pd.DataFrame:
+    """Load a persisted lifecycle spine while preserving API key strings."""
+    return pd.read_csv(path, dtype=API_KEY_DTYPES)
+
+
+def _quality_payload(quality: LifecycleQualityReport) -> dict[str, object]:
+    return asdict(quality)
+
+
+def _manifest_payload(
+    manifest: LifecycleOutputManifest,
+    quality: LifecycleQualityReport,
+) -> dict[str, object]:
+    return {
+        "generated_at": manifest.generated_at,
+        "output_root": str(manifest.output_root),
+        "spine_path": str(manifest.spine_path),
+        "quality_path": str(manifest.quality_path),
+        "manifest_path": str(manifest.manifest_path),
+        "row_count": manifest.row_count,
+        "input_paths": list(manifest.input_paths),
+        "quality": _quality_payload(quality),
+    }
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _timestamp(value: datetime | None) -> str:
+    timestamp = value or datetime.now(timezone.utc)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _compact_stamp(stamp: str) -> str:
+    return stamp.replace("-", "").replace(":", "")
+
+
+__all__ = [
+    "LifecycleOutputManifest",
+    "LIFECYCLE_SPINE_DIR",
+    "load_lifecycle_spine",
+    "write_lifecycle_outputs",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/keys.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/keys.py
@@ -11,6 +11,9 @@ def normalize_api14(value: object) -> str | None:
         return None
 
     digits = re.sub(r"\D", "", str(value).strip())
+    if len(digits) == 8:
+        digits = f"42{digits}"
+
     if not digits.startswith("42"):
         return None
 

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/keys.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/keys.py
@@ -1,0 +1,46 @@
+"""API key normalization for Texas RRC lifecycle joins."""
+
+from __future__ import annotations
+
+import re
+
+
+def normalize_api14(value: object) -> str | None:
+    """Normalize common Texas RRC API shapes to a 14-digit API key."""
+    if value is None:
+        return None
+
+    digits = re.sub(r"\D", "", str(value).strip())
+    if not digits.startswith("42"):
+        return None
+
+    if len(digits) == 10:
+        return f"{digits}0000"
+    if len(digits) == 12:
+        return f"{digits}00"
+    if len(digits) == 14:
+        return digits
+    return None
+
+
+def derive_api10(api14: str | None) -> str | None:
+    """Return the API10 base well key from a normalized API14 value."""
+    normalized = normalize_api14(api14)
+    if normalized is None:
+        return None
+    return normalized[:10]
+
+
+def split_api14(api14: str) -> dict[str, str]:
+    """Split API14 into the lifecycle join fields used downstream."""
+    normalized = normalize_api14(api14)
+    if normalized is None:
+        raise ValueError(f"Invalid Texas API14: {api14}")
+
+    return {
+        "api10": normalized[:10],
+        "county_code": normalized[2:5],
+        "well_unique_number": normalized[5:10],
+        "sidetrack_code": normalized[10:12],
+        "completion_code": normalized[12:14],
+    }

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/quality.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/quality.py
@@ -1,0 +1,130 @@
+"""Quality checks for Texas RRC lifecycle spine outputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Sequence
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class LifecycleQualityReport:
+    """Aggregate quality counts for one lifecycle spine build."""
+
+    row_count: int
+    duplicate_api14: int
+    missing_field_id: int
+    missing_lease_id: int
+    missing_operator_id: int
+    invalid_coordinates: int
+    impossible_dates: int
+    permit_without_wellbore: int
+    completion_without_wellbore: int
+    wellbore_without_completion: int
+    source_gaps: Sequence[str]
+
+
+def assess_lifecycle_quality(
+    spine: pd.DataFrame,
+    source_gaps: Sequence[str] = (),
+) -> LifecycleQualityReport:
+    """Assess lifecycle spine quality and attach row-level flags."""
+    row_flags = [_flags_for_row(row) for _, row in spine.iterrows()]
+    spine["quality_flags"] = ["|".join(flags) for flags in row_flags]
+    duplicate_values = spine["api14"].duplicated().sum() if "api14" in spine else 0
+    return LifecycleQualityReport(
+        row_count=len(spine),
+        duplicate_api14=int(duplicate_values),
+        missing_field_id=_count_flag(row_flags, "missing_field_id"),
+        missing_lease_id=_count_flag(row_flags, "missing_lease_id"),
+        missing_operator_id=_count_flag(row_flags, "missing_operator_id"),
+        invalid_coordinates=_count_flag(row_flags, "invalid_coordinates"),
+        impossible_dates=_count_flag(row_flags, "impossible_dates"),
+        permit_without_wellbore=_count_flag(row_flags, "permit_without_wellbore"),
+        completion_without_wellbore=_count_flag(
+            row_flags, "completion_without_wellbore"
+        ),
+        wellbore_without_completion=_count_flag(row_flags, "wellbore_without_completion"),
+        source_gaps=tuple(source_gaps),
+    )
+
+
+def _flags_for_row(row: pd.Series) -> list[str]:
+    flags = []
+    _append_missing_id_flags(row, flags)
+    if _invalid_coordinates(row):
+        flags.append("invalid_coordinates")
+    if _impossible_dates(row):
+        flags.append("impossible_dates")
+    _append_source_gap_flags(row, flags)
+    return flags
+
+
+def _append_missing_id_flags(row: pd.Series, flags: list[str]) -> None:
+    for column, flag in (
+        ("field_number", "missing_field_id"),
+        ("lease_number", "missing_lease_id"),
+        ("operator_number", "missing_operator_id"),
+    ):
+        if not _has_value(row.get(column)):
+            flags.append(flag)
+
+
+def _append_source_gap_flags(row: pd.Series, flags: list[str]) -> None:
+    has_wellbore = bool(row.get("has_wellbore"))
+    if bool(row.get("has_permit")) and not has_wellbore:
+        flags.append("permit_without_wellbore")
+    if bool(row.get("has_completion")) and not has_wellbore:
+        flags.append("completion_without_wellbore")
+    if has_wellbore and not bool(row.get("has_completion")):
+        flags.append("wellbore_without_completion")
+
+
+def _invalid_coordinates(row: pd.Series) -> bool:
+    latitude = _to_float(row.get("latitude"))
+    longitude = _to_float(row.get("longitude"))
+    if latitude is None or longitude is None:
+        return False
+    return not (25.84 <= latitude <= 36.50 and -106.65 <= longitude <= -93.51)
+
+
+def _impossible_dates(row: pd.Series) -> bool:
+    comparisons = (
+        ("permit_issued_date", "spud_date"),
+        ("spud_date", "completion_date"),
+        ("completion_date", "plug_date"),
+    )
+    for start_column, end_column in comparisons:
+        start = _to_date(row.get(start_column))
+        end = _to_date(row.get(end_column))
+        if start and end and start > end:
+            return True
+    return False
+
+
+def _to_date(value) -> date | None:
+    if not _has_value(value):
+        return None
+    try:
+        return date.fromisoformat(str(value))
+    except ValueError:
+        return None
+
+
+def _to_float(value) -> float | None:
+    if not _has_value(value):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _has_value(value) -> bool:
+    return value is not None and value == value and str(value) != ""
+
+
+def _count_flag(row_flags: list[list[str]], flag: str) -> int:
+    return sum(flag in flags for flags in row_flags)

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/quality.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/quality.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 from typing import Sequence
 
 import pandas as pd
@@ -46,7 +46,9 @@ def assess_lifecycle_quality(
         completion_without_wellbore=_count_flag(
             row_flags, "completion_without_wellbore"
         ),
-        wellbore_without_completion=_count_flag(row_flags, "wellbore_without_completion"),
+        wellbore_without_completion=_count_flag(
+            row_flags, "wellbore_without_completion"
+        ),
         source_gaps=tuple(source_gaps),
     )
 
@@ -107,8 +109,17 @@ def _impossible_dates(row: pd.Series) -> bool:
 def _to_date(value) -> date | None:
     if not _has_value(value):
         return None
+    if isinstance(value, date):
+        return value
+    text = str(value).strip()
+    if not text:
+        return None
     try:
-        return date.fromisoformat(str(value))
+        return date.fromisoformat(text)
+    except ValueError:
+        pass
+    try:
+        return datetime.strptime(text, "%m/%d/%Y").date()
     except ValueError:
         return None
 

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/sources.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/sources.py
@@ -1,0 +1,129 @@
+"""Local raw snapshot readers for Texas RRC lifecycle normalization."""
+
+from __future__ import annotations
+
+import zipfile
+from dataclasses import dataclass
+from importlib.resources import files
+from io import StringIO
+from pathlib import Path
+from typing import Sequence
+
+import pandas as pd
+import yaml
+
+
+@dataclass(frozen=True)
+class LifecycleInputFrames:
+    """Raw lifecycle source frames loaded from local Texas RRC snapshots."""
+
+    wellbores: pd.DataFrame
+    permits: pd.DataFrame
+    completions: pd.DataFrame
+    source_gaps: Sequence[str]
+
+
+SOURCE_DIRS = {
+    "wellbore_query": Path("raw/wellbore/query"),
+    "drilling_permits": Path("raw/permits/drilling"),
+    "completion_data": Path("raw/completions"),
+}
+
+
+def load_lifecycle_inputs(raw_root: Path) -> LifecycleInputFrames:
+    """Load local raw snapshots needed for the lifecycle spine."""
+    root = _local_root(raw_root)
+    wellbores, wellbore_gap = _load_source(root, "wellbore_query")
+    permits, permit_gap = _load_source(root, "drilling_permits")
+    completions, completion_gap = _load_source(root, "completion_data")
+    gaps = tuple(
+        source
+        for source in (wellbore_gap, permit_gap, completion_gap)
+        if source is not None
+    )
+    return LifecycleInputFrames(wellbores, permits, completions, gaps)
+
+
+def _local_root(raw_root: Path) -> Path:
+    value = str(raw_root)
+    if "://" in value:
+        raise ValueError("Lifecycle inputs must be local filesystem paths")
+    return Path(raw_root)
+
+
+def _load_source(root: Path, source_id: str) -> tuple[pd.DataFrame, str | None]:
+    source_dir = root / SOURCE_DIRS[source_id]
+    if not source_dir.exists():
+        return pd.DataFrame(), source_id
+
+    frames = [_read_table(path) for path in sorted(source_dir.rglob("*")) if path.is_file()]
+    frames = [frame for frame in frames if not frame.empty]
+    if not frames:
+        return pd.DataFrame(), source_id
+
+    combined = pd.concat(frames, ignore_index=True)
+    return _normalize_columns(combined, source_id), None
+
+
+def _read_table(path: Path) -> pd.DataFrame:
+    if path.suffix.lower() == ".zip":
+        return _read_zip_tables(path)
+    if path.suffix.lower() not in {".csv", ".txt", ".dat"}:
+        return pd.DataFrame()
+    return _read_table_text(path.read_text(encoding="utf-8", errors="replace"))
+
+
+def _read_zip_tables(path: Path) -> pd.DataFrame:
+    frames = []
+    with zipfile.ZipFile(path) as archive:
+        for name in sorted(archive.namelist()):
+            if Path(name).suffix.lower() not in {".csv", ".txt", ".dat"}:
+                continue
+            text = archive.read(name).decode("utf-8", errors="replace")
+            frame = _read_table_text(text)
+            if not frame.empty:
+                frames.append(frame)
+    if not frames:
+        return pd.DataFrame()
+    return pd.concat(frames, ignore_index=True)
+
+
+def _read_table_text(text: str) -> pd.DataFrame:
+    if not text.strip():
+        return pd.DataFrame()
+    first_line = text.splitlines()[0]
+    separator = "|" if "|" in first_line else None
+    return pd.read_csv(
+        StringIO(text),
+        sep=separator,
+        engine="python",
+        dtype=str,
+        keep_default_na=False,
+    )
+
+
+def _normalize_columns(frame: pd.DataFrame, source_id: str) -> pd.DataFrame:
+    aliases = _alias_lookup()[source_id]
+    rename = {}
+    for column in frame.columns:
+        column_key = _column_key(column)
+        rename[column] = aliases.get(column_key, column.lower().replace(" ", "_"))
+    return frame.rename(columns=rename)
+
+
+def _alias_lookup() -> dict[str, dict[str, str]]:
+    data_path = files("worldenergydata.texas_rrc.data").joinpath(
+        "lifecycle_column_aliases.yml"
+    )
+    config = yaml.safe_load(data_path.read_text(encoding="utf-8"))
+    lookup = {}
+    for source_id, columns in config["sources"].items():
+        lookup[source_id] = {}
+        for canonical, aliases in columns.items():
+            for alias in aliases:
+                lookup[source_id][_column_key(alias)] = canonical
+    return lookup
+
+
+def _column_key(column: str) -> str:
+    return column.strip().upper().replace(" ", "_")

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/sources.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/sources.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import date
 import zipfile
 from dataclasses import dataclass
 from importlib.resources import files
@@ -56,7 +57,11 @@ def _load_source(root: Path, source_id: str) -> tuple[pd.DataFrame, str | None]:
     if not source_dir.exists():
         return pd.DataFrame(), source_id
 
-    frames = [_read_table(path) for path in sorted(source_dir.rglob("*")) if path.is_file()]
+    frames = [
+        _read_table(path, source_id)
+        for path in sorted(source_dir.rglob("*"))
+        if path.is_file()
+    ]
     frames = [frame for frame in frames if not frame.empty]
     if not frames:
         return pd.DataFrame(), source_id
@@ -65,21 +70,34 @@ def _load_source(root: Path, source_id: str) -> tuple[pd.DataFrame, str | None]:
     return _normalize_columns(combined, source_id), None
 
 
-def _read_table(path: Path) -> pd.DataFrame:
+def _read_table(path: Path, source_id: str) -> pd.DataFrame:
     if path.suffix.lower() == ".zip":
-        return _read_zip_tables(path)
+        return _read_zip_tables(path, source_id)
     if path.suffix.lower() not in {".csv", ".txt", ".dat"}:
         return pd.DataFrame()
-    return _read_table_text(path.read_text(encoding="utf-8", errors="replace"))
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if source_id == "drilling_permits" and path.name.lower() == "daf420.dat":
+        frame = _read_daf420_text(text)
+        if not frame.empty:
+            return frame
+    return _read_table_text(text)
 
 
-def _read_zip_tables(path: Path) -> pd.DataFrame:
+def _read_zip_tables(path: Path, source_id: str) -> pd.DataFrame:
     frames = []
     with zipfile.ZipFile(path) as archive:
         for name in sorted(archive.namelist()):
             if Path(name).suffix.lower() not in {".csv", ".txt", ".dat"}:
                 continue
             text = archive.read(name).decode("utf-8", errors="replace")
+            if (
+                source_id == "drilling_permits"
+                and Path(name).name.lower() == "daf420.dat"
+            ):
+                frame = _read_daf420_text(text)
+                if not frame.empty:
+                    frames.append(frame)
+                    continue
             frame = _read_table_text(text)
             if not frame.empty:
                 frames.append(frame)
@@ -100,6 +118,91 @@ def _read_table_text(text: str) -> pd.DataFrame:
         dtype=str,
         keep_default_na=False,
     )
+
+
+def _read_daf420_text(text: str) -> pd.DataFrame:
+    rows: list[dict[str, str]] = []
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip("\r\n")
+        segment = _rrc_segment(line)
+        if segment is None:
+            continue
+        segment_type, segment_start = segment
+        if segment_type == "02":
+            row = _parse_daf420_master(line, segment_start)
+            if row:
+                rows.append(row)
+        elif segment_type == "14" and rows:
+            rows[-1].update(_parse_daf420_surface_location(line, segment_start))
+    return pd.DataFrame(rows)
+
+
+def _rrc_segment(line: str) -> tuple[str, int] | None:
+    for start in (2, 0):
+        segment_type = line[start : start + 2]
+        if segment_type in {"02", "14"}:
+            return segment_type, start + 1
+    return None
+
+
+def _parse_daf420_master(line: str, segment_start: int) -> dict[str, str]:
+    offset = segment_start - 3
+    api_number = _fixed_value(line, 505 + offset, 8)
+    if len(api_number) != 8 or not api_number.isdigit():
+        return {}
+
+    row = {
+        "api_number": api_number,
+        "permit_number": _fixed_value(line, 5 + offset, 7),
+        "permit_type": _fixed_value(line, 68 + offset, 2),
+        "district": _fixed_value(line, 49 + offset, 2),
+        "lease_name": _fixed_value(line, 17 + offset, 32),
+        "operator_number": _fixed_value(line, 62 + offset, 6),
+        "permit_issued_date": _fixed_date(line, 132 + offset),
+        "permit_amended_date": _fixed_date(line, 140 + offset),
+        "permit_extended_date": _fixed_date(line, 148 + offset),
+        "spud_date": _fixed_date(line, 156 + offset),
+        "total_depth": _fixed_value(line, 57 + offset, 5),
+    }
+    return {key: value for key, value in row.items() if value}
+
+
+def _parse_daf420_surface_location(line: str, segment_start: int) -> dict[str, str]:
+    offset = segment_start - 3
+    longitude = _fixed_coordinate(line, 5 + offset, west_longitude=True)
+    latitude = _fixed_coordinate(line, 17 + offset, west_longitude=False)
+    result = {}
+    if latitude:
+        result["latitude"] = latitude
+    if longitude:
+        result["longitude"] = longitude
+    return result
+
+
+def _fixed_value(line: str, start: int, width: int) -> str:
+    if start < 1:
+        return ""
+    return line[start - 1 : start - 1 + width].strip()
+
+
+def _fixed_date(line: str, start: int) -> str:
+    value = _fixed_value(line, start, 8)
+    if len(value) != 8 or not value.isdigit() or value == "00000000":
+        return ""
+    try:
+        return date(int(value[:4]), int(value[4:6]), int(value[6:8])).isoformat()
+    except ValueError:
+        return ""
+
+
+def _fixed_coordinate(line: str, start: int, west_longitude: bool) -> str:
+    value = _fixed_value(line, start, 12)
+    if len(value) != 12 or not value.isdigit() or value == "000000000000":
+        return ""
+    coordinate = int(value[:5]) + int(value[5:]) / 10_000_000
+    if west_longitude:
+        coordinate = -coordinate
+    return f"{coordinate:g}"
 
 
 def _normalize_columns(frame: pd.DataFrame, source_id: str) -> pd.DataFrame:

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/sources.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/sources.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import date
 import zipfile
 from dataclasses import dataclass
+from datetime import date
 from importlib.resources import files
 from io import StringIO
 from pathlib import Path
@@ -138,7 +138,7 @@ def _read_daf420_text(text: str) -> pd.DataFrame:
 
 
 def _rrc_segment(line: str) -> tuple[str, int] | None:
-    for start in (2, 0):
+    for start in (0, 2):
         segment_type = line[start : start + 2]
         if segment_type in {"02", "14"}:
             return segment_type, start + 1

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/spine.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/spine.py
@@ -46,13 +46,25 @@ def build_lifecycle_spine(inputs: LifecycleInputFrames) -> pd.DataFrame:
     wellbores = normalize_wellbore_frame(inputs.wellbores)
     permits = normalize_permit_frame(inputs.permits)
     completions = normalize_completion_frame(inputs.completions)
-    wellbore_rows = _by_api10(wellbores)
-    permit_rows = _by_api10(permits)
-    completion_rows = _by_api10(completions)
-    api10_values = sorted(set(wellbore_rows) | set(permit_rows) | set(completion_rows))
+
+    wellbore_exact = _by_key(wellbores, "api14")
+    permit_exact = _by_key(permits, "api14")
+    completion_exact = _by_key(completions, "api14")
+    wellbore_context = _by_key(wellbores, "api10")
+    permit_context = _by_key(permits, "api10")
+
+    api14_values = sorted(
+        set(wellbore_exact) | set(permit_exact) | set(completion_exact)
+    )
     records = [
-        _build_record(api10, wellbore_rows, permit_rows, completion_rows)
-        for api10 in api10_values
+        _build_record(
+            api14,
+            wellbore_exact.get(api14, {})
+            or wellbore_context.get(derive_api10(api14), {}),
+            permit_exact.get(api14, {}) or permit_context.get(derive_api10(api14), {}),
+            completion_exact.get(api14, {}),
+        )
+        for api14 in api14_values
     ]
     result = pd.DataFrame(records)
     for column in ("has_wellbore", "has_permit", "has_completion"):
@@ -71,35 +83,40 @@ def _normalize_source_frame(frame: pd.DataFrame) -> pd.DataFrame:
         return result
     result["api10"] = result["api14"].apply(derive_api10)
     api_segments = result["api14"].apply(split_api14).apply(pd.Series)
-    for column in ("county_code", "well_unique_number", "sidetrack_code", "completion_code"):
+    for column in (
+        "county_code",
+        "well_unique_number",
+        "sidetrack_code",
+        "completion_code",
+    ):
         result[column] = api_segments[column]
     return result
 
 
-def _by_api10(frame: pd.DataFrame) -> dict[str, dict[str, Any]]:
-    if frame.empty:
+def _by_key(frame: pd.DataFrame, key: str) -> dict[str, dict[str, Any]]:
+    if frame.empty or key not in frame.columns:
         return {}
     rows = {}
-    for api10, group in frame.groupby("api10", sort=True):
-        rows[api10] = _most_complete_row(group).to_dict()
+    for value, group in frame.groupby(key, sort=True):
+        if _has_value(value):
+            rows[str(value)] = _most_complete_row(group).to_dict()
     return rows
 
 
 def _most_complete_row(group: pd.DataFrame) -> pd.Series:
-    completeness = group.apply(lambda row: sum(_has_value(value) for value in row), axis=1)
+    completeness = group.apply(
+        lambda row: sum(_has_value(value) for value in row), axis=1
+    )
     return group.loc[completeness.idxmax()]
 
 
 def _build_record(
-    api10: str,
-    wellbores: dict[str, dict[str, Any]],
-    permits: dict[str, dict[str, Any]],
-    completions: dict[str, dict[str, Any]],
+    api14: str,
+    wellbore: dict[str, Any],
+    permit: dict[str, Any],
+    completion: dict[str, Any],
 ) -> dict[str, Any]:
-    wellbore = wellbores.get(api10, {})
-    permit = permits.get(api10, {})
-    completion = completions.get(api10, {})
-    api14 = _first_value(wellbore, permit, completion, column="api14")
+    api10 = derive_api10(api14)
     record = {"api14": api14, "api10": api10}
     record.update(split_api14(api14))
     record.update(_identifier_values(wellbore, completion, permit))

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/spine.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/spine.py
@@ -1,0 +1,180 @@
+"""Build the Texas RRC API14-centered well lifecycle spine."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.lifecycle.keys import (
+    derive_api10,
+    normalize_api14,
+    split_api14,
+)
+from worldenergydata.texas_rrc.lifecycle.sources import LifecycleInputFrames
+
+
+SOURCE_ORDER = ("wellbore_query", "drilling_permits", "completion_data")
+IDENTIFIER_COLUMNS = (
+    "district",
+    "field_number",
+    "field_name",
+    "lease_number",
+    "lease_name",
+    "operator_number",
+    "operator_name",
+)
+
+
+def normalize_wellbore_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    """Normalize wellbore rows for lifecycle joining."""
+    return _normalize_source_frame(frame)
+
+
+def normalize_permit_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    """Normalize drilling permit rows for lifecycle joining."""
+    return _normalize_source_frame(frame)
+
+
+def normalize_completion_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    """Normalize completion rows for lifecycle joining."""
+    return _normalize_source_frame(frame)
+
+
+def build_lifecycle_spine(inputs: LifecycleInputFrames) -> pd.DataFrame:
+    """Return one lifecycle spine row per API10/API14 well identity."""
+    wellbores = normalize_wellbore_frame(inputs.wellbores)
+    permits = normalize_permit_frame(inputs.permits)
+    completions = normalize_completion_frame(inputs.completions)
+    wellbore_rows = _by_api10(wellbores)
+    permit_rows = _by_api10(permits)
+    completion_rows = _by_api10(completions)
+    api10_values = sorted(set(wellbore_rows) | set(permit_rows) | set(completion_rows))
+    records = [
+        _build_record(api10, wellbore_rows, permit_rows, completion_rows)
+        for api10 in api10_values
+    ]
+    result = pd.DataFrame(records)
+    for column in ("has_wellbore", "has_permit", "has_completion"):
+        if column in result:
+            result[column] = result[column].astype(object)
+    return result
+
+
+def _normalize_source_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    if frame.empty or "api_number" not in frame.columns:
+        return pd.DataFrame()
+    result = frame.copy()
+    result["api14"] = result["api_number"].apply(normalize_api14)
+    result = result[result["api14"].notna()].copy()
+    if result.empty:
+        return result
+    result["api10"] = result["api14"].apply(derive_api10)
+    api_segments = result["api14"].apply(split_api14).apply(pd.Series)
+    for column in ("county_code", "well_unique_number", "sidetrack_code", "completion_code"):
+        result[column] = api_segments[column]
+    return result
+
+
+def _by_api10(frame: pd.DataFrame) -> dict[str, dict[str, Any]]:
+    if frame.empty:
+        return {}
+    rows = {}
+    for api10, group in frame.groupby("api10", sort=True):
+        rows[api10] = _most_complete_row(group).to_dict()
+    return rows
+
+
+def _most_complete_row(group: pd.DataFrame) -> pd.Series:
+    completeness = group.apply(lambda row: sum(_has_value(value) for value in row), axis=1)
+    return group.loc[completeness.idxmax()]
+
+
+def _build_record(
+    api10: str,
+    wellbores: dict[str, dict[str, Any]],
+    permits: dict[str, dict[str, Any]],
+    completions: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    wellbore = wellbores.get(api10, {})
+    permit = permits.get(api10, {})
+    completion = completions.get(api10, {})
+    api14 = _first_value(wellbore, permit, completion, column="api14")
+    record = {"api14": api14, "api10": api10}
+    record.update(split_api14(api14))
+    record.update(_identifier_values(wellbore, completion, permit))
+    record.update(_permit_values(permit))
+    record.update(_lifecycle_values(wellbore, completion, permit))
+    record.update(_well_values(wellbore, permit))
+    record.update(_source_flags(wellbore, permit, completion))
+    record["quality_flags"] = ""
+    return record
+
+
+def _identifier_values(*rows: dict[str, Any]) -> dict[str, Any]:
+    return {column: _first_value(*rows, column=column) for column in IDENTIFIER_COLUMNS}
+
+
+def _permit_values(permit: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "permit_number": permit.get("permit_number"),
+        "permit_status": permit.get("permit_status"),
+        "permit_type": permit.get("permit_type"),
+        "permit_issued_date": permit.get("permit_issued_date"),
+        "permit_amended_date": permit.get("permit_amended_date"),
+        "permit_extended_date": permit.get("permit_extended_date"),
+    }
+
+
+def _lifecycle_values(
+    wellbore: dict[str, Any],
+    completion: dict[str, Any],
+    permit: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "spud_date": permit.get("spud_date"),
+        "completion_date": _first_value(wellbore, completion, column="completion_date"),
+        "plug_date": wellbore.get("plug_date"),
+    }
+
+
+def _well_values(wellbore: dict[str, Any], permit: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "well_status": wellbore.get("well_status"),
+        "well_type": wellbore.get("well_type"),
+        "wellbore_profile": wellbore.get("wellbore_profile"),
+        "total_depth": _first_value(wellbore, permit, column="total_depth"),
+        "latitude": permit.get("latitude") or wellbore.get("latitude"),
+        "longitude": permit.get("longitude") or wellbore.get("longitude"),
+        "coordinates_valid": None,
+    }
+
+
+def _source_flags(
+    wellbore: dict[str, Any],
+    permit: dict[str, Any],
+    completion: dict[str, Any],
+) -> dict[str, Any]:
+    present = {
+        "wellbore_query": bool(wellbore),
+        "drilling_permits": bool(permit),
+        "completion_data": bool(completion),
+    }
+    return {
+        "has_wellbore": present["wellbore_query"],
+        "has_permit": present["drilling_permits"],
+        "has_completion": present["completion_data"],
+        "source_ids": "|".join(source for source in SOURCE_ORDER if present[source]),
+    }
+
+
+def _first_value(*rows: dict[str, Any], column: str) -> Any:
+    for row in rows:
+        value = row.get(column)
+        if _has_value(value):
+            return value
+    return None
+
+
+def _has_value(value: Any) -> bool:
+    return value is not None and value == value and str(value) != ""

--- a/src/worldenergydata/cli/commands/texas_rrc.py
+++ b/src/worldenergydata/cli/commands/texas_rrc.py
@@ -511,6 +511,95 @@ def refresh(
     _execute_refresh_plans(refresher, plans, explicit_sources=bool(source))
 
 
+def _lifecycle_input_paths(raw_root: Path) -> list[str]:
+    raw_path = raw_root / "raw"
+    if not raw_path.exists():
+        return []
+    return [
+        str(path.relative_to(raw_root))
+        for path in sorted(raw_path.rglob("*"))
+        if path.is_file()
+    ]
+
+
+def _print_lifecycle_summary(row_count: int, source_gaps) -> None:
+    table = Table(
+        title="Texas RRC Lifecycle Normalization",
+        show_header=True,
+        header_style="bold cyan",
+    )
+    table.add_column("Metric", style="dim")
+    table.add_column("Value")
+    table.add_row("Lifecycle rows", str(row_count))
+    table.add_row("Source gaps", ", ".join(source_gaps) if source_gaps else "None")
+    console.print(table)
+
+
+@app.command("normalize-lifecycle")
+def normalize_lifecycle(
+    raw_root: Path = typer.Option(
+        Path("/mnt/ace/worldenergydata/data/modules/texas_rrc"),
+        "--raw-root",
+        help="Root containing Texas RRC raw lifecycle snapshots",
+    ),
+    output_root: Path = typer.Option(
+        Path("/mnt/ace/worldenergydata/data/modules/texas_rrc"),
+        "--output-root",
+        help="Root for curated lifecycle outputs",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Build the lifecycle spine summary without writing curated outputs",
+    ),
+    require_sources: bool = typer.Option(
+        False,
+        "--require-sources",
+        help="Fail when any lifecycle source directory is missing or empty",
+    ),
+) -> None:
+    """Normalize local official Texas RRC raw snapshots into a lifecycle spine."""
+    from worldenergydata.texas_rrc.lifecycle.io import write_lifecycle_outputs
+    from worldenergydata.texas_rrc.lifecycle.quality import assess_lifecycle_quality
+    from worldenergydata.texas_rrc.lifecycle.sources import load_lifecycle_inputs
+    from worldenergydata.texas_rrc.lifecycle.spine import build_lifecycle_spine
+
+    try:
+        inputs = load_lifecycle_inputs(raw_root)
+        if require_sources and inputs.source_gaps:
+            console.print(
+                "[red]Error:[/red] missing lifecycle sources: "
+                f"{', '.join(inputs.source_gaps)}"
+            )
+            raise typer.Exit(1)
+
+        spine = build_lifecycle_spine(inputs)
+        quality = assess_lifecycle_quality(spine, source_gaps=inputs.source_gaps)
+        _print_lifecycle_summary(len(spine), inputs.source_gaps)
+
+        if dry_run:
+            console.print("[yellow]Dry run:[/yellow] no lifecycle outputs written")
+            return
+
+        manifest = write_lifecycle_outputs(
+            spine,
+            quality,
+            output_root=output_root,
+            input_paths=_lifecycle_input_paths(raw_root),
+        )
+        console.print(
+            "[green]Wrote lifecycle spine[/green] "
+            f"{manifest.row_count} rows -> {manifest.spine_path}"
+        )
+        console.print(f"[dim]Quality report: {manifest.quality_path}[/dim]")
+        console.print(f"[dim]Manifest: {manifest.manifest_path}[/dim]")
+    except typer.Exit:
+        raise
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+
+
 @app.command()
 def analyze(
     district: Optional[str] = typer.Option(

--- a/src/worldenergydata/cli/commands/texas_rrc.py
+++ b/src/worldenergydata/cli/commands/texas_rrc.py
@@ -557,6 +557,11 @@ def normalize_lifecycle(
         "--require-sources",
         help="Fail when any lifecycle source directory is missing or empty",
     ),
+    allow_non_ace_output: bool = typer.Option(
+        False,
+        "--allow-non-ace-output",
+        help="Allow non-/mnt/ace output roots for isolated tests or sandboxes",
+    ),
 ) -> None:
     """Normalize local official Texas RRC raw snapshots into a lifecycle spine."""
     from worldenergydata.texas_rrc.lifecycle.io import write_lifecycle_outputs
@@ -586,6 +591,7 @@ def normalize_lifecycle(
             quality,
             output_root=output_root,
             input_paths=_lifecycle_input_paths(raw_root),
+            allow_non_ace_root=allow_non_ace_output,
         )
         console.print(
             "[green]Wrote lifecycle spine[/green] "

--- a/tests/unit/texas_rrc/test_lifecycle_cli.py
+++ b/tests/unit/texas_rrc/test_lifecycle_cli.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 import zipfile
+from pathlib import Path
 
 from typer.testing import CliRunner
 

--- a/tests/unit/texas_rrc/test_lifecycle_cli.py
+++ b/tests/unit/texas_rrc/test_lifecycle_cli.py
@@ -24,6 +24,7 @@ def test_normalize_lifecycle_cli_writes_curated_outputs(tmp_path):
             str(raw_root),
             "--output-root",
             str(output_root),
+            "--allow-non-ace-output",
         ],
     )
 

--- a/tests/unit/texas_rrc/test_lifecycle_cli.py
+++ b/tests/unit/texas_rrc/test_lifecycle_cli.py
@@ -1,0 +1,89 @@
+"""CLI tests for Texas RRC lifecycle normalization."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import zipfile
+
+from typer.testing import CliRunner
+
+from worldenergydata.cli.commands.texas_rrc import app
+
+
+def test_normalize_lifecycle_cli_writes_curated_outputs(tmp_path):
+    raw_root = tmp_path / "rrc"
+    output_root = tmp_path / "out"
+    _write_lifecycle_fixture(raw_root)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "normalize-lifecycle",
+            "--raw-root",
+            str(raw_root),
+            "--output-root",
+            str(output_root),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    spine_path = (
+        output_root
+        / "curated"
+        / "well_lifecycle"
+        / "spine"
+        / "well_lifecycle_spine.csv"
+    )
+    quality_path = spine_path.with_name("well_lifecycle_quality.json")
+    manifest_path = spine_path.with_name("manifest.json")
+    assert spine_path.exists()
+    assert quality_path.exists()
+    assert manifest_path.exists()
+    assert "Wrote lifecycle spine" in result.output
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["row_count"] == 1
+    assert manifest["input_paths"]
+
+
+def _write_lifecycle_fixture(root: Path) -> None:
+    _write_zip(
+        root / "raw/wellbore/query/wellbore.zip",
+        "OG_WELLBORE_EWA_Report.csv",
+        "\n".join(
+            [
+                "API_NO,DISTRICT_NO,FIELD_NO,LEASE_NO,OPERATOR_NO,WELL_STATUS",
+                "4200100001,08,12345,98765,456789,A",
+            ]
+        ),
+    )
+    _write_text(
+        root / "raw/permits/drilling/daf420.dat",
+        "\n".join(
+            [
+                "API_NO|PERMIT_NO|APPROVED_DATE|SPUD_DATE|LATITUDE|LONGITUDE",
+                "4200100001|999001|2024-01-15|2024-02-01|31.5|-97.2",
+            ]
+        ),
+    )
+    _write_zip(
+        root / "raw/completions/06-30-2026.zip",
+        "completion.csv",
+        "\n".join(
+            [
+                "API_NO,COMPL_DATE,FORM_TYPE,FIELD_NO,LEASE_NO,OPERATOR_NO",
+                "4200100001,2024-03-01,W-2,12345,98765,456789",
+            ]
+        ),
+    )
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_zip(path: Path, member_name: str, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr(member_name, content)

--- a/tests/unit/texas_rrc/test_lifecycle_io.py
+++ b/tests/unit/texas_rrc/test_lifecycle_io.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 import json
 
 import pandas as pd
+import pytest
 
 from worldenergydata.texas_rrc.lifecycle.quality import LifecycleQualityReport
 
@@ -44,6 +45,7 @@ def test_write_lifecycle_outputs_persists_spine_quality_and_manifest(tmp_path):
         output_root=tmp_path,
         generated_at=datetime(2026, 6, 30, 20, 0, tzinfo=timezone.utc),
         input_paths=["raw/wellbore/query/wellbore.zip"],
+        allow_non_ace_root=True,
     )
 
     spine_path = (
@@ -66,3 +68,28 @@ def test_write_lifecycle_outputs_persists_spine_quality_and_manifest(tmp_path):
     assert manifest_payload["row_count"] == 1
     assert manifest_payload["input_paths"] == ["raw/wellbore/query/wellbore.zip"]
     assert not list(tmp_path.rglob(".staging-*"))
+
+
+def test_write_lifecycle_outputs_rejects_non_ace_root_without_override(tmp_path):
+    from worldenergydata.texas_rrc.lifecycle.io import write_lifecycle_outputs
+
+    quality = LifecycleQualityReport(
+        row_count=0,
+        duplicate_api14=0,
+        missing_field_id=0,
+        missing_lease_id=0,
+        missing_operator_id=0,
+        invalid_coordinates=0,
+        impossible_dates=0,
+        permit_without_wellbore=0,
+        completion_without_wellbore=0,
+        wellbore_without_completion=0,
+        source_gaps=(),
+    )
+
+    with pytest.raises(ValueError, match="/mnt/ace"):
+        write_lifecycle_outputs(
+            pd.DataFrame(),
+            quality,
+            output_root=tmp_path,
+        )

--- a/tests/unit/texas_rrc/test_lifecycle_io.py
+++ b/tests/unit/texas_rrc/test_lifecycle_io.py
@@ -1,0 +1,72 @@
+"""Tests for Texas RRC lifecycle output persistence."""
+
+from datetime import datetime, timezone
+import json
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.lifecycle.quality import LifecycleQualityReport
+
+
+def test_write_lifecycle_outputs_persists_spine_quality_and_manifest(tmp_path):
+    from worldenergydata.texas_rrc.lifecycle.io import (
+        load_lifecycle_spine,
+        write_lifecycle_outputs,
+    )
+
+    spine = pd.DataFrame(
+        [
+            {
+                "api14": "42001000010000",
+                "api10": "4200100001",
+                "field_number": "11111",
+                "quality_flags": "",
+            }
+        ]
+    )
+    quality = LifecycleQualityReport(
+        row_count=1,
+        duplicate_api14=0,
+        missing_field_id=0,
+        missing_lease_id=0,
+        missing_operator_id=0,
+        invalid_coordinates=0,
+        impossible_dates=0,
+        permit_without_wellbore=0,
+        completion_without_wellbore=0,
+        wellbore_without_completion=0,
+        source_gaps=("directional_surveys",),
+    )
+
+    manifest = write_lifecycle_outputs(
+        spine,
+        quality,
+        output_root=tmp_path,
+        generated_at=datetime(2026, 6, 30, 20, 0, tzinfo=timezone.utc),
+        input_paths=["raw/wellbore/query/wellbore.zip"],
+    )
+
+    spine_path = (
+        tmp_path
+        / "curated"
+        / "well_lifecycle"
+        / "spine"
+        / "well_lifecycle_spine.csv"
+    )
+    quality_path = spine_path.with_name("well_lifecycle_quality.json")
+    manifest_path = spine_path.with_name("manifest.json")
+    assert manifest.spine_path == spine_path
+    assert manifest.quality_path == quality_path
+    assert manifest.manifest_path == manifest_path
+    assert spine_path.exists()
+    assert load_lifecycle_spine(spine_path).loc[0, "api14"] == "42001000010000"
+
+    quality_payload = json.loads(quality_path.read_text(encoding="utf-8"))
+    assert quality_payload["row_count"] == 1
+    assert quality_payload["source_gaps"] == ["directional_surveys"]
+
+    manifest_payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest_payload["generated_at"] == "2026-06-30T20:00:00Z"
+    assert manifest_payload["row_count"] == 1
+    assert manifest_payload["input_paths"] == ["raw/wellbore/query/wellbore.zip"]
+    assert not list(tmp_path.rglob(".staging-*"))

--- a/tests/unit/texas_rrc/test_lifecycle_io.py
+++ b/tests/unit/texas_rrc/test_lifecycle_io.py
@@ -1,7 +1,7 @@
 """Tests for Texas RRC lifecycle output persistence."""
 
-from datetime import datetime, timezone
 import json
+from datetime import datetime, timezone
 
 import pandas as pd
 import pytest

--- a/tests/unit/texas_rrc/test_lifecycle_io.py
+++ b/tests/unit/texas_rrc/test_lifecycle_io.py
@@ -47,11 +47,7 @@ def test_write_lifecycle_outputs_persists_spine_quality_and_manifest(tmp_path):
     )
 
     spine_path = (
-        tmp_path
-        / "curated"
-        / "well_lifecycle"
-        / "spine"
-        / "well_lifecycle_spine.csv"
+        tmp_path / "curated" / "well_lifecycle" / "spine" / "well_lifecycle_spine.csv"
     )
     quality_path = spine_path.with_name("well_lifecycle_quality.json")
     manifest_path = spine_path.with_name("manifest.json")

--- a/tests/unit/texas_rrc/test_lifecycle_keys.py
+++ b/tests/unit/texas_rrc/test_lifecycle_keys.py
@@ -1,0 +1,51 @@
+"""Tests for Texas RRC lifecycle API key normalization."""
+
+import pytest
+
+from worldenergydata.texas_rrc.lifecycle.keys import (
+    derive_api10,
+    normalize_api14,
+    split_api14,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw_api", "expected"),
+    [
+        ("42-001-00001", "42001000010000"),
+        ("4200100001", "42001000010000"),
+        ("420010000100", "42001000010000"),
+        ("42001000010102", "42001000010102"),
+    ],
+)
+def test_normalize_api14_accepts_common_rrc_api_shapes(raw_api, expected):
+    assert normalize_api14(raw_api) == expected
+
+
+@pytest.mark.parametrize(
+    "raw_api",
+    [
+        "4300100001",
+        "420010001",
+        "not-an-api",
+        "",
+        None,
+    ],
+)
+def test_normalize_api14_rejects_invalid_or_non_texas_values(raw_api):
+    assert normalize_api14(raw_api) is None
+
+
+def test_split_api14_returns_join_segments():
+    assert split_api14("42001000010102") == {
+        "api10": "4200100001",
+        "county_code": "001",
+        "well_unique_number": "00001",
+        "sidetrack_code": "01",
+        "completion_code": "02",
+    }
+
+
+def test_derive_api10_returns_base_join_key():
+    assert derive_api10("42001000010102") == "4200100001"
+    assert derive_api10(None) is None

--- a/tests/unit/texas_rrc/test_lifecycle_keys.py
+++ b/tests/unit/texas_rrc/test_lifecycle_keys.py
@@ -12,6 +12,7 @@ from worldenergydata.texas_rrc.lifecycle.keys import (
 @pytest.mark.parametrize(
     ("raw_api", "expected"),
     [
+        ("00100001", "42001000010000"),
         ("42-001-00001", "42001000010000"),
         ("4200100001", "42001000010000"),
         ("420010000100", "42001000010000"),

--- a/tests/unit/texas_rrc/test_lifecycle_quality.py
+++ b/tests/unit/texas_rrc/test_lifecycle_quality.py
@@ -1,0 +1,60 @@
+"""Tests for Texas RRC lifecycle spine quality checks."""
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.lifecycle.quality import assess_lifecycle_quality
+
+
+def test_assess_lifecycle_quality_counts_core_gap_classes():
+    spine = pd.DataFrame(
+        [
+            {
+                "api14": "42001000010000",
+                "field_number": "",
+                "lease_number": None,
+                "operator_number": "",
+                "latitude": "40.0",
+                "longitude": "-97.2",
+                "permit_issued_date": "2024-02-15",
+                "spud_date": "2024-02-01",
+                "completion_date": "2024-04-01",
+                "plug_date": "2024-03-01",
+                "has_wellbore": False,
+                "has_permit": True,
+                "has_completion": True,
+                "quality_flags": "",
+            },
+            {
+                "api14": "42001000010000",
+                "field_number": "11111",
+                "lease_number": "22222",
+                "operator_number": "333333",
+                "latitude": "31.5",
+                "longitude": "-97.2",
+                "permit_issued_date": "2024-01-15",
+                "spud_date": "2024-02-01",
+                "completion_date": "",
+                "plug_date": "",
+                "has_wellbore": True,
+                "has_permit": False,
+                "has_completion": False,
+                "quality_flags": "",
+            },
+        ]
+    )
+
+    report = assess_lifecycle_quality(spine, source_gaps=("directional_surveys",))
+
+    assert report.row_count == 2
+    assert report.duplicate_api14 == 1
+    assert report.missing_field_id == 1
+    assert report.missing_lease_id == 1
+    assert report.missing_operator_id == 1
+    assert report.invalid_coordinates == 1
+    assert report.impossible_dates == 1
+    assert report.permit_without_wellbore == 1
+    assert report.completion_without_wellbore == 1
+    assert report.wellbore_without_completion == 1
+    assert report.source_gaps == ("directional_surveys",)
+    assert "missing_field_id" in spine.loc[0, "quality_flags"]
+    assert "wellbore_without_completion" in spine.loc[1, "quality_flags"]

--- a/tests/unit/texas_rrc/test_lifecycle_quality.py
+++ b/tests/unit/texas_rrc/test_lifecycle_quality.py
@@ -58,3 +58,31 @@ def test_assess_lifecycle_quality_counts_core_gap_classes():
     assert report.source_gaps == ("directional_surveys",)
     assert "missing_field_id" in spine.loc[0, "quality_flags"]
     assert "wellbore_without_completion" in spine.loc[1, "quality_flags"]
+
+
+def test_assess_lifecycle_quality_accepts_official_completion_date_format():
+    spine = pd.DataFrame(
+        [
+            {
+                "api14": "42001000010000",
+                "field_number": "11111",
+                "lease_number": "22222",
+                "operator_number": "333333",
+                "latitude": "31.5",
+                "longitude": "-97.2",
+                "permit_issued_date": "2024-02-01",
+                "spud_date": "2024-04-01",
+                "completion_date": "03/01/2024",
+                "plug_date": "",
+                "has_wellbore": True,
+                "has_permit": True,
+                "has_completion": True,
+                "quality_flags": "",
+            },
+        ]
+    )
+
+    report = assess_lifecycle_quality(spine)
+
+    assert report.impossible_dates == 1
+    assert "impossible_dates" in spine.loc[0, "quality_flags"]

--- a/tests/unit/texas_rrc/test_lifecycle_sources.py
+++ b/tests/unit/texas_rrc/test_lifecycle_sources.py
@@ -8,6 +8,17 @@ from pathlib import Path
 from worldenergydata.texas_rrc.lifecycle.sources import load_lifecycle_inputs
 
 
+def _fixed_record(
+    *, record_type: str, length: int = 512, values: dict[int, str]
+) -> str:
+    chars = [" "] * length
+    chars[2:4] = record_type
+    for start, value in values.items():
+        index = start - 1
+        chars[index : index + len(value)] = value
+    return "".join(chars)
+
+
 def _write_text(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
@@ -65,3 +76,73 @@ def test_load_lifecycle_inputs_reads_local_raw_snapshots(tmp_path):
     assert inputs.permits.iloc[0]["spud_date"] == "2024-02-01"
     assert inputs.completions.iloc[0]["completion_date"] == "2024-03-01"
     assert inputs.completions.iloc[0]["form_type"] == "W-2"
+
+
+def test_load_lifecycle_inputs_reads_official_daf420_fixed_records(tmp_path):
+    master_record = _fixed_record(
+        record_type="02",
+        values={
+            5: "0999001",
+            14: "001",
+            17: "SPRABERRY UNIT                  ",
+            49: "08",
+            57: "12000",
+            62: "456789",
+            68: "12",
+            132: "20240115",
+            140: "20240201",
+            148: "20250115",
+            156: "20240220",
+            505: "00100001",
+        },
+    )
+    surface_location_record = _fixed_record(
+        record_type="14",
+        length=28,
+        values={
+            5: "000972000000",
+            17: "000315000000",
+        },
+    )
+    _write_text(
+        tmp_path / "raw/permits/drilling/daf420.dat",
+        "\n".join([master_record, surface_location_record]),
+    )
+
+    inputs = load_lifecycle_inputs(tmp_path)
+
+    assert inputs.source_gaps == ("wellbore_query", "completion_data")
+    assert inputs.permits.iloc[0].to_dict() == {
+        "api_number": "00100001",
+        "permit_number": "0999001",
+        "permit_type": "12",
+        "district": "08",
+        "lease_name": "SPRABERRY UNIT",
+        "operator_number": "456789",
+        "permit_issued_date": "2024-01-15",
+        "permit_amended_date": "2024-02-01",
+        "permit_extended_date": "2025-01-15",
+        "spud_date": "2024-02-20",
+        "latitude": "31.5",
+        "longitude": "-97.2",
+        "total_depth": "12000",
+    }
+
+
+def test_load_lifecycle_inputs_maps_official_completion_date_alias(tmp_path):
+    _write_zip(
+        tmp_path / "raw/completions/06-30-2026.zip",
+        "completion.csv",
+        "\n".join(
+            [
+                "API_NO,CMPL_OR_RECMPL_DATE,FORM_TYPE",
+                "00100001,2024-03-01,W-2",
+            ]
+        ),
+    )
+
+    inputs = load_lifecycle_inputs(tmp_path)
+
+    assert inputs.source_gaps == ("wellbore_query", "drilling_permits")
+    assert inputs.completions.iloc[0]["api_number"] == "00100001"
+    assert inputs.completions.iloc[0]["completion_date"] == "2024-03-01"

--- a/tests/unit/texas_rrc/test_lifecycle_sources.py
+++ b/tests/unit/texas_rrc/test_lifecycle_sources.py
@@ -19,6 +19,17 @@ def _fixed_record(
     return "".join(chars)
 
 
+def _fixed_record_with_leading_type(
+    *, record_type: str, length: int = 510, values: dict[int, str]
+) -> str:
+    chars = [" "] * length
+    chars[0:2] = record_type
+    for start, value in values.items():
+        index = start - 1
+        chars[index : index + len(value)] = value
+    return "".join(chars)
+
+
 def _write_text(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
@@ -127,6 +138,32 @@ def test_load_lifecycle_inputs_reads_official_daf420_fixed_records(tmp_path):
         "longitude": "-97.2",
         "total_depth": "12000",
     }
+
+
+def test_load_lifecycle_inputs_prefers_leading_daf420_record_type(tmp_path):
+    master_record = _fixed_record_with_leading_type(
+        record_type="02",
+        values={
+            3: "1400001",
+            12: "001",
+            15: "MIDLAND UNIT                    ",
+            47: "08",
+            55: "10500",
+            60: "456789",
+            66: "01",
+            130: "20240115",
+            154: "20240220",
+            503: "00100002",
+        },
+    )
+    _write_text(tmp_path / "raw/permits/drilling/daf420.dat", master_record)
+
+    inputs = load_lifecycle_inputs(tmp_path)
+
+    assert inputs.source_gaps == ("wellbore_query", "completion_data")
+    assert inputs.permits.iloc[0]["api_number"] == "00100002"
+    assert inputs.permits.iloc[0]["permit_number"] == "1400001"
+    assert inputs.permits.iloc[0]["spud_date"] == "2024-02-20"
 
 
 def test_load_lifecycle_inputs_maps_official_completion_date_alias(tmp_path):

--- a/tests/unit/texas_rrc/test_lifecycle_sources.py
+++ b/tests/unit/texas_rrc/test_lifecycle_sources.py
@@ -1,0 +1,67 @@
+"""Tests for loading Texas RRC lifecycle source snapshots."""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+from worldenergydata.texas_rrc.lifecycle.sources import load_lifecycle_inputs
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_zip(path: Path, member_name: str, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr(member_name, content)
+
+
+def test_load_lifecycle_inputs_reads_local_raw_snapshots(tmp_path):
+    _write_zip(
+        tmp_path / "raw/wellbore/query/wellbore.zip",
+        "OG_WELLBORE_EWA_Report.csv",
+        "\n".join(
+            [
+                "API_NO,DISTRICT_NO,FIELD_NO,LEASE_NO,OPERATOR_NO,WELL_STATUS",
+                "4200100001,08,12345,98765,456789,A",
+            ]
+        ),
+    )
+    _write_text(
+        tmp_path / "raw/permits/drilling/daf420.dat",
+        "\n".join(
+            [
+                "API_NO|PERMIT_NO|APPROVED_DATE|SPUD_DATE|LATITUDE|LONGITUDE",
+                "4200100001|999001|2024-01-15|2024-02-01|31.5|-97.2",
+            ]
+        ),
+    )
+    _write_zip(
+        tmp_path / "raw/completions/06-30-2026.zip",
+        "completion.csv",
+        "\n".join(
+            [
+                "API_NO,COMPL_DATE,FORM_TYPE,FIELD_NO,LEASE_NO,OPERATOR_NO",
+                "4200100001,2024-03-01,W-2,12345,98765,456789",
+            ]
+        ),
+    )
+
+    inputs = load_lifecycle_inputs(tmp_path)
+
+    assert inputs.source_gaps == ()
+    assert inputs.wellbores.iloc[0].to_dict() == {
+        "api_number": "4200100001",
+        "district": "08",
+        "field_number": "12345",
+        "lease_number": "98765",
+        "operator_number": "456789",
+        "well_status": "A",
+    }
+    assert inputs.permits.iloc[0]["permit_number"] == "999001"
+    assert inputs.permits.iloc[0]["spud_date"] == "2024-02-01"
+    assert inputs.completions.iloc[0]["completion_date"] == "2024-03-01"
+    assert inputs.completions.iloc[0]["form_type"] == "W-2"

--- a/tests/unit/texas_rrc/test_lifecycle_spine.py
+++ b/tests/unit/texas_rrc/test_lifecycle_spine.py
@@ -53,17 +53,37 @@ def test_build_lifecycle_spine_joins_sources_by_api14():
 
     spine = build_lifecycle_spine(inputs)
 
-    assert len(spine) == 1
-    row = spine.iloc[0]
-    assert row["api14"] == "42001000010000"
-    assert row["api10"] == "4200100001"
-    assert row["field_number"] == "11111"
-    assert row["lease_number"] == "22222"
-    assert row["operator_number"] == "333333"
-    assert row["permit_number"] == "999001"
-    assert row["spud_date"] == "2024-02-01"
-    assert row["completion_date"] == "2024-03-01"
-    assert row["has_wellbore"] is True
-    assert row["has_permit"] is True
-    assert row["has_completion"] is True
-    assert row["source_ids"] == "wellbore_query|drilling_permits|completion_data"
+    assert sorted(spine["api14"].tolist()) == [
+        "42001000010000",
+        "42001000010102",
+    ]
+    base_row = spine.set_index("api14").loc["42001000010000"]
+    assert base_row["api10"] == "4200100001"
+    assert base_row["field_number"] == "11111"
+    assert base_row["lease_number"] == "22222"
+    assert base_row["operator_number"] == "333333"
+    assert base_row["permit_number"] == "999001"
+    assert base_row["spud_date"] == "2024-02-01"
+    assert base_row["completion_date"] is None
+    assert base_row["has_wellbore"] is True
+    assert base_row["has_permit"] is True
+    assert base_row["has_completion"] is False
+    assert base_row["source_ids"] == "wellbore_query|drilling_permits"
+
+    completion_row = spine.set_index("api14").loc["42001000010102"]
+    assert completion_row["api10"] == "4200100001"
+    assert completion_row["sidetrack_code"] == "01"
+    assert completion_row["completion_code"] == "02"
+    assert completion_row["field_number"] == "11111"
+    assert completion_row["lease_number"] == "22222"
+    assert completion_row["operator_number"] == "333333"
+    assert completion_row["permit_number"] == "999001"
+    assert completion_row["spud_date"] == "2024-02-01"
+    assert completion_row["completion_date"] == "2024-03-01"
+    assert completion_row["has_wellbore"] is True
+    assert completion_row["has_permit"] is True
+    assert completion_row["has_completion"] is True
+    assert (
+        completion_row["source_ids"]
+        == "wellbore_query|drilling_permits|completion_data"
+    )

--- a/tests/unit/texas_rrc/test_lifecycle_spine.py
+++ b/tests/unit/texas_rrc/test_lifecycle_spine.py
@@ -1,0 +1,69 @@
+"""Tests for Texas RRC lifecycle spine assembly."""
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.lifecycle.sources import LifecycleInputFrames
+from worldenergydata.texas_rrc.lifecycle.spine import build_lifecycle_spine
+
+
+def test_build_lifecycle_spine_joins_sources_by_api14():
+    inputs = LifecycleInputFrames(
+        wellbores=pd.DataFrame(
+            [
+                {
+                    "api_number": "4200100001",
+                    "district": "08",
+                    "field_number": "11111",
+                    "field_name": "SPRABERRY",
+                    "lease_number": "22222",
+                    "operator_number": "333333",
+                    "well_status": "A",
+                    "well_type": "O",
+                    "total_depth": "12000",
+                }
+            ]
+        ),
+        permits=pd.DataFrame(
+            [
+                {
+                    "api_number": "420010000100",
+                    "permit_number": "999001",
+                    "field_number": "99999",
+                    "permit_issued_date": "2024-01-15",
+                    "spud_date": "2024-02-01",
+                    "latitude": "31.5",
+                    "longitude": "-97.2",
+                }
+            ]
+        ),
+        completions=pd.DataFrame(
+            [
+                {
+                    "api_number": "42001000010102",
+                    "completion_date": "2024-03-01",
+                    "form_type": "W-2",
+                    "field_number": "88888",
+                    "lease_number": "77777",
+                    "operator_number": "666666",
+                }
+            ]
+        ),
+        source_gaps=(),
+    )
+
+    spine = build_lifecycle_spine(inputs)
+
+    assert len(spine) == 1
+    row = spine.iloc[0]
+    assert row["api14"] == "42001000010000"
+    assert row["api10"] == "4200100001"
+    assert row["field_number"] == "11111"
+    assert row["lease_number"] == "22222"
+    assert row["operator_number"] == "333333"
+    assert row["permit_number"] == "999001"
+    assert row["spud_date"] == "2024-02-01"
+    assert row["completion_date"] == "2024-03-01"
+    assert row["has_wellbore"] is True
+    assert row["has_permit"] is True
+    assert row["has_completion"] is True
+    assert row["source_ids"] == "wellbore_query|drilling_permits|completion_data"


### PR DESCRIPTION
## Summary

- Adds Texas RRC lifecycle modules for API14/API10 normalization, direct-source snapshot loading, spine assembly, quality flags, and curated output persistence.
- Adds `worldenergydata texas-rrc normalize-lifecycle` to build the lifecycle spine from local official RRC raw snapshots and write curated outputs under `/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/well_lifecycle/spine/`.
- Hardens the direct-source path for official Texas RRC data: accepts official eight-digit RRC API numbers, parses `daf420.dat` fixed-record drilling-permit master/type-14 surface-location records using the official leading record type before fallback alignment, preserves suffixed API14 completion rows, accepts official `MM/DD/YYYY` completion dates in quality checks, and enforces `/mnt/ace` output by default.
- Documents the source lifecycle, refresh cadence, storage contract, and onshore field-development use cases.

## Validation

- `uv run pytest tests/unit/texas_rrc -q` -> `417 passed`
- `uv run pytest tests/unit/texas_rrc/test_lifecycle_keys.py tests/unit/texas_rrc/test_lifecycle_sources.py tests/unit/texas_rrc/test_lifecycle_spine.py tests/unit/texas_rrc/test_lifecycle_quality.py tests/unit/texas_rrc/test_lifecycle_io.py tests/unit/texas_rrc/test_lifecycle_cli.py -q` -> `22 passed`
- `uv run black --check packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/keys.py packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/sources.py packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/spine.py packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/quality.py packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/io.py src/worldenergydata/cli/commands/texas_rrc.py tests/unit/texas_rrc/test_lifecycle_keys.py tests/unit/texas_rrc/test_lifecycle_sources.py tests/unit/texas_rrc/test_lifecycle_spine.py tests/unit/texas_rrc/test_lifecycle_quality.py tests/unit/texas_rrc/test_lifecycle_io.py tests/unit/texas_rrc/test_lifecycle_cli.py` -> passed
- `uv run ruff check packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/keys.py packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/sources.py packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/spine.py packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/quality.py packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/io.py src/worldenergydata/cli/commands/texas_rrc.py tests/unit/texas_rrc/test_lifecycle_keys.py tests/unit/texas_rrc/test_lifecycle_sources.py tests/unit/texas_rrc/test_lifecycle_spine.py tests/unit/texas_rrc/test_lifecycle_quality.py tests/unit/texas_rrc/test_lifecycle_io.py tests/unit/texas_rrc/test_lifecycle_cli.py` -> passed
- `scripts/legal/legal-sanity-scan.sh` -> `LEGAL_SCAN_MISSING` (script is not present in this repo checkout)

## Direct-source notes

- Official RRC drilling-permit layout reference used for `daf420.dat`: https://www.rrc.texas.gov/media/zgccdjpi/drillingpermitmasterpluslatitudeslongitudes_oga049m_july1.pdf
- Official RRC completion-data manual reference used for `MM/DD/YYYY` completion-date quality parsing: https://www.rrc.texas.gov/media/ltudbyql/cmpldatasubscriptions_usermanual_20171101.pdf
- PatchOps and RRC EWA remain validation-only surfaces, not durable source-of-record inputs.

## Known repo lint note

- A broad `uv run ruff check ... tests/unit/texas_rrc` still fails on pre-existing legacy test issues outside this branch, including unused imports and `== True/False` assertions in existing processor tests.

Closes #662