### PR TITLE
feat(onshore): build Texas RRC field-development metrics

### DIFF
--- a/docs/data-sources/onshore/texas-rrc/field-development-metrics.md
+++ b/docs/data-sources/onshore/texas-rrc/field-development-metrics.md
@@ -1,0 +1,113 @@
+# Texas RRC Field Development Metrics
+
+Texas RRC field-development metrics join the curated well lifecycle spine with
+the field-level production atlas. The output is the onshore analog to the BSEE
+field-development workflow: one row per RRC district and field number, with well
+counts, lifecycle timing, production maturity, remaining activity, and ranking
+features for later field architecture work.
+
+## Source Of Record
+
+The command uses direct Texas RRC source-derived artifacts only.
+
+| Input | Upstream source | Refresh cycle | Curated path |
+| --- | --- | --- | --- |
+| Lifecycle spine | `wellbore_query`, `drilling_permits`, `completion_data` | Monthly for wellbore query; nightly for permits and completions | `/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/well_lifecycle/spine` |
+| Production atlas | `production_pdq` | Monthly, after the last Saturday | `/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/production/field_atlas` |
+
+PatchOps, EWA web forms, and third-party scraper code remain validation
+surfaces only. They are not durable inputs for this output.
+
+## Command
+
+Build or refresh upstream direct-source artifacts first:
+
+```bash
+uv run worldenergydata texas-rrc refresh --source wellbore_query
+uv run worldenergydata texas-rrc refresh --source drilling_permits
+uv run worldenergydata texas-rrc refresh --source completion_data
+uv run worldenergydata texas-rrc refresh --source production_pdq
+uv run worldenergydata texas-rrc normalize-lifecycle --require-sources
+uv run worldenergydata texas-rrc build-production-atlas --require-sources
+```
+
+Then build the field-development metrics:
+
+```bash
+uv run worldenergydata texas-rrc build-field-development-metrics --require-sources
+```
+
+Use `--dry-run` to inspect row counts and source gaps without writing outputs:
+
+```bash
+uv run worldenergydata texas-rrc build-field-development-metrics --dry-run
+```
+
+If curated lifecycle or production artifacts are missing but local raw snapshots
+already exist, the command can rebuild those prerequisites without touching the
+network:
+
+```bash
+uv run worldenergydata texas-rrc build-field-development-metrics \
+  --build-missing-lifecycle \
+  --build-missing-production \
+  --require-sources
+```
+
+Sandbox runs must explicitly opt into non-ACE output roots:
+
+```bash
+uv run worldenergydata texas-rrc build-field-development-metrics \
+  --root /tmp/texas_rrc \
+  --output-root /tmp/texas_rrc_out \
+  --allow-non-ace-output
+```
+
+## Output Contract
+
+The command writes:
+
+```text
+/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/field_development/metrics/
++-- field_development_metrics.csv
++-- field_development_metrics.parquet
++-- field_development_metrics_quality.json
++-- manifest.json
+```
+
+Writes are staged under `.staging-field-development-metrics-*` before
+promotion. By default, writes outside
+`/mnt/ace/worldenergydata/data/modules/texas_rrc` are rejected.
+
+## Metrics
+
+Stable output columns include district and field identifiers, well count,
+active and plugged well counts, permit and completion counts, horizontal and
+directional well counts, drilling-to-completion timing, production start and end
+months, cumulative oil, gas, condensate, and BOE, production per well, lease and
+operator counts, top operator share, maturity class, remaining activity score,
+well density proxy, rank columns, source caveats, and quality flags.
+
+Ranking columns are:
+
+- `rank_cumulative_boe`
+- `rank_remaining_activity`
+- `rank_well_density_proxy`
+- `rank_development_maturity`
+
+`well_density_proxy` is `well_count / lease_count` with
+`well_density_basis = wells_per_lease`. It is not a surface-acreage density.
+
+## Known Caveats
+
+- PDQ production is lease and field grain; this output does not allocate
+  production volumes to individual wells.
+- Fields with lifecycle rows but no production atlas row carry
+  `missing_production`.
+- Fields with production atlas rows but no lifecycle row carry
+  `missing_lifecycle`.
+- `water_and_well_count_unavailable_from_pdq` is preserved from the production
+  atlas quality contract when the direct PDQ member does not expose those
+  values.
+- Pipeline proximity, GIS acreage density, field economics, reserves, and
+  published field reports remain separate follow-on scopes.

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/data/lifecycle_column_aliases.yml
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/data/lifecycle_column_aliases.yml
@@ -7,6 +7,7 @@ sources:
     district:
       - DISTRICT_NO
       - DISTRICT
+      - DISTRICT_CODE
     field_number:
       - FIELD_NO
       - FIELD_NUMBER
@@ -25,15 +26,19 @@ sources:
     well_status:
       - WELL_STATUS
       - STATUS
+      - WELL_TYPE_NAME
     well_type:
       - WELL_TYPE
       - TYPE
+      - OIL_GAS_CODE
     total_depth:
       - TOTAL_DEPTH
       - TD
+      - API_DEPTH
     completion_date:
       - COMPLETION_DATE
       - COMPL_DATE
+      - ORIG_COMPLETION_DT
     plug_date:
       - PLUG_DATE
 

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/__init__.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/__init__.py
@@ -1,0 +1,11 @@
+"""Field-development metrics tools for Texas RRC curated data."""
+
+from worldenergydata.texas_rrc.field_development.sources import (
+    FieldDevelopmentInputs,
+    load_field_development_inputs,
+)
+
+__all__ = [
+    "FieldDevelopmentInputs",
+    "load_field_development_inputs",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/__init__.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/__init__.py
@@ -1,7 +1,16 @@
 """Field-development metrics tools for Texas RRC curated data."""
 
+from worldenergydata.texas_rrc.field_development.io import (
+    FieldDevelopmentOutputManifest,
+    load_field_development_metrics,
+    write_field_development_outputs,
+)
 from worldenergydata.texas_rrc.field_development.metrics import (
     build_field_development_metrics,
+)
+from worldenergydata.texas_rrc.field_development.quality import (
+    FieldDevelopmentQualityReport,
+    assess_field_development_quality,
 )
 from worldenergydata.texas_rrc.field_development.sources import (
     FieldDevelopmentInputs,
@@ -10,6 +19,11 @@ from worldenergydata.texas_rrc.field_development.sources import (
 
 __all__ = [
     "FieldDevelopmentInputs",
+    "FieldDevelopmentOutputManifest",
+    "FieldDevelopmentQualityReport",
+    "assess_field_development_quality",
     "build_field_development_metrics",
+    "load_field_development_metrics",
     "load_field_development_inputs",
+    "write_field_development_outputs",
 ]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/__init__.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/__init__.py
@@ -1,5 +1,8 @@
 """Field-development metrics tools for Texas RRC curated data."""
 
+from worldenergydata.texas_rrc.field_development.metrics import (
+    build_field_development_metrics,
+)
 from worldenergydata.texas_rrc.field_development.sources import (
     FieldDevelopmentInputs,
     load_field_development_inputs,
@@ -7,5 +10,6 @@ from worldenergydata.texas_rrc.field_development.sources import (
 
 __all__ = [
     "FieldDevelopmentInputs",
+    "build_field_development_metrics",
     "load_field_development_inputs",
 ]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/_lifecycle_aggregation.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/_lifecycle_aggregation.py
@@ -1,0 +1,105 @@
+"""Vectorized lifecycle aggregation for field-development metrics."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.field_development._metrics_helpers import ensure_columns
+
+
+def aggregate_lifecycle(
+    lifecycle: pd.DataFrame,
+    field_keys: Sequence[str],
+    input_columns: list[str],
+    empty_frame: pd.DataFrame,
+) -> pd.DataFrame:
+    """Aggregate well-level lifecycle rows into field-level metrics."""
+    if lifecycle.empty:
+        return empty_frame
+    frame = lifecycle.copy()
+    ensure_columns(frame, input_columns)
+    keys = list(field_keys)
+    selected_columns = list(dict.fromkeys(keys + input_columns))
+    working = frame.loc[:, selected_columns].copy()
+    _add_lifecycle_aggregation_columns(working)
+    grouped = working.groupby(keys, sort=True, dropna=True)
+    counts = grouped.size()
+    if counts.empty:
+        return empty_frame
+    result = pd.DataFrame(index=counts.index)
+    result["well_count"] = counts
+    result["lifecycle_field_name"] = grouped["_field_name_value"].first()
+    result["active_well_count"] = grouped["_active_well"].sum()
+    result["plugged_well_count"] = grouped["_plugged_well"].sum()
+    result["permit_count"] = grouped["_permit_present"].sum()
+    result["completion_count"] = grouped["_completion_present"].sum()
+    result["horizontal_well_count"] = grouped["_horizontal_well"].sum()
+    result["directional_well_count"] = grouped["_directional_well"].sum()
+    result["median_permit_to_completion_days"] = grouped[
+        "_permit_to_completion_days"
+    ].median()
+    result["completion_dates"] = grouped["_completion_date_value"].agg(
+        _completion_dates
+    )
+    result["lifecycle_lease_count"] = grouped["_lease_number_value"].nunique(
+        dropna=True
+    )
+    result["lifecycle_operator_count"] = grouped["_operator_number_value"].nunique(
+        dropna=True
+    )
+    return result.reset_index()
+
+
+def _add_lifecycle_aggregation_columns(frame: pd.DataFrame) -> None:
+    status = frame["well_status"].astype("string").str.upper()
+    profile = _profile_text(frame)
+    completion_dates = pd.to_datetime(frame["completion_date"], errors="coerce")
+    permit_dates = pd.to_datetime(frame["permit_issued_date"], errors="coerce")
+    permit_to_completion = (completion_dates - permit_dates).dt.days
+
+    frame["_field_name_value"] = _value_series(frame["field_name"])
+    frame["_lease_number_value"] = _value_series(frame["lease_number"])
+    frame["_operator_number_value"] = _value_series(frame["operator_number"])
+    frame["_active_well"] = status.str.contains(
+        "PRODUCING|ACTIVE|FLOWING|SHUT IN",
+        regex=True,
+        na=False,
+    )
+    frame["_plugged_well"] = status.str.contains("PLUG", regex=False, na=False)
+    frame["_permit_present"] = _present(frame["permit_number"])
+    frame["_completion_present"] = _present(frame["completion_date"])
+    frame["_horizontal_well"] = profile.str.contains(
+        "HORIZONTAL", regex=False, na=False
+    ) | profile.str.contains(r"(?:^|\s)HZ", regex=True, na=False)
+    frame["_directional_well"] = profile.str.contains(
+        "DIRECTIONAL", regex=False, na=False
+    ) | profile.str.contains(r"(?:^|\s)DIR", regex=True, na=False)
+    frame["_permit_to_completion_days"] = permit_to_completion.where(
+        permit_to_completion >= 0
+    )
+    frame["_completion_date_value"] = completion_dates
+
+
+def _profile_text(frame: pd.DataFrame) -> pd.Series:
+    profile = frame["wellbore_profile"].astype("string").fillna("")
+    well_type = frame["well_type"].astype("string").fillna("")
+    return (profile + " " + well_type).str.upper()
+
+
+def _present(values: pd.Series) -> pd.Series:
+    text = values.astype("string")
+    return text.notna() & text.ne("")
+
+
+def _value_series(values: pd.Series) -> pd.Series:
+    text = values.astype("string")
+    return text.where(_present(values), pd.NA)
+
+
+def _completion_dates(values: pd.Series) -> tuple[pd.Timestamp, ...]:
+    return tuple(value for value in values if not pd.isna(value))
+
+
+__all__ = ["aggregate_lifecycle"]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/_metrics_helpers.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/_metrics_helpers.py
@@ -1,0 +1,183 @@
+"""Scalar, date, and ranking helpers for field-development metrics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+
+def median_valid_days(pairs: list[tuple[pd.Timestamp, pd.Timestamp]]) -> float | pd.NA:
+    values = [(end - start).days for start, end in pairs if end >= start]
+    return float(pd.Series(values).median()) if values else pd.NA
+
+
+def date_pairs(
+    frame: pd.DataFrame,
+    start_column: str,
+    end_column: str,
+) -> list[tuple[pd.Timestamp, pd.Timestamp]]:
+    pairs = []
+    for _, row in frame.iterrows():
+        start = to_timestamp(row.get(start_column))
+        end = to_timestamp(row.get(end_column))
+        if start is not None and end is not None:
+            pairs.append((start, end))
+    return pairs
+
+
+def valid_dates(values: pd.Series) -> list[pd.Timestamp]:
+    dates = [to_timestamp(value) for value in values]
+    return [value for value in dates if value is not None]
+
+
+def to_timestamp(value: Any) -> pd.Timestamp | None:
+    if not has_value(value):
+        return None
+    parsed = pd.to_datetime(value, errors="coerce")
+    return None if pd.isna(parsed) else parsed
+
+
+def month_start(value: Any) -> pd.Timestamp | None:
+    if not has_value(value):
+        return None
+    parsed = pd.to_datetime(f"{value}-01", errors="coerce")
+    return None if pd.isna(parsed) else parsed
+
+
+def horizontal_share(row: pd.Series, well_count: int) -> float | pd.NA:
+    count = int_value(row.get("horizontal_well_count"), 0)
+    count += int_value(row.get("directional_well_count"), 0)
+    return ratio(count, well_count)
+
+
+def pdq_water_or_well_count_gap(quality: dict[str, object]) -> bool:
+    gaps = quality.get("metric_gaps", [])
+    return bool(set(gaps).intersection({"water_bbl", "well_count"}))
+
+
+def operator_count(row: pd.Series, has_lifecycle: bool) -> float | pd.NA:
+    if has_value(row.get("operator_count")):
+        return number_or_na(row.get("operator_count"))
+    if has_lifecycle and has_value(row.get("lifecycle_operator_count")):
+        return number_or_na(row.get("lifecycle_operator_count"))
+    return pd.NA
+
+
+def coalesce_number(*values: Any) -> float | pd.NA:
+    for value in values:
+        number = number_or_na(value)
+        if has_value(number):
+            return number
+    return pd.NA
+
+
+def ratio(numerator: Any, denominator: Any) -> float | pd.NA:
+    if not has_value(numerator) or not has_value(denominator):
+        return pd.NA
+    denominator_value = float(denominator)
+    if denominator_value == 0:
+        return pd.NA
+    return float(numerator) / denominator_value
+
+
+def rank_desc(values: pd.Series) -> pd.Series:
+    return values.rank(ascending=False, method="min", na_option="bottom").astype(
+        "Int64"
+    )
+
+
+def count_text(values: pd.Series, predicate) -> int:
+    return sum(predicate(str(value).upper()) for value in values if has_value(value))
+
+
+def count_values(values: pd.Series) -> int:
+    return sum(has_value(value) for value in values)
+
+
+def unique_count(values: pd.Series) -> int:
+    return len({str(value) for value in values if has_value(value)})
+
+
+def profile_text(group: pd.DataFrame) -> pd.Series:
+    return group["wellbore_profile"].astype(str) + " " + group["well_type"].astype(str)
+
+
+def active_status(value: str) -> bool:
+    return any(
+        token in value for token in ("PRODUCING", "ACTIVE", "FLOWING", "SHUT IN")
+    )
+
+
+def plugged_status(value: str) -> bool:
+    return "PLUG" in value
+
+
+def horizontal(value: str) -> bool:
+    return "HORIZONTAL" in value or " HZ" in f" {value}"
+
+
+def directional(value: str) -> bool:
+    return "DIRECTIONAL" in value or " DIR" in f" {value}"
+
+
+def first_value(values: pd.Series) -> Any:
+    for value in values:
+        if has_value(value):
+            return value
+    return pd.NA
+
+
+def first_present(*values: Any) -> Any:
+    for value in values:
+        if has_value(value):
+            return value
+    return pd.NA
+
+
+def number_or_na(value: Any) -> float | pd.NA:
+    if not has_value(value):
+        return pd.NA
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return pd.NA
+
+
+def int_value(value: Any, default: int) -> int:
+    if not has_value(value):
+        return default
+    return int(value)
+
+
+def bool_value(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if not has_value(value):
+        return False
+    return str(value).strip().upper() in {"TRUE", "T", "Y", "YES", "1"}
+
+
+def value_or_na(value: Any) -> Any:
+    return value if has_value(value) else pd.NA
+
+
+def zero(value: Any) -> float:
+    return 0.0 if not has_value(value) else float(value)
+
+
+def has_value(value: Any) -> bool:
+    if value is None or value is pd.NA:
+        return False
+    try:
+        if pd.isna(value):
+            return False
+    except (TypeError, ValueError):
+        pass
+    return str(value) != ""
+
+
+def ensure_columns(frame: pd.DataFrame, columns: list[str]) -> None:
+    for column in columns:
+        if column not in frame:
+            frame[column] = pd.NA

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/io.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/io.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
 import json
-from pathlib import Path
 import shutil
 import subprocess
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Iterable
 
 import pandas as pd

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/io.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/io.py
@@ -1,0 +1,201 @@
+"""Persist Texas RRC field-development metrics outputs."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import shutil
+import subprocess
+from typing import Iterable
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.field_development.quality import (
+    FieldDevelopmentQualityReport,
+)
+from worldenergydata.texas_rrc.source_catalog import SOURCE_CATALOG_ROOT
+
+FIELD_DEVELOPMENT_METRICS_DIR = Path("curated") / "field_development" / "metrics"
+CSV_FILENAME = "field_development_metrics.csv"
+PARQUET_FILENAME = "field_development_metrics.parquet"
+QUALITY_FILENAME = "field_development_metrics_quality.json"
+MANIFEST_FILENAME = "manifest.json"
+METRIC_DTYPES = {
+    "district": "string",
+    "field_number": "string",
+    "field_name": "string",
+    "top_operator_number": "string",
+    "top_operator_name": "string",
+}
+
+
+@dataclass(frozen=True)
+class FieldDevelopmentOutputManifest:
+    """Paths and metadata for one field-development metrics output batch."""
+
+    generated_at: str
+    output_root: Path
+    csv_path: Path
+    parquet_path: Path
+    quality_path: Path
+    manifest_path: Path
+    row_count: int
+    input_paths: tuple[str, ...]
+    source_gaps: tuple[str, ...]
+    command: str | None
+    code_revision: str | None
+
+
+def write_field_development_outputs(
+    metrics: pd.DataFrame,
+    quality: FieldDevelopmentQualityReport,
+    output_root: Path | str = SOURCE_CATALOG_ROOT,
+    generated_at: datetime | None = None,
+    input_paths: Iterable[str | Path] = (),
+    allow_non_ace_root: bool = False,
+    command: str | None = None,
+    code_revision: str | None = None,
+) -> FieldDevelopmentOutputManifest:
+    """Write field-development CSV, Parquet, quality JSON, and manifest."""
+    root = Path(output_root)
+    _validate_output_root(root, allow_non_ace_root)
+    target_dir = root / FIELD_DEVELOPMENT_METRICS_DIR
+    stamp = _timestamp(generated_at)
+    manifest = FieldDevelopmentOutputManifest(
+        generated_at=stamp,
+        output_root=root,
+        csv_path=target_dir / CSV_FILENAME,
+        parquet_path=target_dir / PARQUET_FILENAME,
+        quality_path=target_dir / QUALITY_FILENAME,
+        manifest_path=target_dir / MANIFEST_FILENAME,
+        row_count=len(metrics),
+        input_paths=tuple(str(path) for path in input_paths),
+        source_gaps=tuple(quality.source_gaps),
+        command=command,
+        code_revision=code_revision or _git_revision(),
+    )
+    _write_with_staging(metrics, quality, manifest, target_dir, stamp)
+    return manifest
+
+
+def load_field_development_metrics(path: Path | str) -> pd.DataFrame:
+    """Load persisted field-development metrics from CSV or Parquet."""
+    metrics_path = Path(path)
+    if metrics_path.suffix.lower() == ".parquet":
+        return pd.read_parquet(metrics_path)
+    return pd.read_csv(metrics_path, dtype=METRIC_DTYPES)
+
+
+def _write_with_staging(
+    metrics: pd.DataFrame,
+    quality: FieldDevelopmentQualityReport,
+    manifest: FieldDevelopmentOutputManifest,
+    target_dir: Path,
+    stamp: str,
+) -> None:
+    staging = target_dir / f".staging-field-development-metrics-{_compact_stamp(stamp)}"
+    shutil.rmtree(staging, ignore_errors=True)
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+        metrics.to_csv(staging / CSV_FILENAME, index=False)
+        metrics.to_parquet(staging / PARQUET_FILENAME, index=False)
+        _write_json(staging / QUALITY_FILENAME, _quality_payload(quality))
+        _write_json(staging / MANIFEST_FILENAME, _manifest_payload(manifest, quality))
+        target_dir.mkdir(parents=True, exist_ok=True)
+        for filename in (
+            CSV_FILENAME,
+            PARQUET_FILENAME,
+            QUALITY_FILENAME,
+            MANIFEST_FILENAME,
+        ):
+            (staging / filename).replace(target_dir / filename)
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def _validate_output_root(root: Path, allow_non_ace_root: bool) -> None:
+    if allow_non_ace_root:
+        return
+    if not root.resolve().is_relative_to(SOURCE_CATALOG_ROOT.resolve()):
+        raise ValueError(
+            "Field-development output_root must stay under "
+            f"{SOURCE_CATALOG_ROOT}; pass allow_non_ace_root=True only for "
+            "isolated tests or sandbox runs"
+        )
+
+
+def _quality_payload(quality: FieldDevelopmentQualityReport) -> dict[str, object]:
+    return asdict(quality)
+
+
+def _manifest_payload(
+    manifest: FieldDevelopmentOutputManifest,
+    quality: FieldDevelopmentQualityReport,
+) -> dict[str, object]:
+    return {
+        "generated_at": manifest.generated_at,
+        "output_root": str(manifest.output_root),
+        "csv_path": str(manifest.csv_path),
+        "parquet_path": str(manifest.parquet_path),
+        "quality_path": str(manifest.quality_path),
+        "manifest_path": str(manifest.manifest_path),
+        "row_count": manifest.row_count,
+        "input_paths": list(manifest.input_paths),
+        "source_gaps": list(manifest.source_gaps),
+        "command": manifest.command,
+        "code_revision": manifest.code_revision,
+        "quality": _quality_payload(quality),
+    }
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _timestamp(value: datetime | None) -> str:
+    timestamp = value or datetime.now(timezone.utc)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _compact_stamp(stamp: str) -> str:
+    return stamp.replace("-", "").replace(":", "")
+
+
+def _git_revision() -> str | None:
+    repo_root = Path(__file__).resolve().parents[5]
+    try:
+        revision = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+        )
+        status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    suffix = "+dirty" if status.stdout.strip() else ""
+    value = revision.stdout.strip()
+    return f"{value}{suffix}" if value else None
+
+
+__all__ = [
+    "CSV_FILENAME",
+    "FIELD_DEVELOPMENT_METRICS_DIR",
+    "FieldDevelopmentOutputManifest",
+    "load_field_development_metrics",
+    "write_field_development_outputs",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/metrics.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/metrics.py
@@ -1,0 +1,380 @@
+"""Build field-development metrics from Texas RRC lifecycle and production data."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.field_development._metrics_helpers import (
+    active_status,
+    bool_value,
+    coalesce_number,
+    count_text,
+    count_values,
+    date_pairs,
+    directional,
+    ensure_columns,
+    first_present,
+    first_value,
+    has_value,
+    horizontal,
+    horizontal_share,
+    int_value,
+    median_valid_days,
+    month_start,
+    number_or_na,
+    operator_count,
+    pdq_water_or_well_count_gap,
+    plugged_status,
+    profile_text,
+    rank_desc,
+    ratio,
+    unique_count,
+    valid_dates,
+    value_or_na,
+    zero,
+)
+from worldenergydata.texas_rrc.field_development.sources import (
+    FieldDevelopmentInputs,
+)
+
+FIELD_KEYS = ("district", "field_number")
+OUTPUT_COLUMNS = [
+    "district",
+    "field_number",
+    "field_name",
+    "well_count",
+    "active_well_count",
+    "plugged_well_count",
+    "permit_count",
+    "completion_count",
+    "horizontal_well_count",
+    "directional_well_count",
+    "horizontal_directional_share",
+    "median_permit_to_completion_days",
+    "median_completion_to_first_production_days",
+    "first_production_month",
+    "last_production_month",
+    "still_producing",
+    "production_maturity_class",
+    "cumulative_oil_bbl",
+    "cumulative_gas_mcf",
+    "cumulative_condensate_bbl",
+    "cumulative_boe",
+    "production_per_well_boe",
+    "lease_count",
+    "operator_count",
+    "well_density_proxy",
+    "well_density_basis",
+    "remaining_activity_score",
+    "rank_cumulative_boe",
+    "rank_remaining_activity",
+    "rank_well_density_proxy",
+    "rank_development_maturity",
+    "top_operator_number",
+    "top_operator_name",
+    "top_operator_share",
+    "source_caveats",
+    "quality_flags",
+]
+MATURITY_SCORE = {
+    "mature_active": 5,
+    "growth": 4,
+    "early_development": 3,
+    "late_life": 2,
+    "pre_production": 1,
+    "unknown": 0,
+}
+
+
+def build_field_development_metrics(inputs: FieldDevelopmentInputs) -> pd.DataFrame:
+    """Join lifecycle and production inputs into field-level development metrics."""
+    lifecycle = _aggregate_lifecycle(inputs.lifecycle)
+    production = _prepare_production(inputs.production)
+    joined = lifecycle.merge(
+        production,
+        how="outer",
+        on=list(FIELD_KEYS),
+        suffixes=("", "_production"),
+        indicator=True,
+    )
+    metric_gap = pdq_water_or_well_count_gap(inputs.production_quality)
+    records = [_record_from_joined(row, metric_gap) for _, row in joined.iterrows()]
+    metrics = pd.DataFrame(records, columns=OUTPUT_COLUMNS)
+    return _with_ranks(metrics)
+
+
+def _aggregate_lifecycle(lifecycle: pd.DataFrame) -> pd.DataFrame:
+    if lifecycle.empty:
+        return _empty_lifecycle()
+    frame = lifecycle.copy()
+    ensure_columns(frame, _lifecycle_input_columns())
+    rows = [
+        _lifecycle_record(key, group) for key, group in frame.groupby(list(FIELD_KEYS))
+    ]
+    return pd.DataFrame(rows)
+
+
+def _lifecycle_record(key: tuple[str, str], group: pd.DataFrame) -> dict[str, Any]:
+    dates = date_pairs(group, "permit_issued_date", "completion_date")
+    completion_dates = tuple(valid_dates(group["completion_date"]))
+    return {
+        "district": key[0],
+        "field_number": key[1],
+        "lifecycle_field_name": first_value(group["field_name"]),
+        "well_count": len(group),
+        "active_well_count": count_text(group["well_status"], active_status),
+        "plugged_well_count": count_text(group["well_status"], plugged_status),
+        "permit_count": count_values(group["permit_number"]),
+        "completion_count": count_values(group["completion_date"]),
+        "horizontal_well_count": count_text(profile_text(group), horizontal),
+        "directional_well_count": count_text(profile_text(group), directional),
+        "median_permit_to_completion_days": median_valid_days(dates),
+        "completion_dates": completion_dates,
+        "lifecycle_lease_count": unique_count(group["lease_number"]),
+        "lifecycle_operator_count": unique_count(group["operator_number"]),
+    }
+
+
+def _prepare_production(production: pd.DataFrame) -> pd.DataFrame:
+    if production.empty:
+        return _empty_production()
+    frame = production.copy()
+    ensure_columns(frame, _production_columns())
+    if "aggregation_level" in frame:
+        frame = frame[frame["aggregation_level"] == "field"].copy()
+    return frame.loc[:, _production_columns()]
+
+
+def _record_from_joined(row: pd.Series, metric_gap: bool) -> dict[str, Any]:
+    has_lifecycle = row["_merge"] in {"left_only", "both"}
+    has_production = row["_merge"] in {"right_only", "both"}
+    well_count = int_value(row.get("well_count"), default=0)
+    lease_count = coalesce_number(
+        row.get("lease_count"), row.get("lifecycle_lease_count")
+    )
+    cumulative_boe = number_or_na(row.get("cumulative_boe"))
+    record = _base_record(row, has_lifecycle, well_count, lease_count)
+    record.update(_production_values(row, well_count, cumulative_boe))
+    record.update(_development_values(row, well_count, lease_count, cumulative_boe))
+    record["production_maturity_class"] = _maturity_class(
+        has_lifecycle,
+        cumulative_boe,
+        row.get("still_producing"),
+        row.get("production_span_months"),
+    )
+    record["source_caveats"] = _source_caveats(
+        row, has_lifecycle, has_production, metric_gap
+    )
+    record["quality_flags"] = ""
+    return record
+
+
+def _base_record(
+    row: pd.Series,
+    has_lifecycle: bool,
+    well_count: int,
+    lease_count: float | pd.NA,
+) -> dict[str, Any]:
+    return {
+        "district": row["district"],
+        "field_number": row["field_number"],
+        "field_name": first_present(
+            row.get("field_name"), row.get("lifecycle_field_name")
+        ),
+        "well_count": well_count,
+        "active_well_count": int_value(row.get("active_well_count"), default=0),
+        "plugged_well_count": int_value(row.get("plugged_well_count"), default=0),
+        "permit_count": int_value(row.get("permit_count"), default=0),
+        "completion_count": int_value(row.get("completion_count"), default=0),
+        "horizontal_well_count": int_value(row.get("horizontal_well_count"), default=0),
+        "directional_well_count": int_value(
+            row.get("directional_well_count"), default=0
+        ),
+        "horizontal_directional_share": horizontal_share(row, well_count),
+        "median_permit_to_completion_days": number_or_na(
+            row.get("median_permit_to_completion_days")
+        ),
+        "median_completion_to_first_production_days": _completion_to_production(row),
+        "lease_count": lease_count if has_value(lease_count) else pd.NA,
+        "operator_count": operator_count(row, has_lifecycle),
+    }
+
+
+def _production_values(
+    row: pd.Series,
+    well_count: int,
+    cumulative_boe: float | pd.NA,
+) -> dict[str, Any]:
+    return {
+        "first_production_month": value_or_na(row.get("first_production_month")),
+        "last_production_month": value_or_na(row.get("last_production_month")),
+        "still_producing": bool_value(row.get("still_producing")),
+        "cumulative_oil_bbl": number_or_na(row.get("cumulative_oil_bbl")),
+        "cumulative_gas_mcf": number_or_na(row.get("cumulative_gas_mcf")),
+        "cumulative_condensate_bbl": number_or_na(row.get("cumulative_condensate_bbl")),
+        "cumulative_boe": cumulative_boe,
+        "production_per_well_boe": ratio(cumulative_boe, well_count),
+        "top_operator_number": value_or_na(row.get("top_operator_number")),
+        "top_operator_name": value_or_na(row.get("top_operator_name")),
+        "top_operator_share": number_or_na(row.get("top_operator_share")),
+    }
+
+
+def _development_values(
+    row: pd.Series,
+    well_count: int,
+    lease_count: float | pd.NA,
+    cumulative_boe: float | pd.NA,
+) -> dict[str, Any]:
+    active_share = ratio(row.get("active_well_count"), well_count)
+    current = 1.0 if bool_value(row.get("still_producing")) else 0.0
+    density = ratio(well_count, lease_count) if well_count > 0 else pd.NA
+    return {
+        "well_density_proxy": density,
+        "well_density_basis": "wells_per_lease" if has_value(density) else pd.NA,
+        "remaining_activity_score": round(((zero(active_share) + current) / 2), 6),
+    }
+
+
+def _source_caveats(
+    row: pd.Series,
+    has_lifecycle: bool,
+    has_production: bool,
+    metric_gap: bool,
+) -> str:
+    caveats: list[str] = []
+    if has_production:
+        caveats.extend(["lease_level_production", "no_per_well_allocation"])
+    if not has_production:
+        caveats.append("missing_production")
+    if not has_lifecycle:
+        caveats.append("missing_lifecycle")
+    if _missing_lifecycle_dates(row, has_lifecycle):
+        caveats.append("missing_lifecycle_dates")
+    if has_production and metric_gap:
+        caveats.append("water_and_well_count_unavailable_from_pdq")
+    return "|".join(caveats)
+
+
+def _with_ranks(metrics: pd.DataFrame) -> pd.DataFrame:
+    if metrics.empty:
+        return metrics
+    result = metrics.copy()
+    result["rank_cumulative_boe"] = rank_desc(result["cumulative_boe"])
+    result["rank_remaining_activity"] = rank_desc(result["remaining_activity_score"])
+    result["rank_well_density_proxy"] = rank_desc(result["well_density_proxy"])
+    maturity_scores = result["production_maturity_class"].map(MATURITY_SCORE)
+    result["rank_development_maturity"] = rank_desc(maturity_scores)
+    return result.sort_values(list(FIELD_KEYS), kind="mergesort").reset_index(drop=True)
+
+
+def _maturity_class(
+    has_lifecycle: bool,
+    cumulative_boe: float | pd.NA,
+    still_producing: Any,
+    production_span_months: Any,
+) -> str:
+    if has_lifecycle and (not has_value(cumulative_boe) or float(cumulative_boe) == 0):
+        return "pre_production"
+    if not has_value(cumulative_boe):
+        return "unknown"
+    span = number_or_na(production_span_months)
+    still = bool_value(still_producing)
+    if not still:
+        return "late_life"
+    if has_value(span) and span < 24:
+        return "early_development"
+    if has_value(span) and span <= 84:
+        return "growth"
+    if has_value(span) and span > 84:
+        return "mature_active"
+    return "unknown"
+
+
+def _completion_to_production(row: pd.Series) -> float | pd.NA:
+    first_production = month_start(row.get("first_production_month"))
+    if first_production is None:
+        return pd.NA
+    completion_dates = row.get("completion_dates")
+    if not isinstance(completion_dates, tuple):
+        return pd.NA
+    values = [(first_production - value).days for value in completion_dates]
+    valid = [value for value in values if value >= 0]
+    return float(pd.Series(valid).median()) if valid else pd.NA
+
+
+def _missing_lifecycle_dates(row: pd.Series, has_lifecycle: bool) -> bool:
+    if not has_lifecycle:
+        return False
+    well_count = int_value(row.get("well_count"), default=0)
+    if well_count == 0:
+        return False
+    return int_value(row.get("completion_count"), default=0) < well_count
+
+
+def _lifecycle_input_columns() -> list[str]:
+    return [
+        "district",
+        "field_number",
+        "field_name",
+        "lease_number",
+        "operator_number",
+        "well_status",
+        "well_type",
+        "wellbore_profile",
+        "permit_number",
+        "permit_issued_date",
+        "completion_date",
+    ]
+
+
+def _production_columns() -> list[str]:
+    return [
+        "aggregation_level",
+        "district",
+        "field_number",
+        "field_name",
+        "first_production_month",
+        "last_production_month",
+        "still_producing",
+        "production_span_months",
+        "cumulative_oil_bbl",
+        "cumulative_gas_mcf",
+        "cumulative_condensate_bbl",
+        "cumulative_boe",
+        "lease_count",
+        "operator_count",
+        "top_operator_number",
+        "top_operator_name",
+        "top_operator_share",
+    ]
+
+
+def _empty_lifecycle() -> pd.DataFrame:
+    columns = list(FIELD_KEYS) + [
+        "lifecycle_field_name",
+        "well_count",
+        "active_well_count",
+        "plugged_well_count",
+        "permit_count",
+        "completion_count",
+        "horizontal_well_count",
+        "directional_well_count",
+        "median_permit_to_completion_days",
+        "completion_dates",
+        "lifecycle_lease_count",
+        "lifecycle_operator_count",
+    ]
+    return pd.DataFrame(columns=columns)
+
+
+def _empty_production() -> pd.DataFrame:
+    return pd.DataFrame(columns=_production_columns())
+
+
+__all__ = [
+    "OUTPUT_COLUMNS",
+    "build_field_development_metrics",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/metrics.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/metrics.py
@@ -6,32 +6,23 @@ from typing import Any
 
 import pandas as pd
 
+from worldenergydata.texas_rrc.field_development._lifecycle_aggregation import (
+    aggregate_lifecycle,
+)
 from worldenergydata.texas_rrc.field_development._metrics_helpers import (
-    active_status,
     bool_value,
     coalesce_number,
-    count_text,
-    count_values,
-    date_pairs,
-    directional,
     ensure_columns,
     first_present,
-    first_value,
     has_value,
-    horizontal,
     horizontal_share,
     int_value,
-    median_valid_days,
     month_start,
     number_or_na,
     operator_count,
     pdq_water_or_well_count_gap,
-    plugged_status,
-    profile_text,
     rank_desc,
     ratio,
-    unique_count,
-    valid_dates,
     value_or_na,
     zero,
 )
@@ -106,35 +97,12 @@ def build_field_development_metrics(inputs: FieldDevelopmentInputs) -> pd.DataFr
 
 
 def _aggregate_lifecycle(lifecycle: pd.DataFrame) -> pd.DataFrame:
-    if lifecycle.empty:
-        return _empty_lifecycle()
-    frame = lifecycle.copy()
-    ensure_columns(frame, _lifecycle_input_columns())
-    rows = [
-        _lifecycle_record(key, group) for key, group in frame.groupby(list(FIELD_KEYS))
-    ]
-    return pd.DataFrame(rows)
-
-
-def _lifecycle_record(key: tuple[str, str], group: pd.DataFrame) -> dict[str, Any]:
-    dates = date_pairs(group, "permit_issued_date", "completion_date")
-    completion_dates = tuple(valid_dates(group["completion_date"]))
-    return {
-        "district": key[0],
-        "field_number": key[1],
-        "lifecycle_field_name": first_value(group["field_name"]),
-        "well_count": len(group),
-        "active_well_count": count_text(group["well_status"], active_status),
-        "plugged_well_count": count_text(group["well_status"], plugged_status),
-        "permit_count": count_values(group["permit_number"]),
-        "completion_count": count_values(group["completion_date"]),
-        "horizontal_well_count": count_text(profile_text(group), horizontal),
-        "directional_well_count": count_text(profile_text(group), directional),
-        "median_permit_to_completion_days": median_valid_days(dates),
-        "completion_dates": completion_dates,
-        "lifecycle_lease_count": unique_count(group["lease_number"]),
-        "lifecycle_operator_count": unique_count(group["operator_number"]),
-    }
+    return aggregate_lifecycle(
+        lifecycle,
+        FIELD_KEYS,
+        _lifecycle_input_columns(),
+        _empty_lifecycle(),
+    )
 
 
 def _prepare_production(production: pd.DataFrame) -> pd.DataFrame:

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/quality.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/quality.py
@@ -1,0 +1,57 @@
+"""Quality summaries for Texas RRC field-development metrics."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.field_development.sources import (
+    FieldDevelopmentInputs,
+)
+
+
+@dataclass(frozen=True)
+class FieldDevelopmentQualityReport:
+    """Aggregate caveat and maturity counts for field-development outputs."""
+
+    row_count: int
+    source_gaps: tuple[str, ...]
+    caveat_counts: dict[str, int]
+    maturity_counts: dict[str, int]
+
+
+def assess_field_development_quality(
+    metrics: pd.DataFrame,
+    inputs: FieldDevelopmentInputs,
+) -> FieldDevelopmentQualityReport:
+    """Summarize field-development caveats, maturity mix, and source gaps."""
+    return FieldDevelopmentQualityReport(
+        row_count=len(metrics),
+        source_gaps=tuple(inputs.source_gaps),
+        caveat_counts=_caveat_counts(metrics),
+        maturity_counts=_maturity_counts(metrics),
+    )
+
+
+def _caveat_counts(metrics: pd.DataFrame) -> dict[str, int]:
+    counter: Counter[str] = Counter()
+    if "source_caveats" not in metrics:
+        return {}
+    for value in metrics["source_caveats"].dropna():
+        counter.update(part for part in str(value).split("|") if part)
+    return dict(sorted(counter.items()))
+
+
+def _maturity_counts(metrics: pd.DataFrame) -> dict[str, int]:
+    if "production_maturity_class" not in metrics:
+        return {}
+    counts = metrics["production_maturity_class"].dropna().value_counts()
+    return {str(key): int(value) for key, value in sorted(counts.items())}
+
+
+__all__ = [
+    "FieldDevelopmentQualityReport",
+    "assess_field_development_quality",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/sources.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/sources.py
@@ -2,23 +2,35 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import json
+from dataclasses import dataclass
 from pathlib import Path
 
 import pandas as pd
 
 from worldenergydata.texas_rrc.lifecycle.io import (
     LIFECYCLE_SPINE_DIR,
+)
+from worldenergydata.texas_rrc.lifecycle.io import (
     QUALITY_FILENAME as LIFECYCLE_QUALITY_FILENAME,
+)
+from worldenergydata.texas_rrc.lifecycle.io import (
     SPINE_FILENAME,
     load_lifecycle_spine,
 )
 from worldenergydata.texas_rrc.production_atlas.io import (
     CSV_FILENAME as PRODUCTION_CSV_FILENAME,
+)
+from worldenergydata.texas_rrc.production_atlas.io import (
     PARQUET_FILENAME as PRODUCTION_PARQUET_FILENAME,
+)
+from worldenergydata.texas_rrc.production_atlas.io import (
     PRODUCTION_ATLAS_DIR,
+)
+from worldenergydata.texas_rrc.production_atlas.io import (
     QUALITY_FILENAME as PRODUCTION_QUALITY_FILENAME,
+)
+from worldenergydata.texas_rrc.production_atlas.io import (
     load_production_atlas,
 )
 

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/sources.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/sources.py
@@ -1,0 +1,121 @@
+"""Load curated Texas RRC inputs for field-development metrics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.lifecycle.io import (
+    LIFECYCLE_SPINE_DIR,
+    QUALITY_FILENAME as LIFECYCLE_QUALITY_FILENAME,
+    SPINE_FILENAME,
+    load_lifecycle_spine,
+)
+from worldenergydata.texas_rrc.production_atlas.io import (
+    CSV_FILENAME as PRODUCTION_CSV_FILENAME,
+    PARQUET_FILENAME as PRODUCTION_PARQUET_FILENAME,
+    PRODUCTION_ATLAS_DIR,
+    QUALITY_FILENAME as PRODUCTION_QUALITY_FILENAME,
+    load_production_atlas,
+)
+
+
+@dataclass(frozen=True)
+class FieldDevelopmentInputs:
+    """Curated lifecycle and production inputs for field-development metrics."""
+
+    lifecycle: pd.DataFrame
+    production: pd.DataFrame
+    lifecycle_quality: dict[str, object]
+    production_quality: dict[str, object]
+    source_gaps: tuple[str, ...]
+
+
+def load_field_development_inputs(root: Path | str) -> FieldDevelopmentInputs:
+    """Load curated lifecycle and production inputs from a local Texas RRC root."""
+    local_root = _local_root(root)
+    source_gaps: list[str] = []
+
+    lifecycle = _load_lifecycle(local_root, source_gaps)
+    production = _load_production(local_root, source_gaps)
+    lifecycle_quality = _load_quality(
+        local_root / LIFECYCLE_SPINE_DIR / LIFECYCLE_QUALITY_FILENAME,
+        "well_lifecycle_quality",
+        source_gaps,
+    )
+    production_quality = _load_quality(
+        local_root / PRODUCTION_ATLAS_DIR / PRODUCTION_QUALITY_FILENAME,
+        "production_field_atlas_quality",
+        source_gaps,
+    )
+
+    return FieldDevelopmentInputs(
+        lifecycle=lifecycle,
+        production=production,
+        lifecycle_quality=lifecycle_quality,
+        production_quality=production_quality,
+        source_gaps=tuple(source_gaps),
+    )
+
+
+def _local_root(root: Path | str) -> Path:
+    value = str(root)
+    if "://" in value:
+        raise ValueError("Field-development inputs must be local filesystem paths")
+    return Path(root)
+
+
+def _load_lifecycle(root: Path, source_gaps: list[str]) -> pd.DataFrame:
+    path = root / LIFECYCLE_SPINE_DIR / SPINE_FILENAME
+    if not path.exists():
+        source_gaps.append("well_lifecycle_spine")
+        return pd.DataFrame()
+    return load_lifecycle_spine(path)
+
+
+def _load_production(root: Path, source_gaps: list[str]) -> pd.DataFrame:
+    path = _production_path(root)
+    if path is None:
+        source_gaps.append("production_field_atlas")
+        return pd.DataFrame()
+    production = load_production_atlas(path)
+    if "aggregation_level" not in production.columns:
+        return production.iloc[0:0].copy()
+    fields = production[production["aggregation_level"] == "field"].copy()
+    return fields.reset_index(drop=True)
+
+
+def _production_path(root: Path) -> Path | None:
+    atlas_dir = root / PRODUCTION_ATLAS_DIR
+    parquet_path = atlas_dir / PRODUCTION_PARQUET_FILENAME
+    if parquet_path.exists():
+        return parquet_path
+    csv_path = atlas_dir / PRODUCTION_CSV_FILENAME
+    if csv_path.exists():
+        return csv_path
+    return None
+
+
+def _load_quality(
+    path: Path,
+    gap_name: str,
+    source_gaps: list[str],
+) -> dict[str, object]:
+    if not path.exists():
+        source_gaps.append(gap_name)
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        source_gaps.append(gap_name)
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+__all__ = [
+    "FieldDevelopmentInputs",
+    "load_field_development_inputs",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/completion_packets.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/completion_packets.py
@@ -1,0 +1,145 @@
+"""Parse official Texas RRC brace-delimited completion packet data."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pandas as pd
+
+COMPLETION_FORM_RECORDS = {"G-1", "W-2"}
+FORM_COMPLETION_DATE_INDEX = {"G-1": 18, "W-2": 27}
+FORM_FIELD_MAP = {
+    "G-1": {
+        "operator_name": 14,
+        "lease_name": 24,
+        "lease_number": 25,
+    },
+    "W-2": {
+        "operator_name": 23,
+        "lease_name": 33,
+        "lease_number": 34,
+    },
+}
+
+
+def looks_like_completion_packet_text(text: str) -> bool:
+    """Return True for official completion packetData brace records."""
+    first_line = _first_content_line(text)
+    return bool(first_line and "{" in first_line)
+
+
+def read_completion_packet_text(text: str) -> pd.DataFrame:
+    """Read official W-2/G-1 packetData text into lifecycle completion rows."""
+    rows: list[dict[str, str]] = []
+    context: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        fields = [part.strip() for part in raw_line.rstrip("\r\n").split("{")]
+        record_type = fields[0] if fields else ""
+        if record_type == "PACKET":
+            context = _packet_context(fields)
+            continue
+        if record_type not in COMPLETION_FORM_RECORDS:
+            continue
+        row = _form_row(record_type, fields, context)
+        if row:
+            rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def _first_content_line(text: str) -> str:
+    for line in text.splitlines():
+        if line.strip():
+            return line.strip()
+    return ""
+
+
+def _packet_context(fields: list[str]) -> dict[str, str]:
+    context = {
+        "api_number": _field(fields, 6),
+        "operator_number": _field(fields, 5),
+        "lease_number": _field(fields, 8),
+        "field_number": _field(fields, 25),
+        "district": _field(fields, 27),
+        "field_name": _field(fields, 29),
+        "packet_completion_date": _parse_date(_field(fields, 21)),
+    }
+    return {key: value for key, value in context.items() if value}
+
+
+def _form_row(
+    record_type: str,
+    fields: list[str],
+    context: dict[str, str],
+) -> dict[str, str]:
+    row = dict(context)
+    row.pop("packet_completion_date", None)
+    row.update(_form_context(record_type, fields))
+    row["form_type"] = record_type
+    completion_date = _form_completion_date(record_type, fields, context)
+    if completion_date:
+        row["completion_date"] = completion_date
+    if not _valid_api(row.get("api_number", "")):
+        return {}
+    return row
+
+
+def _form_context(record_type: str, fields: list[str]) -> dict[str, str]:
+    mapped = {}
+    for column, index in FORM_FIELD_MAP.get(record_type, {}).items():
+        value = _field(fields, index)
+        if value:
+            mapped[column] = value
+    return mapped
+
+
+def _form_completion_date(
+    record_type: str,
+    fields: list[str],
+    context: dict[str, str],
+) -> str:
+    for index in (FORM_COMPLETION_DATE_INDEX[record_type], 4):
+        value = _parse_date(_field(fields, index))
+        if value:
+            return value
+    return context.get("packet_completion_date", "")
+
+
+def _field(fields: list[str], index: int) -> str:
+    if index >= len(fields):
+        return ""
+    return fields[index].strip()
+
+
+def _valid_api(value: str) -> bool:
+    return len(value) == 8 and value.isdigit()
+
+
+def _parse_date(value: str) -> str:
+    text = value.strip()
+    if not text or text == "00000000":
+        return ""
+    try:
+        return date.fromisoformat(text).isoformat()
+    except ValueError:
+        pass
+    if len(text) == 8 and text.isdigit():
+        try:
+            return date(int(text[:4]), int(text[4:6]), int(text[6:8])).isoformat()
+        except ValueError:
+            return ""
+    if "/" in text:
+        parts = text.split("/")
+        if len(parts) != 3:
+            return ""
+        try:
+            month, day, year = (int(part) for part in parts)
+            return date(year, month, day).isoformat()
+        except ValueError:
+            return ""
+    return ""
+
+
+__all__ = [
+    "looks_like_completion_packet_text",
+    "read_completion_packet_text",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/io.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/io.py
@@ -25,6 +25,10 @@ API_KEY_DTYPES = {
     "well_unique_number": "string",
     "sidetrack_code": "string",
     "completion_code": "string",
+    "district": "string",
+    "field_number": "string",
+    "lease_number": "string",
+    "operator_number": "string",
 }
 
 

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/io.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/io.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+import json
+import shutil
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
-import json
 from pathlib import Path
-import shutil
 from typing import Iterable
 
 import pandas as pd
@@ -88,7 +88,7 @@ def write_lifecycle_outputs(
 
 def load_lifecycle_spine(path: Path | str) -> pd.DataFrame:
     """Load a persisted lifecycle spine while preserving API key strings."""
-    return pd.read_csv(path, dtype=API_KEY_DTYPES)
+    return pd.read_csv(path, dtype=API_KEY_DTYPES, low_memory=False)
 
 
 def _validate_output_root(root: Path, allow_non_ace_root: bool) -> None:

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/quality.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/quality.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date, datetime
 from typing import Sequence
 
 import pandas as pd
@@ -31,111 +30,104 @@ def assess_lifecycle_quality(
     source_gaps: Sequence[str] = (),
 ) -> LifecycleQualityReport:
     """Assess lifecycle spine quality and attach row-level flags."""
-    row_flags = [_flags_for_row(row) for _, row in spine.iterrows()]
-    spine["quality_flags"] = ["|".join(flags) for flags in row_flags]
+    flags = pd.Series("", index=spine.index, dtype=object)
+    missing_field_id = _append_flag(
+        flags, _missing_mask(spine, "field_number"), "missing_field_id"
+    )
+    missing_lease_id = _append_flag(
+        flags, _missing_mask(spine, "lease_number"), "missing_lease_id"
+    )
+    missing_operator_id = _append_flag(
+        flags, _missing_mask(spine, "operator_number"), "missing_operator_id"
+    )
+    invalid_coordinates = _append_flag(
+        flags, _invalid_coordinates_mask(spine), "invalid_coordinates"
+    )
+    impossible_dates = _append_flag(
+        flags, _impossible_dates_mask(spine), "impossible_dates"
+    )
+
+    has_wellbore = _bool_mask(spine, "has_wellbore")
+    has_permit = _bool_mask(spine, "has_permit")
+    has_completion = _bool_mask(spine, "has_completion")
+    permit_without_wellbore = _append_flag(
+        flags, has_permit & ~has_wellbore, "permit_without_wellbore"
+    )
+    completion_without_wellbore = _append_flag(
+        flags, has_completion & ~has_wellbore, "completion_without_wellbore"
+    )
+    wellbore_without_completion = _append_flag(
+        flags, has_wellbore & ~has_completion, "wellbore_without_completion"
+    )
+
+    spine["quality_flags"] = flags
     duplicate_values = spine["api14"].duplicated().sum() if "api14" in spine else 0
     return LifecycleQualityReport(
         row_count=len(spine),
         duplicate_api14=int(duplicate_values),
-        missing_field_id=_count_flag(row_flags, "missing_field_id"),
-        missing_lease_id=_count_flag(row_flags, "missing_lease_id"),
-        missing_operator_id=_count_flag(row_flags, "missing_operator_id"),
-        invalid_coordinates=_count_flag(row_flags, "invalid_coordinates"),
-        impossible_dates=_count_flag(row_flags, "impossible_dates"),
-        permit_without_wellbore=_count_flag(row_flags, "permit_without_wellbore"),
-        completion_without_wellbore=_count_flag(
-            row_flags, "completion_without_wellbore"
-        ),
-        wellbore_without_completion=_count_flag(
-            row_flags, "wellbore_without_completion"
-        ),
+        missing_field_id=missing_field_id,
+        missing_lease_id=missing_lease_id,
+        missing_operator_id=missing_operator_id,
+        invalid_coordinates=invalid_coordinates,
+        impossible_dates=impossible_dates,
+        permit_without_wellbore=permit_without_wellbore,
+        completion_without_wellbore=completion_without_wellbore,
+        wellbore_without_completion=wellbore_without_completion,
         source_gaps=tuple(source_gaps),
     )
 
 
-def _flags_for_row(row: pd.Series) -> list[str]:
-    flags = []
-    _append_missing_id_flags(row, flags)
-    if _invalid_coordinates(row):
-        flags.append("invalid_coordinates")
-    if _impossible_dates(row):
-        flags.append("impossible_dates")
-    _append_source_gap_flags(row, flags)
-    return flags
+def _append_flag(flags: pd.Series, mask: pd.Series, flag: str) -> int:
+    count = int(mask.sum())
+    if count == 0:
+        return 0
+    existing = flags.loc[mask]
+    separator = existing.ne("").map({True: "|", False: ""})
+    flags.loc[mask] = existing + separator + flag
+    return count
 
 
-def _append_missing_id_flags(row: pd.Series, flags: list[str]) -> None:
-    for column, flag in (
-        ("field_number", "missing_field_id"),
-        ("lease_number", "missing_lease_id"),
-        ("operator_number", "missing_operator_id"),
-    ):
-        if not _has_value(row.get(column)):
-            flags.append(flag)
+def _missing_mask(spine: pd.DataFrame, column: str) -> pd.Series:
+    if column not in spine:
+        return pd.Series(True, index=spine.index)
+    values = spine[column].astype("string")
+    return values.isna() | values.eq("")
 
 
-def _append_source_gap_flags(row: pd.Series, flags: list[str]) -> None:
-    has_wellbore = bool(row.get("has_wellbore"))
-    if bool(row.get("has_permit")) and not has_wellbore:
-        flags.append("permit_without_wellbore")
-    if bool(row.get("has_completion")) and not has_wellbore:
-        flags.append("completion_without_wellbore")
-    if has_wellbore and not bool(row.get("has_completion")):
-        flags.append("wellbore_without_completion")
+def _invalid_coordinates_mask(spine: pd.DataFrame) -> pd.Series:
+    latitude = _numeric_column(spine, "latitude")
+    longitude = _numeric_column(spine, "longitude")
+    has_coordinates = latitude.notna() & longitude.notna()
+    in_bounds = latitude.between(25.84, 36.50) & longitude.between(-106.65, -93.51)
+    return has_coordinates & ~in_bounds
 
 
-def _invalid_coordinates(row: pd.Series) -> bool:
-    latitude = _to_float(row.get("latitude"))
-    longitude = _to_float(row.get("longitude"))
-    if latitude is None or longitude is None:
-        return False
-    return not (25.84 <= latitude <= 36.50 and -106.65 <= longitude <= -93.51)
-
-
-def _impossible_dates(row: pd.Series) -> bool:
-    comparisons = (
+def _impossible_dates_mask(spine: pd.DataFrame) -> pd.Series:
+    result = pd.Series(False, index=spine.index)
+    for start_column, end_column in (
         ("permit_issued_date", "spud_date"),
         ("spud_date", "completion_date"),
         ("completion_date", "plug_date"),
-    )
-    for start_column, end_column in comparisons:
-        start = _to_date(row.get(start_column))
-        end = _to_date(row.get(end_column))
-        if start and end and start > end:
-            return True
-    return False
+    ):
+        start = _date_column(spine, start_column)
+        end = _date_column(spine, end_column)
+        result |= start.notna() & end.notna() & start.gt(end)
+    return result
 
 
-def _to_date(value) -> date | None:
-    if not _has_value(value):
-        return None
-    if isinstance(value, date):
-        return value
-    text = str(value).strip()
-    if not text:
-        return None
-    try:
-        return date.fromisoformat(text)
-    except ValueError:
-        pass
-    try:
-        return datetime.strptime(text, "%m/%d/%Y").date()
-    except ValueError:
-        return None
+def _bool_mask(spine: pd.DataFrame, column: str) -> pd.Series:
+    if column not in spine:
+        return pd.Series(False, index=spine.index)
+    return spine[column].astype("boolean").fillna(False).astype(bool)
 
 
-def _to_float(value) -> float | None:
-    if not _has_value(value):
-        return None
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None
+def _numeric_column(spine: pd.DataFrame, column: str) -> pd.Series:
+    if column not in spine:
+        return pd.Series(pd.NA, index=spine.index, dtype="Float64")
+    return pd.to_numeric(spine[column], errors="coerce")
 
 
-def _has_value(value) -> bool:
-    return value is not None and value == value and str(value) != ""
-
-
-def _count_flag(row_flags: list[list[str]], flag: str) -> int:
-    return sum(flag in flags for flags in row_flags)
+def _date_column(spine: pd.DataFrame, column: str) -> pd.Series:
+    if column not in spine:
+        return pd.Series(pd.NaT, index=spine.index)
+    return pd.to_datetime(spine[column], errors="coerce", format="mixed")

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/sources.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/sources.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import csv
 import zipfile
 from dataclasses import dataclass
 from datetime import date
@@ -29,6 +30,24 @@ SOURCE_DIRS = {
     "drilling_permits": Path("raw/permits/drilling"),
     "completion_data": Path("raw/completions"),
 }
+
+WELLBORE_QUERY_FIELD_COUNT = 59
+WELLBORE_QUERY_POSITION_MAP = {
+    0: "district",
+    2: "api_number",
+    4: "well_type",
+    5: "lease_name",
+    6: "field_number",
+    7: "field_name",
+    8: "lease_number",
+    11: "operator_name",
+    12: "operator_number",
+    15: "total_depth",
+    18: "well_status",
+    20: "plug_date",
+    30: "completion_date",
+}
+WELLBORE_QUERY_DATE_COLUMNS = ("plug_date", "completion_date")
 
 
 def load_lifecycle_inputs(raw_root: Path) -> LifecycleInputFrames:
@@ -75,6 +94,8 @@ def _read_table(path: Path, source_id: str) -> pd.DataFrame:
         return _read_zip_tables(path, source_id)
     if path.suffix.lower() not in {".csv", ".txt", ".dat"}:
         return pd.DataFrame()
+    if source_id == "wellbore_query":
+        return _read_wellbore_query_file(path)
     text = path.read_text(encoding="utf-8", errors="replace")
     if source_id == "drilling_permits" and path.name.lower() == "daf420.dat":
         frame = _read_daf420_text(text)
@@ -98,6 +119,11 @@ def _read_zip_tables(path: Path, source_id: str) -> pd.DataFrame:
                 if not frame.empty:
                     frames.append(frame)
                     continue
+            if source_id == "wellbore_query":
+                frame = _read_wellbore_query_text(text)
+                if not frame.empty:
+                    frames.append(frame)
+                continue
             frame = _read_table_text(text)
             if not frame.empty:
                 frames.append(frame)
@@ -118,6 +144,71 @@ def _read_table_text(text: str) -> pd.DataFrame:
         dtype=str,
         keep_default_na=False,
     )
+
+
+def _read_wellbore_query_file(path: Path) -> pd.DataFrame:
+    first_line = _first_line(path)
+    if _looks_like_wellbore_header(first_line):
+        return _read_table_text(path.read_text(encoding="utf-8", errors="replace"))
+    return _read_headerless_wellbore_query(path)
+
+
+def _read_wellbore_query_text(text: str) -> pd.DataFrame:
+    if not text.strip():
+        return pd.DataFrame()
+    first_line = text.splitlines()[0]
+    if _looks_like_wellbore_header(first_line):
+        return _read_table_text(text)
+    return _read_headerless_wellbore_query(StringIO(text))
+
+
+def _first_line(path: Path) -> str:
+    with path.open(encoding="utf-8", errors="replace") as handle:
+        return handle.readline()
+
+
+def _looks_like_wellbore_header(first_line: str) -> bool:
+    if not first_line.strip():
+        return False
+    try:
+        fields = next(csv.reader([first_line]))
+    except csv.Error:
+        return False
+    column_keys = {_column_key(field) for field in fields}
+    return bool(
+        column_keys.intersection(
+            {
+                "API_NO",
+                "API_NUMBER",
+                "DISTRICT",
+                "DISTRICT_CODE",
+                "FIELD_NUMBER",
+            }
+        )
+    )
+
+
+def _read_headerless_wellbore_query(source) -> pd.DataFrame:
+    raw = pd.read_csv(
+        source,
+        header=None,
+        names=list(range(WELLBORE_QUERY_FIELD_COUNT)),
+        usecols=tuple(WELLBORE_QUERY_POSITION_MAP),
+        engine="python",
+        dtype=str,
+        keep_default_na=False,
+        on_bad_lines="skip",
+    )
+    if raw.empty:
+        return pd.DataFrame()
+
+    result = raw.rename(columns=WELLBORE_QUERY_POSITION_MAP)
+    result = result.loc[:, list(WELLBORE_QUERY_POSITION_MAP.values())]
+    for column in result.columns:
+        result[column] = result[column].astype(str).str.strip()
+    for column in WELLBORE_QUERY_DATE_COLUMNS:
+        result[column] = result[column].map(_date_yyyymmdd)
+    return result
 
 
 def _read_daf420_text(text: str) -> pd.DataFrame:
@@ -187,8 +278,17 @@ def _fixed_value(line: str, start: int, width: int) -> str:
 
 def _fixed_date(line: str, start: int) -> str:
     value = _fixed_value(line, start, 8)
+    return _parse_yyyymmdd(value, fallback="")
+
+
+def _date_yyyymmdd(value: str) -> str:
+    value = str(value).strip()
+    return _parse_yyyymmdd(value, fallback=value)
+
+
+def _parse_yyyymmdd(value: str, fallback: str) -> str:
     if len(value) != 8 or not value.isdigit() or value == "00000000":
-        return ""
+        return fallback
     try:
         return date(int(value[:4]), int(value[4:6]), int(value[6:8])).isoformat()
     except ValueError:

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/sources.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/sources.py
@@ -14,6 +14,11 @@ from typing import Sequence
 import pandas as pd
 import yaml
 
+from worldenergydata.texas_rrc.lifecycle.completion_packets import (
+    looks_like_completion_packet_text,
+    read_completion_packet_text,
+)
+
 
 @dataclass(frozen=True)
 class LifecycleInputFrames:
@@ -97,6 +102,8 @@ def _read_table(path: Path, source_id: str) -> pd.DataFrame:
     if source_id == "wellbore_query":
         return _read_wellbore_query_file(path)
     text = path.read_text(encoding="utf-8", errors="replace")
+    if source_id == "completion_data" and looks_like_completion_packet_text(text):
+        return read_completion_packet_text(text)
     if source_id == "drilling_permits" and path.name.lower() == "daf420.dat":
         frame = _read_daf420_text(text)
         if not frame.empty:
@@ -121,6 +128,13 @@ def _read_zip_tables(path: Path, source_id: str) -> pd.DataFrame:
                     continue
             if source_id == "wellbore_query":
                 frame = _read_wellbore_query_text(text)
+                if not frame.empty:
+                    frames.append(frame)
+                continue
+            if source_id == "completion_data" and looks_like_completion_packet_text(
+                text
+            ):
+                frame = read_completion_packet_text(text)
                 if not frame.empty:
                     frames.append(frame)
                 continue

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/spine.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/spine.py
@@ -13,7 +13,6 @@ from worldenergydata.texas_rrc.lifecycle.keys import (
 )
 from worldenergydata.texas_rrc.lifecycle.sources import LifecycleInputFrames
 
-
 SOURCE_ORDER = ("wellbore_query", "drilling_permits", "completion_data")
 IDENTIFIER_COLUMNS = (
     "district",
@@ -81,33 +80,54 @@ def _normalize_source_frame(frame: pd.DataFrame) -> pd.DataFrame:
     result = result[result["api14"].notna()].copy()
     if result.empty:
         return result
-    result["api10"] = result["api14"].apply(derive_api10)
-    api_segments = result["api14"].apply(split_api14).apply(pd.Series)
-    for column in (
-        "county_code",
-        "well_unique_number",
-        "sidetrack_code",
-        "completion_code",
-    ):
-        result[column] = api_segments[column]
+    api14 = result["api14"].astype("string")
+    result["api10"] = api14.str.slice(0, 10)
+    result["county_code"] = api14.str.slice(2, 5)
+    result["well_unique_number"] = api14.str.slice(5, 10)
+    result["sidetrack_code"] = api14.str.slice(10, 12)
+    result["completion_code"] = api14.str.slice(12, 14)
     return result
 
 
 def _by_key(frame: pd.DataFrame, key: str) -> dict[str, dict[str, Any]]:
     if frame.empty or key not in frame.columns:
         return {}
-    rows = {}
-    for value, group in frame.groupby(key, sort=True):
-        if _has_value(value):
-            rows[str(value)] = _most_complete_row(group).to_dict()
-    return rows
+    key_values = frame[key].astype("string")
+    keyed = frame[key_values.notna() & key_values.ne("")].copy()
+    if keyed.empty:
+        return {}
+
+    duplicated = keyed.duplicated(subset=[key], keep=False)
+    if duplicated.any():
+        unique = keyed.loc[~duplicated]
+        duplicate_rows = keyed.loc[duplicated].copy()
+        duplicate_rows["_row_completeness"] = _row_completeness(duplicate_rows)
+        selected_indices = duplicate_rows.groupby(key, sort=True)[
+            "_row_completeness"
+        ].idxmax()
+        selected_duplicates = duplicate_rows.loc[selected_indices].drop(
+            columns="_row_completeness"
+        )
+        selected = pd.concat([unique, selected_duplicates], ignore_index=True)
+    else:
+        selected = keyed
+
+    selected = selected.sort_values(key)
+    return {
+        str(value): row
+        for value, row in selected.set_index(key, drop=False)
+        .to_dict(orient="index")
+        .items()
+    }
 
 
-def _most_complete_row(group: pd.DataFrame) -> pd.Series:
-    completeness = group.apply(
-        lambda row: sum(_has_value(value) for value in row), axis=1
-    )
-    return group.loc[completeness.idxmax()]
+def _row_completeness(frame: pd.DataFrame) -> pd.Series:
+    completeness = pd.Series(0, index=frame.index, dtype="int16")
+    for column in frame.columns:
+        values = frame[column]
+        present = values.notna() & values.astype("string").ne("")
+        completeness += present.astype("int16")
+    return completeness
 
 
 def _build_record(

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/raw_directory.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/raw_directory.py
@@ -83,6 +83,7 @@ def build_directory_refresh_plan(
     row_count = all_pages[0].row_count if all_pages else 0
     target_dir = _target_dir(entry, output_root)
     selected = _select_entries(source_id, entry, entries, selection)
+    selected_files = tuple(_to_refresh_file(item, target_dir) for item in selected)
     return DirectoryRefreshPlan(
         source_id=source_id,
         refreshable=True,
@@ -92,7 +93,7 @@ def build_directory_refresh_plan(
         target_path=target_dir,
         refresh_cadence=entry["refresh_cadence"],
         row_count=row_count,
-        selected_files=tuple(_to_refresh_file(item, target_dir) for item in selected),
+        selected_files=_deduplicate_refresh_files(selected_files),
     )
 
 
@@ -243,3 +244,17 @@ def _to_refresh_file(
         page_first=entry.page_first,
         target_path=target_dir / entry.filename,
     )
+
+
+def _deduplicate_refresh_files(
+    selected_files: tuple[DirectoryRefreshFile, ...],
+) -> tuple[DirectoryRefreshFile, ...]:
+    seen = set()
+    result = []
+    for item in selected_files:
+        key = (item.filename, item.target_path)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(item)
+    return tuple(result)

--- a/src/worldenergydata/cli/commands/texas_rrc.py
+++ b/src/worldenergydata/cli/commands/texas_rrc.py
@@ -729,6 +729,216 @@ def build_production_atlas_command(
         raise typer.Exit(1)
 
 
+def _field_development_input_paths(root: Path) -> list[str]:
+    from worldenergydata.texas_rrc.field_development import io as field_io
+    from worldenergydata.texas_rrc.lifecycle import io as lifecycle_io
+    from worldenergydata.texas_rrc.production_atlas import io as atlas_io
+
+    candidates = [
+        lifecycle_io.LIFECYCLE_SPINE_DIR / lifecycle_io.SPINE_FILENAME,
+        lifecycle_io.LIFECYCLE_SPINE_DIR / lifecycle_io.QUALITY_FILENAME,
+        atlas_io.PRODUCTION_ATLAS_DIR / atlas_io.PARQUET_FILENAME,
+        atlas_io.PRODUCTION_ATLAS_DIR / atlas_io.CSV_FILENAME,
+        atlas_io.PRODUCTION_ATLAS_DIR / atlas_io.QUALITY_FILENAME,
+    ]
+    output_candidates = {
+        field_io.FIELD_DEVELOPMENT_METRICS_DIR / field_io.CSV_FILENAME,
+        field_io.FIELD_DEVELOPMENT_METRICS_DIR / field_io.PARQUET_FILENAME,
+        field_io.FIELD_DEVELOPMENT_METRICS_DIR / field_io.QUALITY_FILENAME,
+        field_io.FIELD_DEVELOPMENT_METRICS_DIR / field_io.MANIFEST_FILENAME,
+    }
+    return [
+        str(path)
+        for path in candidates
+        if (root / path).exists() and path not in output_candidates
+    ]
+
+
+def _print_field_development_summary(row_count: int, source_gaps) -> None:
+    table = Table(
+        title="Texas RRC Field Development Metrics",
+        show_header=True,
+        header_style="bold cyan",
+    )
+    table.add_column("Metric", style="dim")
+    table.add_column("Value")
+    table.add_row("Field-development rows", str(row_count))
+    table.add_row("Source gaps", ", ".join(source_gaps) if source_gaps else "None")
+    console.print(table)
+
+
+def _print_field_development_outputs(manifest) -> None:
+    console.print(
+        "[green]Wrote field-development metrics[/green] "
+        f"{manifest.row_count} rows -> {manifest.csv_path}"
+    )
+    console.print(f"[dim]Parquet: {manifest.parquet_path}[/dim]")
+    console.print(f"[dim]Quality report: {manifest.quality_path}[/dim]")
+    console.print(f"[dim]Manifest: {manifest.manifest_path}[/dim]")
+
+
+def _build_missing_lifecycle(root: Path, allow_non_ace_output: bool) -> None:
+    from worldenergydata.texas_rrc.lifecycle.io import write_lifecycle_outputs
+    from worldenergydata.texas_rrc.lifecycle.quality import assess_lifecycle_quality
+    from worldenergydata.texas_rrc.lifecycle.sources import load_lifecycle_inputs
+    from worldenergydata.texas_rrc.lifecycle.spine import build_lifecycle_spine
+
+    inputs = load_lifecycle_inputs(root)
+    if inputs.source_gaps:
+        console.print(
+            "[red]Error:[/red] missing lifecycle sources: "
+            f"{', '.join(inputs.source_gaps)}"
+        )
+        raise typer.Exit(1)
+
+    spine = build_lifecycle_spine(inputs)
+    quality = assess_lifecycle_quality(spine, source_gaps=inputs.source_gaps)
+    manifest = write_lifecycle_outputs(
+        spine,
+        quality,
+        output_root=root,
+        input_paths=_lifecycle_input_paths(root),
+        allow_non_ace_root=allow_non_ace_output,
+    )
+    console.print(
+        "[green]Wrote lifecycle spine[/green] "
+        f"{manifest.row_count} rows -> {manifest.spine_path}"
+    )
+
+
+def _build_missing_production(
+    root: Path,
+    allow_non_ace_output: bool,
+    chunksize: int,
+) -> None:
+    _run_build_production_atlas(
+        raw_root=root,
+        output_root=root,
+        dry_run=False,
+        require_sources=True,
+        allow_non_ace_output=allow_non_ace_output,
+        chunksize=chunksize,
+    )
+
+
+def _run_build_field_development_metrics(
+    root: Path,
+    output_root: Path,
+    dry_run: bool,
+    require_sources: bool,
+    build_missing_lifecycle: bool,
+    build_missing_production: bool,
+    allow_non_ace_output: bool,
+    chunksize: int,
+) -> None:
+    from worldenergydata.texas_rrc.field_development import (
+        assess_field_development_quality,
+        build_field_development_metrics,
+        load_field_development_inputs,
+        write_field_development_outputs,
+    )
+
+    inputs = load_field_development_inputs(root)
+    if "well_lifecycle_spine" in inputs.source_gaps and build_missing_lifecycle:
+        _build_missing_lifecycle(root, allow_non_ace_output)
+        inputs = load_field_development_inputs(root)
+    if "production_field_atlas" in inputs.source_gaps and build_missing_production:
+        _build_missing_production(root, allow_non_ace_output, chunksize)
+        inputs = load_field_development_inputs(root)
+
+    source_gaps = tuple(inputs.source_gaps)
+    if source_gaps and (require_sources or not dry_run):
+        console.print(
+            "[red]Error:[/red] missing field-development sources: "
+            f"{', '.join(source_gaps)}"
+        )
+        raise typer.Exit(1)
+
+    metrics = build_field_development_metrics(inputs)
+    quality = assess_field_development_quality(metrics, inputs)
+    _print_field_development_summary(len(metrics), source_gaps)
+
+    if dry_run:
+        console.print("[yellow]Dry run:[/yellow] no field-development outputs written")
+        return
+
+    manifest = write_field_development_outputs(
+        metrics,
+        quality,
+        output_root=output_root,
+        input_paths=_field_development_input_paths(root),
+        allow_non_ace_root=allow_non_ace_output,
+        command=(
+            "worldenergydata texas-rrc build-field-development-metrics "
+            f"--root {root} --output-root {output_root}"
+        ),
+    )
+    _print_field_development_outputs(manifest)
+
+
+@app.command("build-field-development-metrics")
+def build_field_development_metrics_command(
+    root: Path = typer.Option(
+        Path("/mnt/ace/worldenergydata/data/modules/texas_rrc"),
+        "--root",
+        help="Root containing curated Texas RRC lifecycle and production artifacts",
+    ),
+    output_root: Path = typer.Option(
+        Path("/mnt/ace/worldenergydata/data/modules/texas_rrc"),
+        "--output-root",
+        help="Root for curated field-development metric outputs",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Build the field-development summary without writing outputs",
+    ),
+    require_sources: bool = typer.Option(
+        False,
+        "--require-sources",
+        help="Fail when any curated lifecycle or production input is missing",
+    ),
+    build_missing_lifecycle: bool = typer.Option(
+        False,
+        "--build-missing-lifecycle",
+        help="Build missing lifecycle spine from local raw snapshots",
+    ),
+    build_missing_production: bool = typer.Option(
+        False,
+        "--build-missing-production",
+        help="Build missing production atlas from local raw snapshots",
+    ),
+    allow_non_ace_output: bool = typer.Option(
+        False,
+        "--allow-non-ace-output",
+        help="Allow non-/mnt/ace output roots for isolated tests or sandboxes",
+    ),
+    chunksize: int = typer.Option(
+        1_000_000,
+        "--chunksize",
+        min=1,
+        help="Rows per PDQ production chunk when building a missing atlas",
+    ),
+) -> None:
+    """Build Texas RRC field-development metrics from curated direct sources."""
+    try:
+        _run_build_field_development_metrics(
+            root,
+            output_root,
+            dry_run,
+            require_sources,
+            build_missing_lifecycle,
+            build_missing_production,
+            allow_non_ace_output,
+            chunksize,
+        )
+    except typer.Exit:
+        raise
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+
+
 @app.command()
 def analyze(
     district: Optional[str] = typer.Option(

--- a/tests/unit/texas_rrc/test_field_development_cli.py
+++ b/tests/unit/texas_rrc/test_field_development_cli.py
@@ -1,0 +1,146 @@
+"""CLI tests for Texas RRC field-development metrics."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+from typer.testing import CliRunner
+
+from worldenergydata.cli.commands.texas_rrc import app
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+
+def _write_curated_inputs(root: Path) -> None:
+    lifecycle_path = (
+        root / "curated" / "well_lifecycle" / "spine" / "well_lifecycle_spine.csv"
+    )
+    lifecycle_path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        [
+            {
+                "api14": "42001000010000",
+                "api10": "4200100001",
+                "district": "08",
+                "field_number": "00010001",
+                "field_name": "SPRABERRY",
+                "lease_number": "02001",
+                "operator_number": "300001",
+                "well_status": "PRODUCING",
+                "completion_date": "2020-01-01",
+            }
+        ]
+    ).to_csv(lifecycle_path, index=False)
+
+    production_path = (
+        root
+        / "curated"
+        / "production"
+        / "field_atlas"
+        / "production_field_atlas.parquet"
+    )
+    production_path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        [
+            {
+                "aggregation_level": "field",
+                "district": "08",
+                "field_number": "00010001",
+                "field_name": "SPRABERRY",
+                "first_production_month": "2020-02",
+                "last_production_month": "2025-01",
+                "still_producing": True,
+                "production_span_months": 60,
+                "cumulative_boe": 1000.0,
+                "lease_count": 1,
+                "operator_count": 1,
+            }
+        ]
+    ).to_parquet(production_path, index=False)
+
+    _write_json(
+        lifecycle_path.with_name("well_lifecycle_quality.json"),
+        {"row_count": 1, "source_gaps": []},
+    )
+    _write_json(
+        production_path.with_name("production_field_atlas_quality.json"),
+        {"row_count": 1, "metric_gaps": []},
+    )
+
+
+def test_build_field_development_metrics_cli_dry_run(tmp_path):
+    _write_curated_inputs(tmp_path)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "build-field-development-metrics",
+            "--root",
+            str(tmp_path),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Field-development rows" in result.output
+    assert "Dry run" in result.output
+    assert not (tmp_path / "curated/field_development").exists()
+
+
+def test_build_field_development_metrics_cli_refuses_missing_sources(tmp_path):
+    result = CliRunner().invoke(
+        app,
+        [
+            "build-field-development-metrics",
+            "--root",
+            str(tmp_path),
+            "--output-root",
+            str(tmp_path),
+            "--allow-non-ace-output",
+            "--require-sources",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "missing field-development sources" in result.output
+    assert "well_lifecycle_spine" in result.output
+    assert not (tmp_path / "curated/field_development").exists()
+
+
+def test_build_field_development_metrics_cli_writes_with_non_ace_override(tmp_path):
+    output_root = tmp_path / "out"
+    _write_curated_inputs(tmp_path)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "build-field-development-metrics",
+            "--root",
+            str(tmp_path),
+            "--output-root",
+            str(output_root),
+            "--allow-non-ace-output",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Wrote field-development metrics" in result.output
+    assert (
+        output_root
+        / "curated"
+        / "field_development"
+        / "metrics"
+        / "field_development_metrics.csv"
+    ).exists()
+    manifest = json.loads(
+        (
+            output_root / "curated" / "field_development" / "metrics" / "manifest.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert manifest["row_count"] == 1
+    assert manifest["input_paths"]

--- a/tests/unit/texas_rrc/test_field_development_io.py
+++ b/tests/unit/texas_rrc/test_field_development_io.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 import json
+from datetime import datetime, timezone
 
 import pandas as pd
 import pytest

--- a/tests/unit/texas_rrc/test_field_development_io.py
+++ b/tests/unit/texas_rrc/test_field_development_io.py
@@ -1,0 +1,146 @@
+"""Tests for Texas RRC field-development quality and output persistence."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+
+import pandas as pd
+import pytest
+
+from worldenergydata.texas_rrc.field_development.sources import (
+    FieldDevelopmentInputs,
+)
+
+
+def _inputs(source_gaps: tuple[str, ...] = ()) -> FieldDevelopmentInputs:
+    return FieldDevelopmentInputs(
+        lifecycle=pd.DataFrame(),
+        production=pd.DataFrame(),
+        lifecycle_quality={},
+        production_quality={},
+        source_gaps=source_gaps,
+    )
+
+
+def _metrics() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "district": "08",
+                "field_number": "00010001",
+                "field_name": "SPRABERRY",
+                "production_maturity_class": "growth",
+                "source_caveats": (
+                    "lease_level_production|no_per_well_allocation|"
+                    "water_and_well_count_unavailable_from_pdq"
+                ),
+                "cumulative_boe": 1000.0,
+                "rank_cumulative_boe": 1,
+            },
+            {
+                "district": "09",
+                "field_number": "00020001",
+                "field_name": "LIFECYCLE ONLY",
+                "production_maturity_class": "pre_production",
+                "source_caveats": "missing_production|missing_lifecycle_dates",
+                "cumulative_boe": pd.NA,
+                "rank_cumulative_boe": 2,
+            },
+        ]
+    )
+
+
+def test_assess_field_development_quality_counts_caveats_and_maturity():
+    from worldenergydata.texas_rrc.field_development.quality import (
+        assess_field_development_quality,
+    )
+
+    report = assess_field_development_quality(
+        _metrics(),
+        _inputs(source_gaps=("well_lifecycle_quality",)),
+    )
+
+    assert report.row_count == 2
+    assert report.source_gaps == ("well_lifecycle_quality",)
+    assert report.caveat_counts["lease_level_production"] == 1
+    assert report.caveat_counts["missing_production"] == 1
+    assert report.maturity_counts == {"growth": 1, "pre_production": 1}
+
+
+def test_write_field_development_outputs_rejects_non_ace_root_by_default(tmp_path):
+    from worldenergydata.texas_rrc.field_development.io import (
+        write_field_development_outputs,
+    )
+    from worldenergydata.texas_rrc.field_development.quality import (
+        assess_field_development_quality,
+    )
+
+    with pytest.raises(ValueError, match="/mnt/ace"):
+        write_field_development_outputs(
+            _metrics(),
+            assess_field_development_quality(_metrics(), _inputs()),
+            output_root=tmp_path,
+        )
+
+
+def test_write_field_development_outputs_persists_quality_and_manifest(tmp_path):
+    from worldenergydata.texas_rrc.field_development.io import (
+        load_field_development_metrics,
+        write_field_development_outputs,
+    )
+    from worldenergydata.texas_rrc.field_development.quality import (
+        assess_field_development_quality,
+    )
+
+    metrics = _metrics()
+    inputs = _inputs(source_gaps=("production_field_atlas_quality",))
+    quality = assess_field_development_quality(metrics, inputs)
+    lifecycle_path = tmp_path / "curated/well_lifecycle/spine/well_lifecycle_spine.csv"
+    production_path = tmp_path / "curated/production/field_atlas/production.parquet"
+
+    manifest = write_field_development_outputs(
+        metrics,
+        quality,
+        output_root=tmp_path,
+        generated_at=datetime(2026, 7, 1, 3, 0, tzinfo=timezone.utc),
+        input_paths=[lifecycle_path, production_path],
+        allow_non_ace_root=True,
+        command="worldenergydata texas-rrc build-field-development-metrics",
+        code_revision="abc123",
+    )
+
+    assert manifest.csv_path == (
+        tmp_path
+        / "curated"
+        / "field_development"
+        / "metrics"
+        / "field_development_metrics.csv"
+    )
+    assert manifest.parquet_path.exists()
+    assert manifest.quality_path.exists()
+    assert manifest.manifest_path.exists()
+
+    reloaded_csv = load_field_development_metrics(manifest.csv_path)
+    reloaded_parquet = load_field_development_metrics(manifest.parquet_path)
+    assert reloaded_csv.iloc[0]["field_number"] == "00010001"
+    assert reloaded_parquet.iloc[0]["field_number"] == "00010001"
+
+    quality_payload = json.loads(manifest.quality_path.read_text(encoding="utf-8"))
+    assert quality_payload["row_count"] == 2
+    assert quality_payload["source_gaps"] == ["production_field_atlas_quality"]
+    assert quality_payload["caveat_counts"]["no_per_well_allocation"] == 1
+
+    manifest_payload = json.loads(manifest.manifest_path.read_text(encoding="utf-8"))
+    assert manifest_payload["generated_at"] == "2026-07-01T03:00:00Z"
+    assert manifest_payload["row_count"] == 2
+    assert manifest_payload["input_paths"] == [
+        str(lifecycle_path),
+        str(production_path),
+    ]
+    assert (
+        manifest_payload["command"]
+        == "worldenergydata texas-rrc build-field-development-metrics"
+    )
+    assert manifest_payload["code_revision"] == "abc123"
+    assert manifest_payload["quality"]["maturity_counts"]["growth"] == 1

--- a/tests/unit/texas_rrc/test_field_development_metrics.py
+++ b/tests/unit/texas_rrc/test_field_development_metrics.py
@@ -1,0 +1,237 @@
+"""Tests for Texas RRC field-development metric construction."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.field_development.sources import (
+    FieldDevelopmentInputs,
+)
+
+
+def _inputs(
+    lifecycle: list[dict[str, object]],
+    production: list[dict[str, object]],
+    *,
+    source_gaps: tuple[str, ...] = (),
+    production_quality: dict[str, object] | None = None,
+) -> FieldDevelopmentInputs:
+    return FieldDevelopmentInputs(
+        lifecycle=pd.DataFrame(lifecycle),
+        production=pd.DataFrame(production),
+        lifecycle_quality={"row_count": len(lifecycle)},
+        production_quality=production_quality or {"metric_gaps": []},
+        source_gaps=source_gaps,
+    )
+
+
+def test_build_field_development_metrics_joins_sources_and_ranks_fields():
+    from worldenergydata.texas_rrc.field_development.metrics import (
+        build_field_development_metrics,
+    )
+
+    inputs = _inputs(
+        lifecycle=[
+            {
+                "api14": "42001000010000",
+                "district": "08",
+                "field_number": "00010001",
+                "field_name": "SPRABERRY",
+                "lease_number": "02001",
+                "operator_number": "300001",
+                "operator_name": "ALPHA ENERGY",
+                "well_status": "PRODUCING",
+                "well_type": "O",
+                "wellbore_profile": "HORIZONTAL",
+                "permit_number": "100",
+                "permit_issued_date": "2020-01-01",
+                "completion_date": "2020-01-11",
+            },
+            {
+                "api14": "42001000020000",
+                "district": "08",
+                "field_number": "00010001",
+                "field_name": "SPRABERRY",
+                "lease_number": "02002",
+                "operator_number": "300002",
+                "operator_name": "BETA ENERGY",
+                "well_status": "PLUGGED",
+                "well_type": "O",
+                "wellbore_profile": "DIRECTIONAL",
+                "permit_number": "101",
+                "permit_issued_date": "2020-01-01",
+                "completion_date": "2020-01-21",
+            },
+        ],
+        production=[
+            {
+                "aggregation_level": "field",
+                "district": "08",
+                "field_number": "00010001",
+                "field_name": "SPRABERRY",
+                "first_production_month": "2020-02",
+                "last_production_month": "2023-01",
+                "still_producing": True,
+                "production_span_months": 36,
+                "cumulative_oil_bbl": 100.0,
+                "cumulative_gas_mcf": 600.0,
+                "cumulative_condensate_bbl": 10.0,
+                "cumulative_boe": 210.0,
+                "lease_count": 2,
+                "operator_count": 2,
+                "top_operator_number": "300001",
+                "top_operator_name": "ALPHA ENERGY",
+                "top_operator_share": 0.75,
+            }
+        ],
+        production_quality={"metric_gaps": ["water_bbl", "well_count"]},
+    )
+
+    metrics = build_field_development_metrics(inputs)
+    row = metrics.set_index(["district", "field_number"]).loc[("08", "00010001")]
+
+    assert row["field_name"] == "SPRABERRY"
+    assert row["well_count"] == 2
+    assert row["active_well_count"] == 1
+    assert row["plugged_well_count"] == 1
+    assert row["permit_count"] == 2
+    assert row["completion_count"] == 2
+    assert row["horizontal_well_count"] == 1
+    assert row["directional_well_count"] == 1
+    assert row["horizontal_directional_share"] == 1.0
+    assert row["median_permit_to_completion_days"] == 15.0
+    assert row["median_completion_to_first_production_days"] == 16.0
+    assert row["production_maturity_class"] == "growth"
+    assert row["production_per_well_boe"] == 105.0
+    assert row["well_density_proxy"] == 1.0
+    assert row["well_density_basis"] == "wells_per_lease"
+    assert row["remaining_activity_score"] == 0.75
+    assert row["rank_cumulative_boe"] == 1
+    assert row["rank_remaining_activity"] == 1
+    assert row["rank_well_density_proxy"] == 1
+    assert row["top_operator_number"] == "300001"
+    assert row["top_operator_share"] == 0.75
+    assert row["source_caveats"] == (
+        "lease_level_production|no_per_well_allocation|"
+        "water_and_well_count_unavailable_from_pdq"
+    )
+    assert row["quality_flags"] == ""
+
+
+def test_build_field_development_metrics_preserves_missing_source_fields():
+    from worldenergydata.texas_rrc.field_development.metrics import (
+        build_field_development_metrics,
+    )
+
+    inputs = _inputs(
+        lifecycle=[
+            {
+                "api14": "42003000010000",
+                "district": "08",
+                "field_number": "00020001",
+                "field_name": "LIFECYCLE ONLY",
+                "lease_number": "02010",
+                "well_status": "SHUT IN",
+                "permit_number": "200",
+            }
+        ],
+        production=[
+            {
+                "aggregation_level": "field",
+                "district": "09",
+                "field_number": "00030001",
+                "field_name": "PRODUCTION ONLY",
+                "first_production_month": "1990-01",
+                "last_production_month": "2010-01",
+                "still_producing": False,
+                "production_span_months": 240,
+                "cumulative_boe": 500.0,
+                "lease_count": 4,
+                "operator_count": 1,
+            }
+        ],
+    )
+
+    metrics = build_field_development_metrics(inputs)
+    by_field = metrics.set_index(["district", "field_number"])
+    lifecycle_only = by_field.loc[("08", "00020001")]
+    production_only = by_field.loc[("09", "00030001")]
+
+    assert lifecycle_only["well_count"] == 1
+    assert lifecycle_only["active_well_count"] == 1
+    assert pd.isna(lifecycle_only["cumulative_boe"])
+    assert lifecycle_only["production_maturity_class"] == "pre_production"
+    assert "missing_production" in lifecycle_only["source_caveats"]
+    assert "missing_lifecycle_dates" in lifecycle_only["source_caveats"]
+
+    assert production_only["well_count"] == 0
+    assert production_only["production_maturity_class"] == "late_life"
+    assert pd.isna(production_only["production_per_well_boe"])
+    assert pd.isna(production_only["well_density_proxy"])
+    assert "missing_lifecycle" in production_only["source_caveats"]
+
+
+def test_build_field_development_metrics_classifies_maturity_and_dates():
+    from worldenergydata.texas_rrc.field_development.metrics import (
+        build_field_development_metrics,
+    )
+
+    inputs = _inputs(
+        lifecycle=[
+            {
+                "api14": "42001000010000",
+                "district": "01",
+                "field_number": "00000001",
+                "field_name": "EARLY",
+                "permit_issued_date": "2021-03-01",
+                "completion_date": "2021-02-01",
+            },
+            {
+                "api14": "42001000020000",
+                "district": "01",
+                "field_number": "00000002",
+                "field_name": "MATURE",
+                "completion_date": "2010-01-01",
+            },
+            {
+                "api14": "42001000030000",
+                "district": "01",
+                "field_number": "00000003",
+                "field_name": "UNKNOWN",
+            },
+        ],
+        production=[
+            {
+                "aggregation_level": "field",
+                "district": "01",
+                "field_number": "00000001",
+                "field_name": "EARLY",
+                "first_production_month": "2021-02",
+                "last_production_month": "2022-01",
+                "still_producing": True,
+                "production_span_months": 12,
+                "cumulative_boe": 10.0,
+                "lease_count": 1,
+            },
+            {
+                "aggregation_level": "field",
+                "district": "01",
+                "field_number": "00000002",
+                "field_name": "MATURE",
+                "first_production_month": "2010-01",
+                "last_production_month": "2025-01",
+                "still_producing": True,
+                "production_span_months": 180,
+                "cumulative_boe": 20.0,
+                "lease_count": 1,
+            },
+        ],
+    )
+
+    metrics = build_field_development_metrics(inputs).set_index("field_number")
+
+    assert metrics.loc["00000001", "production_maturity_class"] == "early_development"
+    assert pd.isna(metrics.loc["00000001", "median_permit_to_completion_days"])
+    assert metrics.loc["00000002", "production_maturity_class"] == "mature_active"
+    assert metrics.loc["00000003", "production_maturity_class"] == "pre_production"
+    assert metrics.loc["00000002", "rank_development_maturity"] == 1

--- a/tests/unit/texas_rrc/test_field_development_metrics.py
+++ b/tests/unit/texas_rrc/test_field_development_metrics.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import warnings
+from time import perf_counter
+
 import pandas as pd
 
 from worldenergydata.texas_rrc.field_development.sources import (
@@ -235,3 +238,43 @@ def test_build_field_development_metrics_classifies_maturity_and_dates():
     assert metrics.loc["00000002", "production_maturity_class"] == "mature_active"
     assert metrics.loc["00000003", "production_maturity_class"] == "pre_production"
     assert metrics.loc["00000002", "rank_development_maturity"] == 1
+
+
+def test_lifecycle_aggregation_scales_beyond_row_wise_group_processing():
+    from worldenergydata.texas_rrc.field_development.metrics import (
+        _aggregate_lifecycle,
+    )
+
+    row_count = 5_000
+    lifecycle = pd.DataFrame(
+        {
+            "district": ["08"] * row_count,
+            "field_number": [f"{index % 100:08d}" for index in range(row_count)],
+            "field_name": ["SPRABERRY"] * row_count,
+            "lease_number": [f"{index % 300:05d}" for index in range(row_count)],
+            "operator_number": [f"{index % 25:06d}" for index in range(row_count)],
+            "well_status": [
+                "PRODUCING" if index % 2 else "PLUGGED" for index in range(row_count)
+            ],
+            "well_type": ["O"] * row_count,
+            "wellbore_profile": [
+                "HORIZONTAL" if index % 3 else "DIRECTIONAL"
+                for index in range(row_count)
+            ],
+            "permit_number": [str(index) for index in range(row_count)],
+            "permit_issued_date": ["2020-01-01"] * row_count,
+            "completion_date": ["2020-01-11"] * row_count,
+        }
+    )
+
+    started = perf_counter()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        metrics = _aggregate_lifecycle(lifecycle)
+    elapsed = perf_counter() - started
+
+    assert len(metrics) == 100
+    assert metrics["well_count"].sum() == row_count
+    assert metrics["permit_count"].sum() == row_count
+    assert not [warning for warning in caught if warning.category is UserWarning]
+    assert elapsed < 4.0

--- a/tests/unit/texas_rrc/test_field_development_sources.py
+++ b/tests/unit/texas_rrc/test_field_development_sources.py
@@ -1,0 +1,190 @@
+"""Tests for loading Texas RRC field-development input artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+
+def _write_lifecycle(root: Path) -> Path:
+    path = (
+        root
+        / "curated"
+        / "well_lifecycle"
+        / "spine"
+        / "well_lifecycle_spine.csv"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        [
+            {
+                "api14": "42001000010000",
+                "api10": "4200100001",
+                "district": "08",
+                "field_number": "00010001",
+                "field_name": "SPRABERRY",
+                "lease_number": "02001",
+                "operator_number": "300001",
+            }
+        ]
+    ).to_csv(path, index=False)
+    return path
+
+
+def _production_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "aggregation_level": "field",
+                "district": "08",
+                "field_number": "00010001",
+                "field_name": "SPRABERRY",
+                "cumulative_boe": 1000.0,
+            },
+            {
+                "aggregation_level": "lease",
+                "district": "08",
+                "field_number": "00010001",
+                "lease_number": "02001",
+                "cumulative_boe": 600.0,
+            },
+        ]
+    )
+
+
+def _write_production_parquet(root: Path) -> Path:
+    path = (
+        root
+        / "curated"
+        / "production"
+        / "field_atlas"
+        / "production_field_atlas.parquet"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _production_frame().to_parquet(path, index=False)
+    return path
+
+
+def _write_production_csv(root: Path) -> Path:
+    path = (
+        root
+        / "curated"
+        / "production"
+        / "field_atlas"
+        / "production_field_atlas.csv"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _production_frame().to_csv(path, index=False)
+    return path
+
+
+def test_load_field_development_inputs_reads_complete_curated_artifacts(tmp_path):
+    from worldenergydata.texas_rrc.field_development.sources import (
+        load_field_development_inputs,
+    )
+
+    _write_lifecycle(tmp_path)
+    _write_production_parquet(tmp_path)
+    _write_json(
+        tmp_path
+        / "curated/well_lifecycle/spine/well_lifecycle_quality.json",
+        {"row_count": 1, "source_gaps": []},
+    )
+    _write_json(
+        tmp_path
+        / "curated/production/field_atlas/production_field_atlas_quality.json",
+        {"row_count": 2, "metric_gaps": ["water_bbl"]},
+    )
+
+    inputs = load_field_development_inputs(tmp_path)
+
+    assert inputs.source_gaps == ()
+    assert inputs.lifecycle.iloc[0]["api14"] == "42001000010000"
+    assert inputs.lifecycle.iloc[0]["field_number"] == "00010001"
+    assert inputs.production["aggregation_level"].tolist() == ["field"]
+    assert inputs.production.iloc[0]["field_number"] == "00010001"
+    assert inputs.lifecycle_quality["row_count"] == 1
+    assert inputs.production_quality["metric_gaps"] == ["water_bbl"]
+
+
+def test_load_field_development_inputs_reports_missing_lifecycle(tmp_path):
+    from worldenergydata.texas_rrc.field_development.sources import (
+        load_field_development_inputs,
+    )
+
+    _write_production_parquet(tmp_path)
+
+    inputs = load_field_development_inputs(tmp_path)
+
+    assert inputs.lifecycle.empty
+    assert inputs.source_gaps == (
+        "well_lifecycle_spine",
+        "well_lifecycle_quality",
+        "production_field_atlas_quality",
+    )
+
+
+def test_load_field_development_inputs_reports_missing_production(tmp_path):
+    from worldenergydata.texas_rrc.field_development.sources import (
+        load_field_development_inputs,
+    )
+
+    _write_lifecycle(tmp_path)
+
+    inputs = load_field_development_inputs(tmp_path)
+
+    assert inputs.production.empty
+    assert inputs.source_gaps == (
+        "production_field_atlas",
+        "well_lifecycle_quality",
+        "production_field_atlas_quality",
+    )
+
+
+def test_load_field_development_inputs_reports_missing_quality_json(tmp_path):
+    from worldenergydata.texas_rrc.field_development.sources import (
+        load_field_development_inputs,
+    )
+
+    _write_lifecycle(tmp_path)
+    _write_production_parquet(tmp_path)
+
+    inputs = load_field_development_inputs(tmp_path)
+
+    assert inputs.lifecycle_quality == {}
+    assert inputs.production_quality == {}
+    assert inputs.source_gaps == (
+        "well_lifecycle_quality",
+        "production_field_atlas_quality",
+    )
+
+
+def test_load_field_development_inputs_falls_back_to_production_csv(tmp_path):
+    from worldenergydata.texas_rrc.field_development.sources import (
+        load_field_development_inputs,
+    )
+
+    _write_lifecycle(tmp_path)
+    _write_production_csv(tmp_path)
+
+    inputs = load_field_development_inputs(tmp_path)
+
+    assert inputs.production["aggregation_level"].tolist() == ["field"]
+    assert inputs.production.iloc[0]["field_number"] == "00010001"
+
+
+def test_load_field_development_inputs_rejects_url_like_roots():
+    from worldenergydata.texas_rrc.field_development.sources import (
+        load_field_development_inputs,
+    )
+
+    with pytest.raises(ValueError, match="local filesystem path"):
+        load_field_development_inputs("https://www.rrc.texas.gov/data.zip")

--- a/tests/unit/texas_rrc/test_field_development_sources.py
+++ b/tests/unit/texas_rrc/test_field_development_sources.py
@@ -15,13 +15,7 @@ def _write_json(path: Path, payload: dict[str, object]) -> None:
 
 
 def _write_lifecycle(root: Path) -> Path:
-    path = (
-        root
-        / "curated"
-        / "well_lifecycle"
-        / "spine"
-        / "well_lifecycle_spine.csv"
-    )
+    path = root / "curated" / "well_lifecycle" / "spine" / "well_lifecycle_spine.csv"
     path.parent.mkdir(parents=True, exist_ok=True)
     pd.DataFrame(
         [
@@ -75,11 +69,7 @@ def _write_production_parquet(root: Path) -> Path:
 
 def _write_production_csv(root: Path) -> Path:
     path = (
-        root
-        / "curated"
-        / "production"
-        / "field_atlas"
-        / "production_field_atlas.csv"
+        root / "curated" / "production" / "field_atlas" / "production_field_atlas.csv"
     )
     path.parent.mkdir(parents=True, exist_ok=True)
     _production_frame().to_csv(path, index=False)
@@ -94,13 +84,11 @@ def test_load_field_development_inputs_reads_complete_curated_artifacts(tmp_path
     _write_lifecycle(tmp_path)
     _write_production_parquet(tmp_path)
     _write_json(
-        tmp_path
-        / "curated/well_lifecycle/spine/well_lifecycle_quality.json",
+        tmp_path / "curated/well_lifecycle/spine/well_lifecycle_quality.json",
         {"row_count": 1, "source_gaps": []},
     )
     _write_json(
-        tmp_path
-        / "curated/production/field_atlas/production_field_atlas_quality.json",
+        tmp_path / "curated/production/field_atlas/production_field_atlas_quality.json",
         {"row_count": 2, "metric_gaps": ["water_bbl"]},
     )
 

--- a/tests/unit/texas_rrc/test_lifecycle_io.py
+++ b/tests/unit/texas_rrc/test_lifecycle_io.py
@@ -93,3 +93,22 @@ def test_write_lifecycle_outputs_rejects_non_ace_root_without_override(tmp_path)
             quality,
             output_root=tmp_path,
         )
+
+
+def test_load_lifecycle_spine_disables_chunked_dtype_inference(monkeypatch, tmp_path):
+    from worldenergydata.texas_rrc.lifecycle.io import load_lifecycle_spine
+
+    calls = {}
+
+    def fake_read_csv(path, **kwargs):
+        calls["path"] = path
+        calls.update(kwargs)
+        return pd.DataFrame()
+
+    monkeypatch.setattr(pd, "read_csv", fake_read_csv)
+    spine_path = tmp_path / "well_lifecycle_spine.csv"
+
+    load_lifecycle_spine(spine_path)
+
+    assert calls["path"] == spine_path
+    assert calls["low_memory"] is False

--- a/tests/unit/texas_rrc/test_lifecycle_sources.py
+++ b/tests/unit/texas_rrc/test_lifecycle_sources.py
@@ -41,6 +41,32 @@ def _write_zip(path: Path, member_name: str, content: str) -> None:
         archive.writestr(member_name, content)
 
 
+def _official_wellbore_query_row() -> str:
+    columns = [""] * 59
+    columns[0] = "06"
+    columns[1] = "001"
+    columns[2] = "00100001"
+    columns[3] = "ANDERSON"
+    columns[4] = "O"
+    columns[5] = "7-11 RANCH -B-"
+    columns[6] = "16481001"
+    columns[7] = "CAYUGA"
+    columns[8] = "04411"
+    columns[9] = "1"
+    columns[11] = "SUPREME ENERGY COMPANY  INC."
+    columns[12] = "830589"
+    columns[13] = "Land Well"
+    columns[15] = "4023"
+    columns[18] = "SHUT IN"
+    columns[20] = "20250201"
+    columns[27] = "4644117776"
+    columns[28] = "19840112"
+    columns[29] = "19631205"
+    columns[30] = "19631027"
+    columns[58] = "0"
+    return ",".join(f'"{value}"' for value in columns)
+
+
 def test_load_lifecycle_inputs_reads_local_raw_snapshots(tmp_path):
     _write_zip(
         tmp_path / "raw/wellbore/query/wellbore.zip",
@@ -87,6 +113,34 @@ def test_load_lifecycle_inputs_reads_local_raw_snapshots(tmp_path):
     assert inputs.permits.iloc[0]["spud_date"] == "2024-02-01"
     assert inputs.completions.iloc[0]["completion_date"] == "2024-03-01"
     assert inputs.completions.iloc[0]["form_type"] == "W-2"
+
+
+def test_load_lifecycle_inputs_reads_official_headerless_wellbore_query(
+    tmp_path,
+):
+    _write_text(
+        tmp_path / "raw/wellbore/query/OG_WELLBORE_EWA_Report.csv",
+        _official_wellbore_query_row(),
+    )
+
+    inputs = load_lifecycle_inputs(tmp_path)
+
+    assert inputs.source_gaps == ("drilling_permits", "completion_data")
+    assert inputs.wellbores.iloc[0].to_dict() == {
+        "district": "06",
+        "api_number": "00100001",
+        "well_type": "O",
+        "lease_name": "7-11 RANCH -B-",
+        "field_number": "16481001",
+        "field_name": "CAYUGA",
+        "lease_number": "04411",
+        "operator_name": "SUPREME ENERGY COMPANY  INC.",
+        "operator_number": "830589",
+        "total_depth": "4023",
+        "well_status": "SHUT IN",
+        "plug_date": "2025-02-01",
+        "completion_date": "1963-10-27",
+    }
 
 
 def test_load_lifecycle_inputs_reads_official_daf420_fixed_records(tmp_path):

--- a/tests/unit/texas_rrc/test_lifecycle_sources.py
+++ b/tests/unit/texas_rrc/test_lifecycle_sources.py
@@ -67,6 +67,13 @@ def _official_wellbore_query_row() -> str:
     return ",".join(f'"{value}"' for value in columns)
 
 
+def _completion_packet_line(values: dict[int, str], length: int) -> str:
+    columns = [""] * length
+    for index, value in values.items():
+        columns[index] = value
+    return "{".join(columns)
+
+
 def test_load_lifecycle_inputs_reads_local_raw_snapshots(tmp_path):
     _write_zip(
         tmp_path / "raw/wellbore/query/wellbore.zip",
@@ -237,3 +244,51 @@ def test_load_lifecycle_inputs_maps_official_completion_date_alias(tmp_path):
     assert inputs.source_gaps == ("wellbore_query", "drilling_permits")
     assert inputs.completions.iloc[0]["api_number"] == "00100001"
     assert inputs.completions.iloc[0]["completion_date"] == "2024-03-01"
+
+
+def test_load_lifecycle_inputs_reads_official_completion_packet_data(tmp_path):
+    packet = _completion_packet_line(
+        {
+            0: "PACKET",
+            1: "123456",
+            2: "654321",
+            3: "06/29/2026",
+            6: "00100001",
+            25: "12345678",
+            27: "08",
+            29: "SPRABERRY",
+        },
+        61,
+    )
+    form = _completion_packet_line(
+        {
+            0: "W-2",
+            1: "123456",
+            2: "654321",
+            3: "999999",
+            27: "03/01/2024",
+        },
+        83,
+    )
+    _write_zip(
+        tmp_path / "raw/completions/06-30-2026.zip",
+        "08/trackingNo_123456/packetData_123456_Approved.dat",
+        "\n".join(
+            [
+                "123456{W-2{Plat(1)",
+                "",
+                packet,
+                form,
+                "W-2 Casing Data{123456{654321{999999{1{8 5/8",
+            ]
+        ),
+    )
+
+    inputs = load_lifecycle_inputs(tmp_path)
+
+    assert inputs.source_gaps == ("wellbore_query", "drilling_permits")
+    assert inputs.completions.iloc[0]["api_number"] == "00100001"
+    assert inputs.completions.iloc[0]["completion_date"] == "2024-03-01"
+    assert inputs.completions.iloc[0]["form_type"] == "W-2"
+    assert inputs.completions.iloc[0]["district"] == "08"
+    assert inputs.completions.iloc[0]["field_number"] == "12345678"

--- a/tests/unit/texas_rrc/test_raw_refresh_directory.py
+++ b/tests/unit/texas_rrc/test_raw_refresh_directory.py
@@ -116,6 +116,44 @@ def test_directory_discovery_selects_latest_filename_date(tmp_path):
     ]
 
 
+def test_directory_discovery_deduplicates_repeated_target_filenames(tmp_path):
+    from worldenergydata.texas_rrc.raw_refresh import (
+        DirectorySelection,
+        RawSnapshotRefresher,
+    )
+
+    transport = FakeDirectoryTransport(
+        [
+            _page(
+                [
+                    _entry("06-28-2026.zip"),
+                    _entry("06-29-2026.zip"),
+                    _entry("06-29-2026.zip"),
+                ],
+                row_count=3,
+            )
+        ]
+    )
+    refresher = RawSnapshotRefresher(
+        catalog=_catalog_for("completion_data", "latest_by_filename_date"),
+        output_root=tmp_path,
+        transport=transport,
+        clock=fixed_clock,
+    )
+
+    plan = refresher.discover_directory_source(
+        "completion_data",
+        DirectorySelection(),
+        rows_per_page=1000,
+    )
+
+    assert plan.row_count == 3
+    assert [file.filename for file in plan.selected_files] == ["06-29-2026.zip"]
+    assert [file.target_path for file in plan.selected_files] == [
+        tmp_path / "raw" / "completions" / "06-29-2026.zip"
+    ]
+
+
 def test_directory_discovery_selects_date_window_and_all_gis_files(tmp_path):
     from worldenergydata.texas_rrc.raw_refresh import (
         DirectorySelection,


### PR DESCRIPTION
## Summary

Closes #664.

This extends the onshore Texas RRC pipeline from direct-source lifecycle and production inputs into engineering-facing field-development metrics.

Implemented:
- direct-source lifecycle hardening for official RRC raw inputs, including headerless Wellbore Query and brace-delimited completion packetData parsing
- lifecycle quality/spine performance hardening for million-row normalized spines
- field-development source loading, metric construction, persistence, and CLI wiring
- vectorized field lifecycle aggregation so real /mnt/ace builds complete at current scale
- docs for the field-development metrics lifecycle, refresh cycle, outputs, and caveats

/mnt/ace artifact verification:
- path: /mnt/ace/worldenergydata/data/modules/texas_rrc/curated/field_development/metrics
- manifest row_count: 67082
- manifest source_gaps: []
- manifest code_revision: acca43628995deb8b6877ae68226d927025ff758
- outputs: field_development_metrics.csv, field_development_metrics.parquet, field_development_metrics_quality.json, manifest.json

## Verification

- uv run --no-sync pytest tests/unit/texas_rrc -q -> 465 passed in 135.70s
- uv run --no-sync black --check packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle tests/unit/texas_rrc/test_field_development_metrics.py tests/unit/texas_rrc/test_lifecycle_io.py tests/unit/texas_rrc/test_lifecycle_sources.py
- uv run --no-sync isort --check-only --diff packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle tests/unit/texas_rrc/test_field_development_metrics.py tests/unit/texas_rrc/test_lifecycle_io.py tests/unit/texas_rrc/test_lifecycle_sources.py
- uv run --no-sync flake8 packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle tests/unit/texas_rrc/test_field_development_metrics.py tests/unit/texas_rrc/test_lifecycle_io.py tests/unit/texas_rrc/test_lifecycle_sources.py --max-line-length=100 --extend-ignore=E203,W503 --exclude=__pycache__,*.egg-info,.git,.venv
- uv run --no-sync ruff check packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle tests/unit/texas_rrc/test_field_development_metrics.py tests/unit/texas_rrc/test_lifecycle_io.py tests/unit/texas_rrc/test_lifecycle_sources.py
- uv run --no-sync worldenergydata texas-rrc build-field-development-metrics --require-sources -> wrote 67082 rows
- scripts/enforcement/check-no-conflict-markers.sh
- legal fallback deny-list scan over changed source/test paths -> no matches; repo does not include scripts/legal/legal-sanity-scan.sh