### PR TITLE
feat(onshore): rank Texas RRC field opportunities

### DIFF
--- a/.planning/plan-approved/695.md
+++ b/.planning/plan-approved/695.md
@@ -1,0 +1,8 @@
+# Plan approval marker for issue #695
+
+Issue: https://github.com/vamseeachanta/worldenergydata/issues/695
+Plan: docs/plans/2026-07-02-issue-695-texas-rrc-field-opportunity-architecture-ranking.md
+Approval signal: user approved implementation in the active Codex session on 2026-07-02 with "approved; continue".
+Approved scope: implement the reviewed Texas RRC field-opportunity ranking, architecture-signal classification, `/mnt/ace` publication, CLI, tests, and documentation for #695.
+
+This marker records user approval for local execution gates. It is not self-approval.

--- a/docs/data-sources/onshore/texas-rrc/field-opportunity-ranking.md
+++ b/docs/data-sources/onshore/texas-rrc/field-opportunity-ranking.md
@@ -1,0 +1,123 @@
+# Texas RRC Field Opportunity Ranking
+
+## Purpose
+
+The field-opportunity ranking turns the Texas RRC field atlas into a deterministic
+screening table for onshore field-development review. It ranks fields by direct
+source-derived production scale, remaining activity, infrastructure access,
+operator context, and quality/caveat penalties.
+
+This output is a screening heuristic. It is not a reserves estimate, economics
+model, tariff study, pipeline capacity study, right-of-way assessment, or
+engineered facility design.
+
+## Source Lifecycle
+
+The ranking consumes curated outputs produced from official Texas RRC direct
+sources under `/mnt/ace/worldenergydata/data/modules/texas_rrc`:
+
+1. Raw Texas RRC snapshots are refreshed with `worldenergydata texas-rrc refresh`.
+2. Lifecycle, production, and GIS-derived infrastructure artifacts are built
+   into curated datasets.
+3. `publish-field-atlas-reports` creates the field-atlas summary and per-field
+   HTML pages.
+4. `build-field-opportunities` consumes the field-atlas summary and upstream
+   manifests to publish ranked opportunity outputs.
+
+PatchOps is validation-only and is not a durable input dependency.
+
+## Refresh Cadence
+
+Refresh cadence is inherited from the Texas RRC source catalog and the upstream
+commands:
+
+- PDQ production and lifecycle sources refresh through the direct Texas RRC
+  raw-refresh contract.
+- RRC GoDrive GIS directory sources follow the cataloged directory refresh
+  policy and official RRC availability.
+- The opportunity ranking should be rebuilt after any upstream lifecycle,
+  production, infrastructure, or field-atlas refresh.
+
+## Command
+
+```bash
+uv run --no-sync worldenergydata texas-rrc build-field-opportunities \
+  --root /mnt/ace/worldenergydata/data/modules/texas_rrc \
+  --output-root /mnt/ace/worldenergydata/data/modules/texas_rrc \
+  --require-sources
+```
+
+For bounded smoke runs:
+
+```bash
+uv run --no-sync worldenergydata texas-rrc build-field-opportunities \
+  --root /mnt/ace/worldenergydata/data/modules/texas_rrc \
+  --output-root /mnt/ace/worldenergydata/data/modules/texas_rrc \
+  --require-sources \
+  --max-fields 100
+```
+
+## Output Contract
+
+Outputs are written to:
+
+```text
+/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/analysis/field_opportunities/
+  field_opportunity_rankings.csv
+  field_opportunity_rankings.parquet
+  field_opportunity_summary.html
+  field_opportunity_quality.json
+  manifest.json
+```
+
+The ranking is keyed by `district, field_number`. The manifest records input
+paths, upstream manifests, source gaps, scoring version, scoring weights, output
+paths, row count, command, and code revision.
+
+## Scoring
+
+The current scoring version is `texas_rrc_field_opportunity_v1`.
+
+```text
+opportunity_score =
+  0.35 * production_scale_component_score
+  + 0.30 * remaining_activity_component_score
+  + 0.20 * infrastructure_component_score
+  + 0.10 * operator_concentration_component_score
+  + 0.05 * active_well_component_score
+  - quality_penalty_score
+```
+
+Scores are clamped to `0..100`. Component scores normalize upstream ratios or
+percent values to a `0..100` scale while preserving the raw source columns such
+as `remaining_activity_score` and `infrastructure_access_score`. Component
+scores are retained so downstream review can inspect why a field ranked where
+it did. Missing or low-confidence source evidence remains visible through
+`source_caveats`, `quality_flags`, and `quality_penalty_score`.
+
+## Architecture Signals
+
+The architecture signal classes are screening labels:
+
+- `high_access_infill_redevelopment`
+- `infrastructure_constrained_activity`
+- `mature_harvest`
+- `emerging_growth`
+- `low_data_confidence`
+- `monitor_only`
+
+Each row includes an architecture signal reason and a recommended follow-up.
+These labels do not replace engineering, commercial, market-access, or reserves
+work.
+
+## Limitations
+
+- RRC production data is field/lease-grain and may not allocate production per
+  well.
+- RRC GIS-derived infrastructure access is screening-grade and does not prove
+  connection feasibility, product compatibility, tariff access, capacity,
+  ownership, or right-of-way availability.
+- Missing lifecycle, well GIS, infrastructure, or operator evidence lowers
+  confidence rather than being fabricated.
+- Output rankings are deterministic for a given input artifact set but should
+  be regenerated after upstream Texas RRC refreshes.

--- a/docs/plans/2026-07-02-issue-695-texas-rrc-field-opportunity-architecture-ranking.md
+++ b/docs/plans/2026-07-02-issue-695-texas-rrc-field-opportunity-architecture-ranking.md
@@ -1,7 +1,7 @@
 # Plan: Issue #695 - Texas RRC field opportunity and architecture-signal ranking
 
 **Issue:** https://github.com/vamseeachanta/worldenergydata/issues/695
-**Status:** plan-review
+**Status:** implemented
 **Tier:** T2 (screening score contract, architecture-signal classification, `/mnt/ace` output contract, CLI, tests, docs)
 **Client:** N/A
 **Project:** worldenergydata onshore field development

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -79,7 +79,7 @@ This directory contains issue-plan artifacts created during the issue-planning-m
 | [#665](https://github.com/vamseeachanta/worldenergydata/issues/665) | [texas-rrc-pipeline-gis-infrastructure-access](2026-07-01-issue-665-texas-rrc-pipeline-gis-infrastructure-access.md) | plan-approved | 2026-07-01 |
 | [#666](https://github.com/vamseeachanta/worldenergydata/issues/666) | [texas-rrc-onshore-field-atlas-reports](2026-07-01-issue-666-texas-rrc-onshore-field-atlas-reports.md) | plan-approved | 2026-07-01 |
 | [#669](https://github.com/vamseeachanta/worldenergydata/issues/669) | [texas-rrc-godrive-directory-refresh](2026-06-30-issue-669-texas-rrc-godrive-directory-refresh.md) | plan-approved | 2026-06-30 |
-| [#695](https://github.com/vamseeachanta/worldenergydata/issues/695) | [texas-rrc-field-opportunity-architecture-ranking](2026-07-02-issue-695-texas-rrc-field-opportunity-architecture-ranking.md) | plan-review | 2026-07-02 |
+| [#695](https://github.com/vamseeachanta/worldenergydata/issues/695) | [texas-rrc-field-opportunity-architecture-ranking](2026-07-02-issue-695-texas-rrc-field-opportunity-architecture-ranking.md) | implemented | 2026-07-02 |
 
 ## Closed / superseded plans
 

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/opportunities/__init__.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/opportunities/__init__.py
@@ -1,0 +1,23 @@
+"""Texas RRC field-opportunity ranking outputs."""
+
+from worldenergydata.texas_rrc.opportunities.cli_support import (
+    FieldOpportunityBuildResult,
+    run_build_field_opportunities,
+)
+from worldenergydata.texas_rrc.opportunities.scoring import (
+    SCORING_VERSION,
+    build_field_opportunity_rankings,
+)
+from worldenergydata.texas_rrc.opportunities.sources import (
+    FieldOpportunityInputs,
+    load_field_opportunity_inputs,
+)
+
+__all__ = [
+    "FieldOpportunityBuildResult",
+    "FieldOpportunityInputs",
+    "SCORING_VERSION",
+    "build_field_opportunity_rankings",
+    "load_field_opportunity_inputs",
+    "run_build_field_opportunities",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/opportunities/architecture.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/opportunities/architecture.py
@@ -1,0 +1,113 @@
+"""Classify Texas RRC field-opportunity architecture signals."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class ArchitectureSignal:
+    """One screening architecture signal for a ranked Texas RRC field."""
+
+    architecture_signal_class: str
+    architecture_signal_reason: str
+    recommended_followup: str
+
+
+def classify_architecture_signal(row: Mapping[str, object]) -> ArchitectureSignal:
+    """Classify a field into a deterministic screening-signal class."""
+    maturity = _text(row.get("production_maturity_class")).lower()
+    access = _text(row.get("infrastructure_access_class")).lower()
+    production = _number(row.get("production_scale_component_score"))
+    activity = _number(row.get("remaining_activity_component_score"))
+    infrastructure = _number(row.get("infrastructure_component_score"))
+    caveats = _terms(row.get("source_caveats")) + _terms(row.get("quality_flags"))
+
+    if _low_confidence(access, caveats) and not (production >= 75 and activity >= 75):
+        return ArchitectureSignal(
+            "low_data_confidence",
+            "missing or unavailable lifecycle/GIS/infrastructure evidence",
+            "Resolve source gaps before using this field for architecture screening.",
+        )
+    if (
+        maturity in {"growth", "early_development"}
+        and activity >= 70
+        and infrastructure >= 60
+    ):
+        return ArchitectureSignal(
+            "emerging_growth",
+            f"{maturity} maturity with strong activity and infrastructure signal",
+            "Review growth pattern, permits, completions, and local gathering options.",
+        )
+    if (
+        access in {"direct_access", "near_access"}
+        and production >= 70
+        and activity >= 50
+    ):
+        return ArchitectureSignal(
+            "high_access_infill_redevelopment",
+            f"{access} plus high production scale and remaining activity",
+            "Review infill, recompletion, and redevelopment candidates.",
+        )
+    if activity >= 70 and access in _CONSTRAINED_ACCESS_CLASSES:
+        return ArchitectureSignal(
+            "infrastructure_constrained_activity",
+            f"high activity with {access or 'missing'} infrastructure access",
+            "Run follow-up infrastructure, market-access, and routing screening.",
+        )
+    if maturity in {"late_life", "mature_active"} and activity < 35:
+        return ArchitectureSignal(
+            "mature_harvest",
+            f"{maturity} maturity with low remaining activity",
+            "Review harvest, abandonment, and monitoring context.",
+        )
+    return ArchitectureSignal(
+        "monitor_only",
+        "no strong opportunity or constraint signal",
+        "Monitor during the next source refresh cycle.",
+    )
+
+
+_CONSTRAINED_ACCESS_CLASSES = {
+    "",
+    "regional_access",
+    "remote_access",
+    "isolated_or_unknown",
+    "not_available",
+}
+
+
+def _low_confidence(access: str, caveats: tuple[str, ...]) -> bool:
+    if access == "not_available":
+        return True
+    needles = ("missing", "not_available")
+    return any(any(needle in term for needle in needles) for term in caveats)
+
+
+def _terms(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    normalized = str(value).replace(",", ";").replace("|", ";")
+    return tuple(term.strip().lower() for term in normalized.split(";") if term.strip())
+
+
+def _number(value: object) -> float:
+    try:
+        if value is None:
+            return 0.0
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _text(value: object) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+__all__ = [
+    "ArchitectureSignal",
+    "classify_architecture_signal",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/opportunities/cli_support.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/opportunities/cli_support.py
@@ -1,0 +1,104 @@
+"""CLI support for publishing Texas RRC field-opportunity rankings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from worldenergydata.texas_rrc.opportunities.io import (
+    FieldOpportunityOutputManifest,
+    write_field_opportunity_outputs,
+)
+from worldenergydata.texas_rrc.opportunities.quality import (
+    assess_field_opportunity_quality,
+)
+from worldenergydata.texas_rrc.opportunities.scoring import (
+    build_field_opportunity_rankings,
+)
+from worldenergydata.texas_rrc.opportunities.sources import (
+    load_field_opportunity_inputs,
+)
+from worldenergydata.texas_rrc.source_catalog import SOURCE_CATALOG_ROOT
+
+
+@dataclass(frozen=True)
+class FieldOpportunityBuildResult:
+    """Result returned by the field-opportunity publisher."""
+
+    row_count: int
+    source_gaps: tuple[str, ...]
+    dry_run: bool
+    manifest: FieldOpportunityOutputManifest | None
+
+
+def run_build_field_opportunities(
+    root: Path | str = SOURCE_CATALOG_ROOT,
+    output_root: Path | str = SOURCE_CATALOG_ROOT,
+    dry_run: bool = False,
+    require_sources: bool = False,
+    allow_non_ace_output: bool = False,
+    max_fields: int | None = None,
+) -> FieldOpportunityBuildResult:
+    """Build and optionally write Texas RRC field-opportunity outputs."""
+    source_root = Path(root)
+    target_root = Path(output_root)
+    inputs = load_field_opportunity_inputs(source_root)
+    if inputs.source_gaps and (require_sources or not dry_run):
+        raise ValueError(
+            "Cannot build field-opportunity rankings with missing sources: "
+            + ", ".join(inputs.source_gaps)
+        )
+    rankings = build_field_opportunity_rankings(inputs)
+    if max_fields is not None:
+        rankings = rankings.head(max_fields).copy()
+    quality = assess_field_opportunity_quality(rankings, inputs.source_gaps)
+    if dry_run:
+        return FieldOpportunityBuildResult(
+            row_count=len(rankings),
+            source_gaps=inputs.source_gaps,
+            dry_run=True,
+            manifest=None,
+        )
+    manifest = write_field_opportunity_outputs(
+        rankings=rankings,
+        quality=quality,
+        output_root=target_root,
+        input_paths=inputs.input_paths,
+        upstream_manifests=inputs.upstream_manifests,
+        allow_non_ace_root=allow_non_ace_output,
+        command=_command(source_root, target_root, require_sources, max_fields),
+    )
+    return FieldOpportunityBuildResult(
+        row_count=len(rankings),
+        source_gaps=inputs.source_gaps,
+        dry_run=False,
+        manifest=manifest,
+    )
+
+
+def _command(
+    root: Path,
+    output_root: Path,
+    require_sources: bool,
+    max_fields: int | None,
+) -> str:
+    parts = [
+        "worldenergydata",
+        "texas-rrc",
+        "build-field-opportunities",
+        "--root",
+        str(root),
+        "--output-root",
+        str(output_root),
+    ]
+    if require_sources:
+        parts.append("--require-sources")
+    if max_fields is not None:
+        parts.extend(["--max-fields", str(max_fields)])
+    return " ".join(parts)
+
+
+__all__ = [
+    "FieldOpportunityBuildResult",
+    "run_build_field_opportunities",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/opportunities/html.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/opportunities/html.py
@@ -1,0 +1,104 @@
+"""Render self-contained Texas RRC field-opportunity HTML summaries."""
+
+from __future__ import annotations
+
+from html import escape
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.opportunities.quality import FieldOpportunityQuality
+
+
+def render_field_opportunity_summary_html(
+    rankings: pd.DataFrame,
+    quality: FieldOpportunityQuality,
+) -> str:
+    """Render a deterministic HTML summary for opportunity rankings."""
+    rows = "\n".join(_table_row(row) for row in _top_rows(rankings))
+    arch_rows = "\n".join(
+        f"<li>{escape(name)}: {count}</li>"
+        for name, count in quality.architecture_class_counts.items()
+    )
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Texas RRC Field Opportunity Ranking</title>
+<style>
+body {{ font-family: Arial, sans-serif; margin: 24px; color: #1f2933; }}
+table {{ border-collapse: collapse; width: 100%; }}
+th, td {{ border: 1px solid #ccd5df; padding: 6px 8px; text-align: left; }}
+th {{ background: #eef3f8; }}
+.metric {{ display: inline-block; margin: 0 18px 16px 0; }}
+.value {{ font-size: 24px; font-weight: 700; }}
+.note {{ border-left: 4px solid #7c8b9a; padding-left: 12px; color: #46515c; }}
+</style>
+</head>
+<body>
+<h1>Texas RRC Field Opportunity Ranking</h1>
+<p class="note">Scores are a screening heuristic from direct Texas RRC-derived
+curated artifacts. They are not reserves, economics, tariff, capacity,
+right-of-way, or engineered facility-design estimates.</p>
+<section>
+<div class="metric"><div class="value">{quality.row_count}</div><div>Ranked Fields</div></div>
+<div class="metric"><div class="value">{_format(quality.score_max)}</div><div>Top Score</div></div>
+<div class="metric"><div class="value">{quality.low_data_confidence_count}</div><div>Low Confidence</div></div>
+</section>
+<section>
+<h2>Architecture Signals</h2>
+<ul>{arch_rows}</ul>
+</section>
+<section>
+<h2>Top Ranked Fields</h2>
+<table>
+<thead>
+<tr><th>Rank</th><th>Field</th><th>Score</th><th>Class</th><th>Architecture Signal</th><th>Follow-up</th><th>Drivers</th></tr>
+</thead>
+<tbody>
+{rows}
+</tbody>
+</table>
+</section>
+</body>
+</html>
+"""
+
+
+def _top_rows(rankings: pd.DataFrame) -> list[dict[str, object]]:
+    if rankings.empty:
+        return []
+    return (
+        rankings.head(100).where(pd.notna(rankings.head(100)), None).to_dict("records")
+    )
+
+
+def _table_row(row: dict[str, object]) -> str:
+    field = escape(_text(row.get("field_name")))
+    path = escape(_text(row.get("report_path")))
+    link = f'<a href="{path}">{field}</a>' if path else field
+    return (
+        "<tr>"
+        f"<td>{escape(_text(row.get('opportunity_rank')))}</td>"
+        f"<td>{link}</td>"
+        f"<td>{escape(_text(row.get('opportunity_score')))}</td>"
+        f"<td>{escape(_text(row.get('opportunity_class')))}</td>"
+        f"<td>{escape(_text(row.get('architecture_signal_class')))}</td>"
+        f"<td>{escape(_text(row.get('recommended_followup')))}</td>"
+        f"<td>{escape(_text(row.get('key_drivers')))}</td>"
+        "</tr>"
+    )
+
+
+def _format(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.2f}"
+
+
+def _text(value: object) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+__all__ = [
+    "render_field_opportunity_summary_html",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/opportunities/io.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/opportunities/io.py
@@ -1,0 +1,235 @@
+"""Persist Texas RRC field-opportunity ranking outputs."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.opportunities.html import (
+    render_field_opportunity_summary_html,
+)
+from worldenergydata.texas_rrc.opportunities.quality import FieldOpportunityQuality
+from worldenergydata.texas_rrc.opportunities.scoring import (
+    OUTPUT_COLUMNS,
+    SCORING_VERSION,
+    SCORING_WEIGHTS,
+)
+from worldenergydata.texas_rrc.source_catalog import SOURCE_CATALOG_ROOT
+
+FIELD_OPPORTUNITY_DIR = Path("curated") / "analysis" / "field_opportunities"
+RANKINGS_CSV_FILENAME = "field_opportunity_rankings.csv"
+RANKINGS_PARQUET_FILENAME = "field_opportunity_rankings.parquet"
+HTML_FILENAME = "field_opportunity_summary.html"
+QUALITY_FILENAME = "field_opportunity_quality.json"
+MANIFEST_FILENAME = "manifest.json"
+
+
+@dataclass(frozen=True)
+class FieldOpportunityOutputManifest:
+    """Paths and metadata for one field-opportunity output batch."""
+
+    generated_at: str
+    output_root: Path
+    output_dir: Path
+    rankings_csv_path: Path
+    rankings_parquet_path: Path
+    html_path: Path
+    quality_path: Path
+    manifest_path: Path
+    row_count: int
+    input_paths: tuple[str, ...]
+    upstream_manifests: tuple[str, ...]
+    source_gaps: tuple[str, ...]
+    command: str | None
+    code_revision: str | None
+
+
+def write_field_opportunity_outputs(
+    rankings: pd.DataFrame,
+    quality: FieldOpportunityQuality,
+    output_root: Path | str = SOURCE_CATALOG_ROOT,
+    generated_at: datetime | None = None,
+    input_paths: Iterable[str | Path] = (),
+    upstream_manifests: Iterable[str | Path] = (),
+    allow_non_ace_root: bool = False,
+    command: str | None = None,
+    code_revision: str | None = None,
+) -> FieldOpportunityOutputManifest:
+    """Write rankings, summary HTML, quality JSON, and manifest JSON."""
+    root = Path(output_root)
+    _validate_output_root(root, allow_non_ace_root)
+    target_dir = root / FIELD_OPPORTUNITY_DIR
+    stamp = _timestamp(generated_at)
+    manifest = _manifest(
+        root,
+        target_dir,
+        rankings,
+        quality,
+        input_paths,
+        upstream_manifests,
+        command,
+        code_revision,
+        stamp,
+    )
+    _write_with_staging(target_dir, rankings, quality, manifest, stamp)
+    return manifest
+
+
+def _manifest(
+    root: Path,
+    target_dir: Path,
+    rankings: pd.DataFrame,
+    quality: FieldOpportunityQuality,
+    input_paths: Iterable[str | Path],
+    upstream_manifests: Iterable[str | Path],
+    command: str | None,
+    code_revision: str | None,
+    stamp: str,
+) -> FieldOpportunityOutputManifest:
+    return FieldOpportunityOutputManifest(
+        generated_at=stamp,
+        output_root=root,
+        output_dir=target_dir,
+        rankings_csv_path=target_dir / RANKINGS_CSV_FILENAME,
+        rankings_parquet_path=target_dir / RANKINGS_PARQUET_FILENAME,
+        html_path=target_dir / HTML_FILENAME,
+        quality_path=target_dir / QUALITY_FILENAME,
+        manifest_path=target_dir / MANIFEST_FILENAME,
+        row_count=len(rankings),
+        input_paths=tuple(str(path) for path in input_paths),
+        upstream_manifests=tuple(str(path) for path in upstream_manifests),
+        source_gaps=tuple(quality.source_gaps),
+        command=command,
+        code_revision=code_revision or _git_revision(),
+    )
+
+
+def _write_with_staging(
+    target_dir: Path,
+    rankings: pd.DataFrame,
+    quality: FieldOpportunityQuality,
+    manifest: FieldOpportunityOutputManifest,
+    stamp: str,
+) -> None:
+    staging = (
+        target_dir.parent / f".staging-field-opportunities-{_compact_stamp(stamp)}"
+    )
+    backup = target_dir.parent / f".backup-field-opportunities-{_compact_stamp(stamp)}"
+    shutil.rmtree(staging, ignore_errors=True)
+    shutil.rmtree(backup, ignore_errors=True)
+    promoted = False
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+        rankings.to_csv(staging / RANKINGS_CSV_FILENAME, index=False)
+        rankings.to_parquet(staging / RANKINGS_PARQUET_FILENAME, index=False)
+        (staging / HTML_FILENAME).write_text(
+            render_field_opportunity_summary_html(rankings, quality),
+            encoding="utf-8",
+        )
+        _write_json(staging / QUALITY_FILENAME, _quality_payload(quality))
+        _write_json(staging / MANIFEST_FILENAME, _manifest_payload(manifest, quality))
+        target_dir.parent.mkdir(parents=True, exist_ok=True)
+        if target_dir.exists():
+            target_dir.rename(backup)
+        staging.rename(target_dir)
+        promoted = True
+        shutil.rmtree(backup, ignore_errors=True)
+    except Exception:
+        if backup.exists() and not target_dir.exists():
+            backup.rename(target_dir)
+        raise
+    finally:
+        if not promoted:
+            shutil.rmtree(staging, ignore_errors=True)
+        shutil.rmtree(backup, ignore_errors=True)
+
+
+def _validate_output_root(root: Path, allow_non_ace_root: bool) -> None:
+    if allow_non_ace_root:
+        return
+    if not root.resolve().is_relative_to(SOURCE_CATALOG_ROOT.resolve()):
+        raise ValueError(
+            "field-opportunity output_root must stay under "
+            f"{SOURCE_CATALOG_ROOT}; pass allow_non_ace_root=True only for tests"
+        )
+
+
+def _quality_payload(quality: FieldOpportunityQuality) -> dict[str, object]:
+    return asdict(quality)
+
+
+def _manifest_payload(
+    manifest: FieldOpportunityOutputManifest,
+    quality: FieldOpportunityQuality,
+) -> dict[str, object]:
+    return {
+        "generated_at": manifest.generated_at,
+        "output_root": str(manifest.output_root),
+        "output_dir": str(manifest.output_dir),
+        "rankings_csv_path": str(manifest.rankings_csv_path),
+        "rankings_parquet_path": str(manifest.rankings_parquet_path),
+        "html_path": str(manifest.html_path),
+        "quality_path": str(manifest.quality_path),
+        "manifest_path": str(manifest.manifest_path),
+        "row_count": manifest.row_count,
+        "input_paths": list(manifest.input_paths),
+        "upstream_manifests": list(manifest.upstream_manifests),
+        "source_gaps": list(manifest.source_gaps),
+        "command": manifest.command,
+        "code_revision": manifest.code_revision,
+        "scoring_version": SCORING_VERSION,
+        "scoring_weights": SCORING_WEIGHTS,
+        "score_column_contract": OUTPUT_COLUMNS,
+        "quality": _quality_payload(quality),
+    }
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _timestamp(value: datetime | None) -> str:
+    timestamp = value or datetime.now(timezone.utc)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _compact_stamp(stamp: str) -> str:
+    return stamp.replace("-", "").replace(":", "")
+
+
+def _git_revision() -> str | None:
+    repo_root = _repo_root()
+    try:
+        revision = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return revision or None
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[6]
+
+
+__all__ = [
+    "FIELD_OPPORTUNITY_DIR",
+    "FieldOpportunityOutputManifest",
+    "write_field_opportunity_outputs",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/opportunities/quality.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/opportunities/quality.py
@@ -1,0 +1,77 @@
+"""Quality assessment for Texas RRC field-opportunity rankings."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class FieldOpportunityQuality:
+    """Quality summary for a field-opportunity ranking batch."""
+
+    row_count: int
+    source_gaps: tuple[str, ...]
+    opportunity_class_counts: dict[str, int]
+    architecture_class_counts: dict[str, int]
+    caveat_counts: dict[str, int]
+    quality_flag_counts: dict[str, int]
+    low_data_confidence_count: int
+    score_min: float | None
+    score_max: float | None
+    score_mean: float | None
+
+
+def assess_field_opportunity_quality(
+    rankings: pd.DataFrame,
+    source_gaps: tuple[str, ...],
+) -> FieldOpportunityQuality:
+    """Assess score, caveat, and class quality for ranking outputs."""
+    scores = pd.to_numeric(rankings.get("opportunity_score"), errors="coerce")
+    architecture = rankings.get("architecture_signal_class", pd.Series(dtype=object))
+    return FieldOpportunityQuality(
+        row_count=len(rankings),
+        source_gaps=tuple(source_gaps),
+        opportunity_class_counts=_value_counts(rankings.get("opportunity_class")),
+        architecture_class_counts=_value_counts(architecture),
+        caveat_counts=_term_counts(rankings.get("source_caveats")),
+        quality_flag_counts=_term_counts(rankings.get("quality_flags")),
+        low_data_confidence_count=int((architecture == "low_data_confidence").sum()),
+        score_min=_score(scores.min()),
+        score_max=_score(scores.max()),
+        score_mean=_score(scores.mean()),
+    )
+
+
+def _value_counts(series: pd.Series | None) -> dict[str, int]:
+    if series is None:
+        return {}
+    counts = Counter(str(value) for value in series.dropna() if str(value))
+    return dict(sorted(counts.items()))
+
+
+def _term_counts(series: pd.Series | None) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    if series is None:
+        return {}
+    for value in series.dropna():
+        normalized = str(value).replace(",", ";").replace("|", ";")
+        counts.update(term.strip() for term in normalized.split(";") if term.strip())
+    return dict(sorted(counts.items()))
+
+
+def _score(value: object) -> float | None:
+    try:
+        if pd.isna(value):
+            return None
+        return round(float(value), 2)
+    except (TypeError, ValueError):
+        return None
+
+
+__all__ = [
+    "FieldOpportunityQuality",
+    "assess_field_opportunity_quality",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/opportunities/scoring.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/opportunities/scoring.py
@@ -1,0 +1,265 @@
+"""Score Texas RRC field opportunities from direct curated summary data."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.opportunities.architecture import (
+    classify_architecture_signal,
+)
+from worldenergydata.texas_rrc.opportunities.sources import FieldOpportunityInputs
+
+SCORING_VERSION = "texas_rrc_field_opportunity_v1"
+
+SCORING_WEIGHTS = {
+    "production_scale_component_score": 0.35,
+    "remaining_activity_component_score": 0.30,
+    "infrastructure_component_score": 0.20,
+    "operator_concentration_component_score": 0.10,
+    "active_well_component_score": 0.05,
+}
+
+OUTPUT_COLUMNS = [
+    "district",
+    "field_number",
+    "field_name",
+    "field_slug",
+    "report_path",
+    "field_page_filename",
+    "opportunity_rank",
+    "opportunity_score",
+    "opportunity_class",
+    "production_scale_component_score",
+    "remaining_activity_component_score",
+    "infrastructure_component_score",
+    "operator_concentration_component_score",
+    "active_well_component_score",
+    "quality_penalty_score",
+    "architecture_signal_class",
+    "architecture_signal_reason",
+    "recommended_followup",
+    "cumulative_boe",
+    "production_per_well_boe",
+    "remaining_activity_score",
+    "active_well_count",
+    "well_count",
+    "production_maturity_class",
+    "infrastructure_access_class",
+    "infrastructure_access_score",
+    "nearest_pipeline_distance_miles",
+    "nearby_pipeline_count_1mi",
+    "nearby_pipeline_count_5mi",
+    "nearby_pipeline_count_10mi",
+    "top_operator_name",
+    "top_operator_share",
+    "key_drivers",
+    "source_caveats",
+    "quality_flags",
+]
+
+
+def build_field_opportunity_rankings(inputs: FieldOpportunityInputs) -> pd.DataFrame:
+    """Build deterministic field-opportunity rankings."""
+    if inputs.field_atlas_summary.empty:
+        return pd.DataFrame(columns=OUTPUT_COLUMNS)
+    frame = inputs.field_atlas_summary.copy().reset_index(drop=True)
+    frame = frame.where(pd.notna(frame), None)
+    frame["production_scale_component_score"] = _rank_score(frame["cumulative_boe"])
+    frame["remaining_activity_component_score"] = _clipped_number(
+        frame.get("remaining_activity_score")
+    )
+    frame["infrastructure_component_score"] = _infrastructure_scores(frame)
+    frame["operator_concentration_component_score"] = _operator_scores(frame)
+    frame["active_well_component_score"] = _rank_score(frame.get("active_well_count"))
+    frame["quality_penalty_score"] = [
+        _quality_penalty(row) for row in frame.to_dict("records")
+    ]
+    frame["opportunity_score"] = [
+        _opportunity_score(row) for row in frame.to_dict("records")
+    ]
+    frame["opportunity_class"] = [
+        _opportunity_class(row) for row in frame.to_dict("records")
+    ]
+    signals = [classify_architecture_signal(row) for row in frame.to_dict("records")]
+    frame["architecture_signal_class"] = [
+        signal.architecture_signal_class for signal in signals
+    ]
+    frame["architecture_signal_reason"] = [
+        signal.architecture_signal_reason for signal in signals
+    ]
+    frame["recommended_followup"] = [signal.recommended_followup for signal in signals]
+    frame["key_drivers"] = [_key_drivers(row) for row in frame.to_dict("records")]
+    frame = _sort_rankings(frame)
+    frame["opportunity_rank"] = range(1, len(frame) + 1)
+    return frame.reindex(columns=OUTPUT_COLUMNS)
+
+
+def _rank_score(values: Any) -> pd.Series:
+    series = pd.to_numeric(values, errors="coerce")
+    if series.empty:
+        return pd.Series(dtype="float64")
+    ranked = series.rank(method="average", pct=True) * 100.0
+    return ranked.fillna(0.0).round(2)
+
+
+def _clipped_number(values: Any) -> pd.Series:
+    series = pd.to_numeric(values, errors="coerce")
+    non_null = series.dropna()
+    if not non_null.empty and non_null.between(0.0, 1.0).all():
+        series = series * 100.0
+    return series.fillna(0.0).clip(lower=0.0, upper=100.0).round(2)
+
+
+def _infrastructure_scores(frame: pd.DataFrame) -> pd.Series:
+    numeric = pd.to_numeric(frame.get("infrastructure_access_score"), errors="coerce")
+    classes = frame.get("infrastructure_access_class", pd.Series(dtype="object"))
+    fallback = classes.map(
+        lambda value: _INFRASTRUCTURE_CLASS_SCORES.get(_text(value), 0)
+    )
+    scores = numeric.map(_scale_infrastructure_score).fillna(fallback)
+    return scores.fillna(0.0).clip(0.0, 100.0).round(2)
+
+
+def _operator_scores(frame: pd.DataFrame) -> pd.Series:
+    name = frame.get("top_operator_name", pd.Series(dtype="object")).map(_text)
+    share = pd.to_numeric(frame.get("top_operator_share"), errors="coerce")
+    return ((name != "") & share.notna()).map(lambda known: 100.0 if known else 0.0)
+
+
+def _quality_penalty(row: dict[str, Any]) -> float:
+    terms = _terms(row.get("source_caveats")) + _terms(row.get("quality_flags"))
+    penalty = min(25.0, len(terms) * 5.0)
+    if _text(row.get("infrastructure_access_class")) == "not_available":
+        penalty += 10.0
+    for column in _REQUIRED_NUMERIC_COLUMNS:
+        if _is_missing(row.get(column)):
+            penalty += 2.5
+    return round(min(penalty, 40.0), 2)
+
+
+def _opportunity_score(row: dict[str, Any]) -> float:
+    score = sum(
+        _number(row.get(column)) * weight for column, weight in SCORING_WEIGHTS.items()
+    )
+    score -= _number(row.get("quality_penalty_score"))
+    return round(min(100.0, max(0.0, score)), 2)
+
+
+def _opportunity_class(row: dict[str, Any]) -> str:
+    if _has_missing_core_evidence(row):
+        return "low_confidence"
+    score = _number(row.get("opportunity_score"))
+    if score >= 75:
+        return "high_priority"
+    if score >= 45:
+        return "screening_candidate"
+    return "monitor_only"
+
+
+def _has_missing_core_evidence(row: dict[str, Any]) -> bool:
+    if _text(row.get("infrastructure_access_class")) == "not_available":
+        return True
+    if not _text(row.get("top_operator_name")) or _is_missing(
+        row.get("top_operator_share")
+    ):
+        return True
+    terms = set(_terms(row.get("source_caveats")) + _terms(row.get("quality_flags")))
+    return bool(terms.intersection(_CRITICAL_MISSING_TERMS))
+
+
+def _key_drivers(row: dict[str, Any]) -> str:
+    drivers = []
+    if _number(row.get("production_scale_component_score")) >= 75:
+        drivers.append("high production scale")
+    if _number(row.get("remaining_activity_component_score")) >= 75:
+        drivers.append("strong remaining activity")
+    access = _text(row.get("infrastructure_access_class"))
+    if access in {"direct_access", "near_access"}:
+        drivers.append(f"{access} infrastructure signal")
+    if _number(row.get("operator_concentration_component_score")) == 100:
+        drivers.append("operator context available")
+    if _number(row.get("quality_penalty_score")) >= 20:
+        drivers.append("material quality caveats")
+    return "; ".join(drivers)
+
+
+def _sort_rankings(frame: pd.DataFrame) -> pd.DataFrame:
+    sort_columns = ["opportunity_score", "district", "field_number", "field_name"]
+    return frame.sort_values(
+        sort_columns,
+        ascending=[False, True, True, True],
+        kind="mergesort",
+    ).reset_index(drop=True)
+
+
+_INFRASTRUCTURE_CLASS_SCORES = {
+    "direct_access": 100.0,
+    "near_access": 80.0,
+    "regional_access": 55.0,
+    "remote_access": 30.0,
+    "isolated_or_unknown": 15.0,
+    "not_available": 0.0,
+}
+_REQUIRED_NUMERIC_COLUMNS = (
+    "cumulative_boe",
+    "remaining_activity_score",
+    "active_well_count",
+    "infrastructure_access_score",
+    "top_operator_share",
+)
+_CRITICAL_MISSING_TERMS = {
+    "missing_field_atlas_summary",
+    "missing_infrastructure_access",
+    "missing_lifecycle",
+    "missing_well_gis",
+}
+
+
+def _terms(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    normalized = str(value).replace(",", ";").replace("|", ";")
+    return tuple(term.strip() for term in normalized.split(";") if term.strip())
+
+
+def _scale_infrastructure_score(value: object) -> float | None:
+    if _is_missing(value):
+        return None
+    score = _number(value)
+    if 0.0 <= score <= 1.0:
+        return score * 100.0
+    return score
+
+
+def _is_missing(value: object) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, float) and math.isnan(value):
+        return True
+    return str(value).strip() == ""
+
+
+def _number(value: object) -> float:
+    try:
+        if value is None:
+            return 0.0
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _text(value: object) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+__all__ = [
+    "OUTPUT_COLUMNS",
+    "SCORING_VERSION",
+    "SCORING_WEIGHTS",
+    "build_field_opportunity_rankings",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/opportunities/sources.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/opportunities/sources.py
@@ -1,0 +1,123 @@
+"""Load direct curated inputs for Texas RRC field-opportunity rankings."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.field_development.io import (
+    FIELD_DEVELOPMENT_METRICS_DIR,
+)
+from worldenergydata.texas_rrc.infrastructure.io import INFRASTRUCTURE_ACCESS_DIR
+from worldenergydata.texas_rrc.production_atlas.io import PRODUCTION_ATLAS_DIR
+from worldenergydata.texas_rrc.reports.io import (
+    FIELD_ATLAS_REPORT_DIR,
+    MANIFEST_FILENAME,
+    SUMMARY_CSV_FILENAME,
+    SUMMARY_PARQUET_FILENAME,
+)
+
+
+@dataclass(frozen=True)
+class FieldOpportunityInputs:
+    """Direct curated inputs used to rank Texas RRC field opportunities."""
+
+    field_atlas_summary: pd.DataFrame
+    input_paths: tuple[Path, ...]
+    source_gaps: tuple[str, ...]
+    upstream_manifests: tuple[Path, ...]
+
+
+def load_field_opportunity_inputs(root: Path | str) -> FieldOpportunityInputs:
+    """Load the #666 field-atlas summary and upstream manifests."""
+    catalog_root = Path(root)
+    report_dir = catalog_root / FIELD_ATLAS_REPORT_DIR
+    data_path = _existing_data_path(report_dir)
+    manifests = _upstream_manifest_paths(catalog_root)
+    paths = ((data_path,) if data_path else ()) + manifests
+    gaps = []
+    for manifest in manifests:
+        gaps.extend(_manifest_source_gaps(manifest))
+    if data_path is None:
+        gaps.insert(0, "missing_field_atlas_summary")
+        summary = pd.DataFrame()
+    else:
+        summary = _load_frame(data_path)
+    return FieldOpportunityInputs(
+        field_atlas_summary=summary,
+        input_paths=paths,
+        source_gaps=_dedupe(gaps),
+        upstream_manifests=manifests,
+    )
+
+
+def _existing_data_path(directory: Path) -> Path | None:
+    parquet_path = directory / SUMMARY_PARQUET_FILENAME
+    if parquet_path.exists():
+        return parquet_path
+    csv_path = directory / SUMMARY_CSV_FILENAME
+    return csv_path if csv_path.exists() else None
+
+
+def _load_frame(path: Path) -> pd.DataFrame:
+    if path.suffix == ".parquet":
+        frame = pd.read_parquet(path)
+    else:
+        frame = pd.read_csv(
+            path, dtype={"district": "string", "field_number": "string"}
+        )
+    return _normalize_key_columns(frame)
+
+
+def _normalize_key_columns(frame: pd.DataFrame) -> pd.DataFrame:
+    for column in ("district", "field_number"):
+        if column in frame:
+            frame[column] = frame[column].astype("string")
+    return frame
+
+
+def _upstream_manifest_paths(root: Path) -> tuple[Path, ...]:
+    candidates = (
+        root / FIELD_ATLAS_REPORT_DIR / MANIFEST_FILENAME,
+        root / FIELD_DEVELOPMENT_METRICS_DIR / MANIFEST_FILENAME,
+        root / INFRASTRUCTURE_ACCESS_DIR / MANIFEST_FILENAME,
+        root / PRODUCTION_ATLAS_DIR / MANIFEST_FILENAME,
+    )
+    return tuple(path for path in candidates if path.exists())
+
+
+def _manifest_source_gaps(manifest_path: Path) -> list[str]:
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ["unreadable_manifest"]
+    gaps = _string_sequence(payload.get("source_gaps"))
+    if not gaps and isinstance(payload.get("quality"), dict):
+        gaps = _string_sequence(payload["quality"].get("source_gaps"))
+    return gaps
+
+
+def _string_sequence(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item)]
+
+
+def _dedupe(values: list[str]) -> tuple[str, ...]:
+    seen = set()
+    result = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return tuple(result)
+
+
+__all__ = [
+    "FieldOpportunityInputs",
+    "load_field_opportunity_inputs",
+]

--- a/scripts/review/results/2026-07-02-code-695-codex-inline.md
+++ b/scripts/review/results/2026-07-02-code-695-codex-inline.md
@@ -1,0 +1,88 @@
+# Code Review: Issue #695 Texas RRC Field Opportunity Ranking
+
+Reviewer: Codex inline
+Date: 2026-07-02
+Scope: implementation branch `feat/onshore-rrc-field-opportunities-695`
+
+## Verdict
+
+APPROVE after fixes below.
+
+## Findings
+
+### MAJOR - Fractional infrastructure scores were treated as 0..1 component scores
+
+Evidence: live `/mnt/ace` publication showed top-ranked direct-access fields with
+`infrastructure_access_score=1.0` but `infrastructure_component_score` near `1`
+instead of `100`, suppressing total opportunity scores.
+
+Mitigation:
+- Added `test_fractional_infrastructure_scores_are_scaled_to_component_percent`.
+- Updated `opportunities/scoring.py` so fractional infrastructure values are
+  scaled to percent before weighting.
+
+### MAJOR - Fractional remaining-activity scores were treated as 0..1 component scores
+
+Evidence: corrected live `/mnt/ace` publication still showed
+`remaining_activity_score=0.98` becoming `remaining_activity_component_score=0.98`,
+which made top scores peak near `45` despite strong remaining-activity signals.
+
+Mitigation:
+- Added `test_fractional_remaining_activity_scores_are_scaled_to_component_percent`.
+- Updated `opportunities/scoring.py` so remaining-activity series expressed as
+  `0..1` ratios are normalized to `0..100`.
+
+### MAJOR - Routine caveats forced every field to `low_confidence`
+
+Evidence: first full `/mnt/ace` publication after infrastructure scaling produced
+67,082 rows all classified as `low_confidence`, because routine caveats such as
+lease-level production allocation counted the same as missing core evidence.
+
+Mitigation:
+- Added `test_quality_caveats_do_not_force_low_confidence_when_core_sources_exist`.
+- Changed opportunity-class logic so only missing core evidence forces
+  `low_confidence`; routine caveats remain visible through quality penalty and
+  driver text.
+
+### MINOR - Manifest provenance must be regenerated after commit
+
+Evidence: pre-commit live publications correctly wrote full output files, but
+`manifest.json` still recorded `code_revision=23bcb710...` because the
+implementation had not yet been committed.
+
+Mitigation:
+- Required closeout step: after committing, rerun the full
+  `build-field-opportunities` publication and verify `manifest.json` code
+  revision equals the implementation commit SHA.
+
+## Verification Evidence
+
+- `uv run --no-sync black --check packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/opportunities src/worldenergydata/cli/commands/texas_rrc.py tests/unit/texas_rrc/test_field_opportunity_*.py`
+- `uv run --no-sync isort --check-only packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/opportunities src/worldenergydata/cli/commands/texas_rrc.py tests/unit/texas_rrc/test_field_opportunity_*.py`
+- `uv run --no-sync pytest --noconftest -o addopts='' tests/unit/texas_rrc/test_field_opportunity_*.py -q` -> 21 passed
+- `uv run --no-sync pytest --noconftest -o addopts='' tests/unit/texas_rrc -q` -> 526 passed
+- `uv run --no-sync worldenergydata texas-rrc build-field-opportunities --root /mnt/ace/worldenergydata/data/modules/texas_rrc --output-root /mnt/ace/worldenergydata/data/modules/texas_rrc --require-sources --max-fields 100`
+- `uv run --no-sync worldenergydata texas-rrc build-field-opportunities --root /mnt/ace/worldenergydata/data/modules/texas_rrc --output-root /mnt/ace/worldenergydata/data/modules/texas_rrc --require-sources`
+
+Latest pre-commit `/mnt/ace` quality summary:
+
+```json
+{
+  "row_count": 67082,
+  "source_gaps": [],
+  "opportunity_class_counts": {
+    "low_confidence": 45721,
+    "monitor_only": 17278,
+    "screening_candidate": 4083
+  },
+  "architecture_class_counts": {
+    "emerging_growth": 12,
+    "high_access_infill_redevelopment": 2208,
+    "infrastructure_constrained_activity": 3,
+    "low_data_confidence": 50295,
+    "mature_harvest": 10840,
+    "monitor_only": 3724
+  },
+  "score_max": 74.79
+}
+```

--- a/src/worldenergydata/cli/commands/texas_rrc.py
+++ b/src/worldenergydata/cli/commands/texas_rrc.py
@@ -1065,6 +1065,31 @@ def _print_field_atlas_report_outputs(manifest) -> None:
     console.print(f"[dim]Manifest: {manifest.manifest_path}[/dim]")
 
 
+def _print_field_opportunity_summary(row_count: int, source_gaps) -> None:
+    table = Table(
+        title="Texas RRC Field Opportunity Rankings",
+        show_header=True,
+        header_style="bold cyan",
+    )
+    table.add_column("Metric", style="dim")
+    table.add_column("Value")
+    table.add_row("Ranked fields", str(row_count))
+    table.add_row("Source gaps", ", ".join(source_gaps) if source_gaps else "None")
+    console.print(table)
+
+
+def _print_field_opportunity_outputs(manifest) -> None:
+    console.print(
+        "[green]Wrote field-opportunity rankings[/green] "
+        f"{manifest.row_count} rows -> {manifest.output_dir}"
+    )
+    console.print(f"[dim]Rankings CSV: {manifest.rankings_csv_path}[/dim]")
+    console.print(f"[dim]Rankings Parquet: {manifest.rankings_parquet_path}[/dim]")
+    console.print(f"[dim]HTML summary: {manifest.html_path}[/dim]")
+    console.print(f"[dim]Quality report: {manifest.quality_path}[/dim]")
+    console.print(f"[dim]Manifest: {manifest.manifest_path}[/dim]")
+
+
 @app.command("publish-field-atlas-reports")
 def publish_field_atlas_reports_command(
     root: Path = typer.Option(
@@ -1122,6 +1147,68 @@ def publish_field_atlas_reports_command(
             console.print("[yellow]Dry run:[/yellow] no field-atlas reports written")
             return
         _print_field_atlas_report_outputs(result.manifest)
+    except typer.Exit:
+        raise
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+
+
+@app.command("build-field-opportunities")
+def build_field_opportunities_command(
+    root: Path = typer.Option(
+        Path("/mnt/ace/worldenergydata/data/modules/texas_rrc"),
+        "--root",
+        help="Root containing curated Texas RRC field-atlas report inputs",
+    ),
+    output_root: Path = typer.Option(
+        Path("/mnt/ace/worldenergydata/data/modules/texas_rrc"),
+        "--output-root",
+        help="Root for curated field-opportunity ranking outputs",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Build the ranking model without writing outputs",
+    ),
+    require_sources: bool = typer.Option(
+        False,
+        "--require-sources",
+        help="Fail when any curated field-opportunity input is missing",
+    ),
+    allow_non_ace_output: bool = typer.Option(
+        False,
+        "--allow-non-ace-output",
+        help="Allow non-/mnt/ace output roots for isolated tests or sandboxes",
+    ),
+    max_fields: int | None = typer.Option(
+        None,
+        "--max-fields",
+        min=1,
+        help="Limit ranked fields after score sorting",
+    ),
+) -> None:
+    """Build Texas RRC field opportunity and architecture-signal rankings."""
+    from worldenergydata.texas_rrc.opportunities.cli_support import (
+        run_build_field_opportunities,
+    )
+
+    try:
+        result = run_build_field_opportunities(
+            root=root,
+            output_root=output_root,
+            dry_run=dry_run,
+            require_sources=require_sources,
+            allow_non_ace_output=allow_non_ace_output,
+            max_fields=max_fields,
+        )
+        _print_field_opportunity_summary(result.row_count, result.source_gaps)
+        if result.dry_run:
+            console.print(
+                "[yellow]Dry run:[/yellow] no field-opportunity outputs written"
+            )
+            return
+        _print_field_opportunity_outputs(result.manifest)
     except typer.Exit:
         raise
     except Exception as e:

--- a/tests/unit/texas_rrc/test_field_opportunity_architecture.py
+++ b/tests/unit/texas_rrc/test_field_opportunity_architecture.py
@@ -1,0 +1,94 @@
+"""Tests for Texas RRC field opportunity architecture-signal classes."""
+
+from __future__ import annotations
+
+from worldenergydata.texas_rrc.opportunities.architecture import (
+    classify_architecture_signal,
+)
+
+
+def test_classifies_high_access_infill_redevelopment() -> None:
+    signal = classify_architecture_signal(
+        _row(
+            infrastructure_access_class="direct_access",
+            production_scale_component_score=95,
+            remaining_activity_component_score=75,
+            production_maturity_class="mature_active",
+        )
+    )
+
+    assert signal.architecture_signal_class == "high_access_infill_redevelopment"
+    assert "direct_access" in signal.architecture_signal_reason
+
+
+def test_classifies_infrastructure_constrained_activity() -> None:
+    signal = classify_architecture_signal(
+        _row(
+            infrastructure_access_class="remote_access",
+            remaining_activity_component_score=95,
+            production_scale_component_score=60,
+        )
+    )
+
+    assert signal.architecture_signal_class == "infrastructure_constrained_activity"
+    assert "follow-up infrastructure" in signal.recommended_followup
+
+
+def test_classifies_mature_harvest() -> None:
+    signal = classify_architecture_signal(
+        _row(
+            production_maturity_class="late_life",
+            remaining_activity_component_score=10,
+            infrastructure_access_class="direct_access",
+        )
+    )
+
+    assert signal.architecture_signal_class == "mature_harvest"
+
+
+def test_classifies_emerging_growth() -> None:
+    signal = classify_architecture_signal(
+        _row(
+            production_maturity_class="growth",
+            remaining_activity_component_score=90,
+            infrastructure_component_score=80,
+            infrastructure_access_class="near_access",
+        )
+    )
+
+    assert signal.architecture_signal_class == "emerging_growth"
+
+
+def test_classifies_low_data_confidence_first() -> None:
+    signal = classify_architecture_signal(
+        _row(
+            quality_flags="missing_lifecycle",
+            source_caveats="missing_well_gis",
+            infrastructure_access_class="not_available",
+            production_scale_component_score=50,
+            remaining_activity_component_score=60,
+        )
+    )
+
+    assert signal.architecture_signal_class == "low_data_confidence"
+    assert "missing" in signal.architecture_signal_reason
+
+
+def test_classifies_monitor_only_fallback() -> None:
+    signal = classify_architecture_signal(_row())
+
+    assert signal.architecture_signal_class == "monitor_only"
+
+
+def _row(**overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "production_maturity_class": "pre_production",
+        "production_scale_component_score": 20.0,
+        "remaining_activity_component_score": 35.0,
+        "infrastructure_component_score": 30.0,
+        "infrastructure_access_class": "regional_access",
+        "source_caveats": "",
+        "quality_flags": "",
+    }
+    row.update(overrides)
+    return row

--- a/tests/unit/texas_rrc/test_field_opportunity_cli.py
+++ b/tests/unit/texas_rrc/test_field_opportunity_cli.py
@@ -1,0 +1,121 @@
+"""Tests for the Texas RRC field-opportunity CLI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from worldenergydata.cli.commands.texas_rrc import app
+from worldenergydata.texas_rrc.opportunities.cli_support import (
+    run_build_field_opportunities,
+)
+from worldenergydata.texas_rrc.opportunities.io import (
+    FieldOpportunityOutputManifest,
+)
+
+
+def test_build_field_opportunities_cli_calls_support_layer(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_run_build_field_opportunities(**kwargs):
+        calls.append(kwargs)
+        return _Result(
+            row_count=2,
+            source_gaps=(),
+            dry_run=False,
+            manifest=_manifest(tmp_path),
+        )
+
+    monkeypatch.setattr(
+        "worldenergydata.texas_rrc.opportunities.cli_support."
+        "run_build_field_opportunities",
+        fake_run_build_field_opportunities,
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "build-field-opportunities",
+            "--root",
+            str(tmp_path),
+            "--output-root",
+            str(tmp_path),
+            "--allow-non-ace-output",
+            "--max-fields",
+            "2",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        {
+            "root": tmp_path,
+            "output_root": tmp_path,
+            "dry_run": False,
+            "require_sources": False,
+            "allow_non_ace_output": True,
+            "max_fields": 2,
+        }
+    ]
+    assert "Wrote field-opportunity rankings" in result.output
+
+
+def test_run_build_field_opportunities_dry_run_reports_missing_sources(
+    tmp_path: Path,
+) -> None:
+    result = run_build_field_opportunities(
+        root=tmp_path,
+        output_root=tmp_path,
+        dry_run=True,
+        require_sources=False,
+        allow_non_ace_output=True,
+    )
+
+    assert result.dry_run is True
+    assert result.row_count == 0
+    assert "missing_field_atlas_summary" in result.source_gaps
+    assert result.manifest is None
+
+
+def test_run_build_field_opportunities_requires_sources(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="missing_field_atlas_summary"):
+        run_build_field_opportunities(
+            root=tmp_path,
+            output_root=tmp_path,
+            dry_run=True,
+            require_sources=True,
+            allow_non_ace_output=True,
+        )
+
+
+@dataclass(frozen=True)
+class _Result:
+    row_count: int
+    source_gaps: tuple[str, ...]
+    dry_run: bool
+    manifest: FieldOpportunityOutputManifest | None
+
+
+def _manifest(tmp_path: Path) -> FieldOpportunityOutputManifest:
+    target = tmp_path / "curated" / "analysis" / "field_opportunities"
+    return FieldOpportunityOutputManifest(
+        generated_at="2026-07-02T00:00:00Z",
+        output_root=tmp_path,
+        output_dir=target,
+        rankings_csv_path=target / "field_opportunity_rankings.csv",
+        rankings_parquet_path=target / "field_opportunity_rankings.parquet",
+        html_path=target / "field_opportunity_summary.html",
+        quality_path=target / "field_opportunity_quality.json",
+        manifest_path=target / "manifest.json",
+        row_count=2,
+        input_paths=(),
+        upstream_manifests=(),
+        source_gaps=(),
+        command=None,
+        code_revision="test-rev",
+    )

--- a/tests/unit/texas_rrc/test_field_opportunity_html.py
+++ b/tests/unit/texas_rrc/test_field_opportunity_html.py
@@ -1,0 +1,53 @@
+"""Tests for Texas RRC field-opportunity HTML rendering."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.opportunities.html import (
+    render_field_opportunity_summary_html,
+)
+from worldenergydata.texas_rrc.opportunities.quality import (
+    assess_field_opportunity_quality,
+)
+
+
+def test_html_is_self_contained_and_links_field_reports() -> None:
+    rankings = _rankings()
+    quality = assess_field_opportunity_quality(rankings, source_gaps=())
+
+    html = render_field_opportunity_summary_html(rankings, quality)
+
+    assert html.startswith("<!doctype html>")
+    assert "Texas RRC Field Opportunity Ranking" in html
+    assert "Alpha &amp; Beta Field" in html
+    assert "fields/08-12345-alpha-field.html" in html
+    assert "high_access_infill_redevelopment" in html
+    assert "screening heuristic" in html
+    assert "http://" not in html
+    assert "https://" not in html
+    assert "<script src=" not in html
+
+
+def _rankings() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "opportunity_rank": 1,
+                "district": "08",
+                "field_number": "12345",
+                "field_name": "Alpha & Beta Field",
+                "report_path": "fields/08-12345-alpha-field.html",
+                "opportunity_score": 91.2,
+                "opportunity_class": "high_priority",
+                "architecture_signal_class": "high_access_infill_redevelopment",
+                "recommended_followup": "Review infill redevelopment candidates.",
+                "cumulative_boe": 10000,
+                "remaining_activity_score": 82.0,
+                "infrastructure_access_class": "direct_access",
+                "key_drivers": "high production scale",
+                "source_caveats": "direct_rrc_metrics",
+                "quality_flags": "",
+            }
+        ]
+    )

--- a/tests/unit/texas_rrc/test_field_opportunity_io.py
+++ b/tests/unit/texas_rrc/test_field_opportunity_io.py
@@ -1,0 +1,106 @@
+"""Tests for writing Texas RRC field-opportunity outputs."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from worldenergydata.texas_rrc.opportunities.io import (
+    FIELD_OPPORTUNITY_DIR,
+    write_field_opportunity_outputs,
+)
+from worldenergydata.texas_rrc.opportunities.quality import (
+    assess_field_opportunity_quality,
+)
+
+
+def test_writes_staged_rankings_html_quality_and_manifest(tmp_path: Path) -> None:
+    pytest.importorskip("pyarrow")
+    rankings = _rankings()
+    quality = assess_field_opportunity_quality(rankings, source_gaps=())
+
+    manifest = write_field_opportunity_outputs(
+        rankings=rankings,
+        quality=quality,
+        output_root=tmp_path,
+        input_paths=(tmp_path / "field_atlas_summary.csv",),
+        upstream_manifests=(tmp_path / "manifest.json",),
+        allow_non_ace_root=True,
+        command="worldenergydata texas-rrc build-field-opportunities",
+        code_revision="test-rev",
+        generated_at=datetime(2026, 7, 2, tzinfo=timezone.utc),
+    )
+
+    target = tmp_path / FIELD_OPPORTUNITY_DIR
+    assert (target / "field_opportunity_rankings.csv").is_file()
+    assert (target / "field_opportunity_rankings.parquet").is_file()
+    assert (target / "field_opportunity_summary.html").is_file()
+    assert (target / "field_opportunity_quality.json").is_file()
+    assert (target / "manifest.json").is_file()
+    assert manifest.row_count == 1
+    assert manifest.code_revision == "test-rev"
+
+    payload = json.loads((target / "manifest.json").read_text(encoding="utf-8"))
+    assert payload["row_count"] == 1
+    assert payload["scoring_version"] == "texas_rrc_field_opportunity_v1"
+    assert payload["command"] == "worldenergydata texas-rrc build-field-opportunities"
+
+
+def test_rejects_non_ace_output_without_override(tmp_path: Path) -> None:
+    rankings = _rankings()
+    quality = assess_field_opportunity_quality(rankings, source_gaps=())
+
+    with pytest.raises(ValueError, match="field-opportunity output_root"):
+        write_field_opportunity_outputs(
+            rankings=rankings,
+            quality=quality,
+            output_root=tmp_path,
+        )
+
+
+def test_rewrite_removes_stale_outputs(tmp_path: Path) -> None:
+    pytest.importorskip("pyarrow")
+    rankings = _rankings()
+    quality = assess_field_opportunity_quality(rankings, source_gaps=())
+
+    write_field_opportunity_outputs(
+        rankings=rankings,
+        quality=quality,
+        output_root=tmp_path,
+        allow_non_ace_root=True,
+        generated_at=datetime(2026, 7, 2, tzinfo=timezone.utc),
+    )
+    stale = tmp_path / FIELD_OPPORTUNITY_DIR / "stale.txt"
+    stale.write_text("stale", encoding="utf-8")
+
+    write_field_opportunity_outputs(
+        rankings=rankings,
+        quality=quality,
+        output_root=tmp_path,
+        allow_non_ace_root=True,
+        generated_at=datetime(2026, 7, 2, 0, 1, tzinfo=timezone.utc),
+    )
+
+    assert not stale.exists()
+
+
+def _rankings() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "opportunity_rank": 1,
+                "district": "08",
+                "field_number": "12345",
+                "field_name": "Alpha Field",
+                "opportunity_score": 91.2,
+                "opportunity_class": "high_priority",
+                "architecture_signal_class": "high_access_infill_redevelopment",
+                "source_caveats": "direct_rrc_metrics",
+                "quality_flags": "",
+            }
+        ]
+    )

--- a/tests/unit/texas_rrc/test_field_opportunity_scoring.py
+++ b/tests/unit/texas_rrc/test_field_opportunity_scoring.py
@@ -1,0 +1,182 @@
+"""Tests for Texas RRC field-opportunity scoring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.opportunities.scoring import (
+    SCORING_VERSION,
+    build_field_opportunity_rankings,
+)
+from worldenergydata.texas_rrc.opportunities.sources import FieldOpportunityInputs
+
+
+def test_builds_ranked_component_scores_and_preserves_caveats() -> None:
+    rankings = build_field_opportunity_rankings(_inputs())
+
+    assert SCORING_VERSION == "texas_rrc_field_opportunity_v1"
+    assert list(rankings["field_number"]) == ["12345", "77777", "54321"]
+    assert list(rankings["opportunity_rank"]) == [1, 2, 3]
+    assert rankings.loc[0, "opportunity_score"] > rankings.loc[1, "opportunity_score"]
+    assert rankings.loc[1, "opportunity_score"] > rankings.loc[2, "opportunity_score"]
+    assert rankings["opportunity_score"].between(0, 100).all()
+    assert rankings.loc[0, "production_scale_component_score"] == 100.0
+    assert rankings.loc[2, "infrastructure_component_score"] == 0.0
+    assert rankings.loc[2, "quality_penalty_score"] > 0
+    assert rankings.loc[2, "opportunity_class"] == "low_confidence"
+    assert "missing_well_gis" in rankings.loc[2, "source_caveats"]
+
+
+def test_tied_scores_sort_by_stable_field_identity() -> None:
+    frame = _summary_frame().iloc[[0, 0]].copy().reset_index(drop=True)
+    frame.loc[0, "field_number"] = "20000"
+    frame.loc[0, "field_name"] = "Zulu Field"
+    frame.loc[1, "field_number"] = "10000"
+    frame.loc[1, "field_name"] = "Alpha Field"
+
+    rankings = build_field_opportunity_rankings(
+        FieldOpportunityInputs(
+            field_atlas_summary=frame,
+            input_paths=(),
+            source_gaps=(),
+            upstream_manifests=(),
+        )
+    )
+
+    assert list(rankings["field_number"]) == ["10000", "20000"]
+
+
+def test_fractional_infrastructure_scores_are_scaled_to_component_percent() -> None:
+    rankings = build_field_opportunity_rankings(_inputs())
+
+    alpha = rankings[rankings["field_number"] == "12345"].iloc[0]
+
+    assert alpha["infrastructure_component_score"] == 95.0
+
+
+def test_fractional_remaining_activity_scores_are_scaled_to_component_percent() -> None:
+    frame = _summary_frame().copy()
+    frame["remaining_activity_score"] = [0.82, 0.95, 0.04]
+
+    rankings = build_field_opportunity_rankings(
+        FieldOpportunityInputs(
+            field_atlas_summary=frame,
+            input_paths=(),
+            source_gaps=(),
+            upstream_manifests=(),
+        )
+    )
+
+    alpha = rankings[rankings["field_number"] == "12345"].iloc[0]
+
+    assert alpha["remaining_activity_component_score"] == 82.0
+
+
+def test_quality_caveats_do_not_force_low_confidence_when_core_sources_exist() -> None:
+    frame = _summary_frame().iloc[[0]].copy()
+    frame.loc[0, "source_caveats"] = (
+        "lease_level_production|no_per_well_allocation;"
+        "rrc_gis_screening_only|field_centroid_pipeline_screening"
+    )
+
+    rankings = build_field_opportunity_rankings(
+        FieldOpportunityInputs(
+            field_atlas_summary=frame,
+            input_paths=(),
+            source_gaps=(),
+            upstream_manifests=(),
+        )
+    )
+
+    assert rankings.loc[0, "quality_penalty_score"] == 20.0
+    assert rankings.loc[0, "opportunity_class"] != "low_confidence"
+
+
+def _inputs() -> FieldOpportunityInputs:
+    return FieldOpportunityInputs(
+        field_atlas_summary=_summary_frame(),
+        input_paths=(Path("field_atlas_summary.csv"),),
+        source_gaps=(),
+        upstream_manifests=(),
+    )
+
+
+def _summary_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "district": "08",
+                "field_number": "12345",
+                "field_name": "Alpha Field",
+                "field_slug": "alpha-field",
+                "report_path": "fields/08-12345-alpha-field.html",
+                "field_page_filename": "08-12345-alpha-field.html",
+                "well_count": 10,
+                "active_well_count": 7,
+                "production_maturity_class": "mature_active",
+                "remaining_activity_score": 82.0,
+                "cumulative_boe": 10000.0,
+                "production_per_well_boe": 1000.0,
+                "top_operator_name": "Operator A",
+                "top_operator_share": 0.70,
+                "infrastructure_access_class": "direct_access",
+                "infrastructure_access_score": 0.95,
+                "nearest_pipeline_distance_miles": 0.5,
+                "nearby_pipeline_count_1mi": 2,
+                "nearby_pipeline_count_5mi": 8,
+                "nearby_pipeline_count_10mi": 15,
+                "source_caveats": "direct_rrc_metrics",
+                "quality_flags": "",
+            },
+            {
+                "district": "08",
+                "field_number": "77777",
+                "field_name": "Gamma Field",
+                "field_slug": "gamma-field",
+                "report_path": "fields/08-77777-gamma-field.html",
+                "field_page_filename": "08-77777-gamma-field.html",
+                "well_count": 5,
+                "active_well_count": 4,
+                "production_maturity_class": "growth",
+                "remaining_activity_score": 95.0,
+                "cumulative_boe": 2500.0,
+                "production_per_well_boe": 500.0,
+                "top_operator_name": "Operator C",
+                "top_operator_share": 0.40,
+                "infrastructure_access_class": "regional_access",
+                "infrastructure_access_score": 45.0,
+                "nearest_pipeline_distance_miles": 8.0,
+                "nearby_pipeline_count_1mi": 0,
+                "nearby_pipeline_count_5mi": 0,
+                "nearby_pipeline_count_10mi": 1,
+                "source_caveats": "rrc_gis_screening_only",
+                "quality_flags": "",
+            },
+            {
+                "district": "09",
+                "field_number": "54321",
+                "field_name": "Beta Field",
+                "field_slug": "beta-field",
+                "report_path": "fields/09-54321-beta-field.html",
+                "field_page_filename": "09-54321-beta-field.html",
+                "well_count": 4,
+                "active_well_count": 0,
+                "production_maturity_class": "late_life",
+                "remaining_activity_score": 4.0,
+                "cumulative_boe": 300.0,
+                "production_per_well_boe": 75.0,
+                "top_operator_name": "",
+                "top_operator_share": None,
+                "infrastructure_access_class": "not_available",
+                "infrastructure_access_score": None,
+                "nearest_pipeline_distance_miles": None,
+                "nearby_pipeline_count_1mi": None,
+                "nearby_pipeline_count_5mi": None,
+                "nearby_pipeline_count_10mi": None,
+                "source_caveats": "missing_well_gis",
+                "quality_flags": "missing_lifecycle",
+            },
+        ]
+    )

--- a/tests/unit/texas_rrc/test_field_opportunity_sources.py
+++ b/tests/unit/texas_rrc/test_field_opportunity_sources.py
@@ -1,0 +1,86 @@
+"""Tests for Texas RRC field-opportunity source loading."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from worldenergydata.texas_rrc.opportunities.sources import (
+    load_field_opportunity_inputs,
+)
+
+
+def test_loads_field_atlas_summary_and_upstream_manifests(tmp_path: Path) -> None:
+    root = _write_opportunity_source_tree(tmp_path)
+
+    inputs = load_field_opportunity_inputs(root)
+
+    assert inputs.source_gaps == ()
+    assert len(inputs.field_atlas_summary) == 2
+    assert inputs.field_atlas_summary.loc[0, "field_number"] == "12345"
+    assert sorted(path.name for path in inputs.input_paths) == [
+        "field_atlas_summary.csv",
+        "manifest.json",
+        "manifest.json",
+        "manifest.json",
+        "manifest.json",
+    ]
+    assert len(inputs.upstream_manifests) == 4
+
+
+def test_records_missing_field_atlas_summary_gap(tmp_path: Path) -> None:
+    root = _write_opportunity_source_tree(tmp_path)
+    (root / "curated" / "reports" / "field_atlas" / "field_atlas_summary.csv").unlink()
+
+    inputs = load_field_opportunity_inputs(root)
+
+    assert inputs.field_atlas_summary.empty
+    assert inputs.source_gaps == ("missing_field_atlas_summary",)
+
+
+def test_records_unreadable_manifest_gap(tmp_path: Path) -> None:
+    root = _write_opportunity_source_tree(tmp_path)
+    manifest = root / "curated" / "reports" / "field_atlas" / "manifest.json"
+    manifest.write_text("{not-json", encoding="utf-8")
+
+    inputs = load_field_opportunity_inputs(root)
+
+    assert "unreadable_manifest" in inputs.source_gaps
+
+
+def _write_opportunity_source_tree(tmp_path: Path) -> Path:
+    root = tmp_path / "texas_rrc"
+    report_dir = root / "curated" / "reports" / "field_atlas"
+    field_dir = root / "curated" / "field_development" / "metrics"
+    infra_dir = root / "curated" / "infrastructure" / "access"
+    production_dir = root / "curated" / "production" / "field_atlas"
+    for directory in (report_dir, field_dir, infra_dir, production_dir):
+        directory.mkdir(parents=True)
+    (report_dir / "field_atlas_summary.csv").write_text(
+        "\n".join(
+            [
+                "district,field_number,field_name,field_slug,report_path,"
+                "field_page_filename,well_count,active_well_count,"
+                "production_maturity_class,remaining_activity_score,"
+                "cumulative_boe,production_per_well_boe,top_operator_name,"
+                "top_operator_share,infrastructure_access_class,"
+                "infrastructure_access_score,nearest_pipeline_distance_miles,"
+                "nearby_pipeline_count_1mi,nearby_pipeline_count_5mi,"
+                "nearby_pipeline_count_10mi,source_caveats,quality_flags",
+                "08,12345,Alpha Field,alpha-field,fields/alpha.html,"
+                "alpha.html,10,7,mature_active,81.5,2025,202.5,Operator A,"
+                "0.75,direct_access,92,0.8,1,4,10,direct_rrc_metrics,",
+                "09,54321,Beta Field,beta-field,fields/beta.html,beta.html,"
+                "4,0,late_life,4.0,300,75,Operator B,1.0,not_available,"
+                ",,,,,missing_well_gis,no_active_wells",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    for directory in (report_dir, field_dir, infra_dir, production_dir):
+        (directory / "manifest.json").write_text(
+            json.dumps({"row_count": 1, "source_gaps": []}) + "\n",
+            encoding="utf-8",
+        )
+    return root


### PR DESCRIPTION
## Summary
- add Texas RRC field-opportunity source loading, scoring, architecture-signal classification, quality reporting, HTML summary, and staged output writer
- add `worldenergydata texas-rrc build-field-opportunities` with `/mnt/ace` output guardrails and source-gap enforcement
- publish docs, approval marker, and code-stage review artifact for #695

## Validation
- `uv run --no-sync black --check packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/opportunities src/worldenergydata/cli/commands/texas_rrc.py tests/unit/texas_rrc/test_field_opportunity_*.py`
- `uv run --no-sync isort --check-only packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/opportunities src/worldenergydata/cli/commands/texas_rrc.py tests/unit/texas_rrc/test_field_opportunity_*.py`
- `uv run --no-sync pytest --noconftest -o addopts='' tests/unit/texas_rrc/test_field_opportunity_*.py -q` -> 21 passed
- `uv run --no-sync pytest --noconftest -o addopts='' tests/unit/texas_rrc -q` -> 526 passed
- `git diff --cached --check`
- legal scan probe: `scripts/legal/legal-sanity-scan.sh` absent in this checkout

## /mnt/ace publication
- full output written to `/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/analysis/field_opportunities/`
- row count: 67,082
- source gaps: none
- manifest `code_revision`: `bc0c9f1982259cc80972c5119dd1f08d02fbd612`
- top score: 74.79; screening candidates: 4,083

Closes #695