### PR TITLE
feat(texas-rrc): publish onshore field atlas reports

### DIFF
--- a/docs/data-sources/onshore/texas-rrc/field-atlas-reports.md
+++ b/docs/data-sources/onshore/texas-rrc/field-atlas-reports.md
@@ -1,0 +1,57 @@
+# Texas RRC Field Atlas Reports
+
+Issue [#666](https://github.com/vamseeachanta/worldenergydata/issues/666)
+publishes onshore field-atlas reports from direct curated Texas RRC sources.
+
+## Source Lifecycle
+
+| Source | Refresh cycle | Required artifact |
+|---|---:|---|
+| Field-development metrics | After lifecycle and production atlas refresh | `/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/field_development/metrics/field_development_metrics.csv` |
+| Infrastructure access metrics | After RRC GIS refresh and field-development metrics | `/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/infrastructure/access/field_infrastructure_access.csv` |
+| Production atlas | Monthly, after the last Saturday PDQ refresh | `/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/production/field_atlas/production_field_atlas.csv` |
+
+The report publisher is read-only against upstream sources. It does not refresh,
+normalize, or rebuild lifecycle, production, or GIS artifacts.
+
+## Command
+
+```bash
+uv run worldenergydata texas-rrc publish-field-atlas-reports --require-sources
+```
+
+Useful operator options:
+
+```bash
+uv run worldenergydata texas-rrc publish-field-atlas-reports --dry-run
+uv run worldenergydata texas-rrc publish-field-atlas-reports --max-fields 100
+```
+
+Use `--allow-non-ace-output` only for isolated tests or sandbox publication.
+
+## Published Layout
+
+```text
+/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/reports/field_atlas/
+  index.html
+  fields/
+    <district>-<field_number>-<field_slug>.html
+  field_atlas_summary.csv
+  field_atlas_summary.parquet
+  field_atlas_report_quality.json
+  manifest.json
+```
+
+The HTML files are self-contained and use no remote script or style
+dependencies. The machine-readable summary carries one row per published field
+page and preserves the district/field-number key used by the source artifacts.
+
+## Caveats
+
+- Production is sourced from the RRC PDQ production atlas. BOE uses the upstream
+  atlas conversion and inherits the upstream metric gaps.
+- Infrastructure access is a proximity screen to official RRC pipeline GIS
+  geometry. It is not a tie-in feasibility study.
+- A field without an infrastructure row is still reported with
+  `infrastructure_access_class=not_available` and a
+  `missing_infrastructure_access` caveat.

--- a/docs/plans/2026-07-01-issue-666-texas-rrc-onshore-field-atlas-reports.md
+++ b/docs/plans/2026-07-01-issue-666-texas-rrc-onshore-field-atlas-reports.md
@@ -1,7 +1,7 @@
 # Plan: Issue #666 - Texas RRC onshore field atlas and deep-dive reports
 
 **Issue:** https://github.com/vamseeachanta/worldenergydata/issues/666
-**Status:** plan-review
+**Status:** plan-approved
 **Tier:** T2 (HTML report generation, field-page fanout, manifest/provenance, `/mnt/ace` output contract, CLI, tests)
 **Client:** N/A
 **Project:** worldenergydata onshore field development

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -77,7 +77,7 @@ This directory contains issue-plan artifacts created during the issue-planning-m
 | [#663](https://github.com/vamseeachanta/worldenergydata/issues/663) | [texas-rrc-production-field-atlas](2026-06-30-issue-663-texas-rrc-production-field-atlas.md) | plan-approved | 2026-06-30 |
 | [#664](https://github.com/vamseeachanta/worldenergydata/issues/664) | [texas-rrc-field-development-metrics](2026-07-01-issue-664-texas-rrc-field-development-metrics.md) | plan-review | 2026-07-01 |
 | [#665](https://github.com/vamseeachanta/worldenergydata/issues/665) | [texas-rrc-pipeline-gis-infrastructure-access](2026-07-01-issue-665-texas-rrc-pipeline-gis-infrastructure-access.md) | plan-approved | 2026-07-01 |
-| [#666](https://github.com/vamseeachanta/worldenergydata/issues/666) | [texas-rrc-onshore-field-atlas-reports](2026-07-01-issue-666-texas-rrc-onshore-field-atlas-reports.md) | plan-review | 2026-07-01 |
+| [#666](https://github.com/vamseeachanta/worldenergydata/issues/666) | [texas-rrc-onshore-field-atlas-reports](2026-07-01-issue-666-texas-rrc-onshore-field-atlas-reports.md) | plan-approved | 2026-07-01 |
 | [#669](https://github.com/vamseeachanta/worldenergydata/issues/669) | [texas-rrc-godrive-directory-refresh](2026-06-30-issue-669-texas-rrc-godrive-directory-refresh.md) | plan-approved | 2026-06-30 |
 
 ## Closed / superseded plans

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/reports/__init__.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/reports/__init__.py
@@ -1,0 +1,25 @@
+"""Texas RRC report publishing helpers."""
+
+from worldenergydata.texas_rrc.reports.cli_support import (
+    FieldAtlasReportBuildResult,
+    run_publish_field_atlas_reports,
+)
+from worldenergydata.texas_rrc.reports.field_atlas import (
+    FieldAtlasPage,
+    build_field_atlas_pages,
+    build_field_atlas_summary,
+)
+from worldenergydata.texas_rrc.reports.sources import (
+    FieldAtlasReportInputs,
+    load_field_atlas_report_inputs,
+)
+
+__all__ = [
+    "FieldAtlasPage",
+    "FieldAtlasReportBuildResult",
+    "FieldAtlasReportInputs",
+    "build_field_atlas_pages",
+    "build_field_atlas_summary",
+    "load_field_atlas_report_inputs",
+    "run_publish_field_atlas_reports",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/reports/cli_support.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/reports/cli_support.py
@@ -1,0 +1,103 @@
+"""CLI support for publishing Texas RRC field-atlas reports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from worldenergydata.texas_rrc.reports.field_atlas import (
+    build_field_atlas_pages,
+    build_field_atlas_summary,
+)
+from worldenergydata.texas_rrc.reports.io import (
+    FieldAtlasReportOutputManifest,
+    write_field_atlas_report_outputs,
+)
+from worldenergydata.texas_rrc.reports.quality import assess_field_atlas_report_quality
+from worldenergydata.texas_rrc.reports.sources import load_field_atlas_report_inputs
+from worldenergydata.texas_rrc.source_catalog import SOURCE_CATALOG_ROOT
+
+
+@dataclass(frozen=True)
+class FieldAtlasReportBuildResult:
+    """Result returned by the field-atlas report publisher."""
+
+    row_count: int
+    page_count: int
+    source_gaps: tuple[str, ...]
+    dry_run: bool
+    manifest: FieldAtlasReportOutputManifest | None
+
+
+def run_publish_field_atlas_reports(
+    root: Path | str = SOURCE_CATALOG_ROOT,
+    output_root: Path | str = SOURCE_CATALOG_ROOT,
+    dry_run: bool = False,
+    require_sources: bool = False,
+    allow_non_ace_output: bool = False,
+    max_fields: int | None = None,
+) -> FieldAtlasReportBuildResult:
+    """Build and optionally write Texas RRC field-atlas report outputs."""
+    source_root = Path(root)
+    target_root = Path(output_root)
+    inputs = load_field_atlas_report_inputs(source_root)
+    if inputs.source_gaps and (require_sources or not dry_run):
+        raise ValueError(
+            "Cannot publish field-atlas reports with missing sources: "
+            + ", ".join(inputs.source_gaps)
+        )
+    pages = build_field_atlas_pages(inputs, max_fields=max_fields)
+    summary = build_field_atlas_summary(pages)
+    quality = assess_field_atlas_report_quality(summary, pages, inputs.source_gaps)
+    if dry_run:
+        return FieldAtlasReportBuildResult(
+            row_count=len(summary),
+            page_count=len(pages),
+            source_gaps=inputs.source_gaps,
+            dry_run=True,
+            manifest=None,
+        )
+    manifest = write_field_atlas_report_outputs(
+        pages=pages,
+        summary=summary,
+        quality=quality,
+        output_root=target_root,
+        input_paths=inputs.input_paths,
+        allow_non_ace_root=allow_non_ace_output,
+        command=_command(source_root, target_root, require_sources, max_fields),
+    )
+    return FieldAtlasReportBuildResult(
+        row_count=len(summary),
+        page_count=len(pages),
+        source_gaps=inputs.source_gaps,
+        dry_run=False,
+        manifest=manifest,
+    )
+
+
+def _command(
+    root: Path,
+    output_root: Path,
+    require_sources: bool,
+    max_fields: int | None,
+) -> str:
+    parts = [
+        "worldenergydata",
+        "texas-rrc",
+        "publish-field-atlas-reports",
+        "--root",
+        str(root),
+        "--output-root",
+        str(output_root),
+    ]
+    if require_sources:
+        parts.append("--require-sources")
+    if max_fields is not None:
+        parts.extend(["--max-fields", str(max_fields)])
+    return " ".join(parts)
+
+
+__all__ = [
+    "FieldAtlasReportBuildResult",
+    "run_publish_field_atlas_reports",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/reports/field_atlas.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/reports/field_atlas.py
@@ -1,0 +1,317 @@
+"""Assemble Texas RRC field-atlas report models."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Any
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.reports.sources import FieldAtlasReportInputs
+
+SUMMARY_COLUMNS = [
+    "district",
+    "field_number",
+    "field_name",
+    "field_slug",
+    "report_path",
+    "field_page_filename",
+    "well_count",
+    "active_well_count",
+    "permit_count",
+    "completion_count",
+    "production_maturity_class",
+    "remaining_activity_score",
+    "rank_cumulative_boe",
+    "rank_remaining_activity",
+    "rank_well_density_proxy",
+    "cumulative_oil_bbl",
+    "cumulative_gas_mcf",
+    "cumulative_condensate_bbl",
+    "cumulative_boe",
+    "production_per_well_boe",
+    "lease_count",
+    "operator_count",
+    "top_operator_number",
+    "top_operator_name",
+    "top_operator_share",
+    "infrastructure_access_class",
+    "infrastructure_access_score",
+    "nearest_pipeline_distance_miles",
+    "nearby_pipeline_count_1mi",
+    "nearby_pipeline_count_5mi",
+    "nearby_pipeline_count_10mi",
+    "source_caveats",
+    "quality_flags",
+]
+
+_FIELD_COLUMNS = [
+    "well_count",
+    "active_well_count",
+    "permit_count",
+    "completion_count",
+    "production_maturity_class",
+    "remaining_activity_score",
+    "rank_cumulative_boe",
+    "rank_remaining_activity",
+    "rank_well_density_proxy",
+    "cumulative_oil_bbl",
+    "cumulative_gas_mcf",
+    "cumulative_condensate_bbl",
+    "cumulative_boe",
+    "production_per_well_boe",
+    "lease_count",
+    "operator_count",
+    "top_operator_number",
+    "top_operator_name",
+    "top_operator_share",
+]
+_INFRASTRUCTURE_COLUMNS = [
+    "infrastructure_access_class",
+    "infrastructure_access_score",
+    "nearest_pipeline_distance_miles",
+    "nearest_pipeline_identifier",
+    "nearby_pipeline_count_1mi",
+    "nearby_pipeline_count_5mi",
+    "nearby_pipeline_count_10mi",
+]
+_LEASE_COLUMNS = [
+    "lease_number",
+    "lease_name",
+    "operator_number",
+    "operator_name",
+    "cumulative_oil_bbl",
+    "cumulative_gas_mcf",
+    "cumulative_condensate_bbl",
+    "cumulative_boe",
+    "first_production_month",
+    "last_production_month",
+    "still_producing",
+]
+
+
+@dataclass(frozen=True)
+class FieldAtlasPage:
+    """One field deep-dive page and its machine-readable summary row."""
+
+    district: str
+    field_number: str
+    field_name: str
+    field_slug: str
+    field_page_filename: str
+    report_path: str
+    summary: dict[str, Any]
+    lease_rows: tuple[dict[str, Any], ...]
+    source_caveats: tuple[str, ...]
+    quality_flags: tuple[str, ...]
+
+
+def build_field_atlas_pages(
+    inputs: FieldAtlasReportInputs, max_fields: int | None = None
+) -> tuple[FieldAtlasPage, ...]:
+    """Build report page models from curated source inputs."""
+    if inputs.field_development.empty:
+        return ()
+    infrastructure = _indexed_rows(inputs.infrastructure_access)
+    leases = _lease_rows_by_field(inputs.production_atlas)
+    pages = [_build_page(row, infrastructure, leases) for row in _records(inputs)]
+    pages.sort(key=lambda page: _sort_value(page.summary.get("rank_cumulative_boe")))
+    return tuple(pages[:max_fields] if max_fields else pages)
+
+
+def build_field_atlas_summary(pages: tuple[FieldAtlasPage, ...]) -> pd.DataFrame:
+    """Build the machine-readable summary dataframe for report outputs."""
+    records = [page.summary for page in pages]
+    if not records:
+        return pd.DataFrame(columns=SUMMARY_COLUMNS)
+    summary = pd.DataFrame(records)
+    return summary.reindex(columns=SUMMARY_COLUMNS)
+
+
+def slugify_field(value: object) -> str:
+    """Return a stable slug suitable for field report filenames."""
+    text = str(value or "").strip().lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", text).strip("-")
+    return slug or "field"
+
+
+def _records(inputs: FieldAtlasReportInputs) -> list[dict[str, Any]]:
+    return inputs.field_development.where(
+        pd.notna(inputs.field_development), None
+    ).to_dict("records")
+
+
+def _build_page(
+    field: dict[str, Any],
+    infrastructure: dict[tuple[str, str], dict[str, Any]],
+    leases: dict[tuple[str, str], tuple[dict[str, Any], ...]],
+) -> FieldAtlasPage:
+    district = _text(field.get("district"))
+    field_number = _text(field.get("field_number"))
+    field_name = _text(field.get("field_name"))
+    key = (district, field_number)
+    infra = infrastructure.get(key)
+    caveats = _merged_terms(field.get("source_caveats"))
+    flags = _merged_terms(field.get("quality_flags"))
+    if infra:
+        caveats = _merged_terms(*caveats, infra.get("source_caveats"))
+        flags = _merged_terms(*flags, infra.get("quality_flags"))
+    else:
+        caveats = _merged_terms(*caveats, "missing_infrastructure_access")
+    slug = slugify_field(field_name)
+    filename = f"{_slug_token(district)}-{_slug_token(field_number)}-{slug}.html"
+    report_path = str(PurePosixPath("fields") / filename)
+    summary = _summary_row(field, infra, caveats, flags, slug, filename, report_path)
+    return FieldAtlasPage(
+        district=district,
+        field_number=field_number,
+        field_name=field_name,
+        field_slug=slug,
+        field_page_filename=filename,
+        report_path=report_path,
+        summary=summary,
+        lease_rows=leases.get(key, ()),
+        source_caveats=caveats,
+        quality_flags=flags,
+    )
+
+
+def _summary_row(
+    field: dict[str, Any],
+    infra: dict[str, Any] | None,
+    caveats: tuple[str, ...],
+    flags: tuple[str, ...],
+    slug: str,
+    filename: str,
+    report_path: str,
+) -> dict[str, Any]:
+    row = {column: field.get(column) for column in _FIELD_COLUMNS}
+    row.update(
+        {
+            "district": _text(field.get("district")),
+            "field_number": _text(field.get("field_number")),
+            "field_name": _text(field.get("field_name")),
+            "field_slug": slug,
+            "report_path": report_path,
+            "field_page_filename": filename,
+            "source_caveats": "; ".join(caveats),
+            "quality_flags": "; ".join(flags),
+        }
+    )
+    row.update(_infrastructure_summary(infra))
+    selected = {column: row.get(column) for column in SUMMARY_COLUMNS}
+    if infra:
+        selected["nearest_pipeline_identifier"] = infra.get(
+            "nearest_pipeline_identifier"
+        )
+    return selected
+
+
+def _infrastructure_summary(infra: dict[str, Any] | None) -> dict[str, Any]:
+    if not infra:
+        return {
+            "infrastructure_access_class": "not_available",
+            "infrastructure_access_score": None,
+            "nearest_pipeline_distance_miles": None,
+            "nearby_pipeline_count_1mi": None,
+            "nearby_pipeline_count_5mi": None,
+            "nearby_pipeline_count_10mi": None,
+        }
+    return {column: infra.get(column) for column in _INFRASTRUCTURE_COLUMNS}
+
+
+def _indexed_rows(frame: pd.DataFrame) -> dict[tuple[str, str], dict[str, Any]]:
+    if frame.empty:
+        return {}
+    records = frame.where(pd.notna(frame), None).to_dict("records")
+    return {_key(row): row for row in records if _key(row) != ("", "")}
+
+
+def _lease_rows_by_field(
+    frame: pd.DataFrame,
+) -> dict[tuple[str, str], tuple[dict[str, Any], ...]]:
+    rows_by_key: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    if frame.empty or "aggregation_level" not in frame:
+        return {}
+    records = frame.where(pd.notna(frame), None).to_dict("records")
+    for row in records:
+        if _text(row.get("aggregation_level")).lower() != "lease":
+            continue
+        rows_by_key[_key(row)].append(_lease_row(row))
+    return {key: tuple(_sorted_leases(rows)[:10]) for key, rows in rows_by_key.items()}
+
+
+def _lease_row(row: dict[str, Any]) -> dict[str, Any]:
+    return {column: row.get(column) for column in _LEASE_COLUMNS if column in row}
+
+
+def _sorted_leases(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(rows, key=lambda row: _descending_value(row.get("cumulative_boe")))
+
+
+def _key(row: dict[str, Any]) -> tuple[str, str]:
+    return _text(row.get("district")), _text(row.get("field_number"))
+
+
+def _text(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, float) and math.isnan(value):
+        return ""
+    return str(value).strip()
+
+
+def _merged_terms(*values: object) -> tuple[str, ...]:
+    terms: list[str] = []
+    for value in values:
+        for term in _split_terms(value):
+            if term not in terms:
+                terms.append(term)
+    return tuple(terms)
+
+
+def _split_terms(value: object) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, tuple | list):
+        tokens = []
+        for item in value:
+            tokens.extend(_split_terms(item))
+        return tokens
+    text = _text(value)
+    if not text or text.lower() == "nan":
+        return []
+    return [part.strip() for part in re.split(r"[;,]", text) if part.strip()]
+
+
+def _sort_value(value: object) -> tuple[int, float]:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return (1, float("inf"))
+    if math.isnan(number):
+        return (1, float("inf"))
+    return (0, number)
+
+
+def _descending_value(value: object) -> tuple[int, float]:
+    missing, number = _sort_value(value)
+    return (missing, -number)
+
+
+def _slug_token(value: object) -> str:
+    token = re.sub(r"[^A-Za-z0-9]+", "-", _text(value)).strip("-").lower()
+    return token or "unknown"
+
+
+__all__ = [
+    "FieldAtlasPage",
+    "SUMMARY_COLUMNS",
+    "build_field_atlas_pages",
+    "build_field_atlas_summary",
+    "slugify_field",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/reports/html.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/reports/html.py
@@ -1,0 +1,310 @@
+"""Self-contained HTML rendering for Texas RRC field-atlas reports."""
+
+from __future__ import annotations
+
+import html
+import math
+from collections import Counter
+from typing import Any, Iterable
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.reports.field_atlas import FieldAtlasPage
+
+_STYLE = """
+body{margin:0;font-family:Arial,Helvetica,sans-serif;background:#f7f8fa;color:#1f2933}
+main{max-width:1180px;margin:0 auto;padding:24px}
+a{color:#0b5cad;text-decoration:none}a:hover{text-decoration:underline}
+.hero{background:#102a43;color:white;padding:28px 32px}
+.hero h1{margin:0 0 8px;font-size:30px;line-height:1.2}
+.hero p{margin:0;color:#d9e2ec}
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:12px;margin:20px 0}
+.metric,.section{background:white;border:1px solid #d9e2ec;border-radius:6px;padding:16px}
+.metric .label{color:#627d98;font-size:12px;text-transform:uppercase}
+.metric .value{font-size:24px;font-weight:700;margin-top:4px}
+h2{font-size:20px;margin:26px 0 10px}h3{font-size:16px;margin:0 0 10px}
+table{border-collapse:collapse;width:100%;background:white;border:1px solid #d9e2ec}
+th,td{padding:9px 10px;border-bottom:1px solid #e6edf3;text-align:left}
+th{background:#eef3f8;font-size:12px;text-transform:uppercase;color:#486581}
+.two{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:16px}
+.pill{display:inline-block;background:#e6f6ff;border:1px solid #9fdaff;border-radius:4px;padding:2px 6px}
+.muted{color:#627d98}.footer{margin-top:28px;color:#627d98;font-size:13px}
+"""
+
+
+def render_index_html(summary: pd.DataFrame, pages: tuple[FieldAtlasPage, ...]) -> str:
+    """Render the index page for a published field-atlas report set."""
+    rows = summary.to_dict("records") if not summary.empty else []
+    body = [
+        _document_start("Texas RRC Onshore Field Atlas"),
+        _hero(
+            "Texas RRC Onshore Field Atlas",
+            "Direct-source field development, production, and infrastructure reports.",
+        ),
+        "<main>",
+        _index_metrics(rows),
+        "<h2>Top Fields By Cumulative BOE</h2>",
+        _top_fields_table(rows[:25]),
+        '<div class="two">',
+        _distribution_section("Production Maturity", rows, "production_maturity_class"),
+        _distribution_section(
+            "Infrastructure Access", rows, "infrastructure_access_class"
+        ),
+        "</div>",
+        _footer("Sources: Texas RRC curated direct-source artifacts under /mnt/ace."),
+        "</main>",
+        "</body></html>",
+    ]
+    return "".join(body)
+
+
+def render_field_html(page: FieldAtlasPage) -> str:
+    """Render one field deep-dive page."""
+    body = [
+        _document_start(f"{page.field_name} Field Atlas"),
+        _hero(_e(page.field_name), _field_subtitle(page)),
+        "<main>",
+        '<p><a href="../index.html">Back to index</a></p>',
+        _field_metrics(page.summary),
+        '<div class="two">',
+        _section("Lifecycle", _definition_table(_lifecycle_rows(page.summary))),
+        _section("Production", _definition_table(_production_rows(page.summary))),
+        _section(
+            "Infrastructure",
+            _definition_table(_infrastructure_rows(page.summary)),
+        ),
+        _section(
+            "Lease And Operator Context",
+            _definition_table(_operator_rows(page.summary)),
+        ),
+        "</div>",
+        "<h2>Top Leases</h2>",
+        _lease_table(page.lease_rows),
+        "<h2>Provenance And Caveats</h2>",
+        _provenance(page),
+        _footer("Generated from direct Texas RRC curated artifacts."),
+        "</main>",
+        "</body></html>",
+    ]
+    return "".join(body)
+
+
+def _document_start(title: str) -> str:
+    return (
+        '<!doctype html><html lang="en"><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width,initial-scale=1">'
+        f"<title>{_e(title)}</title><style>{_STYLE}</style></head><body>"
+    )
+
+
+def _hero(title: str, subtitle: str) -> str:
+    return f'<header class="hero"><h1>{title}</h1><p>{subtitle}</p></header>'
+
+
+def _index_metrics(rows: list[dict[str, Any]]) -> str:
+    total_boe = sum(_number(row.get("cumulative_boe")) for row in rows)
+    active_fields = sum(1 for row in rows if _number(row.get("active_well_count")) > 0)
+    access_count = sum(1 for row in rows if _has_infrastructure_access(row))
+    return _metric_grid(
+        [
+            ("Fields", len(rows)),
+            ("Active Fields", active_fields),
+            ("Cumulative BOE", total_boe),
+            ("Fields With Infrastructure Row", access_count),
+        ]
+    )
+
+
+def _field_metrics(summary: dict[str, Any]) -> str:
+    return _metric_grid(
+        [
+            ("Cumulative BOE", summary.get("cumulative_boe")),
+            ("Wells", summary.get("well_count")),
+            ("Active Wells", summary.get("active_well_count")),
+            ("Access Class", summary.get("infrastructure_access_class")),
+        ]
+    )
+
+
+def _metric_grid(items: Iterable[tuple[str, object]]) -> str:
+    cells = [
+        f'<div class="metric"><div class="label">{_e(label)}</div>'
+        f'<div class="value">{_fmt(value)}</div></div>'
+        for label, value in items
+    ]
+    return '<section class="grid">' + "".join(cells) + "</section>"
+
+
+def _top_fields_table(rows: list[dict[str, Any]]) -> str:
+    table_rows = []
+    for row in rows:
+        link = _e(str(row.get("report_path") or ""))
+        name = _e(row.get("field_name"))
+        table_rows.append(
+            "<tr>"
+            f'<td><a href="{link}">{name}</a></td>'
+            f"<td>{_e(row.get('district'))}</td>"
+            f"<td>{_e(row.get('field_number'))}</td>"
+            f"<td>{_fmt(row.get('cumulative_boe'))}</td>"
+            f"<td>{_e(row.get('production_maturity_class'))}</td>"
+            f"<td>{_e(row.get('infrastructure_access_class'))}</td>"
+            "</tr>"
+        )
+    return _table(
+        ["Field", "District", "Field Number", "Cumulative BOE", "Maturity", "Access"],
+        table_rows,
+    )
+
+
+def _distribution_section(title: str, rows: list[dict[str, Any]], column: str) -> str:
+    counts = Counter(str(row.get(column) or "not_available") for row in rows)
+    table_rows = [
+        f"<tr><td>{_e(label)}</td><td>{count}</td></tr>"
+        for label, count in counts.most_common()
+    ]
+    return _section(title, _table(["Class", "Fields"], table_rows))
+
+
+def _section(title: str, content: str) -> str:
+    return f'<section class="section"><h3>{_e(title)}</h3>{content}</section>'
+
+
+def _definition_table(rows: Iterable[tuple[str, object]]) -> str:
+    table_rows = [
+        f"<tr><th>{_e(label)}</th><td>{_fmt(value)}</td></tr>" for label, value in rows
+    ]
+    return "<table><tbody>" + "".join(table_rows) + "</tbody></table>"
+
+
+def _lifecycle_rows(summary: dict[str, Any]) -> list[tuple[str, object]]:
+    return [
+        ("Production maturity", summary.get("production_maturity_class")),
+        ("Remaining activity score", summary.get("remaining_activity_score")),
+        ("Permits", summary.get("permit_count")),
+        ("Completions", summary.get("completion_count")),
+        ("Rank by remaining activity", summary.get("rank_remaining_activity")),
+    ]
+
+
+def _production_rows(summary: dict[str, Any]) -> list[tuple[str, object]]:
+    return [
+        ("Oil bbl", summary.get("cumulative_oil_bbl")),
+        ("Gas mcf", summary.get("cumulative_gas_mcf")),
+        ("Condensate bbl", summary.get("cumulative_condensate_bbl")),
+        ("BOE per well", summary.get("production_per_well_boe")),
+        ("Rank by cumulative BOE", summary.get("rank_cumulative_boe")),
+    ]
+
+
+def _infrastructure_rows(summary: dict[str, Any]) -> list[tuple[str, object]]:
+    return [
+        ("Access class", summary.get("infrastructure_access_class")),
+        ("Access score", summary.get("infrastructure_access_score")),
+        ("Nearest pipeline", summary.get("nearest_pipeline_identifier")),
+        ("Nearest pipeline miles", summary.get("nearest_pipeline_distance_miles")),
+        ("Pipelines within 1 mile", summary.get("nearby_pipeline_count_1mi")),
+        ("Pipelines within 5 miles", summary.get("nearby_pipeline_count_5mi")),
+        ("Pipelines within 10 miles", summary.get("nearby_pipeline_count_10mi")),
+    ]
+
+
+def _operator_rows(summary: dict[str, Any]) -> list[tuple[str, object]]:
+    return [
+        ("Lease count", summary.get("lease_count")),
+        ("Operator count", summary.get("operator_count")),
+        ("Top operator number", summary.get("top_operator_number")),
+        ("Top operator", summary.get("top_operator_name")),
+        ("Top operator share", _percent(summary.get("top_operator_share"))),
+    ]
+
+
+def _lease_table(rows: tuple[dict[str, Any], ...]) -> str:
+    if not rows:
+        return '<p class="muted">No lease-level production rows are available.</p>'
+    body = [
+        "<tr>"
+        f"<td>{_e(row.get('lease_number'))}</td>"
+        f"<td>{_e(row.get('lease_name'))}</td>"
+        f"<td>{_e(row.get('operator_name'))}</td>"
+        f"<td>{_fmt(row.get('cumulative_boe'))}</td>"
+        "</tr>"
+        for row in rows
+    ]
+    return _table(["Lease", "Lease Name", "Operator", "Cumulative BOE"], body)
+
+
+def _provenance(page: FieldAtlasPage) -> str:
+    caveats = _tag_list(page.source_caveats)
+    flags = _tag_list(page.quality_flags) or '<span class="muted">None</span>'
+    return (
+        f"<p><strong>Source caveats:</strong> {caveats}</p>"
+        f"<p><strong>Quality flags:</strong> {flags}</p>"
+    )
+
+
+def _tag_list(values: tuple[str, ...]) -> str:
+    return " ".join(f'<span class="pill">{_e(value)}</span>' for value in values)
+
+
+def _table(headers: list[str], rows: list[str]) -> str:
+    header = "".join(f"<th>{_e(value)}</th>" for value in headers)
+    body = "".join(rows) or f'<tr><td colspan="{len(headers)}">No rows</td></tr>'
+    return f"<table><thead><tr>{header}</tr></thead><tbody>{body}</tbody></table>"
+
+
+def _field_subtitle(page: FieldAtlasPage) -> str:
+    return (
+        f"District {_e(page.district)} &bull; Field {_e(page.field_number)} "
+        f"&bull; {_e(page.summary.get('production_maturity_class'))}"
+    )
+
+
+def _footer(text: str) -> str:
+    return f'<footer class="footer">{_e(text)}</footer>'
+
+
+def _fmt(value: object) -> str:
+    if value is None or _is_nan(value):
+        return "Not available"
+    if isinstance(value, str):
+        return _e(value or "Not available")
+    if isinstance(value, int):
+        return f"{value:,}"
+    if isinstance(value, float):
+        return f"{value:,.2f}".rstrip("0").rstrip(".")
+    return _e(value)
+
+
+def _percent(value: object) -> str:
+    if value is None or _is_nan(value):
+        return "Not available"
+    try:
+        return f"{float(value) * 100:.1f}%"
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _number(value: object) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return 0.0 if math.isnan(number) else number
+
+
+def _has_infrastructure_access(row: dict[str, Any]) -> bool:
+    access_class = row.get("infrastructure_access_class")
+    return bool(access_class and access_class != "not_available")
+
+
+def _is_nan(value: object) -> bool:
+    return isinstance(value, float) and math.isnan(value)
+
+
+def _e(value: object) -> str:
+    if value is None or _is_nan(value):
+        return ""
+    return html.escape(str(value), quote=True)
+
+
+__all__ = ["render_field_html", "render_index_html"]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/reports/io.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/reports/io.py
@@ -1,0 +1,258 @@
+"""Persist Texas RRC field-atlas report outputs."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.reports.field_atlas import FieldAtlasPage
+from worldenergydata.texas_rrc.reports.html import render_field_html, render_index_html
+from worldenergydata.texas_rrc.reports.quality import FieldAtlasReportQuality
+from worldenergydata.texas_rrc.source_catalog import SOURCE_CATALOG_ROOT
+
+FIELD_ATLAS_REPORT_DIR = Path("curated") / "reports" / "field_atlas"
+SUMMARY_CSV_FILENAME = "field_atlas_summary.csv"
+SUMMARY_PARQUET_FILENAME = "field_atlas_summary.parquet"
+QUALITY_FILENAME = "field_atlas_report_quality.json"
+MANIFEST_FILENAME = "manifest.json"
+INDEX_FILENAME = "index.html"
+
+
+@dataclass(frozen=True)
+class FieldAtlasReportOutputManifest:
+    """Paths and metadata for one field-atlas report output batch."""
+
+    generated_at: str
+    output_root: Path
+    output_dir: Path
+    index_path: Path
+    summary_csv_path: Path
+    summary_parquet_path: Path
+    quality_path: Path
+    manifest_path: Path
+    row_count: int
+    page_count: int
+    input_paths: tuple[str, ...]
+    source_gaps: tuple[str, ...]
+    command: str | None
+    code_revision: str | None
+
+
+def write_field_atlas_report_outputs(
+    pages: tuple[FieldAtlasPage, ...],
+    summary: pd.DataFrame,
+    quality: FieldAtlasReportQuality,
+    output_root: Path | str = SOURCE_CATALOG_ROOT,
+    generated_at: datetime | None = None,
+    input_paths: Iterable[str | Path] = (),
+    allow_non_ace_root: bool = False,
+    command: str | None = None,
+    code_revision: str | None = None,
+) -> FieldAtlasReportOutputManifest:
+    """Write HTML, summary, quality, and manifest report outputs."""
+    root = Path(output_root)
+    _validate_output_root(root, allow_non_ace_root)
+    target_dir = root / FIELD_ATLAS_REPORT_DIR
+    stamp = _timestamp(generated_at)
+    manifest = _manifest(
+        root,
+        target_dir,
+        summary,
+        pages,
+        quality,
+        input_paths,
+        command,
+        code_revision,
+        stamp,
+    )
+    _write_with_staging(target_dir, pages, summary, quality, manifest, stamp)
+    return manifest
+
+
+def _manifest(
+    root: Path,
+    target_dir: Path,
+    summary: pd.DataFrame,
+    pages: tuple[FieldAtlasPage, ...],
+    quality: FieldAtlasReportQuality,
+    input_paths: Iterable[str | Path],
+    command: str | None,
+    code_revision: str | None,
+    stamp: str,
+) -> FieldAtlasReportOutputManifest:
+    return FieldAtlasReportOutputManifest(
+        generated_at=stamp,
+        output_root=root,
+        output_dir=target_dir,
+        index_path=target_dir / INDEX_FILENAME,
+        summary_csv_path=target_dir / SUMMARY_CSV_FILENAME,
+        summary_parquet_path=target_dir / SUMMARY_PARQUET_FILENAME,
+        quality_path=target_dir / QUALITY_FILENAME,
+        manifest_path=target_dir / MANIFEST_FILENAME,
+        row_count=len(summary),
+        page_count=len(pages),
+        input_paths=tuple(str(path) for path in input_paths),
+        source_gaps=tuple(quality.source_gaps),
+        command=command,
+        code_revision=code_revision or _git_revision(),
+    )
+
+
+def _write_with_staging(
+    target_dir: Path,
+    pages: tuple[FieldAtlasPage, ...],
+    summary: pd.DataFrame,
+    quality: FieldAtlasReportQuality,
+    manifest: FieldAtlasReportOutputManifest,
+    stamp: str,
+) -> None:
+    staging = (
+        target_dir.parent / f".staging-field-atlas-reports-{_compact_stamp(stamp)}"
+    )
+    backup = target_dir.parent / f".backup-field-atlas-reports-{_compact_stamp(stamp)}"
+    shutil.rmtree(staging, ignore_errors=True)
+    shutil.rmtree(backup, ignore_errors=True)
+    promoted = False
+    try:
+        (staging / "fields").mkdir(parents=True, exist_ok=False)
+        _write_html_outputs(staging, pages, summary)
+        summary.to_csv(staging / SUMMARY_CSV_FILENAME, index=False)
+        summary.to_parquet(staging / SUMMARY_PARQUET_FILENAME, index=False)
+        _write_json(staging / QUALITY_FILENAME, _quality_payload(quality))
+        _write_json(staging / MANIFEST_FILENAME, _manifest_payload(manifest, quality))
+        target_dir.parent.mkdir(parents=True, exist_ok=True)
+        if target_dir.exists():
+            target_dir.rename(backup)
+        staging.rename(target_dir)
+        promoted = True
+        shutil.rmtree(backup, ignore_errors=True)
+    except Exception:
+        if backup.exists() and not target_dir.exists():
+            backup.rename(target_dir)
+        raise
+    finally:
+        if not promoted:
+            shutil.rmtree(staging, ignore_errors=True)
+        shutil.rmtree(backup, ignore_errors=True)
+
+
+def _write_html_outputs(
+    staging: Path, pages: tuple[FieldAtlasPage, ...], summary: pd.DataFrame
+) -> None:
+    (staging / INDEX_FILENAME).write_text(
+        render_index_html(summary, pages),
+        encoding="utf-8",
+    )
+    for page in pages:
+        (staging / "fields" / page.field_page_filename).write_text(
+            render_field_html(page),
+            encoding="utf-8",
+        )
+
+
+def _validate_output_root(root: Path, allow_non_ace_root: bool) -> None:
+    if allow_non_ace_root:
+        return
+    if not root.resolve().is_relative_to(SOURCE_CATALOG_ROOT.resolve()):
+        raise ValueError(
+            "Field-atlas report output_root must stay under "
+            f"{SOURCE_CATALOG_ROOT}; pass allow_non_ace_root=True only for "
+            "isolated tests or sandbox runs"
+        )
+
+
+def _quality_payload(quality: FieldAtlasReportQuality) -> dict[str, object]:
+    return asdict(quality)
+
+
+def _manifest_payload(
+    manifest: FieldAtlasReportOutputManifest,
+    quality: FieldAtlasReportQuality,
+) -> dict[str, object]:
+    return {
+        "generated_at": manifest.generated_at,
+        "output_root": str(manifest.output_root),
+        "output_dir": str(manifest.output_dir),
+        "index_path": str(manifest.index_path),
+        "summary_csv_path": str(manifest.summary_csv_path),
+        "summary_parquet_path": str(manifest.summary_parquet_path),
+        "quality_path": str(manifest.quality_path),
+        "manifest_path": str(manifest.manifest_path),
+        "row_count": manifest.row_count,
+        "page_count": manifest.page_count,
+        "input_paths": list(manifest.input_paths),
+        "source_gaps": list(manifest.source_gaps),
+        "command": manifest.command,
+        "code_revision": manifest.code_revision,
+        "quality": _quality_payload(quality),
+    }
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _timestamp(value: datetime | None) -> str:
+    timestamp = value or datetime.now(timezone.utc)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _compact_stamp(stamp: str) -> str:
+    return stamp.replace("-", "").replace(":", "")
+
+
+def _git_revision() -> str | None:
+    repo_root = _repo_root()
+    try:
+        revision = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            timeout=5,
+        )
+        value = revision.stdout.strip()
+        if not value:
+            return None
+        status = subprocess.run(
+            ["git", "status", "--porcelain", "--untracked-files=no"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            timeout=5,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    except subprocess.TimeoutExpired:
+        return value
+    suffix = "+dirty" if status.stdout.strip() else ""
+    return f"{value}{suffix}"
+
+
+def _repo_root() -> Path:
+    path = Path(__file__).resolve()
+    for parent in path.parents:
+        if (parent / ".git").exists():
+            return parent
+    return path.parents[6]
+
+
+__all__ = [
+    "FIELD_ATLAS_REPORT_DIR",
+    "FieldAtlasReportOutputManifest",
+    "write_field_atlas_report_outputs",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/reports/quality.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/reports/quality.py
@@ -1,0 +1,54 @@
+"""Quality assessment for Texas RRC field-atlas reports."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.reports.field_atlas import FieldAtlasPage
+
+
+@dataclass(frozen=True)
+class FieldAtlasReportQuality:
+    """Quality summary for a published field-atlas report batch."""
+
+    row_count: int
+    page_count: int
+    source_gaps: tuple[str, ...]
+    missing_infrastructure_count: int
+    caveat_counts: dict[str, int]
+    quality_flag_counts: dict[str, int]
+
+
+def assess_field_atlas_report_quality(
+    summary: pd.DataFrame,
+    pages: tuple[FieldAtlasPage, ...],
+    source_gaps: tuple[str, ...],
+) -> FieldAtlasReportQuality:
+    """Assess quality and caveat counts for a field-atlas report set."""
+    caveats = Counter()
+    flags = Counter()
+    for page in pages:
+        caveats.update(page.source_caveats)
+        flags.update(page.quality_flags)
+    missing_infra = 0
+    if "infrastructure_access_class" in summary:
+        missing_infra = int(
+            (summary["infrastructure_access_class"] == "not_available").sum()
+        )
+    return FieldAtlasReportQuality(
+        row_count=len(summary),
+        page_count=len(pages),
+        source_gaps=tuple(source_gaps),
+        missing_infrastructure_count=missing_infra,
+        caveat_counts=dict(sorted(caveats.items())),
+        quality_flag_counts=dict(sorted(flags.items())),
+    )
+
+
+__all__ = [
+    "FieldAtlasReportQuality",
+    "assess_field_atlas_report_quality",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/reports/sources.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/reports/sources.py
@@ -1,0 +1,160 @@
+"""Load direct curated inputs for Texas RRC field-atlas reports."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.field_development.io import (
+    CSV_FILENAME as FIELD_DEVELOPMENT_CSV,
+)
+from worldenergydata.texas_rrc.field_development.io import (
+    FIELD_DEVELOPMENT_METRICS_DIR,
+)
+from worldenergydata.texas_rrc.field_development.io import (
+    MANIFEST_FILENAME as FIELD_DEVELOPMENT_MANIFEST,
+)
+from worldenergydata.texas_rrc.field_development.io import (
+    PARQUET_FILENAME as FIELD_DEVELOPMENT_PARQUET,
+)
+from worldenergydata.texas_rrc.field_development.io import (
+    load_field_development_metrics,
+)
+from worldenergydata.texas_rrc.infrastructure.io import (
+    CSV_FILENAME as INFRASTRUCTURE_CSV,
+)
+from worldenergydata.texas_rrc.infrastructure.io import (
+    INFRASTRUCTURE_ACCESS_DIR,
+)
+from worldenergydata.texas_rrc.infrastructure.io import (
+    MANIFEST_FILENAME as INFRASTRUCTURE_MANIFEST,
+)
+from worldenergydata.texas_rrc.infrastructure.io import (
+    PARQUET_FILENAME as INFRASTRUCTURE_PARQUET,
+)
+from worldenergydata.texas_rrc.infrastructure.io import (
+    load_infrastructure_access_metrics,
+)
+from worldenergydata.texas_rrc.production_atlas.io import CSV_FILENAME as PRODUCTION_CSV
+from worldenergydata.texas_rrc.production_atlas.io import (
+    MANIFEST_FILENAME as PRODUCTION_MANIFEST,
+)
+from worldenergydata.texas_rrc.production_atlas.io import (
+    PARQUET_FILENAME as PRODUCTION_PARQUET,
+)
+from worldenergydata.texas_rrc.production_atlas.io import (
+    PRODUCTION_ATLAS_DIR,
+    load_production_atlas,
+)
+
+Loader = Callable[[Path], pd.DataFrame]
+
+
+@dataclass(frozen=True)
+class FieldAtlasReportInputs:
+    """Direct curated inputs used to publish field-atlas reports."""
+
+    field_development: pd.DataFrame
+    infrastructure_access: pd.DataFrame
+    production_atlas: pd.DataFrame
+    input_paths: tuple[Path, ...]
+    source_gaps: tuple[str, ...]
+
+
+def load_field_atlas_report_inputs(root: Path | str) -> FieldAtlasReportInputs:
+    """Load the curated source artifacts used by field-atlas reports."""
+    catalog_root = Path(root)
+    field_df, field_paths, field_gaps = _load_source(
+        catalog_root,
+        FIELD_DEVELOPMENT_METRICS_DIR,
+        FIELD_DEVELOPMENT_CSV,
+        FIELD_DEVELOPMENT_PARQUET,
+        FIELD_DEVELOPMENT_MANIFEST,
+        load_field_development_metrics,
+        "missing_field_development_metrics",
+    )
+    infra_df, infra_paths, infra_gaps = _load_source(
+        catalog_root,
+        INFRASTRUCTURE_ACCESS_DIR,
+        INFRASTRUCTURE_CSV,
+        INFRASTRUCTURE_PARQUET,
+        INFRASTRUCTURE_MANIFEST,
+        load_infrastructure_access_metrics,
+        "missing_infrastructure_access_metrics",
+    )
+    prod_df, prod_paths, prod_gaps = _load_source(
+        catalog_root,
+        PRODUCTION_ATLAS_DIR,
+        PRODUCTION_CSV,
+        PRODUCTION_PARQUET,
+        PRODUCTION_MANIFEST,
+        load_production_atlas,
+        "missing_production_field_atlas",
+    )
+    return FieldAtlasReportInputs(
+        field_development=field_df,
+        infrastructure_access=infra_df,
+        production_atlas=prod_df,
+        input_paths=field_paths + infra_paths + prod_paths,
+        source_gaps=field_gaps + infra_gaps + prod_gaps,
+    )
+
+
+def _load_source(
+    root: Path,
+    source_dir: Path,
+    csv_filename: str,
+    parquet_filename: str,
+    manifest_filename: str,
+    loader: Loader,
+    missing_gap: str,
+) -> tuple[pd.DataFrame, tuple[Path, ...], tuple[str, ...]]:
+    directory = root / source_dir
+    data_path = _existing_data_path(directory, csv_filename, parquet_filename)
+    manifest_path = directory / manifest_filename
+    paths = (data_path,) if data_path else ()
+    if manifest_path.exists():
+        paths = paths + (manifest_path,)
+    if data_path is None:
+        return pd.DataFrame(), paths, (missing_gap,)
+    gaps = _manifest_source_gaps(manifest_path)
+    return loader(data_path), paths, gaps
+
+
+def _existing_data_path(
+    directory: Path, csv_filename: str, parquet_filename: str
+) -> Path | None:
+    parquet_path = directory / parquet_filename
+    if parquet_path.exists():
+        return parquet_path
+    csv_path = directory / csv_filename
+    return csv_path if csv_path.exists() else None
+
+
+def _manifest_source_gaps(manifest_path: Path) -> tuple[str, ...]:
+    if not manifest_path.exists():
+        return ()
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ("unreadable_manifest",)
+    gaps = _string_sequence(payload.get("source_gaps"))
+    if not gaps and isinstance(payload.get("quality"), dict):
+        gaps = _string_sequence(payload["quality"].get("source_gaps"))
+    return tuple(gaps)
+
+
+def _string_sequence(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item)]
+
+
+__all__ = [
+    "FieldAtlasReportInputs",
+    "load_field_atlas_report_inputs",
+]

--- a/scripts/review/results/2026-07-02-code-666-codex-inline.md
+++ b/scripts/review/results/2026-07-02-code-666-codex-inline.md
@@ -1,0 +1,66 @@
+# Code Review: Issue #666 - Texas RRC onshore field atlas reports
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/666
+**Review stage:** code/artifact
+**Reviewer:** Codex inline
+**Date:** 2026-07-02
+**Verdict:** APPROVE after fixes
+
+## Scope Reviewed
+
+- `packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/reports/`
+- `src/worldenergydata/cli/commands/texas_rrc.py`
+- `tests/unit/texas_rrc/test_field_atlas_report_*.py`
+- `docs/data-sources/onshore/texas-rrc/field-atlas-reports.md`
+- Published artifacts under `/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/reports/field_atlas/`
+
+## Findings
+
+### Fixed: Directory promotion could delete existing reports before replacement
+
+The first implementation removed the target report directory before replacing it
+with the staging directory. If the final rename failed after removal, the
+previous published report set would have been lost. The writer now renames the
+existing target to a timestamped backup, promotes staging, removes the backup
+only after successful promotion, and restores the backup on failure when
+possible.
+
+Regression coverage:
+`tests/unit/texas_rrc/test_field_atlas_report_io.py::test_rewrite_removes_stale_field_pages`
+
+### Fixed: Index metric counted `not_available` as infrastructure coverage
+
+The first index metric counted every row with an
+`infrastructure_access_class`, including the fallback `not_available` class.
+The renderer now counts only fields with an actual infrastructure access row,
+which matches the published value of 61,518 out of 67,082 fields.
+
+Regression coverage:
+`tests/unit/texas_rrc/test_field_atlas_report_html.py::test_index_counts_only_fields_with_infrastructure_rows`
+
+## Residual Risks
+
+- The full report publication writes 67,082 HTML files. This is accepted by the
+  issue scope, but operators should expect a non-trivial file count under
+  `/mnt/ace`.
+- Some source rows lack district values; those reports use `unknown` in the
+  page filename while preserving the source field number and caveat trail.
+
+## Verification Evidence
+
+- Red test evidence: focused tests initially failed with
+  `ModuleNotFoundError: No module named 'worldenergydata.texas_rrc.reports'`.
+- Focused #666 tests: `14 passed`.
+- Texas RRC unit suite: `505 passed in 166.96s`.
+- Dry run against `/mnt/ace`: 67,082 summary rows, 67,082 field pages, no source
+  gaps.
+- Full publish: 67,082 field HTML pages; manifest row/page count 67,082; no
+  source gaps.
+- Parquet summary read through project environment: 67,082 rows.
+- HTML self-containment sample: no `http://`, `https://`, or `<script src=`.
+- Black check: pass.
+- isort check: pass.
+- `git diff --check`: pass.
+- Workspace-hub legal diff scan:
+  `bash scripts/legal/legal-sanity-scan.sh --repo=../wt-wed-669 --diff-only`
+  passed.

--- a/src/worldenergydata/cli/commands/texas_rrc.py
+++ b/src/worldenergydata/cli/commands/texas_rrc.py
@@ -1037,6 +1037,98 @@ def build_infrastructure_access_metrics_command(
         raise typer.Exit(1)
 
 
+def _print_field_atlas_report_summary(
+    row_count: int, page_count: int, source_gaps
+) -> None:
+    table = Table(
+        title="Texas RRC Field Atlas Reports",
+        show_header=True,
+        header_style="bold cyan",
+    )
+    table.add_column("Metric", style="dim")
+    table.add_column("Value")
+    table.add_row("Summary rows", str(row_count))
+    table.add_row("Field pages", str(page_count))
+    table.add_row("Source gaps", ", ".join(source_gaps) if source_gaps else "None")
+    console.print(table)
+
+
+def _print_field_atlas_report_outputs(manifest) -> None:
+    console.print(
+        "[green]Wrote field-atlas reports[/green] "
+        f"{manifest.page_count} pages -> {manifest.output_dir}"
+    )
+    console.print(f"[dim]Index: {manifest.index_path}[/dim]")
+    console.print(f"[dim]Summary CSV: {manifest.summary_csv_path}[/dim]")
+    console.print(f"[dim]Summary Parquet: {manifest.summary_parquet_path}[/dim]")
+    console.print(f"[dim]Quality report: {manifest.quality_path}[/dim]")
+    console.print(f"[dim]Manifest: {manifest.manifest_path}[/dim]")
+
+
+@app.command("publish-field-atlas-reports")
+def publish_field_atlas_reports_command(
+    root: Path = typer.Option(
+        Path("/mnt/ace/worldenergydata/data/modules/texas_rrc"),
+        "--root",
+        help="Root containing curated Texas RRC field, production, and access inputs",
+    ),
+    output_root: Path = typer.Option(
+        Path("/mnt/ace/worldenergydata/data/modules/texas_rrc"),
+        "--output-root",
+        help="Root for curated field-atlas report outputs",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Build the report model without writing outputs",
+    ),
+    require_sources: bool = typer.Option(
+        False,
+        "--require-sources",
+        help="Fail when any curated field-atlas report input is missing",
+    ),
+    allow_non_ace_output: bool = typer.Option(
+        False,
+        "--allow-non-ace-output",
+        help="Allow non-/mnt/ace output roots for isolated tests or sandboxes",
+    ),
+    max_fields: int | None = typer.Option(
+        None,
+        "--max-fields",
+        min=1,
+        help="Limit generated field pages after rank sorting",
+    ),
+) -> None:
+    """Publish Texas RRC field-atlas index and field deep-dive reports."""
+    from worldenergydata.texas_rrc.reports.cli_support import (
+        run_publish_field_atlas_reports,
+    )
+
+    try:
+        result = run_publish_field_atlas_reports(
+            root=root,
+            output_root=output_root,
+            dry_run=dry_run,
+            require_sources=require_sources,
+            allow_non_ace_output=allow_non_ace_output,
+            max_fields=max_fields,
+        )
+        _print_field_atlas_report_summary(
+            result.row_count,
+            result.page_count,
+            result.source_gaps,
+        )
+        if result.dry_run:
+            console.print("[yellow]Dry run:[/yellow] no field-atlas reports written")
+            return
+        _print_field_atlas_report_outputs(result.manifest)
+    except typer.Exit:
+        raise
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+
+
 @app.command()
 def analyze(
     district: Optional[str] = typer.Option(

--- a/tests/unit/texas_rrc/test_field_atlas_report_cli.py
+++ b/tests/unit/texas_rrc/test_field_atlas_report_cli.py
@@ -1,0 +1,122 @@
+"""Tests for the Texas RRC field-atlas report CLI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from worldenergydata.cli.commands.texas_rrc import app
+from worldenergydata.texas_rrc.reports.cli_support import (
+    run_publish_field_atlas_reports,
+)
+from worldenergydata.texas_rrc.reports.io import FieldAtlasReportOutputManifest
+
+
+def test_publish_field_atlas_reports_cli_calls_support_layer(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_run_publish_field_atlas_reports(**kwargs):
+        calls.append(kwargs)
+        return _Result(
+            row_count=2,
+            page_count=2,
+            source_gaps=(),
+            dry_run=False,
+            manifest=_manifest(tmp_path),
+        )
+
+    monkeypatch.setattr(
+        "worldenergydata.texas_rrc.reports.cli_support."
+        "run_publish_field_atlas_reports",
+        fake_run_publish_field_atlas_reports,
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "publish-field-atlas-reports",
+            "--root",
+            str(tmp_path),
+            "--output-root",
+            str(tmp_path),
+            "--allow-non-ace-output",
+            "--max-fields",
+            "2",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        {
+            "root": tmp_path,
+            "output_root": tmp_path,
+            "dry_run": False,
+            "require_sources": False,
+            "allow_non_ace_output": True,
+            "max_fields": 2,
+        }
+    ]
+    assert "Wrote field-atlas reports" in result.output
+
+
+def test_run_publish_field_atlas_reports_dry_run_reports_missing_sources(
+    tmp_path: Path,
+) -> None:
+    result = run_publish_field_atlas_reports(
+        root=tmp_path,
+        output_root=tmp_path,
+        dry_run=True,
+        require_sources=False,
+        allow_non_ace_output=True,
+    )
+
+    assert result.dry_run is True
+    assert result.row_count == 0
+    assert result.page_count == 0
+    assert "missing_field_development_metrics" in result.source_gaps
+    assert result.manifest is None
+
+
+def test_run_publish_field_atlas_reports_requires_sources(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="missing_field_development_metrics"):
+        run_publish_field_atlas_reports(
+            root=tmp_path,
+            output_root=tmp_path,
+            dry_run=True,
+            require_sources=True,
+            allow_non_ace_output=True,
+        )
+
+
+@dataclass(frozen=True)
+class _Result:
+    row_count: int
+    page_count: int
+    source_gaps: tuple[str, ...]
+    dry_run: bool
+    manifest: FieldAtlasReportOutputManifest | None
+
+
+def _manifest(tmp_path: Path) -> FieldAtlasReportOutputManifest:
+    target = tmp_path / "curated" / "reports" / "field_atlas"
+    return FieldAtlasReportOutputManifest(
+        generated_at="2026-07-02T00:00:00Z",
+        output_root=tmp_path,
+        output_dir=target,
+        index_path=target / "index.html",
+        summary_csv_path=target / "field_atlas_summary.csv",
+        summary_parquet_path=target / "field_atlas_summary.parquet",
+        quality_path=target / "field_atlas_report_quality.json",
+        manifest_path=target / "manifest.json",
+        row_count=2,
+        page_count=2,
+        input_paths=(),
+        source_gaps=(),
+        command=None,
+        code_revision="test-rev",
+    )

--- a/tests/unit/texas_rrc/test_field_atlas_report_html.py
+++ b/tests/unit/texas_rrc/test_field_atlas_report_html.py
@@ -1,0 +1,111 @@
+"""Tests for Texas RRC field-atlas report HTML rendering."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.reports.field_atlas import FieldAtlasPage
+from worldenergydata.texas_rrc.reports.html import render_field_html, render_index_html
+
+
+def test_index_html_is_self_contained_and_links_field_pages() -> None:
+    page = _page()
+    summary = pd.DataFrame([page.summary])
+
+    html = render_index_html(summary, (page,))
+
+    assert html.startswith("<!doctype html>")
+    assert "Texas RRC Onshore Field Atlas" in html
+    assert "fields/08-12345-alpha-field.html" in html
+    assert "Alpha Field" in html
+    assert "http://" not in html
+    assert "https://" not in html
+    assert "<script src=" not in html
+
+
+def test_index_counts_only_fields_with_infrastructure_rows() -> None:
+    page = _page()
+    row_without_access = dict(page.summary)
+    row_without_access["infrastructure_access_class"] = "not_available"
+    summary = pd.DataFrame([page.summary, row_without_access])
+
+    html = render_index_html(summary, (page,))
+
+    assert "Fields With Infrastructure Row" in html
+    assert '<div class="value">1</div>' in html
+
+
+def test_field_html_escapes_content_and_shows_lifecycle_sections() -> None:
+    page = _page(field_name="Alpha & Beta <Field>")
+
+    html = render_field_html(page)
+
+    assert "Alpha &amp; Beta &lt;Field&gt;" in html
+    assert "Lifecycle" in html
+    assert "Production" in html
+    assert "Infrastructure" in html
+    assert "Lease And Operator Context" in html
+    assert "PL-1" in html
+    assert "Alpha Lease" in html
+    assert "direct_rrc_metrics" in html
+    assert "http://" not in html
+    assert "https://" not in html
+
+
+def _page(field_name: str = "Alpha Field") -> FieldAtlasPage:
+    summary = {
+        "district": "08",
+        "field_number": "12345",
+        "field_name": field_name,
+        "field_slug": "alpha-field",
+        "report_path": "fields/08-12345-alpha-field.html",
+        "field_page_filename": "08-12345-alpha-field.html",
+        "well_count": 10,
+        "active_well_count": 7,
+        "permit_count": 3,
+        "completion_count": 2,
+        "production_maturity_class": "late-life",
+        "remaining_activity_score": 81.5,
+        "rank_cumulative_boe": 1,
+        "rank_remaining_activity": 4,
+        "rank_well_density_proxy": 7,
+        "cumulative_oil_bbl": 1000,
+        "cumulative_gas_mcf": 6000,
+        "cumulative_condensate_bbl": 25,
+        "cumulative_boe": 2025,
+        "production_per_well_boe": 202.5,
+        "lease_count": 2,
+        "operator_count": 2,
+        "top_operator_number": "1001",
+        "top_operator_name": "Operator A",
+        "top_operator_share": 0.75,
+        "infrastructure_access_class": "high",
+        "infrastructure_access_score": 92.0,
+        "nearest_pipeline_distance_miles": 0.8,
+        "nearest_pipeline_identifier": "PL-1",
+        "nearby_pipeline_count_1mi": 1,
+        "nearby_pipeline_count_5mi": 4,
+        "nearby_pipeline_count_10mi": 10,
+        "source_caveats": "direct_rrc_metrics; gis_centroid",
+        "quality_flags": "",
+    }
+    return FieldAtlasPage(
+        district="08",
+        field_number="12345",
+        field_name=field_name,
+        field_slug="alpha-field",
+        field_page_filename="08-12345-alpha-field.html",
+        report_path="fields/08-12345-alpha-field.html",
+        summary=summary,
+        lease_rows=(
+            {
+                "lease_number": "L-1",
+                "lease_name": "Alpha Lease",
+                "operator_number": "1001",
+                "operator_name": "Operator A",
+                "cumulative_boe": 1620.0,
+            },
+        ),
+        source_caveats=("direct_rrc_metrics", "gis_centroid"),
+        quality_flags=(),
+    )

--- a/tests/unit/texas_rrc/test_field_atlas_report_io.py
+++ b/tests/unit/texas_rrc/test_field_atlas_report_io.py
@@ -1,0 +1,151 @@
+"""Tests for writing Texas RRC field-atlas reports."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from worldenergydata.texas_rrc.reports.field_atlas import FieldAtlasPage
+from worldenergydata.texas_rrc.reports.io import (
+    FIELD_ATLAS_REPORT_DIR,
+    write_field_atlas_report_outputs,
+)
+from worldenergydata.texas_rrc.reports.quality import assess_field_atlas_report_quality
+
+
+def test_writes_staged_html_summary_quality_and_manifest(tmp_path: Path) -> None:
+    pytest.importorskip("pyarrow")
+    page = _page()
+    summary = pd.DataFrame([page.summary])
+    quality = assess_field_atlas_report_quality(
+        summary,
+        (page,),
+        source_gaps=("production_metric_gap",),
+    )
+
+    manifest = write_field_atlas_report_outputs(
+        pages=(page,),
+        summary=summary,
+        quality=quality,
+        output_root=tmp_path,
+        input_paths=(tmp_path / "source.csv",),
+        allow_non_ace_root=True,
+        command="worldenergydata texas-rrc publish-field-atlas-reports",
+        code_revision="test-rev",
+    )
+
+    target = tmp_path / FIELD_ATLAS_REPORT_DIR
+    assert (target / "index.html").is_file()
+    assert (target / "fields" / page.field_page_filename).is_file()
+    assert (target / "field_atlas_summary.csv").is_file()
+    assert (target / "field_atlas_summary.parquet").is_file()
+    assert (target / "field_atlas_report_quality.json").is_file()
+    assert manifest.row_count == 1
+    assert manifest.page_count == 1
+    assert manifest.code_revision == "test-rev"
+
+    payload = json.loads((target / "manifest.json").read_text(encoding="utf-8"))
+    assert payload["row_count"] == 1
+    assert payload["page_count"] == 1
+    assert payload["source_gaps"] == ["production_metric_gap"]
+    assert payload["command"] == "worldenergydata texas-rrc publish-field-atlas-reports"
+
+
+def test_rejects_non_ace_output_without_override(tmp_path: Path) -> None:
+    page = _page()
+    summary = pd.DataFrame([page.summary])
+    quality = assess_field_atlas_report_quality(summary, (page,), source_gaps=())
+
+    with pytest.raises(ValueError, match="Field-atlas report output_root"):
+        write_field_atlas_report_outputs(
+            pages=(page,),
+            summary=summary,
+            quality=quality,
+            output_root=tmp_path,
+        )
+
+
+def test_rewrite_removes_stale_field_pages(tmp_path: Path) -> None:
+    pytest.importorskip("pyarrow")
+    page = _page()
+    summary = pd.DataFrame([page.summary])
+    quality = assess_field_atlas_report_quality(summary, (page,), source_gaps=())
+
+    write_field_atlas_report_outputs(
+        pages=(page,),
+        summary=summary,
+        quality=quality,
+        output_root=tmp_path,
+        generated_at=datetime(2026, 7, 2, tzinfo=timezone.utc),
+        allow_non_ace_root=True,
+    )
+    stale = tmp_path / FIELD_ATLAS_REPORT_DIR / "fields" / "stale.html"
+    stale.write_text("stale", encoding="utf-8")
+
+    write_field_atlas_report_outputs(
+        pages=(page,),
+        summary=summary,
+        quality=quality,
+        output_root=tmp_path,
+        generated_at=datetime(2026, 7, 2, 0, 1, tzinfo=timezone.utc),
+        allow_non_ace_root=True,
+    )
+
+    assert not stale.exists()
+    assert (
+        tmp_path / FIELD_ATLAS_REPORT_DIR / "fields" / page.field_page_filename
+    ).is_file()
+
+
+def _page() -> FieldAtlasPage:
+    summary = {
+        "district": "08",
+        "field_number": "12345",
+        "field_name": "Alpha Field",
+        "field_slug": "alpha-field",
+        "report_path": "fields/08-12345-alpha-field.html",
+        "field_page_filename": "08-12345-alpha-field.html",
+        "well_count": 10,
+        "active_well_count": 7,
+        "permit_count": 3,
+        "completion_count": 2,
+        "production_maturity_class": "late-life",
+        "remaining_activity_score": 81.5,
+        "rank_cumulative_boe": 1,
+        "rank_remaining_activity": 4,
+        "rank_well_density_proxy": 7,
+        "cumulative_oil_bbl": 1000,
+        "cumulative_gas_mcf": 6000,
+        "cumulative_condensate_bbl": 25,
+        "cumulative_boe": 2025,
+        "production_per_well_boe": 202.5,
+        "lease_count": 2,
+        "operator_count": 2,
+        "top_operator_number": "1001",
+        "top_operator_name": "Operator A",
+        "top_operator_share": 0.75,
+        "infrastructure_access_class": "high",
+        "infrastructure_access_score": 92.0,
+        "nearest_pipeline_distance_miles": 0.8,
+        "nearby_pipeline_count_1mi": 1,
+        "nearby_pipeline_count_5mi": 4,
+        "nearby_pipeline_count_10mi": 10,
+        "source_caveats": "direct_rrc_metrics; gis_centroid",
+        "quality_flags": "",
+    }
+    return FieldAtlasPage(
+        district="08",
+        field_number="12345",
+        field_name="Alpha Field",
+        field_slug="alpha-field",
+        field_page_filename="08-12345-alpha-field.html",
+        report_path="fields/08-12345-alpha-field.html",
+        summary=summary,
+        lease_rows=(),
+        source_caveats=("direct_rrc_metrics", "gis_centroid"),
+        quality_flags=(),
+    )

--- a/tests/unit/texas_rrc/test_field_atlas_report_models.py
+++ b/tests/unit/texas_rrc/test_field_atlas_report_models.py
@@ -1,0 +1,164 @@
+"""Tests for Texas RRC field-atlas report assembly."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.reports.field_atlas import (
+    SUMMARY_COLUMNS,
+    build_field_atlas_pages,
+    build_field_atlas_summary,
+    slugify_field,
+)
+from worldenergydata.texas_rrc.reports.sources import FieldAtlasReportInputs
+
+
+def test_builds_summary_and_page_models_from_curated_inputs() -> None:
+    pages = build_field_atlas_pages(_inputs())
+    summary = build_field_atlas_summary(pages)
+
+    assert len(pages) == 2
+    first_page = pages[0]
+    assert first_page.district == "08"
+    assert first_page.field_number == "12345"
+    assert first_page.field_page_filename == "08-12345-alpha-field.html"
+    assert first_page.report_path == "fields/08-12345-alpha-field.html"
+    assert first_page.summary["infrastructure_access_class"] == "high"
+    assert first_page.lease_rows[0]["lease_number"] == "L-1"
+    assert first_page.lease_rows[0]["cumulative_boe"] == 1620.0
+    assert "direct_rrc_metrics" in first_page.source_caveats
+    assert "gis_centroid" in first_page.source_caveats
+
+    assert list(summary.columns) == SUMMARY_COLUMNS
+    assert list(summary["field_number"]) == ["12345", "54321"]
+    assert summary.loc[0, "report_path"] == "fields/08-12345-alpha-field.html"
+    assert summary.loc[0, "cumulative_boe"] == 2025.0
+    assert summary.loc[1, "infrastructure_access_class"] == "not_available"
+    assert "missing_infrastructure_access" in summary.loc[1, "source_caveats"]
+
+
+def test_slugify_field_is_stable_for_report_paths() -> None:
+    assert slugify_field("  A&B Field / North  ") == "a-b-field-north"
+    assert slugify_field("") == "field"
+
+
+def test_max_fields_limits_after_rank_sorting() -> None:
+    pages = build_field_atlas_pages(_inputs(), max_fields=1)
+
+    assert [page.field_number for page in pages] == ["12345"]
+
+
+def _inputs() -> FieldAtlasReportInputs:
+    field_development = pd.DataFrame(
+        [
+            {
+                "district": "08",
+                "field_number": "12345",
+                "field_name": "Alpha Field",
+                "well_count": 10,
+                "active_well_count": 7,
+                "permit_count": 3,
+                "completion_count": 2,
+                "production_maturity_class": "late-life",
+                "remaining_activity_score": 81.5,
+                "rank_cumulative_boe": 1,
+                "rank_remaining_activity": 4,
+                "rank_well_density_proxy": 7,
+                "cumulative_oil_bbl": 1000,
+                "cumulative_gas_mcf": 6000,
+                "cumulative_condensate_bbl": 25,
+                "cumulative_boe": 2025,
+                "production_per_well_boe": 202.5,
+                "lease_count": 2,
+                "operator_count": 2,
+                "top_operator_number": "1001",
+                "top_operator_name": "Operator A",
+                "top_operator_share": 0.75,
+                "source_caveats": "direct_rrc_metrics",
+                "quality_flags": "",
+            },
+            {
+                "district": "09",
+                "field_number": "54321",
+                "field_name": "Beta Field",
+                "well_count": 4,
+                "active_well_count": 0,
+                "permit_count": 0,
+                "completion_count": 0,
+                "production_maturity_class": "inactive",
+                "remaining_activity_score": 4.0,
+                "rank_cumulative_boe": 2,
+                "rank_remaining_activity": 9,
+                "rank_well_density_proxy": 6,
+                "cumulative_oil_bbl": 200,
+                "cumulative_gas_mcf": 600,
+                "cumulative_condensate_bbl": 0,
+                "cumulative_boe": 300,
+                "production_per_well_boe": 75.0,
+                "lease_count": 1,
+                "operator_count": 1,
+                "top_operator_number": "1002",
+                "top_operator_name": "Operator B",
+                "top_operator_share": 1.0,
+                "source_caveats": "",
+                "quality_flags": "no_active_wells",
+            },
+        ]
+    )
+    infrastructure = pd.DataFrame(
+        [
+            {
+                "district": "08",
+                "field_number": "12345",
+                "field_name": "Alpha Field",
+                "nearest_pipeline_distance_miles": 0.8,
+                "nearby_pipeline_count_1mi": 1,
+                "nearby_pipeline_count_5mi": 4,
+                "nearby_pipeline_count_10mi": 10,
+                "nearest_pipeline_identifier": "PL-1",
+                "infrastructure_access_score": 92.0,
+                "infrastructure_access_class": "high",
+                "source_caveats": "gis_centroid",
+                "quality_flags": "",
+            }
+        ]
+    )
+    production_atlas = pd.DataFrame(
+        [
+            {
+                "aggregation_level": "lease",
+                "district": "08",
+                "field_number": "12345",
+                "field_name": "Alpha Field",
+                "lease_number": "L-2",
+                "lease_name": "Second Lease",
+                "operator_number": "1002",
+                "operator_name": "Operator B",
+                "cumulative_boe": 405.0,
+                "cumulative_oil_bbl": 200.0,
+                "cumulative_gas_mcf": 1200.0,
+                "cumulative_condensate_bbl": 5.0,
+            },
+            {
+                "aggregation_level": "lease",
+                "district": "08",
+                "field_number": "12345",
+                "field_name": "Alpha Field",
+                "lease_number": "L-1",
+                "lease_name": "Alpha Lease",
+                "operator_number": "1001",
+                "operator_name": "Operator A",
+                "cumulative_boe": 1620.0,
+                "cumulative_oil_bbl": 800.0,
+                "cumulative_gas_mcf": 4800.0,
+                "cumulative_condensate_bbl": 20.0,
+            },
+        ]
+    )
+    return FieldAtlasReportInputs(
+        field_development=field_development,
+        infrastructure_access=infrastructure,
+        production_atlas=production_atlas,
+        input_paths=(),
+        source_gaps=(),
+    )

--- a/tests/unit/texas_rrc/test_field_atlas_report_sources.py
+++ b/tests/unit/texas_rrc/test_field_atlas_report_sources.py
@@ -1,0 +1,108 @@
+"""Tests for Texas RRC field-atlas report source loading."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from worldenergydata.texas_rrc.reports.sources import load_field_atlas_report_inputs
+
+
+def test_loads_direct_curated_sources(tmp_path: Path) -> None:
+    root = _write_report_source_tree(tmp_path)
+
+    inputs = load_field_atlas_report_inputs(root)
+
+    assert inputs.source_gaps == ()
+    assert len(inputs.field_development) == 1
+    assert len(inputs.infrastructure_access) == 1
+    assert len(inputs.production_atlas) == 2
+    assert inputs.field_development.loc[0, "field_number"] == "12345"
+    assert inputs.infrastructure_access.loc[0, "nearest_pipeline_identifier"] == "PL-1"
+    assert sorted(path.name for path in inputs.input_paths) == [
+        "field_development_metrics.csv",
+        "field_infrastructure_access.csv",
+        "manifest.json",
+        "manifest.json",
+        "manifest.json",
+        "production_field_atlas.csv",
+    ]
+
+
+def test_records_missing_source_gaps(tmp_path: Path) -> None:
+    root = _write_report_source_tree(tmp_path)
+    (
+        root / "curated" / "production" / "field_atlas" / "production_field_atlas.csv"
+    ).unlink()
+
+    inputs = load_field_atlas_report_inputs(root)
+
+    assert inputs.production_atlas.empty
+    assert inputs.source_gaps == ("missing_production_field_atlas",)
+
+
+def _write_report_source_tree(tmp_path: Path) -> Path:
+    root = tmp_path / "texas_rrc"
+    field_dir = root / "curated" / "field_development" / "metrics"
+    infra_dir = root / "curated" / "infrastructure" / "access"
+    production_dir = root / "curated" / "production" / "field_atlas"
+    field_dir.mkdir(parents=True)
+    infra_dir.mkdir(parents=True)
+    production_dir.mkdir(parents=True)
+    (field_dir / "field_development_metrics.csv").write_text(
+        "\n".join(
+            [
+                "district,field_number,field_name,well_count,active_well_count,"
+                "permit_count,completion_count,production_maturity_class,"
+                "remaining_activity_score,rank_cumulative_boe,"
+                "rank_remaining_activity,rank_well_density_proxy,"
+                "cumulative_oil_bbl,cumulative_gas_mcf,cumulative_condensate_bbl,"
+                "cumulative_boe,production_per_well_boe,lease_count,operator_count,"
+                "top_operator_number,top_operator_name,top_operator_share,"
+                "source_caveats,quality_flags",
+                "08,12345,Alpha Field,10,7,3,2,late-life,81.5,1,4,7,"
+                "1000,6000,25,2025,202.5,2,2,1001,Operator A,0.75,"
+                "direct_rrc_metrics,",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (infra_dir / "field_infrastructure_access.csv").write_text(
+        "\n".join(
+            [
+                "district,field_number,field_name,nearest_pipeline_distance_miles,"
+                "nearby_pipeline_count_1mi,nearby_pipeline_count_5mi,"
+                "nearby_pipeline_count_10mi,nearest_pipeline_identifier,"
+                "infrastructure_access_score,infrastructure_access_class,"
+                "source_caveats,quality_flags",
+                "08,12345,Alpha Field,0.8,1,4,10,PL-1,92.0,high,gis_centroid,",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (production_dir / "production_field_atlas.csv").write_text(
+        "\n".join(
+            [
+                "aggregation_level,district,field_number,field_name,lease_number,"
+                "lease_name,operator_number,operator_name,cumulative_oil_bbl,"
+                "cumulative_gas_mcf,cumulative_condensate_bbl,cumulative_boe,"
+                "first_production_month,last_production_month,still_producing,"
+                "lease_count,operator_count,top_operator_number,top_operator_name,"
+                "top_operator_boe,top_operator_share",
+                "field,08,12345,Alpha Field,,,,,1000,6000,25,2025,2010-01,"
+                "2026-05,true,2,2,1001,Operator A,1518.75,0.75",
+                "lease,08,12345,Alpha Field,L-1,Alpha Lease,1001,Operator A,800,"
+                "4800,20,1620,2010-01,2026-05,true,,,,,",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    for directory in (field_dir, infra_dir, production_dir):
+        (directory / "manifest.json").write_text(
+            json.dumps({"row_count": 1, "source_gaps": []}) + "\n",
+            encoding="utf-8",
+        )
+    return root


### PR DESCRIPTION
## Summary
- add Texas RRC field-atlas report source loading, model assembly, self-contained HTML rendering, quality reporting, and staged output writer
- add `worldenergydata texas-rrc publish-field-atlas-reports` with dry-run, source gating, max-field, and /mnt/ace output controls
- document the direct-source lifecycle and publish contract; mark the approved #666 plan metadata
- publish reports to `/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/reports/field_atlas/`

## Verification
- focused #666 tests: `14 passed`
- Texas RRC unit suite: `505 passed in 166.96s`
- `uv run --no-sync black --check ...`
- `uv run --no-sync isort --check-only ...`
- `git diff --check`
- `bash scripts/legal/legal-sanity-scan.sh --repo=../wt-wed-669 --diff-only` from workspace-hub
- full publish: 67,082 field HTML pages; manifest row/page count 67,082; source_gaps []

Closes #666