### PR TITLE
docs: ecosystem tagline on README + capabilities page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # WorldEnergyData
 
+> *Everyday complex engineering — made deterministically simple.*
+
 > **Part of the Deckhand API — the API for real-world work.**
 > The public-domain datasets and analyses in this repo feed **Deckhand API paths** (field economics,
 > well benchmarking, basin/decom intel): one call (`POST /api/run`) returns a **standards-traceable

--- a/reports/capabilities/index.html
+++ b/reports/capabilities/index.html
@@ -121,6 +121,7 @@
 <main>
   <header class="hero">
     <h1>worldenergydata — Open Energy-Data Capabilities</h1>
+    <p style="font-style:italic;font-size:14px;margin-top:6px">Everyday complex engineering — made deterministically simple.</p>
     <p>Deterministic offshore field economics, a field-development playbook, and offshore safety
     analytics &mdash; each result computed by unit-tested domain code on public regulatory filings,
     frozen into a report artifact, and rendered to static HTML. Every work below opens a live page,


### PR DESCRIPTION
Adds the ecosystem mantra — "Everyday complex engineering — made deterministically simple." — as an italic one-liner under the README title and as a small muted subtitle in the capabilities page hero (reports/capabilities/index.html, copied verbatim to Pages by scripts/build_pages.py). Tagline insertion only; no other content changes.