### PR TITLE
feat(texas-rrc): add infrastructure access metrics

### DIFF
--- a/docs/data-sources/onshore/texas-rrc/infrastructure-access-metrics.md
+++ b/docs/data-sources/onshore/texas-rrc/infrastructure-access-metrics.md
@@ -1,0 +1,116 @@
+# Texas RRC Infrastructure Access Metrics
+
+Texas RRC infrastructure access metrics extend the onshore field-development
+workflow with official GIS-derived screening features: field well geometry,
+field-centroid pipeline-envelope distance, nearby pipeline counts, and a
+deterministic access class for field architecture triage.
+
+## Source Of Record
+
+The command uses direct Texas RRC source-derived artifacts only.
+
+| Input | Upstream source | Refresh cycle | Local path |
+| --- | --- | --- | --- |
+| Well GIS layers | `well_gis_layers` official RRC GoDrive directory | Twice weekly | `/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/gis/wells` |
+| Pipeline GIS layers | `pipeline_gis_layers` official RRC GoDrive directory | Twice weekly | `/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/gis/pipelines` |
+| Field-development metrics | Lifecycle plus production field atlas | Follows #664 inputs | `/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/field_development/metrics` |
+| Lifecycle spine | Well lifecycle normalization | Follows lifecycle inputs | `/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/well_lifecycle/spine` |
+
+PatchOps remains validation-only. Its nearest-pipeline and well/area query
+surface maps to the internal shapefile loaders and screening functions, but it
+is not a durable input and is not required for repeatable builds.
+
+## Command
+
+Refresh official RRC GIS layers, then build the metrics:
+
+```bash
+uv run worldenergydata texas-rrc build-infrastructure-access-metrics \
+  --refresh-gis \
+  --require-sources
+```
+
+Use `--dry-run` to inspect source gaps and row counts without writing outputs:
+
+```bash
+uv run worldenergydata texas-rrc build-infrastructure-access-metrics --dry-run
+```
+
+Sandbox runs must explicitly opt into non-ACE output roots:
+
+```bash
+uv run worldenergydata texas-rrc build-infrastructure-access-metrics \
+  --root /tmp/texas_rrc \
+  --output-root /tmp/texas_rrc_out \
+  --allow-non-ace-output
+```
+
+## Output Contract
+
+The command writes:
+
+```text
+/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/infrastructure/access/
++-- field_infrastructure_access.csv
++-- field_infrastructure_access.parquet
++-- field_infrastructure_access_quality.json
++-- manifest.json
+```
+
+Writes are staged under `.staging-infrastructure-access-*` before promotion.
+By default, writes outside `/mnt/ace/worldenergydata/data/modules/texas_rrc`
+are rejected.
+
+## Stable Columns
+
+Stable output columns include:
+
+- `district`
+- `field_number`
+- `field_name`
+- `field_well_count_with_location`
+- `field_centroid_latitude`
+- `field_centroid_longitude`
+- `field_latitude_min`
+- `field_latitude_max`
+- `field_longitude_min`
+- `field_longitude_max`
+- `field_extent_miles`
+- `nearest_pipeline_distance_miles`
+- `nearby_pipeline_count_1mi`
+- `nearby_pipeline_count_5mi`
+- `nearby_pipeline_count_10mi`
+- `nearest_pipeline_source_county`
+- `nearest_pipeline_identifier`
+- `infrastructure_access_score`
+- `infrastructure_access_class`
+- `source_caveats`
+- `quality_flags`
+
+The join key is `district, field_number`, matching the field-development
+metrics.
+
+## Scoring
+
+| Class | Rule | Score |
+| --- | --- | --- |
+| `direct_access` | nearest pipeline distance `<= 1` mile | `1.0` |
+| `near_access` | nearest pipeline distance `> 1` and `<= 5` miles | `0.75` |
+| `regional_access` | nearest pipeline distance `> 5` and `<= 10` miles | `0.5` |
+| `remote_access` | nearest pipeline distance `> 10` and `<= 25` miles | `0.25` |
+| `isolated_or_unknown` | no pipeline within 25 miles, no pipeline source, or no field well locations | `0.0` |
+
+## Caveats
+
+- RRC GIS pipeline presence is a planning-screening signal only.
+- Distances and counts are field-level screening metrics from the field centroid
+  to mapped pipeline envelopes, filtered to the dominant county among matched
+  well GIS points.
+- The output does not claim pipeline capacity, ownership, tariff, product
+  compatibility, right-of-way availability, or engineered tie-in feasibility.
+- Distances use deterministic local screening math, not survey-grade GIS or
+  engineered route analysis.
+- Fields without matched lifecycle API keys and well GIS points carry
+  `missing_well_gis`.
+- Missing or malformed official GIS source files are surfaced in quality JSON
+  and manifest `source_gaps`.

--- a/docs/plans/2026-07-01-issue-665-texas-rrc-pipeline-gis-infrastructure-access.md
+++ b/docs/plans/2026-07-01-issue-665-texas-rrc-pipeline-gis-infrastructure-access.md
@@ -1,7 +1,7 @@
 # Plan: Issue #665 - Texas RRC pipeline and GIS infrastructure access metrics
 
 **Issue:** https://github.com/vamseeachanta/worldenergydata/issues/665
-**Status:** plan-review
+**Status:** plan-approved
 **Tier:** T2 (official GIS fanout, shapefile normalization, spatial metrics, `/mnt/ace` output contract, CLI, tests)
 **Client:** N/A
 **Project:** worldenergydata onshore field development

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -76,7 +76,7 @@ This directory contains issue-plan artifacts created during the issue-planning-m
 | [#662](https://github.com/vamseeachanta/worldenergydata/issues/662) | [texas-rrc-well-lifecycle-spine](2026-06-30-issue-662-texas-rrc-well-lifecycle-spine.md) | plan-review | 2026-06-30 |
 | [#663](https://github.com/vamseeachanta/worldenergydata/issues/663) | [texas-rrc-production-field-atlas](2026-06-30-issue-663-texas-rrc-production-field-atlas.md) | plan-approved | 2026-06-30 |
 | [#664](https://github.com/vamseeachanta/worldenergydata/issues/664) | [texas-rrc-field-development-metrics](2026-07-01-issue-664-texas-rrc-field-development-metrics.md) | plan-review | 2026-07-01 |
-| [#665](https://github.com/vamseeachanta/worldenergydata/issues/665) | [texas-rrc-pipeline-gis-infrastructure-access](2026-07-01-issue-665-texas-rrc-pipeline-gis-infrastructure-access.md) | plan-review | 2026-07-01 |
+| [#665](https://github.com/vamseeachanta/worldenergydata/issues/665) | [texas-rrc-pipeline-gis-infrastructure-access](2026-07-01-issue-665-texas-rrc-pipeline-gis-infrastructure-access.md) | plan-approved | 2026-07-01 |
 | [#669](https://github.com/vamseeachanta/worldenergydata/issues/669) | [texas-rrc-godrive-directory-refresh](2026-06-30-issue-669-texas-rrc-godrive-directory-refresh.md) | plan-approved | 2026-06-30 |
 
 ## Closed / superseded plans

--- a/packages/worldenergydata-texas_rrc/pyproject.toml
+++ b/packages/worldenergydata-texas_rrc/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "pandas>=2.3.3,<3.0",
     "pyarrow>=14.0.0,<20.0",
     "pyyaml>=6.0,<7.0",
+    "pyshp>=2.3,<3",
 ]
 
 [project.urls]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/__init__.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/__init__.py
@@ -1,8 +1,7 @@
 # ABOUTME: Texas Railroad Commission module for oil and gas data integration
 # ABOUTME: Provides access to Texas production, well, and drilling permit data
 
-"""
-Texas Railroad Commission Integration Module for WorldEnergyData.
+"""Texas Railroad Commission Integration Module for WorldEnergyData.
 
 This module provides integration with the Texas Railroad Commission (RRC)
 data sources, enabling collection and analysis of Texas oil and gas data.
@@ -33,19 +32,33 @@ Example usage:
     well_data = client.get_well_by_api("42-123-45678")
 """
 
-from .api_client import TexasRRCClient
-from .cache import FileDownloadCache, TexasRRCCache
-from .errors import (
-    TexasRRCAPIError,
-    TexasRRCConfigurationError,
-    TexasRRCDataError,
-    TexasRRCError,
-    TexasRRCRateLimitError,
-    TexasRRCValidationError,
-)
-from .texas_rrc import TexasRRC
+from importlib import import_module
 
 __version__ = "1.0.0"
+_LAZY_EXPORTS = {
+    "TexasRRC": ".texas_rrc",
+    "TexasRRCClient": ".api_client",
+    "TexasRRCCache": ".cache",
+    "FileDownloadCache": ".cache",
+    "TexasRRCError": ".errors",
+    "TexasRRCAPIError": ".errors",
+    "TexasRRCRateLimitError": ".errors",
+    "TexasRRCConfigurationError": ".errors",
+    "TexasRRCDataError": ".errors",
+    "TexasRRCValidationError": ".errors",
+}
+
+
+def __getattr__(name: str):
+    """Load public Texas RRC exports only when they are requested."""
+    if name not in _LAZY_EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = import_module(_LAZY_EXPORTS[name], __name__)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
 __all__ = [
     # Main class
     "TexasRRC",

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/__init__.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/__init__.py
@@ -1,21 +1,27 @@
 """Field-development metrics tools for Texas RRC curated data."""
 
-from worldenergydata.texas_rrc.field_development.io import (
-    FieldDevelopmentOutputManifest,
-    load_field_development_metrics,
-    write_field_development_outputs,
-)
-from worldenergydata.texas_rrc.field_development.metrics import (
-    build_field_development_metrics,
-)
-from worldenergydata.texas_rrc.field_development.quality import (
-    FieldDevelopmentQualityReport,
-    assess_field_development_quality,
-)
-from worldenergydata.texas_rrc.field_development.sources import (
-    FieldDevelopmentInputs,
-    load_field_development_inputs,
-)
+from importlib import import_module
+
+_LAZY_EXPORTS = {
+    "FieldDevelopmentOutputManifest": ".io",
+    "load_field_development_metrics": ".io",
+    "write_field_development_outputs": ".io",
+    "build_field_development_metrics": ".metrics",
+    "FieldDevelopmentQualityReport": ".quality",
+    "assess_field_development_quality": ".quality",
+    "FieldDevelopmentInputs": ".sources",
+    "load_field_development_inputs": ".sources",
+}
+
+
+def __getattr__(name: str):
+    """Load field-development exports only when requested."""
+    if name not in _LAZY_EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = import_module(_LAZY_EXPORTS[name], __name__)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
 
 __all__ = [
     "FieldDevelopmentInputs",

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/__init__.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/field_development/__init__.py
@@ -23,6 +23,7 @@ def __getattr__(name: str):
     globals()[name] = value
     return value
 
+
 __all__ = [
     "FieldDevelopmentInputs",
     "FieldDevelopmentOutputManifest",

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/godrive.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/godrive.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from html.parser import HTMLParser
-import re
 from xml.etree import ElementTree
 
 

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/infrastructure/__init__.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/infrastructure/__init__.py
@@ -1,0 +1,37 @@
+"""Infrastructure access metrics for Texas RRC onshore field development."""
+
+from worldenergydata.texas_rrc.infrastructure.access_metrics import (
+    InfrastructureAccessInputs,
+    build_infrastructure_access_metrics,
+)
+from worldenergydata.texas_rrc.infrastructure.gis_sources import (
+    GisSourceError,
+    PipelineGisRecord,
+    WellGisRecord,
+    load_pipeline_gis_records,
+    load_well_gis_records,
+)
+from worldenergydata.texas_rrc.infrastructure.io import (
+    InfrastructureAccessOutputManifest,
+    load_infrastructure_access_metrics,
+    write_infrastructure_access_outputs,
+)
+from worldenergydata.texas_rrc.infrastructure.quality import (
+    InfrastructureAccessQualityReport,
+    assess_infrastructure_access_quality,
+)
+
+__all__ = [
+    "GisSourceError",
+    "InfrastructureAccessInputs",
+    "InfrastructureAccessOutputManifest",
+    "InfrastructureAccessQualityReport",
+    "PipelineGisRecord",
+    "WellGisRecord",
+    "assess_infrastructure_access_quality",
+    "build_infrastructure_access_metrics",
+    "load_infrastructure_access_metrics",
+    "load_pipeline_gis_records",
+    "load_well_gis_records",
+    "write_infrastructure_access_outputs",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/infrastructure/access_metrics.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/infrastructure/access_metrics.py
@@ -1,0 +1,476 @@
+"""Build field-level Texas RRC infrastructure access metrics."""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.infrastructure.gis_sources import (
+    PipelineGisRecord,
+    WellGisRecord,
+    normalize_api_number,
+)
+from worldenergydata.texas_rrc.infrastructure.spatial import field_geometry
+
+FIELD_KEYS = ("district", "field_number")
+OUTPUT_COLUMNS = [
+    "district",
+    "field_number",
+    "field_name",
+    "field_well_count_with_location",
+    "field_centroid_latitude",
+    "field_centroid_longitude",
+    "field_latitude_min",
+    "field_latitude_max",
+    "field_longitude_min",
+    "field_longitude_max",
+    "field_extent_miles",
+    "nearest_pipeline_distance_miles",
+    "nearby_pipeline_count_1mi",
+    "nearby_pipeline_count_5mi",
+    "nearby_pipeline_count_10mi",
+    "nearest_pipeline_source_county",
+    "nearest_pipeline_identifier",
+    "infrastructure_access_score",
+    "infrastructure_access_class",
+    "source_caveats",
+    "quality_flags",
+]
+ACCESS_SCORE = {
+    "direct_access": 1.0,
+    "near_access": 0.75,
+    "regional_access": 0.5,
+    "remote_access": 0.25,
+    "isolated_or_unknown": 0.0,
+}
+GRID_DEGREES = 0.25
+
+
+@dataclass(frozen=True)
+class InfrastructureAccessInputs:
+    """Inputs needed to build field-level infrastructure access metrics."""
+
+    field_development: pd.DataFrame
+    lifecycle: pd.DataFrame
+    well_gis: tuple[WellGisRecord, ...]
+    pipeline_gis: tuple[PipelineGisRecord, ...]
+    source_gaps: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _IndexedPipeline:
+    record: PipelineGisRecord
+    bbox: tuple[float, float, float, float]
+
+
+@dataclass(frozen=True)
+class _PipelineDistance:
+    record: PipelineGisRecord
+    distance_miles: float
+
+
+@dataclass(frozen=True)
+class _PipelineSpatialIndex:
+    by_cell: dict[tuple[str | None, int, int], tuple[_IndexedPipeline, ...]]
+    all_records: tuple[_IndexedPipeline, ...]
+
+
+def build_infrastructure_access_metrics(
+    inputs: InfrastructureAccessInputs,
+    nearby_radius_miles: float = 25.0,
+) -> pd.DataFrame:
+    """Join field-development, lifecycle, wells, and pipelines into metrics."""
+    field_rows = _field_rows(inputs.field_development)
+    lifecycle_rows = _lifecycle_rows(inputs.lifecycle)
+    wells_by_api = _wells_by_api(inputs.well_gis)
+    well_points_by_field = _well_points_by_field(lifecycle_rows, wells_by_api)
+    pipeline_index = _pipeline_index(inputs.pipeline_gis)
+    keys = sorted(set(field_rows) | set(well_points_by_field))
+    records = [
+        _record_for_field(
+            key,
+            field_rows.get(key),
+            lifecycle_rows.get(key, []),
+            well_points_by_field.get(key, ()),
+            pipeline_index,
+            len(inputs.pipeline_gis),
+            set(inputs.source_gaps),
+            nearby_radius_miles,
+        )
+        for key in keys
+    ]
+    return pd.DataFrame(records, columns=OUTPUT_COLUMNS)
+
+
+def _record_for_field(
+    key: tuple[str, str],
+    field_row: dict[str, Any] | None,
+    lifecycle_rows: list[dict[str, Any]],
+    well_points: tuple[tuple[WellGisRecord, float, float], ...],
+    pipeline_index: _PipelineSpatialIndex,
+    pipeline_count: int,
+    source_gaps: set[str],
+    nearby_radius_miles: float,
+) -> dict[str, Any]:
+    district, field_number = key
+    points = tuple((item[1], item[2]) for item in well_points)
+    caveats = [
+        "rrc_gis_screening_only",
+        "field_centroid_pipeline_screening",
+        "pipeline_envelope_distance_screening",
+    ]
+    flags: list[str] = []
+    if field_row is None:
+        caveats.append("missing_field_development_metrics")
+    if "pipeline_gis_layers" in source_gaps or pipeline_count == 0:
+        caveats.append("missing_pipeline_gis")
+        flags.append("missing_pipeline_gis")
+    if not points:
+        caveats.append("missing_well_gis")
+        flags.append("missing_well_gis")
+        return _empty_geometry_record(
+            district, field_number, field_row, lifecycle_rows, caveats, flags
+        )
+
+    geometry = field_geometry(points)
+    screening_county = _dominant_county(well_points)
+    counties = {screening_county} if screening_county else set()
+    if screening_county:
+        caveats.append("dominant_county_pipeline_filter")
+    candidate_pipelines = ()
+    if pipeline_count and "pipeline_gis_layers" not in source_gaps:
+        candidate_pipelines = _indexed_candidate_pipelines(
+            geometry,
+            counties,
+            pipeline_index,
+            nearby_radius_miles,
+        )
+    screening_point = (geometry.centroid_latitude, geometry.centroid_longitude)
+    pipeline_distances = _pipeline_distances(screening_point, candidate_pipelines)
+    nearest = min(
+        pipeline_distances,
+        key=lambda item: item.distance_miles,
+        default=None,
+    )
+    if nearest is None or nearest.distance_miles > nearby_radius_miles:
+        caveats.append("no_pipeline_within_25_miles")
+    access_class = _access_class(None if nearest is None else nearest.distance_miles)
+    return {
+        "district": district,
+        "field_number": field_number,
+        "field_name": _field_name(field_row, lifecycle_rows),
+        "field_well_count_with_location": geometry.well_count,
+        "field_centroid_latitude": round(geometry.centroid_latitude, 8),
+        "field_centroid_longitude": round(geometry.centroid_longitude, 8),
+        "field_latitude_min": geometry.latitude_min,
+        "field_latitude_max": geometry.latitude_max,
+        "field_longitude_min": geometry.longitude_min,
+        "field_longitude_max": geometry.longitude_max,
+        "field_extent_miles": geometry.extent_miles,
+        "nearest_pipeline_distance_miles": (
+            pd.NA if nearest is None else nearest.distance_miles
+        ),
+        "nearby_pipeline_count_1mi": _nearby_count(pipeline_distances, 1.0),
+        "nearby_pipeline_count_5mi": _nearby_count(pipeline_distances, 5.0),
+        "nearby_pipeline_count_10mi": _nearby_count(pipeline_distances, 10.0),
+        "nearest_pipeline_source_county": (
+            pd.NA if nearest is None else nearest.record.county_fips
+        ),
+        "nearest_pipeline_identifier": (
+            pd.NA if nearest is None else nearest.record.pipeline_identifier
+        ),
+        "infrastructure_access_score": ACCESS_SCORE[access_class],
+        "infrastructure_access_class": access_class,
+        "source_caveats": "|".join(dict.fromkeys(caveats)),
+        "quality_flags": "|".join(dict.fromkeys(flags)),
+    }
+
+
+def _empty_geometry_record(
+    district: str,
+    field_number: str,
+    field_row: dict[str, Any] | None,
+    lifecycle_rows: list[dict[str, Any]],
+    caveats: list[str],
+    flags: list[str],
+) -> dict[str, Any]:
+    return {
+        "district": district,
+        "field_number": field_number,
+        "field_name": _field_name(field_row, lifecycle_rows),
+        "field_well_count_with_location": 0,
+        "field_centroid_latitude": pd.NA,
+        "field_centroid_longitude": pd.NA,
+        "field_latitude_min": pd.NA,
+        "field_latitude_max": pd.NA,
+        "field_longitude_min": pd.NA,
+        "field_longitude_max": pd.NA,
+        "field_extent_miles": pd.NA,
+        "nearest_pipeline_distance_miles": pd.NA,
+        "nearby_pipeline_count_1mi": 0,
+        "nearby_pipeline_count_5mi": 0,
+        "nearby_pipeline_count_10mi": 0,
+        "nearest_pipeline_source_county": pd.NA,
+        "nearest_pipeline_identifier": pd.NA,
+        "infrastructure_access_score": 0.0,
+        "infrastructure_access_class": "isolated_or_unknown",
+        "source_caveats": "|".join(dict.fromkeys(caveats)),
+        "quality_flags": "|".join(dict.fromkeys(flags)),
+    }
+
+
+def _field_rows(frame: pd.DataFrame) -> dict[tuple[str, str], dict[str, Any]]:
+    if frame.empty:
+        return {}
+    rows = {}
+    for row in frame.to_dict("records"):
+        key = _field_key(row)
+        if key:
+            rows[key] = row
+    return rows
+
+
+def _lifecycle_rows(frame: pd.DataFrame) -> dict[tuple[str, str], list[dict[str, Any]]]:
+    if frame.empty:
+        return {}
+    rows: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for row in frame.to_dict("records"):
+        key = _field_key(row)
+        if key:
+            rows.setdefault(key, []).append(row)
+    return rows
+
+
+def _field_key(row: dict[str, Any]) -> tuple[str, str] | None:
+    district = _string(row.get("district"))
+    field_number = _string(row.get("field_number"))
+    if not district or not field_number:
+        return None
+    return district, field_number
+
+
+def _wells_by_api(
+    well_gis: tuple[WellGisRecord, ...],
+) -> dict[str, list[WellGisRecord]]:
+    wells: dict[str, list[WellGisRecord]] = {}
+    for well in well_gis:
+        api_number = normalize_api_number(well.api_number)
+        if api_number:
+            wells.setdefault(api_number, []).append(well)
+    return wells
+
+
+def _well_points_by_field(
+    lifecycle_rows: dict[tuple[str, str], list[dict[str, Any]]],
+    wells_by_api: dict[str, list[WellGisRecord]],
+) -> dict[tuple[str, str], tuple[tuple[WellGisRecord, float, float], ...]]:
+    result = {}
+    for key, rows in lifecycle_rows.items():
+        matched = []
+        seen = set()
+        for row in rows:
+            for column in ("api14", "api10", "api_number"):
+                api_number = normalize_api_number(row.get(column))
+                for well in wells_by_api.get(api_number or "", []):
+                    point_key = (well.api_number, well.latitude, well.longitude)
+                    if point_key not in seen:
+                        matched.append((well, well.latitude, well.longitude))
+                        seen.add(point_key)
+        if matched:
+            result[key] = tuple(matched)
+    return result
+
+
+def _dominant_county(
+    well_points: tuple[tuple[WellGisRecord, float, float], ...],
+) -> str | None:
+    counts = Counter(item[0].county_fips for item in well_points if item[0].county_fips)
+    if not counts:
+        return None
+    return sorted(counts.items(), key=lambda item: (-item[1], item[0]))[0][0]
+
+
+def _pipeline_distances(
+    point: tuple[float, float],
+    pipelines: tuple[_IndexedPipeline, ...],
+) -> tuple[_PipelineDistance, ...]:
+    return tuple(
+        _PipelineDistance(
+            pipeline.record,
+            round(_point_bbox_distance_miles(point, pipeline.bbox), 6),
+        )
+        for pipeline in pipelines
+    )
+
+
+def _point_bbox_distance_miles(
+    point: tuple[float, float],
+    bbox: tuple[float, float, float, float],
+) -> float:
+    latitude, longitude = point
+    min_lon, min_lat, max_lon, max_lat = bbox
+    if longitude < min_lon:
+        delta_lon = min_lon - longitude
+    elif longitude > max_lon:
+        delta_lon = longitude - max_lon
+    else:
+        delta_lon = 0.0
+    if latitude < min_lat:
+        delta_lat = min_lat - latitude
+    elif latitude > max_lat:
+        delta_lat = latitude - max_lat
+    else:
+        delta_lat = 0.0
+    return math.hypot(
+        delta_lat * 69.0,
+        delta_lon * 69.0 * abs(math.cos(math.radians(latitude))),
+    )
+
+
+def _nearby_count(
+    pipeline_distances: tuple[_PipelineDistance, ...],
+    radius_miles: float,
+) -> int:
+    nearby = set()
+    for item in pipeline_distances:
+        if item.distance_miles <= radius_miles:
+            nearby.add(item.record.pipeline_identifier or item.record.source_file)
+    return len(nearby)
+
+
+def _pipeline_index(pipelines: tuple[PipelineGisRecord, ...]) -> _PipelineSpatialIndex:
+    buckets: dict[tuple[str | None, int, int], list[_IndexedPipeline]] = {}
+    all_records = []
+    for pipeline in pipelines:
+        indexed = _IndexedPipeline(pipeline, _pipeline_bbox(pipeline))
+        all_records.append(indexed)
+        min_x, min_y, max_x, max_y = indexed.bbox
+        for cell_x in range(_cell(min_x), _cell(max_x) + 1):
+            for cell_y in range(_cell(min_y), _cell(max_y) + 1):
+                buckets.setdefault((pipeline.county_fips, cell_x, cell_y), []).append(
+                    indexed
+                )
+    return _PipelineSpatialIndex(
+        by_cell={key: tuple(value) for key, value in buckets.items()},
+        all_records=tuple(all_records),
+    )
+
+
+def _indexed_candidate_pipelines(
+    geometry,
+    field_counties: set[str],
+    pipeline_index: _PipelineSpatialIndex,
+    padding_miles: float,
+) -> tuple[_IndexedPipeline, ...]:
+    bbox = _padded_centroid_bbox(geometry, padding_miles)
+    indexed = _indexed_candidates_for_bbox(bbox, field_counties, pipeline_index)
+    return tuple(item for item in indexed if _bboxes_intersect(bbox, item.bbox))
+
+
+def _indexed_candidates_for_bbox(
+    bbox: tuple[float, float, float, float],
+    field_counties: set[str],
+    pipeline_index: _PipelineSpatialIndex,
+) -> tuple[_IndexedPipeline, ...]:
+    if not field_counties:
+        return pipeline_index.all_records
+    counties: tuple[str | None, ...] = (*tuple(sorted(field_counties)), None)
+    min_x, min_y, max_x, max_y = bbox
+    seen = set()
+    candidates = []
+    for county in counties:
+        for cell_x in range(_cell(min_x), _cell(max_x) + 1):
+            for cell_y in range(_cell(min_y), _cell(max_y) + 1):
+                for item in pipeline_index.by_cell.get((county, cell_x, cell_y), ()):
+                    key = id(item.record)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    candidates.append(item)
+    return tuple(candidates)
+
+
+def _cell(value: float) -> int:
+    return math.floor(value / GRID_DEGREES)
+
+
+def _padded_centroid_bbox(
+    geometry, padding_miles: float
+) -> tuple[float, float, float, float]:
+    padding_lat = padding_miles / 69.0
+    miles_per_lon = 69.0
+    if geometry.centroid_latitude:
+        miles_per_lon = 69.0 * abs(math.cos(math.radians(geometry.centroid_latitude)))
+    padding_lon = padding_miles / miles_per_lon if miles_per_lon else padding_lat
+    return (
+        geometry.centroid_longitude - padding_lon,
+        geometry.centroid_latitude - padding_lat,
+        geometry.centroid_longitude + padding_lon,
+        geometry.centroid_latitude + padding_lat,
+    )
+
+
+def _pipeline_bbox(pipeline: PipelineGisRecord) -> tuple[float, float, float, float]:
+    longitudes = [point[0] for point in pipeline.coordinates]
+    latitudes = [point[1] for point in pipeline.coordinates]
+    return min(longitudes), min(latitudes), max(longitudes), max(latitudes)
+
+
+def _bboxes_intersect(
+    first: tuple[float, float, float, float],
+    second: tuple[float, float, float, float],
+) -> bool:
+    first_min_x, first_min_y, first_max_x, first_max_y = first
+    second_min_x, second_min_y, second_max_x, second_max_y = second
+    return not (
+        first_max_x < second_min_x
+        or second_max_x < first_min_x
+        or first_max_y < second_min_y
+        or second_max_y < first_min_y
+    )
+
+
+def _access_class(distance_miles: float | None) -> str:
+    if distance_miles is None:
+        return "isolated_or_unknown"
+    if distance_miles <= 1.0:
+        return "direct_access"
+    if distance_miles <= 5.0:
+        return "near_access"
+    if distance_miles <= 10.0:
+        return "regional_access"
+    if distance_miles <= 25.0:
+        return "remote_access"
+    return "isolated_or_unknown"
+
+
+def _field_name(
+    field_row: dict[str, Any] | None,
+    lifecycle_rows: list[dict[str, Any]],
+) -> object:
+    if field_row and _string(field_row.get("field_name")):
+        return field_row["field_name"]
+    for row in lifecycle_rows:
+        if _string(row.get("field_name")):
+            return row["field_name"]
+    return pd.NA
+
+
+def _string(value: object) -> str | None:
+    if value is None or pd.isna(value):
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+__all__ = [
+    "ACCESS_SCORE",
+    "FIELD_KEYS",
+    "OUTPUT_COLUMNS",
+    "InfrastructureAccessInputs",
+    "build_infrastructure_access_metrics",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/infrastructure/cli_support.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/infrastructure/cli_support.py
@@ -1,0 +1,184 @@
+"""CLI support for building Texas RRC infrastructure access metrics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.field_development.io import (
+    CSV_FILENAME as FIELD_DEVELOPMENT_CSV,
+)
+from worldenergydata.texas_rrc.field_development.io import (
+    FIELD_DEVELOPMENT_METRICS_DIR,
+)
+from worldenergydata.texas_rrc.field_development.io import (
+    MANIFEST_FILENAME as FIELD_DEVELOPMENT_MANIFEST,
+)
+from worldenergydata.texas_rrc.field_development.io import (
+    PARQUET_FILENAME as FIELD_DEVELOPMENT_PARQUET,
+)
+from worldenergydata.texas_rrc.field_development.io import (
+    load_field_development_metrics,
+)
+from worldenergydata.texas_rrc.infrastructure.access_metrics import (
+    InfrastructureAccessInputs,
+    build_infrastructure_access_metrics,
+)
+from worldenergydata.texas_rrc.infrastructure.gis_sources import (
+    load_gis_inputs,
+)
+from worldenergydata.texas_rrc.infrastructure.io import (
+    write_infrastructure_access_outputs,
+)
+from worldenergydata.texas_rrc.infrastructure.quality import (
+    assess_infrastructure_access_quality,
+)
+from worldenergydata.texas_rrc.lifecycle.io import (
+    LIFECYCLE_SPINE_DIR,
+)
+from worldenergydata.texas_rrc.lifecycle.io import (
+    MANIFEST_FILENAME as LIFECYCLE_MANIFEST,
+)
+from worldenergydata.texas_rrc.lifecycle.io import (
+    SPINE_FILENAME,
+    load_lifecycle_spine,
+)
+
+
+@dataclass(frozen=True)
+class InfrastructureAccessBuildResult:
+    """Result returned to the Typer command for printing and exit handling."""
+
+    row_count: int
+    source_gaps: tuple[str, ...]
+    dry_run: bool
+    manifest: object | None
+
+
+@dataclass(frozen=True)
+class CuratedInputs:
+    """Curated non-GIS inputs for infrastructure metrics."""
+
+    field_development: pd.DataFrame
+    lifecycle: pd.DataFrame
+    source_gaps: tuple[str, ...]
+    input_paths: tuple[str, ...]
+
+
+def run_build_infrastructure_access_metrics(
+    root: Path,
+    output_root: Path,
+    dry_run: bool,
+    require_sources: bool,
+    refresh_gis: bool,
+    nearby_radius_miles: float,
+    allow_non_ace_output: bool,
+    rows_per_page: int,
+) -> InfrastructureAccessBuildResult:
+    """Build and optionally persist infrastructure access metrics."""
+    if refresh_gis:
+        refresh_gis_sources(root, rows_per_page)
+    curated = load_curated_inputs(root)
+    gis = load_gis_inputs(root)
+    source_gaps = tuple(dict.fromkeys((*curated.source_gaps, *gis.source_gaps)))
+    if source_gaps and (require_sources or not dry_run):
+        raise ValueError(f"missing infrastructure sources: {', '.join(source_gaps)}")
+    metrics = build_infrastructure_access_metrics(
+        InfrastructureAccessInputs(
+            field_development=curated.field_development,
+            lifecycle=curated.lifecycle,
+            well_gis=gis.well_gis,
+            pipeline_gis=gis.pipeline_gis,
+            source_gaps=source_gaps,
+        ),
+        nearby_radius_miles=nearby_radius_miles,
+    )
+    quality = assess_infrastructure_access_quality(
+        metrics,
+        source_gaps=source_gaps,
+        malformed_source_files=gis.malformed_source_files,
+    )
+    if dry_run:
+        return InfrastructureAccessBuildResult(len(metrics), source_gaps, True, None)
+    manifest = write_infrastructure_access_outputs(
+        metrics,
+        quality,
+        output_root=output_root,
+        input_paths=(*curated.input_paths, *gis.input_paths),
+        allow_non_ace_root=allow_non_ace_output,
+        command=(
+            "worldenergydata texas-rrc build-infrastructure-access-metrics "
+            f"--root {root} --output-root {output_root}"
+        ),
+    )
+    return InfrastructureAccessBuildResult(len(metrics), source_gaps, False, manifest)
+
+
+def refresh_gis_sources(root: Path, rows_per_page: int) -> None:
+    """Refresh official RRC well and pipeline GIS directory sources."""
+    import worldenergydata.texas_rrc.raw_refresh as raw_refresh
+
+    refresher = raw_refresh.RawSnapshotRefresher(output_root=root)
+    for source_id in ("well_gis_layers", "pipeline_gis_layers"):
+        refresher.refresh_source(source_id, rows_per_page=rows_per_page)
+
+
+def load_curated_inputs(root: Path | str) -> CuratedInputs:
+    """Load #664 field-development metrics and lifecycle spine."""
+    local_root = Path(root)
+    source_gaps: list[str] = []
+    input_paths: list[str] = []
+    field_development = _load_field_development(local_root, source_gaps, input_paths)
+    lifecycle = _load_lifecycle(local_root, source_gaps, input_paths)
+    return CuratedInputs(
+        field_development=field_development,
+        lifecycle=lifecycle,
+        source_gaps=tuple(source_gaps),
+        input_paths=tuple(input_paths),
+    )
+
+
+def _load_field_development(
+    root: Path,
+    source_gaps: list[str],
+    input_paths: list[str],
+) -> pd.DataFrame:
+    metrics_dir = root / FIELD_DEVELOPMENT_METRICS_DIR
+    parquet_path = metrics_dir / FIELD_DEVELOPMENT_PARQUET
+    csv_path = metrics_dir / FIELD_DEVELOPMENT_CSV
+    path = parquet_path if parquet_path.exists() else csv_path
+    if not path.exists():
+        source_gaps.append("field_development_metrics")
+        return pd.DataFrame()
+    input_paths.append(str(path))
+    manifest_path = metrics_dir / FIELD_DEVELOPMENT_MANIFEST
+    if manifest_path.exists():
+        input_paths.append(str(manifest_path))
+    return load_field_development_metrics(path)
+
+
+def _load_lifecycle(
+    root: Path,
+    source_gaps: list[str],
+    input_paths: list[str],
+) -> pd.DataFrame:
+    spine_dir = root / LIFECYCLE_SPINE_DIR
+    spine_path = spine_dir / SPINE_FILENAME
+    if not spine_path.exists():
+        source_gaps.append("well_lifecycle_spine")
+        return pd.DataFrame()
+    input_paths.append(str(spine_path))
+    manifest_path = spine_dir / LIFECYCLE_MANIFEST
+    if manifest_path.exists():
+        input_paths.append(str(manifest_path))
+    return load_lifecycle_spine(spine_path)
+
+
+__all__ = [
+    "InfrastructureAccessBuildResult",
+    "load_curated_inputs",
+    "refresh_gis_sources",
+    "run_build_infrastructure_access_metrics",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/infrastructure/gis_sources.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/infrastructure/gis_sources.py
@@ -1,0 +1,325 @@
+"""Load official Texas RRC well and pipeline GIS shapefile ZIPs."""
+
+from __future__ import annotations
+
+import math
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable
+from zipfile import BadZipFile, ZipFile
+
+import shapefile
+
+
+class GisSourceError(ValueError):
+    """Raised when a GIS source ZIP cannot be read as a shapefile."""
+
+
+@dataclass(frozen=True)
+class WellGisRecord:
+    """One Texas RRC well point from official GIS layers."""
+
+    api_number: str | None
+    county_fips: str | None
+    latitude: float
+    longitude: float
+    source_file: str
+
+
+@dataclass(frozen=True)
+class PipelineGisRecord:
+    """One Texas RRC pipeline polyline from official GIS layers."""
+
+    pipeline_identifier: str | None
+    county_fips: str | None
+    coordinates: tuple[tuple[float, float], ...]
+    source_file: str
+
+
+@dataclass(frozen=True)
+class GisLoadResult:
+    """GIS load result with structured gaps for CLI and quality reports."""
+
+    well_gis: tuple[WellGisRecord, ...]
+    pipeline_gis: tuple[PipelineGisRecord, ...]
+    source_gaps: tuple[str, ...]
+    malformed_source_files: tuple[str, ...]
+    input_paths: tuple[str, ...]
+
+
+API_ALIASES = (
+    "API",
+    "API_NO",
+    "API_NUM",
+    "API_NUMBER",
+    "APINUM",
+    "API_UWI",
+    "API14",
+    "API10",
+)
+COUNTY_ALIASES = ("CNTY_FIPS", "COUNTY_FIP", "COUNTYFIPS", "FIPS", "COUNTY")
+PIPELINE_ID_ALIASES = (
+    "T4PERMIT",
+    "PERMIT",
+    "P5NUM",
+    "PIPE_ID",
+    "PIPELINEID",
+    "SEGMENT",
+    "OBJECTID",
+)
+
+
+def load_well_gis_records(raw_root: Path | str) -> tuple[WellGisRecord, ...]:
+    """Load well point records from zipped official RRC shapefiles."""
+    return tuple(_load_zip_records(_local_root(raw_root), _well_records_from_reader))
+
+
+def load_pipeline_gis_records(raw_root: Path | str) -> tuple[PipelineGisRecord, ...]:
+    """Load pipeline polyline records from zipped official RRC shapefiles."""
+    return tuple(
+        _load_zip_records(_local_root(raw_root), _pipeline_records_from_reader)
+    )
+
+
+def load_gis_inputs(root: Path | str) -> GisLoadResult:
+    """Load GIS records under a Texas RRC root without aborting on one bad ZIP."""
+    local_root = _local_root(root)
+    source_gaps: list[str] = []
+    malformed: list[str] = []
+    input_paths: list[str] = []
+    well_root = local_root / "raw" / "gis" / "wells"
+    pipeline_root = local_root / "raw" / "gis" / "pipelines"
+    wells = _safe_load_source(
+        well_root,
+        "well_gis_layers",
+        _well_records_from_reader,
+        source_gaps,
+        malformed,
+        input_paths,
+    )
+    pipelines = _safe_load_source(
+        pipeline_root,
+        "pipeline_gis_layers",
+        _pipeline_records_from_reader,
+        source_gaps,
+        malformed,
+        input_paths,
+    )
+    return GisLoadResult(
+        well_gis=wells,
+        pipeline_gis=pipelines,
+        source_gaps=tuple(source_gaps),
+        malformed_source_files=tuple(malformed),
+        input_paths=tuple(input_paths),
+    )
+
+
+def normalize_api_number(value: object) -> str | None:
+    """Normalize Texas API-like values to a 14-digit comparison key."""
+    if value is None:
+        return None
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return None
+        value = int(value)
+    text = str(value).strip()
+    if not text or text.lower() in {"nan", "none", "<na>"}:
+        return None
+    digits = _digits(value)
+    if not digits:
+        return None
+    if len(digits) == 8:
+        return f"42{digits}0000"
+    if len(digits) == 10:
+        return f"{digits}0000"
+    if len(digits) >= 14:
+        return digits[:14]
+    return None
+
+
+def normalize_county_fips(value: object) -> str | None:
+    """Normalize county/FIPS values to the Texas three-digit county key."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text or text.lower() in {"nan", "none", "<na>"}:
+        return None
+    digits = re.sub(r"\D", "", text)
+    if not digits:
+        return None
+    return digits[-3:].zfill(3)
+
+
+def _safe_load_source(
+    raw_root: Path,
+    source_id: str,
+    loader: Callable,
+    source_gaps: list[str],
+    malformed: list[str],
+    input_paths: list[str],
+) -> tuple:
+    zip_paths = _zip_paths(raw_root)
+    if not zip_paths:
+        source_gaps.append(source_id)
+        return ()
+    input_paths.extend(str(path.relative_to(raw_root.parents[2])) for path in zip_paths)
+    records = []
+    for zip_path in zip_paths:
+        try:
+            records.extend(_records_from_zip(zip_path, loader))
+        except GisSourceError as exc:
+            malformed.append(str(exc))
+    if not records:
+        source_gaps.append(source_id)
+    return tuple(records)
+
+
+def _local_root(root: Path | str) -> Path:
+    value = str(root)
+    if "://" in value:
+        raise ValueError("GIS source inputs must be local filesystem paths")
+    return Path(root)
+
+
+def _load_zip_records(raw_root: Path, loader: Callable) -> Iterable:
+    for zip_path in _zip_paths(raw_root):
+        yield from _records_from_zip(zip_path, loader)
+
+
+def _zip_paths(raw_root: Path) -> tuple[Path, ...]:
+    if not raw_root.exists():
+        return ()
+    return tuple(sorted(path for path in raw_root.rglob("*.zip") if path.is_file()))
+
+
+def _records_from_zip(zip_path: Path, loader: Callable) -> Iterable:
+    try:
+        with ZipFile(zip_path) as archive:
+            _validate_members(zip_path, archive)
+            with tempfile.TemporaryDirectory() as tmp:
+                _extract_members_safely(zip_path, archive, Path(tmp))
+                shapefiles = sorted(Path(tmp).rglob("*.shp"))
+                if not shapefiles:
+                    raise GisSourceError(f"{zip_path.name}: missing .shp member")
+                for shp_path in shapefiles:
+                    reader = shapefile.Reader(str(shp_path))
+                    yield from loader(reader, zip_path.name)
+    except BadZipFile as exc:
+        raise GisSourceError(f"{zip_path.name}: invalid ZIP archive") from exc
+    except GisSourceError:
+        raise
+    except Exception as exc:  # pyshp raises mixed exception types
+        raise GisSourceError(f"{zip_path.name}: {exc}") from exc
+
+
+def _validate_members(zip_path: Path, archive: ZipFile) -> None:
+    suffixes = {Path(name).suffix.lower() for name in archive.namelist()}
+    missing = {".shp", ".shx", ".dbf"} - suffixes
+    if missing:
+        raise GisSourceError(
+            f"{zip_path.name}: missing required shapefile members "
+            f"{', '.join(sorted(missing))}"
+        )
+
+
+def _extract_members_safely(zip_path: Path, archive: ZipFile, target_dir: Path) -> None:
+    root = target_dir.resolve()
+    for member in archive.namelist():
+        member_path = Path(member)
+        target = (target_dir / member_path).resolve()
+        if member_path.is_absolute() or not target.is_relative_to(root):
+            raise GisSourceError(f"{zip_path.name}: unsafe ZIP member path {member!r}")
+    archive.extractall(target_dir)
+
+
+def _well_records_from_reader(
+    reader: shapefile.Reader,
+    source_file: str,
+) -> Iterable[WellGisRecord]:
+    for item in reader.iterShapeRecords():
+        if not item.shape.points:
+            continue
+        longitude, latitude = item.shape.points[0]
+        attrs = _attributes(reader, item.record)
+        raw_api = _first_attr(attrs, API_ALIASES)
+        yield WellGisRecord(
+            api_number=normalize_api_number(raw_api),
+            county_fips=_well_county_fips(attrs, raw_api, source_file),
+            latitude=float(latitude),
+            longitude=float(longitude),
+            source_file=source_file,
+        )
+
+
+def _pipeline_records_from_reader(
+    reader: shapefile.Reader,
+    source_file: str,
+) -> Iterable[PipelineGisRecord]:
+    for item in reader.iterShapeRecords():
+        coordinates = tuple((float(x), float(y)) for x, y in item.shape.points)
+        if len(coordinates) < 2:
+            continue
+        attrs = _attributes(reader, item.record)
+        yield PipelineGisRecord(
+            pipeline_identifier=_string_or_none(
+                _first_attr(attrs, PIPELINE_ID_ALIASES)
+            ),
+            county_fips=normalize_county_fips(_first_attr(attrs, COUNTY_ALIASES)),
+            coordinates=coordinates,
+            source_file=source_file,
+        )
+
+
+def _attributes(reader: shapefile.Reader, record) -> dict[str, object]:
+    fields = [field[0].upper().strip() for field in reader.fields[1:]]
+    return dict(zip(fields, list(record)))
+
+
+def _first_attr(attrs: dict[str, object], aliases: tuple[str, ...]) -> object | None:
+    for alias in aliases:
+        if alias in attrs:
+            return attrs[alias]
+    return None
+
+
+def _well_county_fips(
+    attrs: dict[str, object],
+    raw_api: object | None,
+    source_file: str,
+) -> str | None:
+    county = normalize_county_fips(_first_attr(attrs, COUNTY_ALIASES))
+    if county:
+        return county
+    api_digits = _digits(raw_api)
+    if len(api_digits) == 8:
+        return api_digits[:3]
+    match = re.match(r"well(\d{3})", source_file.lower())
+    return match.group(1) if match else None
+
+
+def _digits(value: object | None) -> str:
+    if value is None:
+        return ""
+    return re.sub(r"\D", "", str(value).strip())
+
+
+def _string_or_none(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+__all__ = [
+    "GisLoadResult",
+    "GisSourceError",
+    "PipelineGisRecord",
+    "WellGisRecord",
+    "load_gis_inputs",
+    "load_pipeline_gis_records",
+    "load_well_gis_records",
+    "normalize_api_number",
+    "normalize_county_fips",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/infrastructure/io.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/infrastructure/io.py
@@ -1,0 +1,211 @@
+"""Persist Texas RRC infrastructure access metric outputs."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.infrastructure.quality import (
+    DIRECT_SOURCE_CAVEATS,
+    SCORING_THRESHOLDS_MILES,
+    InfrastructureAccessQualityReport,
+)
+from worldenergydata.texas_rrc.source_catalog import SOURCE_CATALOG_ROOT
+
+INFRASTRUCTURE_ACCESS_DIR = Path("curated") / "infrastructure" / "access"
+CSV_FILENAME = "field_infrastructure_access.csv"
+PARQUET_FILENAME = "field_infrastructure_access.parquet"
+QUALITY_FILENAME = "field_infrastructure_access_quality.json"
+MANIFEST_FILENAME = "manifest.json"
+METRIC_DTYPES = {
+    "district": "string",
+    "field_number": "string",
+    "field_name": "string",
+    "nearest_pipeline_source_county": "string",
+    "nearest_pipeline_identifier": "string",
+}
+
+
+@dataclass(frozen=True)
+class InfrastructureAccessOutputManifest:
+    """Paths and metadata for one infrastructure access output batch."""
+
+    generated_at: str
+    output_root: Path
+    csv_path: Path
+    parquet_path: Path
+    quality_path: Path
+    manifest_path: Path
+    row_count: int
+    input_paths: tuple[str, ...]
+    source_gaps: tuple[str, ...]
+    command: str | None
+    code_revision: str | None
+
+
+def write_infrastructure_access_outputs(
+    metrics: pd.DataFrame,
+    quality: InfrastructureAccessQualityReport,
+    output_root: Path | str = SOURCE_CATALOG_ROOT,
+    generated_at: datetime | None = None,
+    input_paths: Iterable[str | Path] = (),
+    allow_non_ace_root: bool = False,
+    command: str | None = None,
+    code_revision: str | None = None,
+) -> InfrastructureAccessOutputManifest:
+    """Write CSV, Parquet, quality JSON, and manifest outputs."""
+    root = Path(output_root)
+    _validate_output_root(root, allow_non_ace_root)
+    target_dir = root / INFRASTRUCTURE_ACCESS_DIR
+    stamp = _timestamp(generated_at)
+    manifest = InfrastructureAccessOutputManifest(
+        generated_at=stamp,
+        output_root=root,
+        csv_path=target_dir / CSV_FILENAME,
+        parquet_path=target_dir / PARQUET_FILENAME,
+        quality_path=target_dir / QUALITY_FILENAME,
+        manifest_path=target_dir / MANIFEST_FILENAME,
+        row_count=len(metrics),
+        input_paths=tuple(str(path) for path in input_paths),
+        source_gaps=tuple(quality.source_gaps),
+        command=command,
+        code_revision=code_revision or _git_revision(),
+    )
+    _write_with_staging(metrics, quality, manifest, target_dir, stamp)
+    return manifest
+
+
+def load_infrastructure_access_metrics(path: Path | str) -> pd.DataFrame:
+    """Load persisted infrastructure access metrics from CSV or Parquet."""
+    metrics_path = Path(path)
+    if metrics_path.suffix.lower() == ".parquet":
+        return pd.read_parquet(metrics_path)
+    return pd.read_csv(metrics_path, dtype=METRIC_DTYPES)
+
+
+def _write_with_staging(
+    metrics: pd.DataFrame,
+    quality: InfrastructureAccessQualityReport,
+    manifest: InfrastructureAccessOutputManifest,
+    target_dir: Path,
+    stamp: str,
+) -> None:
+    staging = target_dir / f".staging-infrastructure-access-{_compact_stamp(stamp)}"
+    shutil.rmtree(staging, ignore_errors=True)
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+        metrics.to_csv(staging / CSV_FILENAME, index=False)
+        metrics.to_parquet(staging / PARQUET_FILENAME, index=False)
+        _write_json(staging / QUALITY_FILENAME, _quality_payload(quality))
+        _write_json(staging / MANIFEST_FILENAME, _manifest_payload(manifest, quality))
+        target_dir.mkdir(parents=True, exist_ok=True)
+        for filename in (
+            CSV_FILENAME,
+            PARQUET_FILENAME,
+            QUALITY_FILENAME,
+            MANIFEST_FILENAME,
+        ):
+            (staging / filename).replace(target_dir / filename)
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def _validate_output_root(root: Path, allow_non_ace_root: bool) -> None:
+    if allow_non_ace_root:
+        return
+    if not root.resolve().is_relative_to(SOURCE_CATALOG_ROOT.resolve()):
+        raise ValueError(
+            "Infrastructure access output_root must stay under "
+            f"{SOURCE_CATALOG_ROOT}; pass allow_non_ace_root=True only for "
+            "isolated tests or sandbox runs"
+        )
+
+
+def _quality_payload(quality: InfrastructureAccessQualityReport) -> dict[str, object]:
+    return asdict(quality)
+
+
+def _manifest_payload(
+    manifest: InfrastructureAccessOutputManifest,
+    quality: InfrastructureAccessQualityReport,
+) -> dict[str, object]:
+    return {
+        "generated_at": manifest.generated_at,
+        "output_root": str(manifest.output_root),
+        "csv_path": str(manifest.csv_path),
+        "parquet_path": str(manifest.parquet_path),
+        "quality_path": str(manifest.quality_path),
+        "manifest_path": str(manifest.manifest_path),
+        "row_count": manifest.row_count,
+        "input_paths": list(manifest.input_paths),
+        "source_gaps": list(manifest.source_gaps),
+        "scoring_thresholds_miles": SCORING_THRESHOLDS_MILES,
+        "direct_source_caveats": DIRECT_SOURCE_CAVEATS,
+        "command": manifest.command,
+        "code_revision": manifest.code_revision,
+        "quality": _quality_payload(quality),
+    }
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _timestamp(value: datetime | None) -> str:
+    timestamp = value or datetime.now(timezone.utc)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _compact_stamp(stamp: str) -> str:
+    return stamp.replace("-", "").replace(":", "")
+
+
+def _git_revision() -> str | None:
+    repo_root = Path(__file__).resolve().parents[5]
+    try:
+        revision = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            timeout=5,
+        )
+        value = revision.stdout.strip()
+        if not value:
+            return None
+        status = subprocess.run(
+            ["git", "status", "--porcelain", "--untracked-files=no"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            timeout=5,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    except subprocess.TimeoutExpired:
+        return value
+    suffix = "+dirty" if status.stdout.strip() else ""
+    return f"{value}{suffix}"
+
+
+__all__ = [
+    "CSV_FILENAME",
+    "INFRASTRUCTURE_ACCESS_DIR",
+    "InfrastructureAccessOutputManifest",
+    "load_infrastructure_access_metrics",
+    "write_infrastructure_access_outputs",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/infrastructure/quality.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/infrastructure/quality.py
@@ -1,0 +1,97 @@
+"""Quality summaries for Texas RRC infrastructure access metrics."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Sequence
+
+import pandas as pd
+
+SCORING_THRESHOLDS_MILES = {
+    "direct_access_max": 1.0,
+    "near_access_max": 5.0,
+    "regional_access_max": 10.0,
+    "remote_access_max": 25.0,
+}
+DIRECT_SOURCE_CAVEATS = [
+    "rrc_gis_screening_only",
+    "field_centroid_pipeline_screening",
+    "dominant_county_pipeline_filter",
+    "pipeline_envelope_distance_screening",
+    "pipeline_presence_not_capacity_or_tariff",
+    "pipeline_route_not_engineered_tie_in",
+    "patchops_validation_only",
+]
+
+
+@dataclass(frozen=True)
+class InfrastructureAccessQualityReport:
+    """Aggregate quality report for infrastructure access outputs."""
+
+    row_count: int
+    source_gaps: tuple[str, ...]
+    access_class_counts: dict[str, int]
+    caveat_counts: dict[str, int]
+    missing_well_gis_count: int
+    missing_pipeline_source_count: int
+    malformed_source_file_count: int
+    malformed_source_files: tuple[str, ...]
+    nearest_pipeline_distance_min_miles: float | None
+    nearest_pipeline_distance_max_miles: float | None
+
+
+def assess_infrastructure_access_quality(
+    metrics: pd.DataFrame,
+    source_gaps: Sequence[str] = (),
+    malformed_source_files: Sequence[str] = (),
+) -> InfrastructureAccessQualityReport:
+    """Summarize access-class mix, caveats, and source gaps."""
+    distances = pd.to_numeric(
+        metrics.get("nearest_pipeline_distance_miles", pd.Series(dtype="float64")),
+        errors="coerce",
+    ).dropna()
+    return InfrastructureAccessQualityReport(
+        row_count=len(metrics),
+        source_gaps=tuple(source_gaps),
+        access_class_counts=_value_counts(metrics, "infrastructure_access_class"),
+        caveat_counts=_caveat_counts(metrics),
+        missing_well_gis_count=_caveat_count(metrics, "missing_well_gis"),
+        missing_pipeline_source_count=_caveat_count(metrics, "missing_pipeline_gis"),
+        malformed_source_file_count=len(tuple(malformed_source_files)),
+        malformed_source_files=tuple(malformed_source_files),
+        nearest_pipeline_distance_min_miles=(
+            None if distances.empty else float(distances.min())
+        ),
+        nearest_pipeline_distance_max_miles=(
+            None if distances.empty else float(distances.max())
+        ),
+    )
+
+
+def _value_counts(metrics: pd.DataFrame, column: str) -> dict[str, int]:
+    if column not in metrics:
+        return {}
+    counts = metrics[column].dropna().value_counts()
+    return {str(key): int(value) for key, value in sorted(counts.items())}
+
+
+def _caveat_counts(metrics: pd.DataFrame) -> dict[str, int]:
+    counter: Counter[str] = Counter()
+    if "source_caveats" not in metrics:
+        return {}
+    for value in metrics["source_caveats"].dropna():
+        counter.update(part for part in str(value).split("|") if part)
+    return dict(sorted(counter.items()))
+
+
+def _caveat_count(metrics: pd.DataFrame, caveat: str) -> int:
+    return _caveat_counts(metrics).get(caveat, 0)
+
+
+__all__ = [
+    "DIRECT_SOURCE_CAVEATS",
+    "SCORING_THRESHOLDS_MILES",
+    "InfrastructureAccessQualityReport",
+    "assess_infrastructure_access_quality",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/infrastructure/spatial.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/infrastructure/spatial.py
@@ -1,0 +1,229 @@
+"""Deterministic spatial helpers for Texas RRC infrastructure screening."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Iterable
+
+from worldenergydata.texas_rrc.infrastructure.gis_sources import PipelineGisRecord
+
+EARTH_RADIUS_MILES = 3958.7613
+MILES_PER_DEGREE_LATITUDE = 69.0
+
+
+@dataclass(frozen=True)
+class FieldGeometry:
+    """Screening geometry for one field's well locations."""
+
+    well_count: int
+    centroid_latitude: float
+    centroid_longitude: float
+    latitude_min: float
+    latitude_max: float
+    longitude_min: float
+    longitude_max: float
+    extent_miles: float
+
+
+@dataclass(frozen=True)
+class NearestPipelineResult:
+    """Nearest pipeline screening result."""
+
+    distance_miles: float
+    pipeline_identifier: str | None
+    source_county: str | None
+    source_file: str
+
+
+def haversine_miles(
+    latitude_a: float,
+    longitude_a: float,
+    latitude_b: float,
+    longitude_b: float,
+) -> float:
+    """Return great-circle distance in miles."""
+    lat_a = math.radians(latitude_a)
+    lat_b = math.radians(latitude_b)
+    delta_lat = math.radians(latitude_b - latitude_a)
+    delta_lon = math.radians(longitude_b - longitude_a)
+    value = (
+        math.sin(delta_lat / 2) ** 2
+        + math.cos(lat_a) * math.cos(lat_b) * math.sin(delta_lon / 2) ** 2
+    )
+    return 2 * EARTH_RADIUS_MILES * math.asin(math.sqrt(value))
+
+
+def point_to_polyline_distance_miles(
+    latitude: float,
+    longitude: float,
+    coordinates: tuple[tuple[float, float], ...],
+) -> float:
+    """Return the approximate nearest distance from a point to a polyline."""
+    if not coordinates:
+        raise ValueError("coordinates must not be empty")
+    if len(coordinates) == 1:
+        lon, lat = coordinates[0]
+        return haversine_miles(latitude, longitude, lat, lon)
+    ref_lat = latitude
+    point = (0.0, 0.0)
+    projected = [
+        _project(lon, lat, origin_longitude=longitude, origin_latitude=ref_lat)
+        for lon, lat in coordinates
+    ]
+    return min(
+        _point_segment_distance(point, start, end)
+        for start, end in zip(projected, projected[1:])
+    )
+
+
+def field_geometry(points: Iterable[tuple[float, float]]) -> FieldGeometry:
+    """Build field centroid, bounds, and extent from ``(lat, lon)`` points."""
+    values = tuple(points)
+    if not values:
+        raise ValueError("field geometry requires at least one point")
+    latitudes = [point[0] for point in values]
+    longitudes = [point[1] for point in values]
+    centroid_latitude = sum(latitudes) / len(latitudes)
+    centroid_longitude = sum(longitudes) / len(longitudes)
+    return FieldGeometry(
+        well_count=len(values),
+        centroid_latitude=centroid_latitude,
+        centroid_longitude=centroid_longitude,
+        latitude_min=min(latitudes),
+        latitude_max=max(latitudes),
+        longitude_min=min(longitudes),
+        longitude_max=max(longitudes),
+        extent_miles=_extent_miles(values),
+    )
+
+
+def filter_candidate_pipelines(
+    geometry: FieldGeometry,
+    field_counties: set[str],
+    pipelines: tuple[PipelineGisRecord, ...],
+    padding_miles: float,
+) -> tuple[PipelineGisRecord, ...]:
+    """Prefilter pipelines by county and padded bounding box."""
+    padding_lat = padding_miles / MILES_PER_DEGREE_LATITUDE
+    miles_per_lon = _miles_per_degree_longitude(geometry.centroid_latitude)
+    padding_lon = padding_miles / miles_per_lon if miles_per_lon else padding_lat
+    bbox = (
+        geometry.longitude_min - padding_lon,
+        geometry.latitude_min - padding_lat,
+        geometry.longitude_max + padding_lon,
+        geometry.latitude_max + padding_lat,
+    )
+    candidates = []
+    for pipeline in pipelines:
+        if field_counties and pipeline.county_fips not in field_counties:
+            if pipeline.county_fips is not None:
+                continue
+        if _bboxes_intersect(bbox, _pipeline_bbox(pipeline)):
+            candidates.append(pipeline)
+    return tuple(candidates)
+
+
+def nearest_pipeline(
+    field_points: tuple[tuple[float, float], ...],
+    pipelines: tuple[PipelineGisRecord, ...],
+) -> NearestPipelineResult | None:
+    """Return nearest pipeline to any field well point."""
+    best: tuple[float, PipelineGisRecord] | None = None
+    for point in field_points:
+        for pipeline in pipelines:
+            distance = point_to_polyline_distance_miles(
+                latitude=point[0],
+                longitude=point[1],
+                coordinates=pipeline.coordinates,
+            )
+            if best is None or distance < best[0]:
+                best = (distance, pipeline)
+    if best is None:
+        return None
+    distance, pipeline = best
+    return NearestPipelineResult(
+        distance_miles=round(distance, 6),
+        pipeline_identifier=pipeline.pipeline_identifier,
+        source_county=pipeline.county_fips,
+        source_file=pipeline.source_file,
+    )
+
+
+def _project(
+    longitude: float,
+    latitude: float,
+    *,
+    origin_longitude: float,
+    origin_latitude: float,
+) -> tuple[float, float]:
+    x = (longitude - origin_longitude) * _miles_per_degree_longitude(origin_latitude)
+    y = (latitude - origin_latitude) * MILES_PER_DEGREE_LATITUDE
+    return x, y
+
+
+def _point_segment_distance(
+    point: tuple[float, float],
+    start: tuple[float, float],
+    end: tuple[float, float],
+) -> float:
+    px, py = point
+    sx, sy = start
+    ex, ey = end
+    dx = ex - sx
+    dy = ey - sy
+    if dx == 0 and dy == 0:
+        return math.hypot(px - sx, py - sy)
+    t = max(0.0, min(1.0, ((px - sx) * dx + (py - sy) * dy) / (dx * dx + dy * dy)))
+    return math.hypot(px - (sx + t * dx), py - (sy + t * dy))
+
+
+def _extent_miles(points: tuple[tuple[float, float], ...]) -> float:
+    if len(points) < 2:
+        return 0.0
+    latitudes = [point[0] for point in points]
+    longitudes = [point[1] for point in points]
+    return round(
+        haversine_miles(
+            min(latitudes),
+            min(longitudes),
+            max(latitudes),
+            max(longitudes),
+        ),
+        6,
+    )
+
+
+def _miles_per_degree_longitude(latitude: float) -> float:
+    return MILES_PER_DEGREE_LATITUDE * abs(math.cos(math.radians(latitude)))
+
+
+def _pipeline_bbox(pipeline: PipelineGisRecord) -> tuple[float, float, float, float]:
+    longitudes = [point[0] for point in pipeline.coordinates]
+    latitudes = [point[1] for point in pipeline.coordinates]
+    return min(longitudes), min(latitudes), max(longitudes), max(latitudes)
+
+
+def _bboxes_intersect(
+    first: tuple[float, float, float, float],
+    second: tuple[float, float, float, float],
+) -> bool:
+    first_min_x, first_min_y, first_max_x, first_max_y = first
+    second_min_x, second_min_y, second_max_x, second_max_y = second
+    return not (
+        first_max_x < second_min_x
+        or second_max_x < first_min_x
+        or first_max_y < second_min_y
+        or second_max_y < first_min_y
+    )
+
+
+__all__ = [
+    "FieldGeometry",
+    "NearestPipelineResult",
+    "field_geometry",
+    "filter_candidate_pipelines",
+    "haversine_miles",
+    "nearest_pipeline",
+    "point_to_polyline_distance_miles",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/spine.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/lifecycle/spine.py
@@ -66,6 +66,7 @@ def build_lifecycle_spine(inputs: LifecycleInputFrames) -> pd.DataFrame:
         for api14 in api14_values
     ]
     result = pd.DataFrame(records)
+    result = result.astype(object).where(pd.notna(result), None)
     for column in ("has_wellbore", "has_permit", "has_completion"):
         if column in result:
             result[column] = result[column].astype(object)

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/production_atlas/__init__.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/production_atlas/__init__.py
@@ -1,19 +1,27 @@
 """Production atlas tools for Texas RRC PDQ data."""
 
-from worldenergydata.texas_rrc.production_atlas.atlas import (
-    build_production_atlas,
-    build_production_atlas_from_chunks,
-    normalize_production_frame,
-)
-from worldenergydata.texas_rrc.production_atlas.io import (
-    ProductionAtlasOutputManifest,
-    load_production_atlas,
-    write_production_atlas_outputs,
-)
-from worldenergydata.texas_rrc.production_atlas.sources import (
-    ProductionInputFrame,
-    load_production_inputs,
-)
+from importlib import import_module
+
+_LAZY_EXPORTS = {
+    "build_production_atlas": ".atlas",
+    "build_production_atlas_from_chunks": ".atlas",
+    "normalize_production_frame": ".atlas",
+    "ProductionAtlasOutputManifest": ".io",
+    "load_production_atlas": ".io",
+    "write_production_atlas_outputs": ".io",
+    "ProductionInputFrame": ".sources",
+    "load_production_inputs": ".sources",
+}
+
+
+def __getattr__(name: str):
+    """Load production-atlas exports only when requested."""
+    if name not in _LAZY_EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = import_module(_LAZY_EXPORTS[name], __name__)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
 
 __all__ = [
     "ProductionAtlasOutputManifest",

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/production_atlas/__init__.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/production_atlas/__init__.py
@@ -23,6 +23,7 @@ def __getattr__(name: str):
     globals()[name] = value
     return value
 
+
 __all__ = [
     "ProductionAtlasOutputManifest",
     "ProductionInputFrame",

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/production_atlas/io.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/production_atlas/io.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import datetime, timezone
 import json
-from pathlib import Path
 import shutil
 import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Iterable, Sequence
 
 import pandas as pd

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/raw_directory.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/raw_directory.py
@@ -13,7 +13,10 @@ from worldenergydata.texas_rrc.godrive import (
     GoDriveDirectoryEntry,
     GoDriveDirectoryPage,
 )
-from worldenergydata.texas_rrc.raw_transport import DownloadedArtifact
+from worldenergydata.texas_rrc.raw_transport import (
+    DownloadedArtifact,
+    RetryableDownloadError,
+)
 from worldenergydata.texas_rrc.source_catalog import SOURCE_CATALOG_ROOT
 
 
@@ -109,20 +112,54 @@ def download_directory_files(
     rows_per_page: int,
     validate_artifact,
     retrieved_at: str,
+    max_attempts: int = 1,
 ) -> tuple[SnapshotArtifactManifest, ...]:
     """Download selected directory files into a staging directory."""
     download_file = getattr(transport, "download_godrive_directory_file_to")
     artifacts = []
     for item in plan.selected_files:
         part_path = staging / f"{item.filename}.part"
-        artifact = download_file(plan.download_url, item, part_path, rows_per_page)
-        validate_artifact(artifact)
+        artifact = _download_directory_file_with_retries(
+            download_file,
+            plan.download_url,
+            item,
+            part_path,
+            rows_per_page,
+            validate_artifact,
+            max_attempts,
+        )
         final_staged = staging / item.filename
         part_path.replace(final_staged)
         artifacts.append(
             _artifact_manifest(item, artifact, item.target_path, retrieved_at)
         )
     return tuple(artifacts)
+
+
+def _download_directory_file_with_retries(
+    download_file,
+    download_url: str | None,
+    item: DirectoryRefreshFile,
+    part_path: Path,
+    rows_per_page: int,
+    validate_artifact,
+    max_attempts: int,
+) -> DownloadedArtifact:
+    for attempt in range(1, max_attempts + 1):
+        part_path.unlink(missing_ok=True)
+        try:
+            artifact = download_file(download_url, item, part_path, rows_per_page)
+            validate_artifact(artifact)
+            return artifact
+        except RetryableDownloadError:
+            if attempt == max_attempts:
+                raise
+        except ValueError:
+            raise
+        except Exception:
+            if attempt == max_attempts:
+                raise
+    raise RuntimeError("directory download retry loop exited without a result")
 
 
 def promote_directory_files(plan: DirectoryRefreshPlan, staging: Path) -> None:

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/raw_refresh.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/raw_refresh.py
@@ -125,6 +125,7 @@ class RawSnapshotRefresher:
                 rows_per_page,
                 self._validate_artifact,
                 retrieved_at,
+                max_attempts=self.max_attempts,
             )
             promote_directory_files(plan, staging)
             return self._write_directory_manifest(plan, retrieved_at, artifacts)

--- a/scripts/review/results/2026-07-01-code-665-codex-inline.md
+++ b/scripts/review/results/2026-07-01-code-665-codex-inline.md
@@ -1,0 +1,29 @@
+# Codex Inline Code Review — Issue #665
+
+Verdict: APPROVE after inline fix.
+
+Scope reviewed:
+- Texas RRC infrastructure access metrics package.
+- Official RRC GIS ZIP loading and quality reporting.
+- CLI build path and `/mnt/ace` output persistence.
+- Regression tests and documentation.
+
+Findings:
+
+1. MAJOR — `load_gis_inputs()` claimed malformed GIS ZIP tolerance but discarded an entire source when any one ZIP failed.
+   - Impact: one corrupt county ZIP could erase all well or pipeline GIS records from a refresh.
+   - Resolution: `load_gis_inputs()` now loads ZIPs independently, preserves valid direct-source records, and records only malformed files in the quality payload.
+   - Regression: `test_load_gis_inputs_preserves_good_records_when_one_zip_is_malformed`.
+
+2. MINOR — GIS ZIP extraction needed an explicit unsafe-member-path guard.
+   - Impact: direct-source ZIPs are trusted operational inputs, but local refresh code should still reject path traversal in archive members.
+   - Resolution: extraction now validates member targets before extracting.
+   - Regression: `test_load_gis_records_rejects_unsafe_zip_member_paths`.
+
+Residual caveats:
+- Field-level pipeline access uses screening geometry, not engineered tie-in routing or capacity/tariff data.
+- The output manifest records these caveats via `direct_source_caveats` and per-row `source_caveats`.
+
+Verification:
+- `tests/unit/texas_rrc` passed under the system Python runner used for this session.
+- Formatting and focused lint checks passed for touched infrastructure/lifecycle/CLI files.

--- a/src/worldenergydata/cli/__init__.py
+++ b/src/worldenergydata/cli/__init__.py
@@ -1,9 +1,15 @@
-"""
-WorldEnergyData CLI Package
+"""WorldEnergyData CLI package."""
 
-Unified command-line interface for global energy market data operations.
-"""
+from importlib import import_module
 
-from worldenergydata.cli.main import app
+
+def __getattr__(name: str):
+    """Load the Typer app only when requested."""
+    if name != "app":
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = import_module("worldenergydata.cli.main").app
+    globals()[name] = value
+    return value
+
 
 __all__ = ["app"]

--- a/src/worldenergydata/cli/commands/__init__.py
+++ b/src/worldenergydata/cli/commands/__init__.py
@@ -1,5 +1,4 @@
-"""
-CLI Command Modules
+"""CLI command modules.
 
 Each module provides subcommands for a specific domain:
 - bsee: BSEE data operations and analysis
@@ -17,21 +16,33 @@ Each module provides subcommands for a specific domain:
 - lng_terminals: Global LNG terminal dataset with engineering design data
 """
 
-from worldenergydata.cli.commands import (
-    bsee,
-    canada,
-    dashboard,
-    eia,
-    fdas,
-    landman,
-    lng_terminals,
-    marine_safety,
-    metocean,
-    mexico_cnh,
-    ndbc,
-    sodir,
-    texas_rrc,
-)
+from importlib import import_module
+
+_COMMAND_MODULES = {
+    "bsee",
+    "canada",
+    "dashboard",
+    "eia",
+    "fdas",
+    "landman",
+    "lng_terminals",
+    "marine_safety",
+    "metocean",
+    "mexico_cnh",
+    "ndbc",
+    "sodir",
+    "texas_rrc",
+}
+
+
+def __getattr__(name: str):
+    """Load command modules only when requested."""
+    if name not in _COMMAND_MODULES:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = import_module(f"{__name__}.{name}")
+    globals()[name] = module
+    return module
+
 
 __all__ = [
     "bsee",

--- a/src/worldenergydata/cli/commands/texas_rrc.py
+++ b/src/worldenergydata/cli/commands/texas_rrc.py
@@ -939,6 +939,104 @@ def build_field_development_metrics_command(
         raise typer.Exit(1)
 
 
+def _print_infrastructure_access_summary(row_count: int, source_gaps) -> None:
+    table = Table(
+        title="Texas RRC Infrastructure Access Metrics",
+        show_header=True,
+        header_style="bold cyan",
+    )
+    table.add_column("Metric", style="dim")
+    table.add_column("Value")
+    table.add_row("Infrastructure access rows", str(row_count))
+    table.add_row("Source gaps", ", ".join(source_gaps) if source_gaps else "None")
+    console.print(table)
+
+
+def _print_infrastructure_access_outputs(manifest) -> None:
+    console.print(
+        "[green]Wrote infrastructure access metrics[/green] "
+        f"{manifest.row_count} rows -> {manifest.csv_path}"
+    )
+    console.print(f"[dim]Parquet: {manifest.parquet_path}[/dim]")
+    console.print(f"[dim]Quality report: {manifest.quality_path}[/dim]")
+    console.print(f"[dim]Manifest: {manifest.manifest_path}[/dim]")
+
+
+@app.command("build-infrastructure-access-metrics")
+def build_infrastructure_access_metrics_command(
+    root: Path = typer.Option(
+        Path("/mnt/ace/worldenergydata/data/modules/texas_rrc"),
+        "--root",
+        help="Root containing Texas RRC curated metrics and raw GIS layers",
+    ),
+    output_root: Path = typer.Option(
+        Path("/mnt/ace/worldenergydata/data/modules/texas_rrc"),
+        "--output-root",
+        help="Root for curated infrastructure access metric outputs",
+    ),
+    refresh_gis: bool = typer.Option(
+        False,
+        "--refresh-gis",
+        help="Refresh official RRC well and pipeline GIS layers before building",
+    ),
+    require_sources: bool = typer.Option(
+        False,
+        "--require-sources",
+        help="Fail when any curated or GIS input source is missing",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Build the infrastructure access summary without writing outputs",
+    ),
+    nearby_radius_miles: float = typer.Option(
+        25.0,
+        "--nearby-radius-miles",
+        min=1.0,
+        help="Maximum distance used for nearby pipeline screening",
+    ),
+    allow_non_ace_output: bool = typer.Option(
+        False,
+        "--allow-non-ace-output",
+        help="Allow non-/mnt/ace output roots for isolated tests or sandboxes",
+    ),
+    rows_per_page: int = typer.Option(
+        1000,
+        "--rows-per-page",
+        min=1,
+        help="GoDrive directory rows requested per page when refreshing GIS",
+    ),
+) -> None:
+    """Build Texas RRC field-level infrastructure access metrics."""
+    from worldenergydata.texas_rrc.infrastructure.cli_support import (
+        run_build_infrastructure_access_metrics,
+    )
+
+    try:
+        result = run_build_infrastructure_access_metrics(
+            root=root,
+            output_root=output_root,
+            dry_run=dry_run,
+            require_sources=require_sources,
+            refresh_gis=refresh_gis,
+            nearby_radius_miles=nearby_radius_miles,
+            allow_non_ace_output=allow_non_ace_output,
+            rows_per_page=rows_per_page,
+        )
+        _print_infrastructure_access_summary(result.row_count, result.source_gaps)
+        if result.dry_run:
+            console.print(
+                "[yellow]Dry run:[/yellow] no infrastructure access outputs written"
+            )
+            return
+        _print_infrastructure_access_outputs(result.manifest)
+    except typer.Exit:
+        raise
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+
+
 @app.command()
 def analyze(
     district: Optional[str] = typer.Option(

--- a/tests/unit/texas_rrc/test_infrastructure_access_cli.py
+++ b/tests/unit/texas_rrc/test_infrastructure_access_cli.py
@@ -1,0 +1,225 @@
+"""CLI tests for Texas RRC infrastructure access metrics."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile
+
+import pandas as pd
+import shapefile
+from typer.testing import CliRunner
+
+from worldenergydata.cli.commands.texas_rrc import app
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+
+def _zip_shapefile(base: Path, zip_path: Path) -> None:
+    with ZipFile(zip_path, "w", compression=ZIP_DEFLATED) as archive:
+        for suffix in (".shp", ".shx", ".dbf"):
+            archive.write(base.with_suffix(suffix), base.with_suffix(suffix).name)
+
+
+def _write_well_zip(root: Path) -> None:
+    raw = root / "raw/gis/wells"
+    raw.mkdir(parents=True, exist_ok=True)
+    base = raw / "well001"
+    writer = shapefile.Writer(str(base), shapeType=shapefile.POINT)
+    writer.field("API", "C")
+    writer.field("CNTY_FIPS", "C")
+    writer.point(-102.0, 31.0)
+    writer.record("42001000010000", "001")
+    writer.close()
+    _zip_shapefile(base, raw / "well001.zip")
+
+
+def _write_pipeline_zip(root: Path) -> None:
+    raw = root / "raw/gis/pipelines"
+    raw.mkdir(parents=True, exist_ok=True)
+    base = raw / "pipeline001"
+    writer = shapefile.Writer(str(base), shapeType=shapefile.POLYLINE)
+    writer.field("T4PERMIT", "C")
+    writer.field("CNTY_FIPS", "C")
+    writer.line([[(-102.0, 30.9), (-102.0, 31.1)]])
+    writer.record("T4-12345", "001")
+    writer.close()
+    _zip_shapefile(base, raw / "pipeline001.zip")
+
+
+def _write_curated_inputs(root: Path) -> None:
+    lifecycle_path = (
+        root / "curated" / "well_lifecycle" / "spine" / "well_lifecycle_spine.csv"
+    )
+    lifecycle_path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        [
+            {
+                "api14": "42001000010000",
+                "api10": "4200100001",
+                "district": "08",
+                "field_number": "00010001",
+                "field_name": "SPRABERRY",
+            }
+        ]
+    ).to_csv(lifecycle_path, index=False)
+
+    metrics_path = (
+        root
+        / "curated"
+        / "field_development"
+        / "metrics"
+        / "field_development_metrics.parquet"
+    )
+    metrics_path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        [
+            {
+                "district": "08",
+                "field_number": "00010001",
+                "field_name": "SPRABERRY",
+                "well_count": 1,
+            }
+        ]
+    ).to_parquet(metrics_path, index=False)
+
+    _write_json(
+        lifecycle_path.with_name("manifest.json"),
+        {"row_count": 1, "input_paths": ["raw/wells/example.zip"]},
+    )
+    _write_json(
+        metrics_path.with_name("manifest.json"),
+        {"row_count": 1, "input_paths": ["curated/well_lifecycle/spine/manifest.json"]},
+    )
+
+
+def _write_all_inputs(root: Path) -> None:
+    _write_curated_inputs(root)
+    _write_well_zip(root)
+    _write_pipeline_zip(root)
+    _write_json(
+        root / "raw/gis/wells/manifest.json",
+        {"source_id": "well_gis_layers", "artifacts": []},
+    )
+    _write_json(
+        root / "raw/gis/pipelines/manifest.json",
+        {"source_id": "pipeline_gis_layers", "artifacts": []},
+    )
+
+
+def test_build_infrastructure_access_metrics_cli_refuses_missing_sources(tmp_path):
+    result = CliRunner().invoke(
+        app,
+        [
+            "build-infrastructure-access-metrics",
+            "--root",
+            str(tmp_path),
+            "--output-root",
+            str(tmp_path),
+            "--allow-non-ace-output",
+            "--require-sources",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "missing infrastructure sources" in result.output
+    assert "field_development_metrics" in result.output
+    assert "well_lifecycle_spine" in result.output
+    assert "well_gis_layers" in result.output
+    assert "pipeline_gis_layers" in result.output
+
+
+def test_build_infrastructure_access_metrics_cli_dry_run(tmp_path):
+    _write_all_inputs(tmp_path)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "build-infrastructure-access-metrics",
+            "--root",
+            str(tmp_path),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Infrastructure access rows" in result.output
+    assert "Dry run" in result.output
+    assert not (tmp_path / "curated/infrastructure/access").exists()
+
+
+def test_build_infrastructure_access_metrics_cli_writes_outputs(tmp_path):
+    output_root = tmp_path / "out"
+    _write_all_inputs(tmp_path)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "build-infrastructure-access-metrics",
+            "--root",
+            str(tmp_path),
+            "--output-root",
+            str(output_root),
+            "--allow-non-ace-output",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Wrote infrastructure access metrics" in result.output
+    assert (
+        output_root
+        / "curated"
+        / "infrastructure"
+        / "access"
+        / "field_infrastructure_access.csv"
+    ).exists()
+    manifest = json.loads(
+        (
+            output_root / "curated" / "infrastructure" / "access" / "manifest.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert manifest["row_count"] == 1
+    assert "rrc_gis_screening_only" in manifest["direct_source_caveats"]
+
+
+def test_build_infrastructure_access_metrics_cli_refreshes_gis_when_requested(
+    monkeypatch,
+    tmp_path,
+):
+    import worldenergydata.texas_rrc.raw_refresh as raw_refresh
+
+    _write_curated_inputs(tmp_path)
+    refreshed: list[str] = []
+
+    class FakeRefresher:
+        def __init__(self, output_root):
+            self.output_root = output_root
+
+        def refresh_source(self, source_id, selection=None, rows_per_page=1000):
+            refreshed.append(source_id)
+            if source_id == "well_gis_layers":
+                _write_well_zip(self.output_root)
+            if source_id == "pipeline_gis_layers":
+                _write_pipeline_zip(self.output_root)
+            return object()
+
+    monkeypatch.setattr(raw_refresh, "RawSnapshotRefresher", FakeRefresher)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "build-infrastructure-access-metrics",
+            "--root",
+            str(tmp_path),
+            "--output-root",
+            str(tmp_path / "out"),
+            "--allow-non-ace-output",
+            "--refresh-gis",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert refreshed == ["well_gis_layers", "pipeline_gis_layers"]

--- a/tests/unit/texas_rrc/test_infrastructure_access_metrics.py
+++ b/tests/unit/texas_rrc/test_infrastructure_access_metrics.py
@@ -1,0 +1,354 @@
+"""Tests for Texas RRC field-level infrastructure access metrics."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.infrastructure.gis_sources import (
+    PipelineGisRecord,
+    WellGisRecord,
+)
+
+
+def _field_development() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "district": "08",
+                "field_number": "00010001",
+                "field_name": "SPRABERRY",
+                "well_count": 2,
+            },
+            {
+                "district": "08",
+                "field_number": "00020001",
+                "field_name": "REMOTE FIELD",
+                "well_count": 1,
+            },
+            {
+                "district": "09",
+                "field_number": "00030001",
+                "field_name": "NO GIS FIELD",
+                "well_count": 1,
+            },
+        ]
+    )
+
+
+def _lifecycle() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "api14": "42001000010000",
+                "api10": "4200100001",
+                "district": "08",
+                "field_number": "00010001",
+                "field_name": "SPRABERRY",
+            },
+            {
+                "api14": "42001000020000",
+                "api10": "4200100002",
+                "district": "08",
+                "field_number": "00010001",
+                "field_name": "SPRABERRY",
+            },
+            {
+                "api14": "42003000010000",
+                "api10": "4200300001",
+                "district": "08",
+                "field_number": "00020001",
+                "field_name": "REMOTE FIELD",
+            },
+            {
+                "api14": "42005000010000",
+                "api10": "4200500001",
+                "district": "08",
+                "field_number": "00040001",
+                "field_name": "GIS ONLY FIELD",
+            },
+        ]
+    )
+
+
+def _well_gis() -> tuple[WellGisRecord, ...]:
+    return (
+        WellGisRecord("42001000010000", "001", 31.0, -102.0, "well001.zip"),
+        WellGisRecord("42001000020000", "001", 31.02, -102.02, "well001.zip"),
+        WellGisRecord("42003000010000", "003", 32.0, -103.0, "well003.zip"),
+        WellGisRecord("42005000010000", "005", 30.0, -101.0, "well005.zip"),
+    )
+
+
+def _pipeline_gis() -> tuple[PipelineGisRecord, ...]:
+    return (
+        PipelineGisRecord(
+            "near-001",
+            "001",
+            ((-102.0, 30.95), (-102.0, 31.1)),
+            "pipeline001.zip",
+        ),
+        PipelineGisRecord(
+            "regional-003",
+            "003",
+            ((-103.12, 31.95), (-103.12, 32.05)),
+            "pipeline003.zip",
+        ),
+    )
+
+
+def test_build_infrastructure_access_metrics_scores_pipeline_access():
+    from worldenergydata.texas_rrc.infrastructure.access_metrics import (
+        InfrastructureAccessInputs,
+        build_infrastructure_access_metrics,
+    )
+
+    metrics = build_infrastructure_access_metrics(
+        InfrastructureAccessInputs(
+            field_development=_field_development(),
+            lifecycle=_lifecycle(),
+            well_gis=_well_gis(),
+            pipeline_gis=_pipeline_gis(),
+            source_gaps=(),
+        )
+    ).set_index(["district", "field_number"])
+
+    spraberry = metrics.loc[("08", "00010001")]
+    assert spraberry["field_well_count_with_location"] == 2
+    assert spraberry["nearest_pipeline_identifier"] == "near-001"
+    assert spraberry["nearest_pipeline_distance_miles"] <= 1.0
+    assert spraberry["nearby_pipeline_count_1mi"] == 1
+    assert spraberry["nearby_pipeline_count_5mi"] == 1
+    assert spraberry["infrastructure_access_class"] == "direct_access"
+    assert spraberry["infrastructure_access_score"] == 1.0
+    assert "rrc_gis_screening_only" in spraberry["source_caveats"]
+
+    remote = metrics.loc[("08", "00020001")]
+    assert 5.0 < remote["nearest_pipeline_distance_miles"] <= 10.0
+    assert remote["infrastructure_access_class"] == "regional_access"
+    assert remote["infrastructure_access_score"] == 0.5
+
+    missing = metrics.loc[("09", "00030001")]
+    assert missing["field_well_count_with_location"] == 0
+    assert pd.isna(missing["nearest_pipeline_distance_miles"])
+    assert missing["infrastructure_access_class"] == "isolated_or_unknown"
+    assert "missing_well_gis" in missing["source_caveats"]
+
+
+def test_build_infrastructure_access_metrics_screens_from_field_centroid(monkeypatch):
+    import worldenergydata.texas_rrc.infrastructure.access_metrics as access_metrics
+    import worldenergydata.texas_rrc.infrastructure.spatial as spatial
+
+    def fake_distance(latitude, longitude, coordinates):
+        raise AssertionError("field screening should use pipeline envelope distance")
+
+    monkeypatch.setattr(
+        spatial,
+        "point_to_polyline_distance_miles",
+        fake_distance,
+    )
+
+    metrics = access_metrics.build_infrastructure_access_metrics(
+        access_metrics.InfrastructureAccessInputs(
+            field_development=pd.DataFrame(
+                [
+                    {
+                        "district": "08",
+                        "field_number": "00010001",
+                        "field_name": "SPRABERRY",
+                    }
+                ]
+            ),
+            lifecycle=pd.DataFrame(
+                [
+                    {
+                        "api14": "42001000010000",
+                        "district": "08",
+                        "field_number": "00010001",
+                    },
+                    {
+                        "api14": "42001000020000",
+                        "district": "08",
+                        "field_number": "00010001",
+                    },
+                ]
+            ),
+            well_gis=(
+                WellGisRecord("42001000010000", "001", 31.0, -102.0, "well001.zip"),
+                WellGisRecord("42001000020000", "001", 31.1, -102.1, "well001.zip"),
+            ),
+            pipeline_gis=(
+                PipelineGisRecord(
+                    "pipe-1", "001", ((-102.0, 31.0), (-102.0, 31.2)), "pipe.zip"
+                ),
+                PipelineGisRecord(
+                    "pipe-2", "001", ((-102.1, 31.0), (-102.1, 31.2)), "pipe.zip"
+                ),
+                PipelineGisRecord(
+                    "pipe-3", "001", ((-102.2, 31.0), (-102.2, 31.2)), "pipe.zip"
+                ),
+            ),
+            source_gaps=(),
+        )
+    )
+
+    row = metrics.iloc[0]
+    assert row["nearby_pipeline_count_1mi"] == 0
+    assert row["nearby_pipeline_count_5mi"] == 2
+    assert row["nearby_pipeline_count_10mi"] == 3
+    assert 2.0 < row["nearest_pipeline_distance_miles"] < 3.5
+
+
+def test_build_infrastructure_access_metrics_uses_pipeline_envelope_distance(
+    monkeypatch,
+):
+    import worldenergydata.texas_rrc.infrastructure.access_metrics as access_metrics
+    import worldenergydata.texas_rrc.infrastructure.spatial as spatial
+
+    def fake_distance(latitude, longitude, coordinates):
+        raise AssertionError("field screening should use pipeline envelope distance")
+
+    monkeypatch.setattr(
+        spatial,
+        "point_to_polyline_distance_miles",
+        fake_distance,
+    )
+
+    metrics = access_metrics.build_infrastructure_access_metrics(
+        access_metrics.InfrastructureAccessInputs(
+            field_development=pd.DataFrame(
+                [
+                    {
+                        "district": "08",
+                        "field_number": "00010001",
+                        "field_name": "SPRABERRY",
+                    }
+                ]
+            ),
+            lifecycle=pd.DataFrame(
+                [
+                    {
+                        "api14": "42001000010000",
+                        "district": "08",
+                        "field_number": "00010001",
+                    },
+                ]
+            ),
+            well_gis=(
+                WellGisRecord("42001000010000", "001", 31.0, -102.0, "well001.zip"),
+            ),
+            pipeline_gis=(
+                PipelineGisRecord(
+                    "near", "001", ((-102.0, 31.0), (-102.0, 31.2)), "pipe.zip"
+                ),
+                PipelineGisRecord(
+                    "far-envelope",
+                    "001",
+                    ((-101.7, 31.0), (-101.7, 31.2)),
+                    "pipe.zip",
+                ),
+            ),
+            source_gaps=(),
+        )
+    )
+
+    row = metrics.iloc[0]
+    assert row["nearest_pipeline_identifier"] == "near"
+    assert row["nearest_pipeline_distance_miles"] == 0.0
+    assert row["nearby_pipeline_count_10mi"] == 1
+
+
+def test_build_infrastructure_access_metrics_filters_by_dominant_field_county():
+    from worldenergydata.texas_rrc.infrastructure.access_metrics import (
+        InfrastructureAccessInputs,
+        build_infrastructure_access_metrics,
+    )
+
+    metrics = build_infrastructure_access_metrics(
+        InfrastructureAccessInputs(
+            field_development=pd.DataFrame(
+                [
+                    {
+                        "district": "08",
+                        "field_number": "00010001",
+                        "field_name": "SPRABERRY",
+                    }
+                ]
+            ),
+            lifecycle=pd.DataFrame(
+                [
+                    {
+                        "api14": "42001000010000",
+                        "district": "08",
+                        "field_number": "00010001",
+                    },
+                    {
+                        "api14": "42001000020000",
+                        "district": "08",
+                        "field_number": "00010001",
+                    },
+                    {
+                        "api14": "42003000010000",
+                        "district": "08",
+                        "field_number": "00010001",
+                    },
+                ]
+            ),
+            well_gis=(
+                WellGisRecord("42001000010000", "001", 31.0, -102.0, "well001.zip"),
+                WellGisRecord("42001000020000", "001", 31.0, -102.1, "well001.zip"),
+                WellGisRecord("42003000010000", "003", 31.0, -102.2, "well003.zip"),
+            ),
+            pipeline_gis=(
+                PipelineGisRecord(
+                    "dominant-county",
+                    "001",
+                    ((-102.0, 30.9), (-102.0, 31.1)),
+                    "pipe001.zip",
+                ),
+                PipelineGisRecord(
+                    "other-county",
+                    "003",
+                    ((-102.1, 30.9), (-102.1, 31.1)),
+                    "pipe003.zip",
+                ),
+            ),
+            source_gaps=(),
+        )
+    )
+
+    row = metrics.iloc[0]
+    assert row["nearest_pipeline_identifier"] == "dominant-county"
+    assert "dominant_county_pipeline_filter" in row["source_caveats"]
+
+
+def test_build_infrastructure_access_metrics_preserves_gis_only_fields():
+    from worldenergydata.texas_rrc.infrastructure.access_metrics import (
+        InfrastructureAccessInputs,
+        build_infrastructure_access_metrics,
+    )
+
+    metrics = build_infrastructure_access_metrics(
+        InfrastructureAccessInputs(
+            field_development=_field_development(),
+            lifecycle=_lifecycle(),
+            well_gis=_well_gis(),
+            pipeline_gis=_pipeline_gis(),
+            source_gaps=("pipeline_gis_layers",),
+        )
+    )
+
+    gis_only = metrics.set_index(["district", "field_number"]).loc[("08", "00040001")]
+
+    assert gis_only["field_name"] == "GIS ONLY FIELD"
+    assert gis_only["field_well_count_with_location"] == 1
+    assert gis_only["infrastructure_access_class"] == "isolated_or_unknown"
+    assert "missing_field_development_metrics" in gis_only["source_caveats"]
+    assert "missing_pipeline_gis" in gis_only["source_caveats"]
+    assert tuple(
+        metrics[["district", "field_number"]].itertuples(index=False, name=None)
+    ) == (
+        ("08", "00010001"),
+        ("08", "00020001"),
+        ("08", "00040001"),
+        ("09", "00030001"),
+    )

--- a/tests/unit/texas_rrc/test_infrastructure_gis_sources.py
+++ b/tests/unit/texas_rrc/test_infrastructure_gis_sources.py
@@ -1,0 +1,138 @@
+"""Tests for loading official Texas RRC GIS shapefile ZIPs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile
+
+import pytest
+import shapefile
+
+
+def _zip_shapefile(base: Path, zip_path: Path) -> None:
+    with ZipFile(zip_path, "w", compression=ZIP_DEFLATED) as archive:
+        for suffix in (".shp", ".shx", ".dbf"):
+            archive.write(base.with_suffix(suffix), base.with_suffix(suffix).name)
+
+
+def _write_well_zip(root: Path) -> Path:
+    base = root / "well001"
+    writer = shapefile.Writer(str(base), shapeType=shapefile.POINT)
+    writer.field("API", "C")
+    writer.field("CNTY_FIPS", "C")
+    writer.point(-102.0, 31.0)
+    writer.record("42-001-00001-00-00", "1")
+    writer.point(-95.5, 31.9)
+    writer.record("00130641", "")
+    writer.close()
+    zip_path = root / "well001.zip"
+    _zip_shapefile(base, zip_path)
+    return zip_path
+
+
+def _write_pipeline_zip(root: Path) -> Path:
+    base = root / "pipeline001"
+    writer = shapefile.Writer(str(base), shapeType=shapefile.POLYLINE)
+    writer.field("T4PERMIT", "C")
+    writer.field("CNTY_FIPS", "C")
+    writer.line([[(-102.0, 30.9), (-102.0, 31.2)]])
+    writer.record("T4-12345", "001")
+    writer.close()
+    zip_path = root / "pipeline001.zip"
+    _zip_shapefile(base, zip_path)
+    return zip_path
+
+
+def test_load_well_gis_records_normalizes_api_and_preserves_source(tmp_path):
+    from worldenergydata.texas_rrc.infrastructure.gis_sources import (
+        load_well_gis_records,
+    )
+
+    zip_path = _write_well_zip(tmp_path)
+
+    records = load_well_gis_records(tmp_path)
+
+    assert len(records) == 2
+    record = records[0]
+    assert record.api_number == "42001000010000"
+    assert record.county_fips == "001"
+    assert record.latitude == 31.0
+    assert record.longitude == -102.0
+    assert record.source_file == zip_path.name
+    assert records[1].api_number == "42001306410000"
+    assert records[1].county_fips == "001"
+
+
+def test_load_pipeline_gis_records_keeps_polyline_coordinates(tmp_path):
+    from worldenergydata.texas_rrc.infrastructure.gis_sources import (
+        load_pipeline_gis_records,
+    )
+
+    zip_path = _write_pipeline_zip(tmp_path)
+
+    records = load_pipeline_gis_records(tmp_path)
+
+    assert len(records) == 1
+    record = records[0]
+    assert record.pipeline_identifier == "T4-12345"
+    assert record.county_fips == "001"
+    assert record.coordinates == ((-102.0, 30.9), (-102.0, 31.2))
+    assert record.source_file == zip_path.name
+
+
+def test_load_gis_records_rejects_remote_paths():
+    from worldenergydata.texas_rrc.infrastructure.gis_sources import (
+        load_well_gis_records,
+    )
+
+    with pytest.raises(ValueError, match="local filesystem"):
+        load_well_gis_records("https://example.com/wells.zip")
+
+
+def test_load_gis_records_reports_malformed_zip(tmp_path):
+    from worldenergydata.texas_rrc.infrastructure.gis_sources import (
+        GisSourceError,
+        load_pipeline_gis_records,
+    )
+
+    with ZipFile(tmp_path / "pipeline001.zip", "w", compression=ZIP_DEFLATED) as bad:
+        bad.writestr("pipeline001.shp", b"not-a-real-shapefile")
+
+    with pytest.raises(GisSourceError, match="missing required shapefile members"):
+        load_pipeline_gis_records(tmp_path)
+
+
+def test_load_gis_inputs_preserves_good_records_when_one_zip_is_malformed(tmp_path):
+    from worldenergydata.texas_rrc.infrastructure.gis_sources import load_gis_inputs
+
+    well_root = tmp_path / "raw" / "gis" / "wells"
+    pipeline_root = tmp_path / "raw" / "gis" / "pipelines"
+    well_root.mkdir(parents=True)
+    pipeline_root.mkdir(parents=True)
+    _write_well_zip(well_root)
+    _write_pipeline_zip(pipeline_root)
+    with ZipFile(well_root / "well999.zip", "w", compression=ZIP_DEFLATED) as bad:
+        bad.writestr("well999.shp", b"not-a-real-shapefile")
+
+    result = load_gis_inputs(tmp_path)
+
+    assert len(result.well_gis) == 2
+    assert len(result.pipeline_gis) == 1
+    assert result.source_gaps == ()
+    assert len(result.malformed_source_files) == 1
+    assert "well999.zip" in result.malformed_source_files[0]
+
+
+def test_load_gis_records_rejects_unsafe_zip_member_paths(tmp_path):
+    from worldenergydata.texas_rrc.infrastructure.gis_sources import (
+        GisSourceError,
+        load_well_gis_records,
+    )
+
+    with ZipFile(tmp_path / "well001.zip", "w", compression=ZIP_DEFLATED) as bad:
+        bad.writestr("../well001.shp", b"")
+        bad.writestr("well001.shx", b"")
+        bad.writestr("well001.dbf", b"")
+
+    with pytest.raises(GisSourceError, match="unsafe ZIP member path"):
+        load_well_gis_records(tmp_path)

--- a/tests/unit/texas_rrc/test_infrastructure_io.py
+++ b/tests/unit/texas_rrc/test_infrastructure_io.py
@@ -1,0 +1,147 @@
+"""Tests for Texas RRC infrastructure access quality and persistence."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+
+import pandas as pd
+import pytest
+
+
+def _metrics() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "district": "08",
+                "field_number": "00010001",
+                "field_name": "SPRABERRY",
+                "field_well_count_with_location": 2,
+                "nearest_pipeline_distance_miles": 0.2,
+                "infrastructure_access_class": "direct_access",
+                "source_caveats": "rrc_gis_screening_only",
+            },
+            {
+                "district": "09",
+                "field_number": "00030001",
+                "field_name": "NO GIS FIELD",
+                "field_well_count_with_location": 0,
+                "nearest_pipeline_distance_miles": pd.NA,
+                "infrastructure_access_class": "isolated_or_unknown",
+                "source_caveats": "missing_well_gis|missing_pipeline_gis",
+            },
+        ]
+    )
+
+
+def test_assess_infrastructure_quality_counts_classes_and_missing_geometry():
+    from worldenergydata.texas_rrc.infrastructure.quality import (
+        assess_infrastructure_access_quality,
+    )
+
+    quality = assess_infrastructure_access_quality(
+        _metrics(),
+        source_gaps=("pipeline_gis_layers",),
+        malformed_source_files=("bad_pipeline.zip",),
+    )
+
+    assert quality.row_count == 2
+    assert quality.source_gaps == ("pipeline_gis_layers",)
+    assert quality.access_class_counts == {
+        "direct_access": 1,
+        "isolated_or_unknown": 1,
+    }
+    assert quality.missing_well_gis_count == 1
+    assert quality.missing_pipeline_source_count == 1
+    assert quality.malformed_source_file_count == 1
+    assert quality.nearest_pipeline_distance_min_miles == 0.2
+    assert quality.nearest_pipeline_distance_max_miles == 0.2
+
+
+def test_write_infrastructure_access_outputs_rejects_non_ace_root_by_default(tmp_path):
+    from worldenergydata.texas_rrc.infrastructure.io import (
+        write_infrastructure_access_outputs,
+    )
+    from worldenergydata.texas_rrc.infrastructure.quality import (
+        assess_infrastructure_access_quality,
+    )
+
+    with pytest.raises(ValueError, match="/mnt/ace"):
+        write_infrastructure_access_outputs(
+            _metrics(),
+            assess_infrastructure_access_quality(_metrics()),
+            output_root=tmp_path,
+        )
+
+
+def test_write_infrastructure_access_outputs_persists_quality_and_manifest(tmp_path):
+    from worldenergydata.texas_rrc.infrastructure.io import (
+        load_infrastructure_access_metrics,
+        write_infrastructure_access_outputs,
+    )
+    from worldenergydata.texas_rrc.infrastructure.quality import (
+        SCORING_THRESHOLDS_MILES,
+        assess_infrastructure_access_quality,
+    )
+
+    quality = assess_infrastructure_access_quality(
+        _metrics(),
+        source_gaps=("well_gis_layers",),
+        malformed_source_files=("bad_well.zip",),
+    )
+    input_paths = [
+        tmp_path / "raw/gis/wells/manifest.json",
+        tmp_path / "raw/gis/pipelines/manifest.json",
+        tmp_path / "curated/field_development/metrics/manifest.json",
+    ]
+
+    manifest = write_infrastructure_access_outputs(
+        _metrics(),
+        quality,
+        output_root=tmp_path,
+        generated_at=datetime(2026, 7, 1, 4, 0, tzinfo=timezone.utc),
+        input_paths=input_paths,
+        allow_non_ace_root=True,
+        command="worldenergydata texas-rrc build-infrastructure-access-metrics",
+        code_revision="abc123",
+    )
+
+    assert manifest.csv_path.exists()
+    assert manifest.parquet_path.exists()
+    assert manifest.quality_path.exists()
+    assert manifest.manifest_path.exists()
+
+    reloaded = load_infrastructure_access_metrics(manifest.csv_path)
+    assert reloaded.iloc[0]["field_number"] == "00010001"
+    assert load_infrastructure_access_metrics(manifest.parquet_path).shape[0] == 2
+
+    quality_payload = json.loads(manifest.quality_path.read_text(encoding="utf-8"))
+    assert quality_payload["source_gaps"] == ["well_gis_layers"]
+    assert quality_payload["malformed_source_file_count"] == 1
+
+    manifest_payload = json.loads(manifest.manifest_path.read_text(encoding="utf-8"))
+    assert manifest_payload["generated_at"] == "2026-07-01T04:00:00Z"
+    assert manifest_payload["row_count"] == 2
+    assert manifest_payload["input_paths"] == [str(path) for path in input_paths]
+    assert manifest_payload["scoring_thresholds_miles"] == SCORING_THRESHOLDS_MILES
+    assert manifest_payload["code_revision"] == "abc123"
+    assert manifest_payload["quality"]["access_class_counts"]["direct_access"] == 1
+
+
+def test_git_revision_returns_head_when_status_times_out(monkeypatch):
+    import worldenergydata.texas_rrc.infrastructure.io as infrastructure_io
+
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append((args, kwargs))
+        if args == ["git", "rev-parse", "HEAD"]:
+            return subprocess.CompletedProcess(args, 0, stdout="abc123\n", stderr="")
+        raise subprocess.TimeoutExpired(args, timeout=kwargs.get("timeout"))
+
+    monkeypatch.setattr(infrastructure_io.subprocess, "run", fake_run)
+
+    assert infrastructure_io._git_revision() == "abc123"
+    assert calls[1][0] == ["git", "status", "--porcelain", "--untracked-files=no"]
+    assert all(call[1]["timeout"] == 5 for call in calls)

--- a/tests/unit/texas_rrc/test_infrastructure_spatial.py
+++ b/tests/unit/texas_rrc/test_infrastructure_spatial.py
@@ -1,0 +1,114 @@
+"""Tests for Texas RRC infrastructure spatial screening helpers."""
+
+from __future__ import annotations
+
+import math
+
+
+def test_haversine_distance_uses_miles_for_texas_scale():
+    from worldenergydata.texas_rrc.infrastructure.spatial import haversine_miles
+
+    distance = haversine_miles(31.0, -102.0, 31.1, -102.0)
+
+    assert distance == pytest_approx(6.91, abs=0.08)
+
+
+def test_point_to_pipeline_distance_uses_polyline_segments():
+    from worldenergydata.texas_rrc.infrastructure.spatial import (
+        point_to_polyline_distance_miles,
+    )
+
+    distance = point_to_polyline_distance_miles(
+        latitude=31.05,
+        longitude=-102.05,
+        coordinates=((-102.0, 31.0), (-102.0, 31.1)),
+    )
+
+    assert distance == pytest_approx(2.96, abs=0.10)
+
+
+def test_field_bounds_and_extent_are_deterministic():
+    from worldenergydata.texas_rrc.infrastructure.spatial import field_geometry
+
+    geometry = field_geometry(((31.0, -102.0), (31.1, -102.1), (30.9, -101.9)))
+
+    assert geometry.well_count == 3
+    assert geometry.centroid_latitude == pytest_approx(31.0, abs=0.000001)
+    assert geometry.centroid_longitude == pytest_approx(-102.0, abs=0.000001)
+    assert geometry.latitude_min == 30.9
+    assert geometry.latitude_max == 31.1
+    assert geometry.longitude_min == -102.1
+    assert geometry.longitude_max == -101.9
+    assert geometry.extent_miles > 18.0
+
+
+def test_field_extent_uses_bounds_instead_of_pairwise_distances(monkeypatch):
+    import worldenergydata.texas_rrc.infrastructure.spatial as spatial
+
+    calls = {"total": 0}
+
+    def fake_haversine(latitude_a, longitude_a, latitude_b, longitude_b):
+        calls["total"] += 1
+        return 10.0
+
+    monkeypatch.setattr(spatial, "haversine_miles", fake_haversine)
+
+    points = tuple(
+        (31.0 + index * 0.001, -102.0 - index * 0.001) for index in range(20)
+    )
+    geometry = spatial.field_geometry(points)
+
+    assert geometry.extent_miles == 10.0
+    assert calls["total"] == 1
+
+
+def test_candidate_pipeline_prefilter_prefers_county_then_bbox():
+    from worldenergydata.texas_rrc.infrastructure.gis_sources import PipelineGisRecord
+    from worldenergydata.texas_rrc.infrastructure.spatial import (
+        field_geometry,
+        filter_candidate_pipelines,
+    )
+
+    local = PipelineGisRecord(
+        pipeline_identifier="near",
+        county_fips="001",
+        coordinates=((-102.0, 31.0), (-102.0, 31.1)),
+        source_file="pipeline001.zip",
+    )
+    wrong_county = PipelineGisRecord(
+        pipeline_identifier="wrong-county",
+        county_fips="003",
+        coordinates=((-102.01, 31.0), (-102.01, 31.1)),
+        source_file="pipeline003.zip",
+    )
+    no_county_far = PipelineGisRecord(
+        pipeline_identifier="far",
+        county_fips=None,
+        coordinates=((-100.0, 31.0), (-100.0, 31.1)),
+        source_file="pipeline000.zip",
+    )
+
+    candidates = filter_candidate_pipelines(
+        geometry=field_geometry(((31.02, -102.02),)),
+        field_counties={"001"},
+        pipelines=(local, wrong_county, no_county_far),
+        padding_miles=10.0,
+    )
+
+    assert tuple(item.pipeline_identifier for item in candidates) == ("near",)
+
+
+def test_nearest_pipeline_handles_no_candidates():
+    from worldenergydata.texas_rrc.infrastructure.spatial import nearest_pipeline
+
+    nearest = nearest_pipeline(field_points=((31.0, -102.0),), pipelines=())
+
+    assert nearest is None
+
+
+def pytest_approx(value: float, abs: float):  # noqa: A002 - mirrors pytest API
+    import pytest
+
+    if not math.isfinite(value):
+        raise AssertionError("expected finite comparison value")
+    return pytest.approx(value, abs=abs)

--- a/tests/unit/texas_rrc/test_raw_refresh_directory.py
+++ b/tests/unit/texas_rrc/test_raw_refresh_directory.py
@@ -286,6 +286,51 @@ def test_directory_refresh_writes_all_files_and_artifact_manifest(tmp_path):
     )
 
 
+def test_directory_refresh_retries_transient_file_download(tmp_path):
+    from worldenergydata.texas_rrc.raw_refresh import RawSnapshotRefresher
+
+    class FlakyDirectoryTransport(FakeDirectoryTransport):
+        def __init__(self, pages, payloads):
+            super().__init__(pages, payloads)
+            self.attempts: dict[str, int] = {}
+
+        def download_godrive_directory_file_to(
+            self,
+            url: str,
+            entry,
+            output_path: Path,
+            rows_per_page: int = 1000,
+        ):
+            self.attempts[entry.filename] = self.attempts.get(entry.filename, 0) + 1
+            if entry.filename == "well003.zip" and self.attempts[entry.filename] == 1:
+                raise OSError("tls alert internal error")
+            return super().download_godrive_directory_file_to(
+                url,
+                entry,
+                output_path,
+                rows_per_page,
+            )
+
+    transport = FlakyDirectoryTransport(
+        [_page([_entry("well001.zip"), _entry("well003.zip")])],
+        payloads={"well001.zip": b"one", "well003.zip": b"three"},
+    )
+    refresher = RawSnapshotRefresher(
+        catalog=_catalog_for("well_gis_layers", "all_files"),
+        output_root=tmp_path,
+        transport=transport,
+        clock=fixed_clock,
+        max_attempts=2,
+    )
+
+    manifest = refresher.refresh_source("well_gis_layers")
+
+    assert manifest.status == "downloaded"
+    assert transport.attempts["well003.zip"] == 2
+    assert (tmp_path / "raw" / "gis" / "wells" / "well003.zip").read_bytes() == b"three"
+    assert not list(tmp_path.rglob("*.part"))
+
+
 def test_directory_refresh_failure_removes_staging_and_preserves_existing_files(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -4426,6 +4426,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d5/7b/65f55513d3c769fd677f90032d8d8703e3dc17e88a41b6074d2177548bca/PyPyDispatcher-2.1.2.tar.gz", hash = "sha256:b6bec5dfcff9d2535bca2b23c80eae367b1ac250a645106948d315fcfa9130f2", size = 23224, upload-time = "2017-07-03T14:20:51.806Z" }
 
 [[package]]
+name = "pyshp"
+version = "2.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/dc/8d5c654580a7398702026b6e34fdbe622bfdaef3b50e7f3f4244a11a90a0/pyshp-2.4.2.tar.gz", hash = "sha256:50d56ca9301960b00da7158e8428f64054da504f3c507b54df878232c9902232", size = 1739226, upload-time = "2026-06-06T16:46:42.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/22/ffcd94c7d57cb5dc0c45d0a158237f4c991ab3e187a75842e04ea3c94f6c/pyshp-2.4.2-py2.py3-none-any.whl", hash = "sha256:7a013b5e8333f5923a9eb012e2048ae15b3399f11abf2e0044b10176decbd68a", size = 49071, upload-time = "2026-06-06T16:46:41.37Z" },
+]
+
+[[package]]
 name = "pysocks"
 version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -7527,6 +7536,7 @@ source = { editable = "packages/worldenergydata-texas_rrc" }
 dependencies = [
     { name = "pandas" },
     { name = "pyarrow" },
+    { name = "pyshp" },
     { name = "pyyaml" },
     { name = "worldenergydata-core" },
 ]
@@ -7535,6 +7545,7 @@ dependencies = [
 requires-dist = [
     { name = "pandas", specifier = ">=2.3.3,<3.0" },
     { name = "pyarrow", specifier = ">=14.0.0,<20.0" },
+    { name = "pyshp", specifier = ">=2.3,<3" },
     { name = "pyyaml", specifier = ">=6.0,<7.0" },
     { name = "worldenergydata-core", editable = "packages/worldenergydata-core" },
 ]


### PR DESCRIPTION
## Summary
- Add Texas RRC infrastructure access metrics from direct RRC well and pipeline GIS ZIPs.
- Persist field-level CSV, Parquet, quality JSON, and manifest under `/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/infrastructure/access`.
- Add CLI support, quality summaries, direct-source caveats, docs, and regression tests.
- Preserve valid GIS records when one source ZIP is malformed and reject unsafe ZIP member paths.

Closes #665

## Verification
- `PKG_PATHS=$(printf ':%s' packages/*/src); PYTHONPATH=/tmp/wed_py313${PKG_PATHS}:src python3 -m pytest -o addopts= tests/unit/texas_rrc -q` -> 491 passed.
- `python3 -m black --check` on touched infrastructure/lifecycle/CLI/test files -> passed.
- `python3 -m isort --check-only` on touched infrastructure/lifecycle/CLI/test files -> passed.
- `python3 -m flake8` on touched infrastructure/lifecycle/CLI/test files -> passed.
- `scripts/enforcement/check-no-conflict-markers.sh` -> passed.

## Data Artifacts
- `/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/infrastructure/access/field_infrastructure_access.csv`
- `/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/infrastructure/access/field_infrastructure_access.parquet`
- `/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/infrastructure/access/field_infrastructure_access_quality.json`
- `/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/infrastructure/access/manifest.json`

Manifest revision: `831ee0ddbfc96ae90c80acd57d7283d2e5094146`.
Rows: 61,518. Source gaps: none. Malformed GIS source files: 0.

## Review
- Inline adversarial review artifact: `scripts/review/results/2026-07-01-code-665-codex-inline.md`.
- `scripts/legal/legal-sanity-scan.sh` and `scripts/enforcement/check-no-abs-paths.sh` are absent in this repo checkout; conflict-marker scan was run instead.