### PR TITLE
feat(onshore): publish Texas RRC field architecture portfolio

### DIFF
--- a/docs/data-sources/onshore/texas-rrc/field-architecture-portfolio.md
+++ b/docs/data-sources/onshore/texas-rrc/field-architecture-portfolio.md
@@ -1,0 +1,104 @@
+# Texas RRC Field Architecture Portfolio
+
+The field architecture portfolio is the final onshore screening packet in the
+Texas RRC pilot. It consumes the field-architecture dossier index and publishes a
+portfolio-level action queue, rollups, quality metadata, and an HTML report under
+`/mnt/ace/worldenergydata/data/modules/texas_rrc`.
+
+The durable source of record is official Texas RRC data. LinkedIn posts,
+PatchOps, and scraper examples are discovery or validation context only; they are
+not persisted as authoritative source data.
+
+## Lifecycle
+
+The full onshore lifecycle is:
+
+1. Official Texas RRC raw snapshots refresh into `/mnt/ace`.
+2. Well lifecycle, production atlas, and GIS infrastructure metrics are curated.
+3. Field-development metrics combine well, field, production, and infrastructure
+   signals.
+4. Field atlas reports produce field-level summaries and drill-down HTML pages.
+5. Field opportunity rankings classify architecture signals and follow-up needs.
+6. Field architecture dossiers create bounded per-field review packets.
+7. The portfolio report turns the dossier index into a field-development action
+   queue and portfolio rollups.
+
+The portfolio builder consumes:
+
+- `curated/analysis/field_architecture_dossiers/field_architecture_dossier_index.parquet`
+  or `.csv`
+- `curated/analysis/field_architecture_dossiers/manifest.json`
+- `curated/analysis/field_architecture_dossiers/quality.json`
+- `curated/analysis/field_architecture_dossiers/fields/*.html`
+
+## Refresh Cadence
+
+Refresh upstream artifacts first, then rebuild the portfolio:
+
+```bash
+worldenergydata texas-rrc build-field-architecture-portfolio --require-sources
+```
+
+Use dry-run mode to inspect source health without writing:
+
+```bash
+worldenergydata texas-rrc build-field-architecture-portfolio --dry-run
+```
+
+The portfolio should be rebuilt after any upstream raw, lifecycle, production,
+infrastructure, field-atlas, opportunity, or dossier refresh. It inherits source
+gaps from the dossier manifest and quality files rather than hiding missing or
+partial source evidence.
+
+## Outputs
+
+The default output directory is:
+
+```text
+/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/analysis/field_architecture_portfolio/
+```
+
+The packet contains:
+
+- `field_architecture_action_queue.csv`
+- `field_architecture_action_queue.parquet`
+- `field_architecture_class_summary.csv`
+- `field_architecture_class_summary.parquet`
+- `field_architecture_followup_summary.csv`
+- `field_architecture_followup_summary.parquet`
+- `field_architecture_portfolio.html`
+- `quality.json`
+- `field_architecture_portfolio_quality.json`
+- `manifest.json`
+
+`quality.json` and `field_architecture_portfolio_quality.json` intentionally carry
+the same payload.
+
+## Action Queue
+
+Each row preserves field identifiers, architecture signal class, opportunity
+score/rank, field-development context, source caveats, quality flags, and a safe
+relative link back to the source dossier when the dossier is inside the expected
+`field_architecture_dossiers/fields/` directory.
+
+Architecture classes map to deterministic screening actions:
+
+- `low_data_confidence` -> `data_completion_review`
+- `infrastructure_constrained_activity` -> `infrastructure_constraint_screen`
+- `high_access_infill_redevelopment` -> `infill_redevelopment_screen`
+- `emerging_growth` -> `growth_appraisal_screen`
+- `mature_harvest` -> `mature_harvest_review`
+- `monitor_only` -> `monitor_only`
+
+Rows with unknown classes are routed to `data_completion_review` and receive an
+`unknown_architecture_signal_class` caveat.
+
+## Limitations
+
+The portfolio is a screening and prioritization product. It does not estimate or
+assert reserves, economics, tariffs, pipeline capacity, right-of-way status,
+route feasibility, product compatibility, ownership, or engineered facility
+design. It preserves upstream Texas RRC caveats such as lease-level production
+allocation, no per-well production allocation, GIS screening-only distances,
+dominant-county pipeline filtering, missing well GIS, and PDQ water or well-count
+metric gaps.

--- a/docs/plans/2026-07-02-issue-707-texas-rrc-field-architecture-portfolio.md
+++ b/docs/plans/2026-07-02-issue-707-texas-rrc-field-architecture-portfolio.md
@@ -1,7 +1,7 @@
 # Plan: Issue #707 - Texas RRC field architecture portfolio report
 
 **Issue:** https://github.com/vamseeachanta/worldenergydata/issues/707
-**Status:** plan-review
+**Status:** plan-approved
 **Tier:** T2 (new report package, portfolio action model, HTML and machine-readable outputs, CLI, tests, docs)
 **Client:** N/A
 **Project:** worldenergydata onshore field development

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -81,7 +81,7 @@ This directory contains issue-plan artifacts created during the issue-planning-m
 | [#669](https://github.com/vamseeachanta/worldenergydata/issues/669) | [texas-rrc-godrive-directory-refresh](2026-06-30-issue-669-texas-rrc-godrive-directory-refresh.md) | plan-approved | 2026-06-30 |
 | [#695](https://github.com/vamseeachanta/worldenergydata/issues/695) | [texas-rrc-field-opportunity-architecture-ranking](2026-07-02-issue-695-texas-rrc-field-opportunity-architecture-ranking.md) | implemented | 2026-07-02 |
 | [#702](https://github.com/vamseeachanta/worldenergydata/issues/702) | [texas-rrc-field-architecture-dossiers](2026-07-02-issue-702-texas-rrc-field-architecture-dossiers.md) | implemented | 2026-07-02 |
-| [#707](https://github.com/vamseeachanta/worldenergydata/issues/707) | [texas-rrc-field-architecture-portfolio](2026-07-02-issue-707-texas-rrc-field-architecture-portfolio.md) | plan-review | 2026-07-02 |
+| [#707](https://github.com/vamseeachanta/worldenergydata/issues/707) | [texas-rrc-field-architecture-portfolio](2026-07-02-issue-707-texas-rrc-field-architecture-portfolio.md) | plan-approved | 2026-07-02 |
 
 ## Closed / superseded plans
 

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/architecture_portfolio/__init__.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/architecture_portfolio/__init__.py
@@ -1,0 +1,3 @@
+"""Texas RRC field-architecture portfolio publishing."""
+
+__all__: list[str] = []

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/architecture_portfolio/cli_support.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/architecture_portfolio/cli_support.py
@@ -1,0 +1,148 @@
+"""CLI support for publishing Texas RRC field-architecture portfolio reports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.architecture_portfolio.io import (
+    FieldArchitecturePortfolioOutputManifest,
+    write_field_architecture_portfolio_outputs,
+)
+from worldenergydata.texas_rrc.architecture_portfolio.models import (
+    build_field_architecture_action_queue,
+    summarize_architecture_classes,
+    summarize_followup_recommendations,
+)
+from worldenergydata.texas_rrc.architecture_portfolio.quality import (
+    assess_field_architecture_portfolio_quality,
+)
+from worldenergydata.texas_rrc.architecture_portfolio.sources import (
+    load_field_architecture_portfolio_inputs,
+)
+from worldenergydata.texas_rrc.source_catalog import SOURCE_CATALOG_ROOT
+
+
+@dataclass(frozen=True)
+class FieldArchitecturePortfolioBuildResult:
+    """Result returned by the field-architecture portfolio publisher."""
+
+    row_count: int
+    blocking_source_gaps: tuple[str, ...]
+    informational_source_gaps: tuple[str, ...]
+    dry_run: bool
+    manifest: FieldArchitecturePortfolioOutputManifest | None
+
+
+def run_build_field_architecture_portfolio(
+    root: Path | str = SOURCE_CATALOG_ROOT,
+    output_root: Path | str = SOURCE_CATALOG_ROOT,
+    dry_run: bool = False,
+    require_sources: bool = False,
+    allow_non_ace_output: bool = False,
+) -> FieldArchitecturePortfolioBuildResult:
+    """Build and optionally write Texas RRC field-architecture portfolio outputs."""
+    source_root = Path(root)
+    target_root = Path(output_root)
+    inputs = load_field_architecture_portfolio_inputs(source_root)
+    blocking_source_gaps = tuple(inputs.blocking_source_gaps)
+    informational_source_gaps = _dedupe(
+        (*inputs.informational_source_gaps, *_rank_source_gaps(inputs.dossier_index))
+    )
+    if blocking_source_gaps and (require_sources or not dry_run):
+        raise ValueError(
+            "Cannot build field-architecture portfolio with missing sources: "
+            + ", ".join(blocking_source_gaps)
+        )
+
+    action_queue = build_field_architecture_action_queue(
+        inputs.dossier_index,
+        input_dossier_dir=inputs.input_dossier_dir,
+        output_root=target_root,
+    )
+    class_summary = summarize_architecture_classes(action_queue)
+    followup_summary = summarize_followup_recommendations(action_queue)
+    quality = assess_field_architecture_portfolio_quality(
+        action_queue,
+        blocking_source_gaps,
+        informational_source_gaps,
+    )
+    if dry_run:
+        return FieldArchitecturePortfolioBuildResult(
+            row_count=len(action_queue),
+            blocking_source_gaps=blocking_source_gaps,
+            informational_source_gaps=informational_source_gaps,
+            dry_run=True,
+            manifest=None,
+        )
+    if action_queue.empty:
+        raise ValueError(
+            "Cannot publish field-architecture portfolio: no_portfolio_rows"
+        )
+    manifest = write_field_architecture_portfolio_outputs(
+        action_queue=action_queue,
+        class_summary=class_summary,
+        followup_summary=followup_summary,
+        quality=quality,
+        output_root=target_root,
+        input_paths=inputs.input_paths,
+        dossier_input_paths=inputs.dossier_input_paths,
+        upstream_manifests=inputs.upstream_manifest_paths,
+        allow_non_ace_root=allow_non_ace_output,
+        command=_command(source_root, target_root, require_sources),
+    )
+    return FieldArchitecturePortfolioBuildResult(
+        row_count=len(action_queue),
+        blocking_source_gaps=blocking_source_gaps,
+        informational_source_gaps=informational_source_gaps,
+        dry_run=False,
+        manifest=manifest,
+    )
+
+
+def _command(root: Path, output_root: Path, require_sources: bool) -> str:
+    parts = [
+        "worldenergydata",
+        "texas-rrc",
+        "build-field-architecture-portfolio",
+        "--root",
+        str(root),
+        "--output-root",
+        str(output_root),
+    ]
+    if require_sources:
+        parts.append("--require-sources")
+    return " ".join(parts)
+
+
+def _rank_source_gaps(dossier_index: object) -> tuple[str, ...]:
+    if not isinstance(dossier_index, pd.DataFrame):
+        return ()
+    if dossier_index.empty or "opportunity_rank" not in dossier_index:
+        return ()
+    values = dossier_index["opportunity_rank"]
+    invalid = pd.to_numeric(values, errors="coerce").isna() & values.notna()
+    try:
+        invalid &= values.astype(str).str.strip().ne("")
+    except (TypeError, ValueError):
+        pass
+    return ("invalid_opportunity_rank",) if bool(invalid.any()) else ()
+
+
+def _dedupe(values: tuple[str, ...]) -> tuple[str, ...]:
+    seen = set()
+    result = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return tuple(result)
+
+
+__all__ = [
+    "FieldArchitecturePortfolioBuildResult",
+    "run_build_field_architecture_portfolio",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/architecture_portfolio/html.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/architecture_portfolio/html.py
@@ -1,0 +1,142 @@
+"""Render self-contained Texas RRC field-architecture portfolio HTML."""
+
+from __future__ import annotations
+
+from html import escape
+from urllib.parse import urlparse
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.architecture_portfolio.quality import (
+    FieldArchitecturePortfolioQuality,
+)
+
+
+def render_field_architecture_portfolio_html(
+    action_queue: pd.DataFrame,
+    class_summary: pd.DataFrame,
+    followup_summary: pd.DataFrame,
+    quality: FieldArchitecturePortfolioQuality,
+) -> str:
+    """Render the portfolio packet as one self-contained HTML document."""
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Texas RRC Field Architecture Portfolio</title>
+<style>
+body {{ font-family: Arial, sans-serif; margin: 2rem; color: #202124; }}
+table {{ border-collapse: collapse; width: 100%; margin: 1rem 0 2rem; }}
+th, td {{ border: 1px solid #d0d7de; padding: 0.4rem; text-align: left; }}
+th {{ background: #f6f8fa; }}
+.muted {{ color: #57606a; }}
+</style>
+</head>
+<body>
+<h1>Texas RRC Field Architecture Portfolio</h1>
+<p>Screening-only portfolio summary; no reserves, economics, tariffs, capacity,
+right-of-way, route, or engineered facility design conclusions.</p>
+<h2>Source Health</h2>
+{_source_health(quality)}
+<h2>Architecture Class Distribution</h2>
+{_table(class_summary)}
+<h2>Portfolio Action Queue</h2>
+{_action_queue_table(action_queue)}
+<h2>Follow-up Summary</h2>
+{_table(followup_summary)}
+<h2>Limitations</h2>
+{_limitations(action_queue)}
+</body>
+</html>
+"""
+
+
+def _source_health(quality: FieldArchitecturePortfolioQuality) -> str:
+    blocking = _tags(quality.blocking_source_gaps)
+    informational = _tags(quality.informational_source_gaps)
+    none = '<span class="muted">None</span>'
+    return (
+        f"<p><strong>Rows:</strong> {quality.row_count}</p>"
+        f"<p><strong>Blocking gaps:</strong> {blocking or none}</p>"
+        f"<p><strong>Informational gaps:</strong> {informational or none}</p>"
+    )
+
+
+def _action_queue_table(frame: pd.DataFrame) -> str:
+    columns = [
+        "portfolio_rank",
+        "field_name",
+        "architecture_signal_class",
+        "portfolio_action",
+        "followup_priority",
+        "opportunity_score",
+        "recommended_followup",
+        "source_dossier_href",
+        "dossier_path",
+        "source_caveats",
+        "quality_flags",
+    ]
+    rows = []
+    for _, row in frame.iterrows():
+        cells = []
+        for column in columns:
+            if column == "source_dossier_href":
+                cells.append(f"<td>{_dossier_link(row)}</td>")
+            else:
+                cells.append(f"<td>{escape(str(row.get(column, '')))}</td>")
+        rows.append("<tr>" + "".join(cells) + "</tr>")
+    return _table_shell(columns, rows)
+
+
+def _dossier_link(row: pd.Series) -> str:
+    href = str(row.get("source_dossier_href") or "")
+    path = str(row.get("dossier_path") or "")
+    if not href or not _safe_href(href):
+        return escape(path)
+    return f'<a href="{escape(href, quote=True)}">{escape(path)}</a>'
+
+
+def _safe_href(href: str) -> bool:
+    parsed = urlparse(href)
+    return not parsed.scheme and not href.startswith("/") and "\x00" not in href
+
+
+def _table(frame: pd.DataFrame) -> str:
+    columns = [str(column) for column in frame.columns]
+    rows = []
+    for _, row in frame.iterrows():
+        rows.append(
+            "<tr>"
+            + "".join(
+                f"<td>{escape(str(row.get(column, '')))}</td>" for column in columns
+            )
+            + "</tr>"
+        )
+    return _table_shell(columns, rows)
+
+
+def _table_shell(columns: list[str], rows: list[str]) -> str:
+    header = "".join(f"<th>{escape(column)}</th>" for column in columns)
+    body = (
+        "\n".join(rows)
+        or f'<tr><td colspan="{len(columns)}" class="muted">None</td></tr>'
+    )
+    return f"<table><thead><tr>{header}</tr></thead><tbody>{body}</tbody></table>"
+
+
+def _limitations(action_queue: pd.DataFrame) -> str:
+    values = []
+    if "portfolio_limitations" in action_queue:
+        for value in action_queue["portfolio_limitations"]:
+            values.extend(
+                part.strip() for part in str(value).split(";") if part.strip()
+            )
+    tags = _tags(tuple(dict.fromkeys(values)))
+    return tags or '<p class="muted">None</p>'
+
+
+def _tags(values: tuple[str, ...]) -> str:
+    return " ".join(f"<span>{escape(value)}</span>" for value in values)
+
+
+__all__ = ["render_field_architecture_portfolio_html"]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/architecture_portfolio/io.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/architecture_portfolio/io.py
@@ -1,0 +1,308 @@
+"""Persist Texas RRC field-architecture portfolio outputs."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.architecture_portfolio.html import (
+    render_field_architecture_portfolio_html,
+)
+from worldenergydata.texas_rrc.architecture_portfolio.models import (
+    ACTION_SPECS,
+    PORTFOLIO_LIMITATIONS,
+)
+from worldenergydata.texas_rrc.architecture_portfolio.quality import (
+    FieldArchitecturePortfolioQuality,
+)
+from worldenergydata.texas_rrc.source_catalog import SOURCE_CATALOG_ROOT
+
+FIELD_ARCHITECTURE_PORTFOLIO_DIR = (
+    Path("curated") / "analysis" / "field_architecture_portfolio"
+)
+ACTION_QUEUE_CSV_FILENAME = "field_architecture_action_queue.csv"
+ACTION_QUEUE_PARQUET_FILENAME = "field_architecture_action_queue.parquet"
+CLASS_SUMMARY_CSV_FILENAME = "field_architecture_class_summary.csv"
+CLASS_SUMMARY_PARQUET_FILENAME = "field_architecture_class_summary.parquet"
+FOLLOWUP_SUMMARY_CSV_FILENAME = "field_architecture_followup_summary.csv"
+FOLLOWUP_SUMMARY_PARQUET_FILENAME = "field_architecture_followup_summary.parquet"
+HTML_FILENAME = "field_architecture_portfolio.html"
+QUALITY_FILENAME = "quality.json"
+COMPONENT_QUALITY_FILENAME = "field_architecture_portfolio_quality.json"
+MANIFEST_FILENAME = "manifest.json"
+
+
+@dataclass(frozen=True)
+class FieldArchitecturePortfolioOutputManifest:
+    """Paths and metadata for one field-architecture portfolio output batch."""
+
+    generated_at: str
+    output_root: Path
+    output_dir: Path
+    action_queue_csv_path: Path
+    action_queue_parquet_path: Path
+    class_summary_csv_path: Path
+    class_summary_parquet_path: Path
+    followup_summary_csv_path: Path
+    followup_summary_parquet_path: Path
+    html_path: Path
+    quality_path: Path
+    component_quality_path: Path
+    manifest_path: Path
+    row_count: int
+    class_summary_row_count: int
+    followup_summary_row_count: int
+    input_paths: tuple[str, ...]
+    dossier_input_paths: tuple[str, ...]
+    upstream_manifests: tuple[str, ...]
+    blocking_source_gaps: tuple[str, ...]
+    informational_source_gaps: tuple[str, ...]
+    limitations: tuple[str, ...]
+    action_specs: dict[str, dict[str, object]]
+    command: str | None
+    code_revision: str | None
+
+
+def write_field_architecture_portfolio_outputs(
+    action_queue: pd.DataFrame,
+    class_summary: pd.DataFrame,
+    followup_summary: pd.DataFrame,
+    quality: FieldArchitecturePortfolioQuality,
+    output_root: Path | str = SOURCE_CATALOG_ROOT,
+    generated_at: datetime | None = None,
+    input_paths: Iterable[str | Path] = (),
+    dossier_input_paths: Iterable[str | Path] = (),
+    upstream_manifests: Iterable[str | Path] = (),
+    allow_non_ace_root: bool = False,
+    command: str | None = None,
+    code_revision: str | None = None,
+) -> FieldArchitecturePortfolioOutputManifest:
+    """Write action queue, rollups, HTML, quality aliases, and manifest JSON."""
+    root = Path(output_root)
+    _validate_output_root(root, allow_non_ace_root)
+    target_dir = root / FIELD_ARCHITECTURE_PORTFOLIO_DIR
+    stamp = _timestamp(generated_at)
+    limitations = _limitations(action_queue)
+    manifest = _manifest(
+        root,
+        target_dir,
+        action_queue,
+        class_summary,
+        followup_summary,
+        quality,
+        input_paths,
+        dossier_input_paths,
+        upstream_manifests,
+        limitations,
+        command,
+        code_revision,
+        stamp,
+    )
+    _write_with_staging(
+        target_dir,
+        action_queue,
+        class_summary,
+        followup_summary,
+        quality,
+        manifest,
+        stamp,
+    )
+    return manifest
+
+
+def _manifest(
+    root: Path,
+    target_dir: Path,
+    action_queue: pd.DataFrame,
+    class_summary: pd.DataFrame,
+    followup_summary: pd.DataFrame,
+    quality: FieldArchitecturePortfolioQuality,
+    input_paths: Iterable[str | Path],
+    dossier_input_paths: Iterable[str | Path],
+    upstream_manifests: Iterable[str | Path],
+    limitations: tuple[str, ...],
+    command: str | None,
+    code_revision: str | None,
+    stamp: str,
+) -> FieldArchitecturePortfolioOutputManifest:
+    return FieldArchitecturePortfolioOutputManifest(
+        generated_at=stamp,
+        output_root=root,
+        output_dir=target_dir,
+        action_queue_csv_path=target_dir / ACTION_QUEUE_CSV_FILENAME,
+        action_queue_parquet_path=target_dir / ACTION_QUEUE_PARQUET_FILENAME,
+        class_summary_csv_path=target_dir / CLASS_SUMMARY_CSV_FILENAME,
+        class_summary_parquet_path=target_dir / CLASS_SUMMARY_PARQUET_FILENAME,
+        followup_summary_csv_path=target_dir / FOLLOWUP_SUMMARY_CSV_FILENAME,
+        followup_summary_parquet_path=target_dir / FOLLOWUP_SUMMARY_PARQUET_FILENAME,
+        html_path=target_dir / HTML_FILENAME,
+        quality_path=target_dir / QUALITY_FILENAME,
+        component_quality_path=target_dir / COMPONENT_QUALITY_FILENAME,
+        manifest_path=target_dir / MANIFEST_FILENAME,
+        row_count=len(action_queue),
+        class_summary_row_count=len(class_summary),
+        followup_summary_row_count=len(followup_summary),
+        input_paths=tuple(str(path) for path in input_paths),
+        dossier_input_paths=tuple(str(path) for path in dossier_input_paths),
+        upstream_manifests=tuple(str(path) for path in upstream_manifests),
+        blocking_source_gaps=tuple(quality.blocking_source_gaps),
+        informational_source_gaps=tuple(quality.informational_source_gaps),
+        limitations=limitations,
+        action_specs=_action_specs_payload(),
+        command=command,
+        code_revision=code_revision or _git_revision(),
+    )
+
+
+def _write_with_staging(
+    target_dir: Path,
+    action_queue: pd.DataFrame,
+    class_summary: pd.DataFrame,
+    followup_summary: pd.DataFrame,
+    quality: FieldArchitecturePortfolioQuality,
+    manifest: FieldArchitecturePortfolioOutputManifest,
+    stamp: str,
+) -> None:
+    staging = target_dir.parent / f".staging-field-portfolio-{_compact_stamp(stamp)}"
+    backup = target_dir.parent / f".backup-field-portfolio-{_compact_stamp(stamp)}"
+    shutil.rmtree(staging, ignore_errors=True)
+    shutil.rmtree(backup, ignore_errors=True)
+    promoted = False
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+        action_queue.to_csv(staging / ACTION_QUEUE_CSV_FILENAME, index=False)
+        action_queue.to_parquet(staging / ACTION_QUEUE_PARQUET_FILENAME, index=False)
+        class_summary.to_csv(staging / CLASS_SUMMARY_CSV_FILENAME, index=False)
+        class_summary.to_parquet(staging / CLASS_SUMMARY_PARQUET_FILENAME, index=False)
+        followup_summary.to_csv(staging / FOLLOWUP_SUMMARY_CSV_FILENAME, index=False)
+        followup_summary.to_parquet(
+            staging / FOLLOWUP_SUMMARY_PARQUET_FILENAME, index=False
+        )
+        (staging / HTML_FILENAME).write_text(
+            render_field_architecture_portfolio_html(
+                action_queue,
+                class_summary,
+                followup_summary,
+                quality,
+            ),
+            encoding="utf-8",
+        )
+        quality_payload = asdict(quality)
+        _write_json(staging / QUALITY_FILENAME, quality_payload)
+        _write_json(staging / COMPONENT_QUALITY_FILENAME, quality_payload)
+        _write_json(staging / MANIFEST_FILENAME, _manifest_payload(manifest, quality))
+        target_dir.parent.mkdir(parents=True, exist_ok=True)
+        if target_dir.exists():
+            target_dir.rename(backup)
+        staging.rename(target_dir)
+        promoted = True
+        shutil.rmtree(backup, ignore_errors=True)
+    except Exception:
+        if backup.exists() and not target_dir.exists():
+            backup.rename(target_dir)
+        raise
+    finally:
+        if not promoted:
+            shutil.rmtree(staging, ignore_errors=True)
+        shutil.rmtree(backup, ignore_errors=True)
+
+
+def _manifest_payload(
+    manifest: FieldArchitecturePortfolioOutputManifest,
+    quality: FieldArchitecturePortfolioQuality,
+) -> dict[str, object]:
+    payload = asdict(manifest)
+    for key, value in list(payload.items()):
+        if isinstance(value, Path):
+            payload[key] = str(value)
+    payload["input_paths"] = list(manifest.input_paths)
+    payload["dossier_input_paths"] = list(manifest.dossier_input_paths)
+    payload["upstream_manifests"] = list(manifest.upstream_manifests)
+    payload["blocking_source_gaps"] = list(manifest.blocking_source_gaps)
+    payload["informational_source_gaps"] = list(manifest.informational_source_gaps)
+    payload["limitations"] = list(manifest.limitations)
+    payload["quality"] = asdict(quality)
+    return payload
+
+
+def _action_specs_payload() -> dict[str, dict[str, object]]:
+    return {
+        architecture_class: asdict(spec)
+        for architecture_class, spec in ACTION_SPECS.items()
+    }
+
+
+def _limitations(action_queue: pd.DataFrame) -> tuple[str, ...]:
+    values: list[str] = []
+    if "portfolio_limitations" in action_queue:
+        for value in action_queue["portfolio_limitations"]:
+            values.extend(
+                part.strip() for part in str(value).split(";") if part.strip()
+            )
+    return tuple(dict.fromkeys(values)) or PORTFOLIO_LIMITATIONS
+
+
+def _validate_output_root(root: Path, allow_non_ace_root: bool) -> None:
+    if allow_non_ace_root:
+        return
+    if not root.resolve().is_relative_to(SOURCE_CATALOG_ROOT.resolve()):
+        raise ValueError(
+            "field-architecture portfolio output_root must stay under "
+            f"{SOURCE_CATALOG_ROOT}; pass allow_non_ace_root=True only for tests"
+        )
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _timestamp(value: datetime | None) -> str:
+    timestamp = value or datetime.now(timezone.utc)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _compact_stamp(stamp: str) -> str:
+    return stamp.replace("-", "").replace(":", "")
+
+
+def _git_revision() -> str | None:
+    repo_root = _repo_root()
+    try:
+        revision = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return None
+    return revision or None
+
+
+def _repo_root() -> Path:
+    path = Path(__file__).resolve()
+    for parent in path.parents:
+        if (parent / ".git").exists():
+            return parent
+    return path.parents[6]
+
+
+__all__ = [
+    "FIELD_ARCHITECTURE_PORTFOLIO_DIR",
+    "FieldArchitecturePortfolioOutputManifest",
+    "write_field_architecture_portfolio_outputs",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/architecture_portfolio/models.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/architecture_portfolio/models.py
@@ -1,0 +1,345 @@
+"""Portfolio action queue and rollup models for Texas RRC dossiers."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pandas as pd
+
+PORTFOLIO_LIMITATIONS = (
+    "screening-only portfolio summary",
+    "no reserves conclusions",
+    "no economics, tariff, pipeline capacity, right-of-way, route, or facility-design conclusions",
+)
+
+
+@dataclass(frozen=True)
+class PortfolioActionSpec:
+    """Screening action vocabulary for one architecture signal class."""
+
+    portfolio_action: str
+    priority_sort: int
+    followup_priority: str
+    development_theme: str
+
+
+ACTION_SPECS: dict[str, PortfolioActionSpec] = {
+    "low_data_confidence": PortfolioActionSpec(
+        portfolio_action="data_completion_review",
+        priority_sort=10,
+        followup_priority="source_data_first",
+        development_theme="Source/data completion before architecture interpretation",
+    ),
+    "infrastructure_constrained_activity": PortfolioActionSpec(
+        portfolio_action="infrastructure_constraint_screen",
+        priority_sort=20,
+        followup_priority="high",
+        development_theme="Infrastructure constraint and route/market-access evidence review",
+    ),
+    "high_access_infill_redevelopment": PortfolioActionSpec(
+        portfolio_action="infill_redevelopment_screen",
+        priority_sort=30,
+        followup_priority="high",
+        development_theme="Infill, recompletion, redevelopment candidate review",
+    ),
+    "emerging_growth": PortfolioActionSpec(
+        portfolio_action="growth_appraisal_screen",
+        priority_sort=40,
+        followup_priority="medium",
+        development_theme="Growth-field activity and infrastructure follow-up",
+    ),
+    "mature_harvest": PortfolioActionSpec(
+        portfolio_action="mature_harvest_review",
+        priority_sort=50,
+        followup_priority="medium",
+        development_theme="Late-life harvest, recompletion, abandonment, or surveillance review",
+    ),
+    "monitor_only": PortfolioActionSpec(
+        portfolio_action="monitor_only",
+        priority_sort=90,
+        followup_priority="low",
+        development_theme="Watchlist monitoring without active development recommendation",
+    ),
+}
+
+ACTION_QUEUE_COLUMNS = [
+    "portfolio_rank",
+    "district",
+    "field_number",
+    "field_name",
+    "field_slug",
+    "architecture_signal_class",
+    "portfolio_action",
+    "followup_priority",
+    "development_theme",
+    "review_sequence",
+    "opportunity_rank",
+    "opportunity_score",
+    "recommended_followup",
+    "dossier_focus",
+    "dossier_path",
+    "source_dossier_href",
+    "source_field_atlas_report_path",
+    "production_maturity_class",
+    "remaining_activity_score",
+    "active_well_count",
+    "well_count",
+    "permit_count",
+    "completion_count",
+    "cumulative_boe",
+    "production_per_well_boe",
+    "infrastructure_access_class",
+    "infrastructure_access_score",
+    "nearest_pipeline_distance_miles",
+    "top_operator_name",
+    "top_operator_share",
+    "source_caveats",
+    "quality_flags",
+    "portfolio_limitations",
+]
+
+
+def build_field_architecture_action_queue(
+    dossier_index: pd.DataFrame,
+    input_dossier_dir: Path | str | None = None,
+    output_root: Path | str | None = None,
+) -> pd.DataFrame:
+    """Build a deterministic screening action queue from the #702 dossier index."""
+    queue = dossier_index.copy()
+    for column in ACTION_QUEUE_COLUMNS:
+        if column not in queue:
+            queue[column] = ""
+
+    specs = queue["architecture_signal_class"].astype(str).map(_action_spec)
+    queue["_priority_sort"] = [spec.priority_sort for spec in specs]
+    queue["portfolio_action"] = [spec.portfolio_action for spec in specs]
+    queue["followup_priority"] = [spec.followup_priority for spec in specs]
+    queue["development_theme"] = [spec.development_theme for spec in specs]
+    queue["source_caveats"] = [
+        _with_unknown_caveat(caveats, architecture_class)
+        for caveats, architecture_class in zip(
+            queue["source_caveats"],
+            queue["architecture_signal_class"],
+        )
+    ]
+    if input_dossier_dir is not None and output_root is not None:
+        source_links = [
+            _source_dossier_href(dossier_path, input_dossier_dir, output_root)
+            for dossier_path in queue["dossier_path"]
+        ]
+        queue["source_dossier_href"] = [source_link[0] for source_link in source_links]
+        queue["source_caveats"] = [
+            _append_caveat(caveats, source_link[1])
+            for caveats, source_link in zip(queue["source_caveats"], source_links)
+        ]
+    queue["portfolio_limitations"] = "; ".join(PORTFOLIO_LIMITATIONS)
+    queue["_opportunity_rank_sort"] = pd.to_numeric(
+        queue["opportunity_rank"],
+        errors="coerce",
+    ).fillna(float("inf"))
+
+    queue = queue.sort_values(
+        [
+            "_priority_sort",
+            "_opportunity_rank_sort",
+            "district",
+            "field_number",
+            "field_name",
+        ],
+        kind="mergesort",
+    ).reset_index(drop=True)
+    queue["portfolio_rank"] = range(1, len(queue) + 1)
+    queue["review_sequence"] = (
+        queue.groupby("portfolio_action", sort=False).cumcount() + 1
+    )
+    return queue[ACTION_QUEUE_COLUMNS]
+
+
+def summarize_architecture_classes(action_queue: pd.DataFrame) -> pd.DataFrame:
+    """Summarize action-queue metrics by architecture signal class."""
+    rows = []
+    for architecture_class, group in action_queue.groupby(
+        "architecture_signal_class",
+        sort=False,
+    ):
+        scores = _numeric(group, "opportunity_score")
+        rows.append(
+            {
+                "architecture_signal_class": architecture_class,
+                "field_count": int(len(group)),
+                "portfolio_action": _first(group, "portfolio_action"),
+                "development_theme": _first(group, "development_theme"),
+                "mean_opportunity_score": (
+                    float(scores.mean()) if not scores.empty else 0.0
+                ),
+                "median_opportunity_score": (
+                    float(scores.median()) if not scores.empty else 0.0
+                ),
+                "total_cumulative_boe": _numeric(group, "cumulative_boe").sum(),
+                "total_active_well_count": int(
+                    _numeric(group, "active_well_count").sum()
+                ),
+                "total_permit_count": int(_numeric(group, "permit_count").sum()),
+                "total_completion_count": int(
+                    _numeric(group, "completion_count").sum()
+                ),
+                "direct_or_near_access_count": int(
+                    group.get("infrastructure_access_class", pd.Series(dtype="string"))
+                    .astype(str)
+                    .isin({"direct_access", "near_access"})
+                    .sum()
+                ),
+                "top_caveats": _top_tokens(group, "source_caveats"),
+                "top_quality_flags": _top_tokens(group, "quality_flags"),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def summarize_followup_recommendations(action_queue: pd.DataFrame) -> pd.DataFrame:
+    """Summarize portfolio routing counts by follow-up recommendation."""
+    rows = []
+    group_columns = ["recommended_followup", "portfolio_action", "development_theme"]
+    for keys, group in action_queue.groupby(group_columns, sort=False, dropna=False):
+        scores = _numeric(group, "opportunity_score")
+        rows.append(
+            {
+                "recommended_followup": keys[0],
+                "portfolio_action": keys[1],
+                "development_theme": keys[2],
+                "field_count": int(len(group)),
+                "min_opportunity_score": (
+                    float(scores.min()) if not scores.empty else 0.0
+                ),
+                "max_opportunity_score": (
+                    float(scores.max()) if not scores.empty else 0.0
+                ),
+                "mean_opportunity_score": (
+                    float(scores.mean()) if not scores.empty else 0.0
+                ),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _action_spec(value: object) -> PortfolioActionSpec:
+    return ACTION_SPECS.get(str(value), ACTION_SPECS["low_data_confidence"])
+
+
+def _with_unknown_caveat(caveats: object, architecture_class: object) -> str:
+    tokens = _tokens(caveats)
+    if str(architecture_class) not in ACTION_SPECS:
+        tokens.append("unknown_architecture_signal_class")
+    return "; ".join(_dedupe(tokens))
+
+
+def _append_caveat(caveats: object, caveat: str) -> str:
+    tokens = _tokens(caveats)
+    if caveat:
+        tokens.append(caveat)
+    return "; ".join(_dedupe(tokens))
+
+
+def _source_dossier_href(
+    dossier_path: object,
+    input_dossier_dir: Path | str,
+    output_root: Path | str,
+) -> tuple[str, str]:
+    caveat = "source_dossier_link_not_relative_to_output_root"
+    raw_path = _text(dossier_path)
+    if not raw_path or "\x00" in raw_path or urlparse(raw_path).scheme:
+        return "", caveat
+
+    input_dir = Path(input_dossier_dir).resolve(strict=False)
+    output_analysis_dir = (Path(output_root) / "curated" / "analysis").resolve(
+        strict=False
+    )
+    portfolio_dir = output_analysis_dir / "field_architecture_portfolio"
+    allowed_dir = (input_dir / "fields").resolve(strict=False)
+    if input_dir.parent.resolve(strict=False) != output_analysis_dir:
+        return "", caveat
+
+    candidate = Path(raw_path)
+    if not candidate.is_absolute():
+        candidate = input_dir / candidate
+    resolved_candidate = candidate.resolve(strict=False)
+    if resolved_candidate.suffix.lower() != ".html":
+        return "", caveat
+    if not resolved_candidate.is_relative_to(allowed_dir):
+        return "", caveat
+
+    href = os.path.relpath(
+        resolved_candidate,
+        portfolio_dir.resolve(strict=False),
+    ).replace(os.sep, "/")
+    if not href or "\x00" in href or href.startswith("/") or urlparse(href).scheme:
+        return "", caveat
+    resolved_href = (portfolio_dir / href).resolve(strict=False)
+    if resolved_href != resolved_candidate:
+        return "", caveat
+    return href, ""
+
+
+def _tokens(value: object) -> list[str]:
+    try:
+        if pd.isna(value):
+            return []
+    except (TypeError, ValueError):
+        pass
+    return [part.strip() for part in str(value).split(";") if part.strip()]
+
+
+def _text(value: object) -> str:
+    try:
+        if pd.isna(value):
+            return ""
+    except (TypeError, ValueError):
+        pass
+    return str(value).strip()
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen = set()
+    result = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _first(frame: pd.DataFrame, column: str) -> str:
+    if column not in frame or frame.empty:
+        return ""
+    value = frame[column].iloc[0]
+    return "" if pd.isna(value) else str(value)
+
+
+def _numeric(frame: pd.DataFrame, column: str) -> pd.Series:
+    if column not in frame:
+        return pd.Series(dtype="float64")
+    return pd.to_numeric(frame[column], errors="coerce").dropna()
+
+
+def _top_tokens(frame: pd.DataFrame, column: str, limit: int = 5) -> str:
+    if column not in frame:
+        return ""
+    counts: dict[str, int] = {}
+    for value in frame[column]:
+        for token in _tokens(value):
+            counts[token] = counts.get(token, 0) + 1
+    tokens = sorted(counts, key=lambda token: (-counts[token], token))[:limit]
+    return "; ".join(tokens)
+
+
+__all__ = [
+    "ACTION_SPECS",
+    "PORTFOLIO_LIMITATIONS",
+    "build_field_architecture_action_queue",
+    "summarize_architecture_classes",
+    "summarize_followup_recommendations",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/architecture_portfolio/quality.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/architecture_portfolio/quality.py
@@ -1,0 +1,82 @@
+"""Quality summaries for Texas RRC field-architecture portfolio outputs."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class FieldArchitecturePortfolioQuality:
+    """Quality metadata for one portfolio output batch."""
+
+    row_count: int
+    blocking_source_gaps: tuple[str, ...]
+    informational_source_gaps: tuple[str, ...]
+    portfolio_action_counts: dict[str, int]
+    development_theme_counts: dict[str, int]
+    caveat_counts: dict[str, int]
+    quality_flag_counts: dict[str, int]
+    limitation_count: int
+
+
+def assess_field_architecture_portfolio_quality(
+    action_queue: pd.DataFrame,
+    blocking_source_gaps: tuple[str, ...] = (),
+    informational_source_gaps: tuple[str, ...] = (),
+) -> FieldArchitecturePortfolioQuality:
+    """Assess action, theme, caveat, flag, and inherited source-gap counts."""
+    return FieldArchitecturePortfolioQuality(
+        row_count=len(action_queue),
+        blocking_source_gaps=tuple(blocking_source_gaps),
+        informational_source_gaps=tuple(informational_source_gaps),
+        portfolio_action_counts=_value_counts(action_queue, "portfolio_action"),
+        development_theme_counts=_value_counts(action_queue, "development_theme"),
+        caveat_counts=_token_counts(action_queue, "source_caveats"),
+        quality_flag_counts=_token_counts(action_queue, "quality_flags"),
+        limitation_count=len(
+            {
+                token
+                for value in action_queue.get("portfolio_limitations", [])
+                for token in _tokens(value, delimiter_pattern=r"[;]")
+            }
+        ),
+    )
+
+
+def _value_counts(frame: pd.DataFrame, column: str) -> dict[str, int]:
+    if column not in frame:
+        return {}
+    counts = frame[column].dropna().astype(str).value_counts(sort=False)
+    return {key: int(value) for key, value in counts.items()}
+
+
+def _token_counts(frame: pd.DataFrame, column: str) -> dict[str, int]:
+    if column not in frame:
+        return {}
+    counter: Counter[str] = Counter()
+    for value in frame[column]:
+        counter.update(_tokens(value))
+    return dict(counter)
+
+
+def _tokens(value: object, delimiter_pattern: str = r"[;|,]") -> list[str]:
+    if value is None:
+        return []
+    try:
+        if pd.isna(value):
+            return []
+    except (TypeError, ValueError):
+        pass
+    return [
+        part.strip() for part in re.split(delimiter_pattern, str(value)) if part.strip()
+    ]
+
+
+__all__ = [
+    "FieldArchitecturePortfolioQuality",
+    "assess_field_architecture_portfolio_quality",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/architecture_portfolio/sources.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/architecture_portfolio/sources.py
@@ -1,0 +1,221 @@
+"""Load #702 dossier outputs for Texas RRC portfolio publication."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.dossiers.io import (
+    FIELD_ARCHITECTURE_DOSSIER_DIR,
+    INDEX_CSV_FILENAME,
+    INDEX_PARQUET_FILENAME,
+    MANIFEST_FILENAME,
+    QUALITY_FILENAME,
+)
+
+
+@dataclass(frozen=True)
+class FieldArchitecturePortfolioInputs:
+    """Curated #702 dossier packet used to build the portfolio report."""
+
+    dossier_index: pd.DataFrame
+    input_dossier_dir: Path
+    index_path: Path | None
+    manifest_path: Path
+    quality_path: Path
+    dossier_manifest: dict[str, object]
+    dossier_quality: dict[str, object]
+    input_paths: tuple[Path, ...]
+    dossier_input_paths: tuple[Path, ...]
+    upstream_manifest_paths: tuple[Path, ...]
+    dossier_page_paths: tuple[Path, ...]
+    blocking_source_gaps: tuple[str, ...]
+    informational_source_gaps: tuple[str, ...]
+
+
+def load_field_architecture_portfolio_inputs(
+    root: Path | str,
+) -> FieldArchitecturePortfolioInputs:
+    """Load the direct #702 dossier packet from a Texas RRC module root."""
+    catalog_root = Path(root)
+    dossier_dir = catalog_root / FIELD_ARCHITECTURE_DOSSIER_DIR
+    blocking_gaps: list[str] = []
+    input_paths: list[Path] = []
+
+    index_path = _existing_index_path(dossier_dir)
+    dossier_index = _load_index(index_path, blocking_gaps, input_paths)
+
+    manifest_path = dossier_dir / MANIFEST_FILENAME
+    manifest = _load_json(
+        manifest_path,
+        "missing_field_architecture_dossier_manifest",
+        blocking_gaps,
+        input_paths,
+    )
+
+    quality_path = dossier_dir / QUALITY_FILENAME
+    quality = _load_json(
+        quality_path,
+        "missing_field_architecture_dossier_quality",
+        blocking_gaps,
+        input_paths,
+    )
+
+    return FieldArchitecturePortfolioInputs(
+        dossier_index=dossier_index,
+        input_dossier_dir=dossier_dir,
+        index_path=index_path,
+        manifest_path=manifest_path,
+        quality_path=quality_path,
+        dossier_manifest=manifest,
+        dossier_quality=quality,
+        input_paths=tuple(input_paths),
+        dossier_input_paths=_path_sequence(manifest.get("input_paths")),
+        upstream_manifest_paths=_upstream_manifest_paths(manifest),
+        dossier_page_paths=_dossier_page_paths(dossier_dir, dossier_index),
+        blocking_source_gaps=_dedupe(
+            [
+                *blocking_gaps,
+                *_gap_sequence(manifest, quality, "blocking_source_gaps"),
+            ]
+        ),
+        informational_source_gaps=_dedupe(
+            _gap_sequence(manifest, quality, "informational_source_gaps")
+        ),
+    )
+
+
+def _existing_index_path(dossier_dir: Path) -> Path | None:
+    parquet_path = dossier_dir / INDEX_PARQUET_FILENAME
+    if parquet_path.exists():
+        return parquet_path
+    csv_path = dossier_dir / INDEX_CSV_FILENAME
+    return csv_path if csv_path.exists() else None
+
+
+def _load_index(
+    path: Path | None,
+    blocking_gaps: list[str],
+    input_paths: list[Path],
+) -> pd.DataFrame:
+    if path is None:
+        blocking_gaps.append("missing_field_architecture_dossier_index")
+        return pd.DataFrame()
+    input_paths.append(path)
+    if path.suffix.lower() == ".parquet":
+        frame = pd.read_parquet(path)
+    else:
+        frame = pd.read_csv(
+            path, dtype={"district": "string", "field_number": "string"}
+        )
+    return _normalize_key_columns(frame)
+
+
+def _normalize_key_columns(frame: pd.DataFrame) -> pd.DataFrame:
+    for column in ("district", "field_number"):
+        if column in frame:
+            frame[column] = frame[column].astype("string")
+    return frame
+
+
+def _load_json(
+    path: Path,
+    missing_gap: str,
+    blocking_gaps: list[str],
+    input_paths: list[Path],
+) -> dict[str, object]:
+    if not path.exists():
+        blocking_gaps.append(missing_gap)
+        return {}
+    input_paths.append(path)
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        blocking_gaps.append(f"unreadable_{path.stem}")
+        return {}
+
+
+def _upstream_manifest_paths(manifest: dict[str, object]) -> tuple[Path, ...]:
+    paths = []
+    for values in (manifest.get("input_paths"), manifest.get("upstream_manifests")):
+        if not isinstance(values, list):
+            continue
+        paths.extend(
+            Path(str(value))
+            for value in values
+            if Path(str(value)).name == "manifest.json"
+        )
+    return _dedupe_paths(paths)
+
+
+def _path_sequence(value: object) -> tuple[Path, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(Path(str(item)) for item in value if str(item))
+
+
+def _dossier_page_paths(dossier_dir: Path, index: pd.DataFrame) -> tuple[Path, ...]:
+    if "dossier_path" not in index:
+        return tuple(sorted((dossier_dir / "fields").glob("*.html")))
+    paths = []
+    for value in index["dossier_path"]:
+        if pd.isna(value):
+            continue
+        path = Path(str(value))
+        candidate = path if path.is_absolute() else dossier_dir / path
+        if candidate.exists() and candidate.suffix.lower() == ".html":
+            paths.append(candidate)
+    return tuple(paths)
+
+
+def _gap_sequence(
+    manifest: dict[str, object],
+    quality: dict[str, object],
+    key: str,
+) -> list[str]:
+    values: list[str] = []
+    values.extend(_string_sequence(manifest.get(key)))
+    manifest_quality = manifest.get("quality")
+    if isinstance(manifest_quality, dict):
+        values.extend(_string_sequence(manifest_quality.get(key)))
+    values.extend(_string_sequence(quality.get(key)))
+    return values
+
+
+def _string_sequence(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item)]
+
+
+def _dedupe(values: Iterable[str]) -> tuple[str, ...]:
+    seen = set()
+    result = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return tuple(result)
+
+
+def _dedupe_paths(paths: Iterable[Path]) -> tuple[Path, ...]:
+    seen = set()
+    result = []
+    for path in paths:
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(path)
+    return tuple(result)
+
+
+__all__ = [
+    "FieldArchitecturePortfolioInputs",
+    "load_field_architecture_portfolio_inputs",
+]

--- a/scripts/review/results/2026-07-02-code-707-claude.md
+++ b/scripts/review/results/2026-07-02-code-707-claude.md
@@ -1,0 +1,38 @@
+Ignoring 19 permissions.allow entries from .claude/settings.json: this workspace has not been trusted. Run Claude Code interactively here once and accept the trust dialog, or set projects["/mnt/local-analysis/worldenergydata"].hasTrustDialogAccepted: true in /home/vamsee/.claude.json.
+All 12 targeted tests pass. I've completed a full adversarial pass over the 2,421-line bundle against the plan, focusing on the seven named risks plus a broader correctness/security sweep.
+
+## Verdict: **APPROVE** (with minor, non-blocking observations)
+
+I attempted to break each of the seven previously-found risks and could not. Each is now implemented and pinned by a test. Below are the findings — the first block is the risk-by-risk verification (what I tried to falsify), the second is the residual non-blocking nits.
+
+`★ Insight ─────────────────────────────────────`
+- The design's strongest property is **layered fail-closed link safety**: `models._source_dossier_href` does the full plan algorithm (same-analysis-root check → NUL/scheme reject → suffix+containment check → relpath → re-resolution equality check), and `html._safe_href` is a second, independent gate. Belt-and-suspenders on the one attack surface (path/URL injection into HTML).
+- The **comma-vs-semicolon delimiter split** is the subtle correctness win: caveat/flag token-counting splits on `[;|,]`, but `limitation_count` deliberately splits on `[;]` only (`quality.py:1303`) so the comma-bearing third limitation ("no economics, tariff, …") stays one token. That is exactly the "limitation semantics" bug class.
+- Provenance is **three-tier**: files actually opened (`input_paths`), the #702 manifest's own `input_paths` (`dossier_input_paths`), and the manifest.json-filtered subset (`upstream_manifests`) — all serialized into `manifest.json`.
+`─────────────────────────────────────────────────`
+
+## Risk-by-risk verification (all CLEARED)
+
+1. **Invalid `opportunity_rank` policy** — `cli_support.py:412-423` (`_rank_source_gaps`) coerces to numeric, flags only genuinely-non-numeric *non-null, non-empty* values as `invalid_opportunity_rank`, classifies it **informational (non-blocking)**, dedupes it into the gap list (`:343-345`), and `models.py:1047-1050` sorts invalid ranks to `+inf` rather than crashing. Missing ranks are *not* flagged invalid (`values.notna()` guard). Pinned by `test_..._reports_invalid_rank_as_informational` (diff 1683-1698): asserts `blocking == ()`, `invalid_opportunity_rank in informational`, `row_count == 1`. **Cleared.**
+
+2. **Full source provenance in manifest** — `cli_support.py:376-387` passes all three provenance tiers; `io.py:746-748` serializes them; `_manifest_payload` (`:819-821`) forces them to JSON lists. `sources.py:1489-1499` derives `upstream_manifests` by name-filtering `manifest.json` across both `input_paths` and `upstream_manifests` keys. Pinned by `test_loads_dossier_packet_and_gap_schema` (diff 2335-2344) and `..._io` `dossier_input_paths` assertion. **Cleared.**
+
+3. **`action_specs` in manifest** — `io.py:829-833` (`_action_specs_payload`) emits the full `ACTION_SPECS` vocabulary; stored at `:752`, serialized via `asdict`. Pinned by io test 2007-2018 (`priority_sort == 30`). **Cleared.**
+
+4. **`/mnt/ace` output guard test** — `io.py:846-853` (`_validate_output_root`) uses `is_relative_to(SOURCE_CATALOG_ROOT.resolve())`; I confirmed `SOURCE_CATALOG_ROOT = /mnt/ace/worldenergydata/data/modules/texas_rrc` (the module root, not a broad parent). Pinned by `test_rejects_non_ace_output_root_without_override` (diff 2022-2039). **Cleared.**
+
+5. **Unsafe HTML links** — dual gate (item above). `html._safe_href` (`:545-547`) rejects scheme, leading `/` (also kills protocol-relative `//host`), and NUL; hrefs escaped with `quote=True` (no attribute breakout → no XSS). Pinned by the html test asserting the `https://…` row renders as escaped text and `http(s)://` never appear in output (diff 1885-1891). **Cleared.**
+
+6. **Empty-queue handling** — `cli_support.py:372-375` raises `ValueError: no_portfolio_rows` before writing, and only on the publish path (dry-run returns first at `:364-371`, matching plan pseudocode). Empty/missing index instead surfaces as a blocking gap and raises earlier on non-dry-run. Build-queue is crash-safe on an empty frame (`range(1,1)`, empty `specs`). **Cleared.**
+
+7. **Limitation semantics** — delimiter fix described in insight above; `io._limitations` / `html._limitations` split on `;` only and dedupe to the 3-token tuple, falling back to `PORTFOLIO_LIMITATIONS`. Pinned by quality test `limitation_count == 2` on a 2-token input (diff 2290). **Cleared.**
+
+## Residual non-blocking observations (do not block closeout)
+
+1. **`html._safe_href` is a strictly weaker gate than the model algorithm** (`html.py:545-547`). It does *not* re-verify containment under the allowed `fields/` dir, so a hand-crafted `source_dossier_href` like `../../../secret.html` (relative, no scheme, no NUL) would render as a link. Not reachable in the production pipeline (the column is only ever populated by the validated `models._source_dossier_href`, and the value is HTML-escaped so there is no XSS), but if `render_field_architecture_portfolio_html` is ever fed an externally-authored action_queue, the second gate won't catch traversal. Severity: low / defense-in-depth only.
+
+2. **Links are emitted without an existence check** (`models.py:1176-1191`). The plan's algorithm (steps 4–9) does not require the target file to exist, so this conforms to spec, but a stale `dossier_path` pointing at a since-deleted `fields/*.html` will still produce a live-looking `<a href>` to a broken target. Cosmetic.
+
+3. **Error-string drift from the plan** — code raises `no_portfolio_rows` (`cli_support.py:374`) where the plan pseudocode names it `no_portfolio_candidates`. Purely a label; no behavioral impact.
+
+None of these three warrants blocking the merge. The seven targeted risks are fixed, tested, and the targeted suite is green (12 passed).

--- a/scripts/review/results/2026-07-02-code-707-codex.md
+++ b/scripts/review/results/2026-07-02-code-707-codex.md
@@ -1,0 +1,22 @@
+APPROVE for [#707](https://github.com/vamseeachanta/worldenergydata/issues/707).
+
+Findings:
+- None blocking after the Claude MINOR review fixes were applied.
+
+Defect checks performed:
+- `packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/architecture_portfolio/cli_support.py:50` now keeps upstream missing sources as blocking while routing malformed `opportunity_rank` into informational gaps at lines 51-52. This matches the model-layer tolerance and avoids aborting a full portfolio for one nonnumeric rank.
+- `packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/architecture_portfolio/sources.py:77` captures the #702 dossier manifest `input_paths`, while line 78 captures deduped upstream manifests from both `input_paths` and explicit `upstream_manifests`.
+- `packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/architecture_portfolio/io.py:63` and line 68 persist `dossier_input_paths` and serialized `action_specs` in the manifest. The writer still validates the output root before staging at lines 88-90.
+- `tests/unit/texas_rrc/test_field_architecture_portfolio_io.py:125` covers the non-ACE output-root rejection path.
+
+Evidence:
+- `PYTHONPATH="$(printf '%s:' packages/*/src)src" timeout 240 uv run --no-sync python -m pytest ...test_field_architecture_portfolio_*.py -q` -> `12 passed in 18.23s`
+- `PYTHONPATH="$(printf '%s:' packages/*/src)src" timeout 240 uv run --no-sync black --check --diff src/ tests/ packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/architecture_portfolio` -> `1230 files would be left unchanged`
+- `PYTHONPATH="$(printf '%s:' packages/*/src)src" timeout 240 uv run --no-sync isort --check-only --diff src/ tests/ packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/architecture_portfolio` -> exit 0
+- `PYTHONPATH="$(printf '%s:' packages/*/src)src" timeout 240 uv run --no-sync flake8 src/ --max-line-length=100 --extend-ignore=E203,W503 --exclude=__pycache__,*.egg-info,.git,.venv` -> exit 0
+- `PYTHONPATH="$(printf '%s:' packages/*/src)src" timeout 240 uv run --no-sync ruff check ...` -> `All checks passed!`
+- `scripts/legal/legal-sanity-scan.sh` -> `legal-sanity-scan: PASS`
+- `/mnt/ace` smoke via `run_build_field_architecture_portfolio(..., require_sources=True)` -> 37 rows, no blocking gaps, 5 upstream manifests, 8 dossier input paths, 6 action specs.
+
+Residual validation caveat:
+- `uv sync --all-packages --all-extras` resolved 357 packages but hung twice in uv `pip_compileall.py`; both attempts were terminated after several minutes. The exact targeted pytest and lint/legal gates ran successfully with `uv run --no-sync` against the existing venv.

--- a/scripts/review/results/2026-07-02-code-707-gemini-unavailable.md
+++ b/scripts/review/results/2026-07-02-code-707-gemini-unavailable.md
@@ -1,0 +1,5 @@
+UNAVAILABLE: Gemini code review for issue #707 could not run.
+
+Evidence: `gemini --skip-trust --approval-mode plan -p ...` failed with
+`IneligibleTierError: This client is no longer supported for Gemini Code Assist
+for individuals`.

--- a/scripts/review/results/2026-07-02-code-707-legal-sanity-scan.txt
+++ b/scripts/review/results/2026-07-02-code-707-legal-sanity-scan.txt
@@ -1,0 +1,1 @@
+legal-sanity-scan: PASS

--- a/src/worldenergydata/cli/commands/texas_rrc.py
+++ b/src/worldenergydata/cli/commands/texas_rrc.py
@@ -1126,6 +1126,48 @@ def _print_field_architecture_dossier_outputs(manifest) -> None:
     console.print(f"[dim]Manifest: {manifest.manifest_path}[/dim]")
 
 
+def _print_field_architecture_portfolio_summary(
+    row_count: int,
+    blocking_source_gaps,
+    informational_source_gaps,
+) -> None:
+    table = Table(
+        title="Texas RRC Field Architecture Portfolio",
+        show_header=True,
+        header_style="bold cyan",
+    )
+    table.add_column("Metric", style="dim")
+    table.add_column("Value")
+    table.add_row("Portfolio rows", str(row_count))
+    table.add_row(
+        "Blocking source gaps",
+        ", ".join(blocking_source_gaps) if blocking_source_gaps else "None",
+    )
+    table.add_row(
+        "Informational source gaps",
+        ", ".join(informational_source_gaps) if informational_source_gaps else "None",
+    )
+    console.print(table)
+
+
+def _print_field_architecture_portfolio_outputs(manifest) -> None:
+    console.print(
+        "[green]Wrote field-architecture portfolio[/green] "
+        f"{manifest.row_count} rows -> {manifest.output_dir}"
+    )
+    console.print(f"[dim]Action Queue CSV: {manifest.action_queue_csv_path}[/dim]")
+    console.print(
+        f"[dim]Action Queue Parquet: {manifest.action_queue_parquet_path}[/dim]"
+    )
+    console.print(f"[dim]Class Summary CSV: {manifest.class_summary_csv_path}[/dim]")
+    console.print(
+        f"[dim]Follow-up Summary CSV: {manifest.followup_summary_csv_path}[/dim]"
+    )
+    console.print(f"[dim]HTML report: {manifest.html_path}[/dim]")
+    console.print(f"[dim]Quality report: {manifest.quality_path}[/dim]")
+    console.print(f"[dim]Manifest: {manifest.manifest_path}[/dim]")
+
+
 @app.command("publish-field-atlas-reports")
 def publish_field_atlas_reports_command(
     root: Path = typer.Option(
@@ -1318,6 +1360,65 @@ def build_field_architecture_dossiers_command(
             )
             return
         _print_field_architecture_dossier_outputs(result.manifest)
+    except typer.Exit:
+        raise
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+
+
+@app.command("build-field-architecture-portfolio")
+def build_field_architecture_portfolio_command(
+    root: Path = typer.Option(
+        Path("/mnt/ace/worldenergydata/data/modules/texas_rrc"),
+        "--root",
+        help="Root containing curated Texas RRC field-architecture dossier inputs",
+    ),
+    output_root: Path = typer.Option(
+        Path("/mnt/ace/worldenergydata/data/modules/texas_rrc"),
+        "--output-root",
+        help="Root for curated field-architecture portfolio outputs",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Build portfolio models without writing outputs",
+    ),
+    require_sources: bool = typer.Option(
+        False,
+        "--require-sources",
+        help="Fail when any curated portfolio input is missing",
+    ),
+    allow_non_ace_output: bool = typer.Option(
+        False,
+        "--allow-non-ace-output",
+        help="Allow non-/mnt/ace output roots for isolated tests or sandboxes",
+    ),
+) -> None:
+    """Build Texas RRC field architecture portfolio action report."""
+    from worldenergydata.texas_rrc.architecture_portfolio.cli_support import (
+        run_build_field_architecture_portfolio,
+    )
+
+    try:
+        result = run_build_field_architecture_portfolio(
+            root=root,
+            output_root=output_root,
+            dry_run=dry_run,
+            require_sources=require_sources,
+            allow_non_ace_output=allow_non_ace_output,
+        )
+        _print_field_architecture_portfolio_summary(
+            result.row_count,
+            result.blocking_source_gaps,
+            result.informational_source_gaps,
+        )
+        if result.dry_run:
+            console.print(
+                "[yellow]Dry run:[/yellow] no field-architecture portfolio outputs written"
+            )
+            return
+        _print_field_architecture_portfolio_outputs(result.manifest)
     except typer.Exit:
         raise
     except Exception as e:

--- a/tests/unit/texas_rrc/test_field_architecture_portfolio_cli.py
+++ b/tests/unit/texas_rrc/test_field_architecture_portfolio_cli.py
@@ -1,0 +1,204 @@
+"""Tests for Texas RRC field-architecture portfolio CLI support."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from typer.testing import CliRunner
+
+from worldenergydata.cli.commands.texas_rrc import app
+from worldenergydata.texas_rrc.architecture_portfolio.cli_support import (
+    FieldArchitecturePortfolioBuildResult,
+    run_build_field_architecture_portfolio,
+)
+from worldenergydata.texas_rrc.architecture_portfolio.io import (
+    FieldArchitecturePortfolioOutputManifest,
+)
+
+
+def test_build_field_architecture_portfolio_cli_calls_support_layer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_run_build_field_architecture_portfolio(**kwargs):
+        calls.append(kwargs)
+        return _Result(
+            row_count=2,
+            blocking_source_gaps=(),
+            informational_source_gaps=("pdq_water_gap",),
+            dry_run=False,
+            manifest=_manifest(tmp_path),
+        )
+
+    monkeypatch.setattr(
+        "worldenergydata.texas_rrc.architecture_portfolio.cli_support."
+        "run_build_field_architecture_portfolio",
+        fake_run_build_field_architecture_portfolio,
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "build-field-architecture-portfolio",
+            "--root",
+            str(tmp_path),
+            "--output-root",
+            str(tmp_path),
+            "--allow-non-ace-output",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        {
+            "root": tmp_path,
+            "output_root": tmp_path,
+            "dry_run": False,
+            "require_sources": False,
+            "allow_non_ace_output": True,
+        }
+    ]
+    assert "Wrote field-architecture portfolio" in result.output
+
+
+def test_run_build_field_architecture_portfolio_dry_run_reports_missing_sources(
+    tmp_path: Path,
+) -> None:
+    result = run_build_field_architecture_portfolio(
+        root=tmp_path,
+        output_root=tmp_path,
+        dry_run=True,
+        require_sources=False,
+        allow_non_ace_output=True,
+    )
+
+    assert isinstance(result, FieldArchitecturePortfolioBuildResult)
+    assert result.dry_run is True
+    assert result.row_count == 0
+    assert "missing_field_architecture_dossier_index" in result.blocking_source_gaps
+    assert result.manifest is None
+
+
+def test_run_build_field_architecture_portfolio_publishes_from_dossier_sources(
+    tmp_path: Path,
+) -> None:
+    root = _write_portfolio_source_tree(tmp_path)
+
+    result = run_build_field_architecture_portfolio(
+        root=root,
+        output_root=root,
+        allow_non_ace_output=True,
+    )
+
+    assert result.dry_run is False
+    assert result.manifest is not None
+    assert result.manifest.row_count == 1
+    output_dir = root / "curated" / "analysis" / "field_architecture_portfolio"
+    action_queue = pd.read_csv(output_dir / "field_architecture_action_queue.csv")
+    assert action_queue.loc[0, "source_dossier_href"] == (
+        "../field_architecture_dossiers/fields/aguila.html"
+    )
+    assert (output_dir / "field_architecture_portfolio.html").is_file()
+
+
+def test_run_build_field_architecture_portfolio_reports_invalid_rank_as_informational(
+    tmp_path: Path,
+) -> None:
+    root = _write_portfolio_source_tree(tmp_path, opportunity_rank="not-a-number")
+
+    result = run_build_field_architecture_portfolio(
+        root=root,
+        output_root=root,
+        dry_run=True,
+        require_sources=True,
+        allow_non_ace_output=True,
+    )
+
+    assert result.blocking_source_gaps == ()
+    assert "invalid_opportunity_rank" in result.informational_source_gaps
+    assert result.row_count == 1
+
+
+@dataclass(frozen=True)
+class _Result:
+    row_count: int
+    blocking_source_gaps: tuple[str, ...]
+    informational_source_gaps: tuple[str, ...]
+    dry_run: bool
+    manifest: FieldArchitecturePortfolioOutputManifest | None
+
+
+def _manifest(tmp_path: Path) -> FieldArchitecturePortfolioOutputManifest:
+    target = tmp_path / "curated" / "analysis" / "field_architecture_portfolio"
+    return FieldArchitecturePortfolioOutputManifest(
+        generated_at="2026-07-02T00:00:00Z",
+        output_root=tmp_path,
+        output_dir=target,
+        action_queue_csv_path=target / "field_architecture_action_queue.csv",
+        action_queue_parquet_path=target / "field_architecture_action_queue.parquet",
+        class_summary_csv_path=target / "field_architecture_class_summary.csv",
+        class_summary_parquet_path=target / "field_architecture_class_summary.parquet",
+        followup_summary_csv_path=target / "field_architecture_followup_summary.csv",
+        followup_summary_parquet_path=target
+        / "field_architecture_followup_summary.parquet",
+        html_path=target / "field_architecture_portfolio.html",
+        quality_path=target / "quality.json",
+        component_quality_path=target / "field_architecture_portfolio_quality.json",
+        manifest_path=target / "manifest.json",
+        row_count=2,
+        class_summary_row_count=1,
+        followup_summary_row_count=1,
+        input_paths=(),
+        dossier_input_paths=(),
+        upstream_manifests=(),
+        blocking_source_gaps=(),
+        informational_source_gaps=(),
+        limitations=("no reserves conclusions",),
+        action_specs={},
+        command=None,
+        code_revision="test-rev",
+    )
+
+
+def _write_portfolio_source_tree(
+    tmp_path: Path,
+    opportunity_rank: int | str = 1,
+) -> Path:
+    root = tmp_path / "texas_rrc"
+    dossier_dir = root / "curated" / "analysis" / "field_architecture_dossiers"
+    fields_dir = dossier_dir / "fields"
+    fields_dir.mkdir(parents=True)
+    (fields_dir / "aguila.html").write_text("<html></html>\n", encoding="utf-8")
+    pd.DataFrame(
+        [
+            {
+                "district": "05",
+                "field_number": "00870500",
+                "field_name": "Aguila Vado",
+                "field_slug": "aguila-vado",
+                "architecture_signal_class": "high_access_infill_redevelopment",
+                "opportunity_rank": opportunity_rank,
+                "opportunity_score": 74.79,
+                "recommended_followup": "Review infill",
+                "dossier_focus": "High access infill candidate",
+                "dossier_path": "fields/aguila.html",
+                "source_caveats": "lease_level_production",
+                "quality_flags": "screening_only",
+            }
+        ]
+    ).to_csv(dossier_dir / "field_architecture_dossier_index.csv", index=False)
+    (dossier_dir / "manifest.json").write_text(
+        '{"input_paths":["curated/reports/field_atlas/manifest.json"],'
+        '"blocking_source_gaps":[],"informational_source_gaps":["pdq_water_gap"]}\n',
+        encoding="utf-8",
+    )
+    (dossier_dir / "quality.json").write_text(
+        '{"blocking_source_gaps":[],"informational_source_gaps":["pdq_water_gap"]}\n',
+        encoding="utf-8",
+    )
+    return root

--- a/tests/unit/texas_rrc/test_field_architecture_portfolio_html.py
+++ b/tests/unit/texas_rrc/test_field_architecture_portfolio_html.py
@@ -1,0 +1,107 @@
+"""Tests for Texas RRC field-architecture portfolio HTML rendering."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.architecture_portfolio.html import (
+    render_field_architecture_portfolio_html,
+)
+from worldenergydata.texas_rrc.architecture_portfolio.quality import (
+    FieldArchitecturePortfolioQuality,
+)
+
+
+def test_renders_self_contained_portfolio_html_with_safe_links() -> None:
+    action_queue = pd.DataFrame(
+        [
+            {
+                "portfolio_rank": 1,
+                "field_name": "Aguila <Vado>",
+                "district": "05",
+                "field_number": "00870500",
+                "architecture_signal_class": "high_access_infill_redevelopment",
+                "portfolio_action": "infill_redevelopment_screen",
+                "followup_priority": "high",
+                "opportunity_score": 74.79,
+                "recommended_followup": "Review <infill>",
+                "source_dossier_href": (
+                    "../field_architecture_dossiers/fields/aguila-dossier.html"
+                ),
+                "dossier_path": "fields/aguila-dossier.html",
+                "source_caveats": "lease_level_production",
+                "quality_flags": "screening_only",
+                "portfolio_limitations": "no reserves conclusions",
+            },
+            {
+                "portfolio_rank": 2,
+                "field_name": "Southern Bay",
+                "district": "03",
+                "field_number": "84750500",
+                "architecture_signal_class": "high_access_infill_redevelopment",
+                "portfolio_action": "infill_redevelopment_screen",
+                "followup_priority": "high",
+                "opportunity_score": 50.0,
+                "recommended_followup": "Review infill",
+                "source_dossier_href": "https://example.invalid/dossier.html",
+                "dossier_path": "fields/<unsafe>.html",
+                "source_caveats": "source_dossier_link_not_relative_to_output_root",
+                "quality_flags": "screening_only",
+                "portfolio_limitations": "no reserves conclusions",
+            },
+        ]
+    )
+    class_summary = pd.DataFrame(
+        [
+            {
+                "architecture_signal_class": "high_access_infill_redevelopment",
+                "field_count": 1,
+                "portfolio_action": "infill_redevelopment_screen",
+                "development_theme": "Infill review",
+                "mean_opportunity_score": 74.79,
+                "direct_or_near_access_count": 1,
+                "top_caveats": "lease_level_production",
+                "top_quality_flags": "screening_only",
+            }
+        ]
+    )
+    followup_summary = pd.DataFrame(
+        [
+            {
+                "recommended_followup": "Review <infill>",
+                "portfolio_action": "infill_redevelopment_screen",
+                "development_theme": "Infill review",
+                "field_count": 1,
+                "min_opportunity_score": 74.79,
+                "max_opportunity_score": 74.79,
+            }
+        ]
+    )
+    quality = FieldArchitecturePortfolioQuality(
+        row_count=2,
+        blocking_source_gaps=("missing_context",),
+        informational_source_gaps=("water_bbl",),
+        portfolio_action_counts={"infill_redevelopment_screen": 1},
+        development_theme_counts={"Infill review": 1},
+        caveat_counts={"lease_level_production": 1},
+        quality_flag_counts={"screening_only": 1},
+        limitation_count=1,
+    )
+
+    html = render_field_architecture_portfolio_html(
+        action_queue,
+        class_summary,
+        followup_summary,
+        quality,
+    )
+
+    assert "Aguila &lt;Vado&gt;" in html
+    assert "Review &lt;infill&gt;" in html
+    assert "../field_architecture_dossiers/fields/aguila-dossier.html" in html
+    assert 'href="https://example.invalid/dossier.html"' not in html
+    assert "fields/&lt;unsafe&gt;.html" in html
+    assert "missing_context" in html
+    assert "water_bbl" in html
+    assert "no reserves conclusions" in html
+    assert "http://" not in html
+    assert "https://" not in html

--- a/tests/unit/texas_rrc/test_field_architecture_portfolio_io.py
+++ b/tests/unit/texas_rrc/test_field_architecture_portfolio_io.py
@@ -1,0 +1,142 @@
+"""Tests for Texas RRC field-architecture portfolio output persistence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from worldenergydata.texas_rrc.architecture_portfolio.io import (
+    FIELD_ARCHITECTURE_PORTFOLIO_DIR,
+    write_field_architecture_portfolio_outputs,
+)
+from worldenergydata.texas_rrc.architecture_portfolio.quality import (
+    FieldArchitecturePortfolioQuality,
+)
+
+
+def test_writes_staged_portfolio_outputs_quality_aliases_and_manifest(
+    tmp_path: Path,
+) -> None:
+    action_queue = pd.DataFrame(
+        [
+            {
+                "portfolio_rank": 1,
+                "field_name": "Aguila Vado",
+                "architecture_signal_class": "high_access_infill_redevelopment",
+                "portfolio_action": "infill_redevelopment_screen",
+                "development_theme": "Infill candidate review",
+                "source_dossier_href": "../field_architecture_dossiers/fields/aguila.html",
+                "dossier_path": "fields/aguila.html",
+                "source_caveats": "lease_level_production",
+                "quality_flags": "screening_only",
+                "portfolio_limitations": "no reserves conclusions",
+            }
+        ]
+    )
+    class_summary = pd.DataFrame(
+        [
+            {
+                "architecture_signal_class": "high_access_infill_redevelopment",
+                "field_count": 1,
+                "portfolio_action": "infill_redevelopment_screen",
+            }
+        ]
+    )
+    followup_summary = pd.DataFrame(
+        [
+            {
+                "recommended_followup": "Review infill",
+                "portfolio_action": "infill_redevelopment_screen",
+                "field_count": 1,
+            }
+        ]
+    )
+    quality = FieldArchitecturePortfolioQuality(
+        row_count=1,
+        blocking_source_gaps=(),
+        informational_source_gaps=("pdq_water_gap",),
+        portfolio_action_counts={"infill_redevelopment_screen": 1},
+        development_theme_counts={"Infill candidate review": 1},
+        caveat_counts={"lease_level_production": 1},
+        quality_flag_counts={"screening_only": 1},
+        limitation_count=1,
+    )
+
+    manifest = write_field_architecture_portfolio_outputs(
+        action_queue=action_queue,
+        class_summary=class_summary,
+        followup_summary=followup_summary,
+        quality=quality,
+        output_root=tmp_path,
+        input_paths=[tmp_path / "field_architecture_dossier_index.csv"],
+        dossier_input_paths=[tmp_path / "field_atlas_summary.csv"],
+        upstream_manifests=[tmp_path / "manifest.json"],
+        allow_non_ace_root=True,
+        command="worldenergydata texas-rrc build-field-architecture-portfolio",
+        code_revision="test-revision",
+    )
+
+    output_dir = tmp_path / FIELD_ARCHITECTURE_PORTFOLIO_DIR
+    assert manifest.row_count == 1
+    assert (output_dir / "field_architecture_action_queue.csv").exists()
+    assert (output_dir / "field_architecture_action_queue.parquet").exists()
+    assert (output_dir / "field_architecture_class_summary.csv").exists()
+    assert (output_dir / "field_architecture_class_summary.parquet").exists()
+    assert (output_dir / "field_architecture_followup_summary.csv").exists()
+    assert (output_dir / "field_architecture_followup_summary.parquet").exists()
+    assert (output_dir / "field_architecture_portfolio.html").exists()
+    generic_quality = json.loads((output_dir / "quality.json").read_text())
+    component_quality = json.loads(
+        (output_dir / "field_architecture_portfolio_quality.json").read_text()
+    )
+    assert generic_quality == component_quality
+    manifest_payload = json.loads((output_dir / "manifest.json").read_text())
+    assert manifest_payload["quality_path"] == str(output_dir / "quality.json")
+    assert manifest_payload["component_quality_path"] == str(
+        output_dir / "field_architecture_portfolio_quality.json"
+    )
+    assert manifest_payload["html_path"] == str(
+        output_dir / "field_architecture_portfolio.html"
+    )
+    assert manifest_payload["command"] == (
+        "worldenergydata texas-rrc build-field-architecture-portfolio"
+    )
+    assert manifest_payload["dossier_input_paths"] == [
+        str(tmp_path / "field_atlas_summary.csv")
+    ]
+    assert (
+        manifest_payload["action_specs"]["high_access_infill_redevelopment"][
+            "portfolio_action"
+        ]
+        == "infill_redevelopment_screen"
+    )
+    assert (
+        manifest_payload["action_specs"]["high_access_infill_redevelopment"][
+            "priority_sort"
+        ]
+        == 30
+    )
+    assert manifest_payload["limitations"] == ["no reserves conclusions"]
+
+
+def test_rejects_non_ace_output_root_without_override(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="must stay under"):
+        write_field_architecture_portfolio_outputs(
+            action_queue=pd.DataFrame(),
+            class_summary=pd.DataFrame(),
+            followup_summary=pd.DataFrame(),
+            quality=FieldArchitecturePortfolioQuality(
+                row_count=0,
+                blocking_source_gaps=(),
+                informational_source_gaps=(),
+                portfolio_action_counts={},
+                development_theme_counts={},
+                caveat_counts={},
+                quality_flag_counts={},
+                limitation_count=0,
+            ),
+            output_root=tmp_path,
+        )

--- a/tests/unit/texas_rrc/test_field_architecture_portfolio_models.py
+++ b/tests/unit/texas_rrc/test_field_architecture_portfolio_models.py
@@ -1,0 +1,185 @@
+"""Tests for Texas RRC field-architecture portfolio models."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.architecture_portfolio.models import (
+    build_field_architecture_action_queue,
+    summarize_architecture_classes,
+    summarize_followup_recommendations,
+)
+
+
+def test_builds_action_queue_with_priority_and_unknown_class_caveat() -> None:
+    dossier_index = pd.DataFrame(
+        [
+            {
+                "district": "05",
+                "field_number": "00870500",
+                "field_name": "Aguila Vado",
+                "field_slug": "aguila-vado",
+                "architecture_signal_class": "high_access_infill_redevelopment",
+                "opportunity_rank": 1,
+                "opportunity_score": 74.79,
+                "source_caveats": "lease_level_production",
+                "quality_flags": "",
+            },
+            {
+                "district": "03",
+                "field_number": "84750500",
+                "field_name": "Southern Bay",
+                "field_slug": "southern-bay",
+                "architecture_signal_class": "low_data_confidence",
+                "opportunity_rank": 9,
+                "opportunity_score": 12.5,
+                "source_caveats": "",
+                "quality_flags": "",
+            },
+            {
+                "district": "02",
+                "field_number": "27135750",
+                "field_name": "Eagleville",
+                "field_slug": "eagleville",
+                "architecture_signal_class": "not_in_contract",
+                "opportunity_rank": 2,
+                "opportunity_score": 60.0,
+                "source_caveats": "existing_caveat",
+                "quality_flags": "",
+            },
+        ]
+    )
+
+    queue = build_field_architecture_action_queue(dossier_index)
+
+    assert queue["field_name"].tolist() == ["Eagleville", "Southern Bay", "Aguila Vado"]
+    assert queue["portfolio_rank"].tolist() == [1, 2, 3]
+    assert queue["portfolio_action"].tolist() == [
+        "data_completion_review",
+        "data_completion_review",
+        "infill_redevelopment_screen",
+    ]
+    assert queue["followup_priority"].tolist() == [
+        "source_data_first",
+        "source_data_first",
+        "high",
+    ]
+    assert queue["review_sequence"].tolist() == [1, 2, 1]
+    assert "unknown_architecture_signal_class" in queue.loc[0, "source_caveats"]
+    assert queue.loc[2, "development_theme"] == (
+        "Infill, recompletion, redevelopment candidate review"
+    )
+
+
+def test_summarizes_architecture_classes_and_followups() -> None:
+    queue = build_field_architecture_action_queue(
+        pd.DataFrame(
+            [
+                {
+                    "district": "05",
+                    "field_number": "00870500",
+                    "field_name": "Aguila Vado",
+                    "architecture_signal_class": "high_access_infill_redevelopment",
+                    "opportunity_rank": 1,
+                    "opportunity_score": 70.0,
+                    "recommended_followup": "Review infill",
+                    "cumulative_boe": 10.0,
+                    "active_well_count": 2,
+                    "permit_count": 1,
+                    "completion_count": 3,
+                    "infrastructure_access_class": "direct_access",
+                    "source_caveats": "beta; alpha",
+                    "quality_flags": "flag_b",
+                },
+                {
+                    "district": "03",
+                    "field_number": "84750500",
+                    "field_name": "Southern Bay",
+                    "architecture_signal_class": "high_access_infill_redevelopment",
+                    "opportunity_rank": 2,
+                    "opportunity_score": 50.0,
+                    "recommended_followup": "Review infill",
+                    "cumulative_boe": 20.0,
+                    "active_well_count": 4,
+                    "permit_count": 2,
+                    "completion_count": 1,
+                    "infrastructure_access_class": "regional_access",
+                    "source_caveats": "alpha",
+                    "quality_flags": "flag_a; flag_b",
+                },
+            ]
+        )
+    )
+
+    class_summary = summarize_architecture_classes(queue)
+    followup_summary = summarize_followup_recommendations(queue)
+
+    assert class_summary.loc[0, "architecture_signal_class"] == (
+        "high_access_infill_redevelopment"
+    )
+    assert class_summary.loc[0, "field_count"] == 2
+    assert class_summary.loc[0, "mean_opportunity_score"] == 60.0
+    assert class_summary.loc[0, "median_opportunity_score"] == 60.0
+    assert class_summary.loc[0, "total_cumulative_boe"] == 30.0
+    assert class_summary.loc[0, "total_active_well_count"] == 6
+    assert class_summary.loc[0, "total_permit_count"] == 3
+    assert class_summary.loc[0, "total_completion_count"] == 4
+    assert class_summary.loc[0, "direct_or_near_access_count"] == 1
+    assert class_summary.loc[0, "top_caveats"] == "alpha; beta"
+    assert class_summary.loc[0, "top_quality_flags"] == "flag_b; flag_a"
+
+    assert followup_summary.loc[0, "recommended_followup"] == "Review infill"
+    assert followup_summary.loc[0, "field_count"] == 2
+    assert followup_summary.loc[0, "min_opportunity_score"] == 50.0
+    assert followup_summary.loc[0, "max_opportunity_score"] == 70.0
+
+
+def test_action_queue_builds_safe_dossier_href_and_rejects_unsafe_paths(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "texas_rrc"
+    input_dossier_dir = root / "curated" / "analysis" / "field_architecture_dossiers"
+    fields_dir = input_dossier_dir / "fields"
+    fields_dir.mkdir(parents=True)
+    (fields_dir / "aguila-dossier.html").write_text("<html></html>\n", encoding="utf-8")
+
+    queue = build_field_architecture_action_queue(
+        pd.DataFrame(
+            [
+                {
+                    "district": "05",
+                    "field_number": "00870500",
+                    "field_name": "Aguila Vado",
+                    "architecture_signal_class": "high_access_infill_redevelopment",
+                    "opportunity_rank": 1,
+                    "dossier_path": "fields/aguila-dossier.html",
+                    "source_caveats": "",
+                },
+                {
+                    "district": "03",
+                    "field_number": "84750500",
+                    "field_name": "Southern Bay",
+                    "architecture_signal_class": "high_access_infill_redevelopment",
+                    "opportunity_rank": 2,
+                    "dossier_path": "fields/southern-dossier.html\x00",
+                    "source_caveats": "",
+                },
+            ]
+        ),
+        input_dossier_dir=input_dossier_dir,
+        output_root=root,
+    )
+
+    assert queue.loc[0, "source_dossier_href"] == (
+        "../field_architecture_dossiers/fields/aguila-dossier.html"
+    )
+    assert queue.loc[1, "source_dossier_href"] == ""
+    assert (
+        "source_dossier_link_not_relative_to_output_root"
+        in queue.loc[
+            1,
+            "source_caveats",
+        ]
+    )

--- a/tests/unit/texas_rrc/test_field_architecture_portfolio_quality.py
+++ b/tests/unit/texas_rrc/test_field_architecture_portfolio_quality.py
@@ -1,0 +1,54 @@
+"""Tests for Texas RRC field-architecture portfolio quality summaries."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.architecture_portfolio.quality import (
+    assess_field_architecture_portfolio_quality,
+)
+
+
+def test_assesses_portfolio_quality_counts_and_inherited_gaps() -> None:
+    action_queue = pd.DataFrame(
+        [
+            {
+                "portfolio_action": "data_completion_review",
+                "development_theme": "Source/data completion before architecture interpretation",
+                "source_caveats": "missing_context; lease_level_production",
+                "quality_flags": "flag_b",
+                "portfolio_limitations": "screening-only; no reserves",
+            },
+            {
+                "portfolio_action": "infill_redevelopment_screen",
+                "development_theme": "Infill, recompletion, redevelopment candidate review",
+                "source_caveats": "lease_level_production",
+                "quality_flags": "flag_a; flag_b",
+                "portfolio_limitations": "screening-only; no reserves",
+            },
+        ]
+    )
+
+    quality = assess_field_architecture_portfolio_quality(
+        action_queue,
+        blocking_source_gaps=("missing_index",),
+        informational_source_gaps=("water_bbl", "well_count"),
+    )
+
+    assert quality.row_count == 2
+    assert quality.blocking_source_gaps == ("missing_index",)
+    assert quality.informational_source_gaps == ("water_bbl", "well_count")
+    assert quality.portfolio_action_counts == {
+        "data_completion_review": 1,
+        "infill_redevelopment_screen": 1,
+    }
+    assert quality.development_theme_counts == {
+        "Infill, recompletion, redevelopment candidate review": 1,
+        "Source/data completion before architecture interpretation": 1,
+    }
+    assert quality.caveat_counts == {
+        "lease_level_production": 2,
+        "missing_context": 1,
+    }
+    assert quality.quality_flag_counts == {"flag_b": 2, "flag_a": 1}
+    assert quality.limitation_count == 2

--- a/tests/unit/texas_rrc/test_field_architecture_portfolio_sources.py
+++ b/tests/unit/texas_rrc/test_field_architecture_portfolio_sources.py
@@ -1,0 +1,124 @@
+"""Tests for Texas RRC field-architecture portfolio source loading."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.architecture_portfolio.sources import (
+    load_field_architecture_portfolio_inputs,
+)
+from worldenergydata.texas_rrc.dossiers.io import FIELD_ARCHITECTURE_DOSSIER_DIR
+
+
+def test_loads_dossier_packet_and_gap_schema(tmp_path: Path) -> None:
+    root = _write_portfolio_source_tree(tmp_path)
+
+    inputs = load_field_architecture_portfolio_inputs(root)
+
+    assert inputs.blocking_source_gaps == (
+        "top_blocking_gap",
+        "nested_blocking_gap",
+        "quality_blocking_gap",
+    )
+    assert inputs.informational_source_gaps == (
+        "top_info_gap",
+        "nested_info_gap",
+        "quality_info_gap",
+    )
+    assert inputs.input_dossier_dir == root / FIELD_ARCHITECTURE_DOSSIER_DIR
+    assert inputs.index_path.name == "field_architecture_dossier_index.csv"
+    assert inputs.manifest_path.name == "manifest.json"
+    assert inputs.quality_path.name == "quality.json"
+    assert [path.name for path in inputs.dossier_page_paths] == [
+        "05-00870500-aguila-vado-dossier.html",
+        "03-84750500-southern-bay-dossier.html",
+    ]
+    assert inputs.upstream_manifest_paths == (
+        root / "curated" / "reports" / "field_atlas" / "manifest.json",
+        root / "curated" / "field_development" / "metrics" / "manifest.json",
+        root / "curated" / "infrastructure" / "access" / "manifest.json",
+    )
+    assert inputs.dossier_input_paths == (
+        root / "curated" / "reports" / "field_atlas" / "manifest.json",
+        root / "curated" / "field_development" / "metrics" / "manifest.json",
+        root / "curated" / "reports" / "field_atlas" / "summary.csv",
+    )
+    assert len(inputs.dossier_index) == 2
+    assert inputs.dossier_index.loc[0, "district"] == "05"
+    assert inputs.dossier_index.loc[0, "field_number"] == "00870500"
+
+
+def _write_portfolio_source_tree(tmp_path: Path) -> Path:
+    root = tmp_path / "texas_rrc"
+    dossier_dir = root / FIELD_ARCHITECTURE_DOSSIER_DIR
+    fields_dir = dossier_dir / "fields"
+    fields_dir.mkdir(parents=True)
+
+    pd.DataFrame(
+        [
+            {
+                "district": "05",
+                "field_number": "00870500",
+                "field_name": "Aguila Vado",
+                "dossier_path": "fields/05-00870500-aguila-vado-dossier.html",
+            },
+            {
+                "district": "03",
+                "field_number": "84750500",
+                "field_name": "Southern Bay",
+                "dossier_path": "fields/03-84750500-southern-bay-dossier.html",
+            },
+        ]
+    ).to_csv(dossier_dir / "field_architecture_dossier_index.csv", index=False)
+
+    for filename in (
+        "05-00870500-aguila-vado-dossier.html",
+        "03-84750500-southern-bay-dossier.html",
+    ):
+        (fields_dir / filename).write_text("<html></html>\n", encoding="utf-8")
+
+    (dossier_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "input_paths": [
+                    str(root / "curated" / "reports" / "field_atlas" / "manifest.json"),
+                    str(
+                        root
+                        / "curated"
+                        / "field_development"
+                        / "metrics"
+                        / "manifest.json"
+                    ),
+                    str(root / "curated" / "reports" / "field_atlas" / "summary.csv"),
+                ],
+                "upstream_manifests": [
+                    str(
+                        root / "curated" / "infrastructure" / "access" / "manifest.json"
+                    ),
+                    str(root / "curated" / "reports" / "field_atlas" / "manifest.json"),
+                ],
+                "blocking_source_gaps": ["top_blocking_gap"],
+                "informational_source_gaps": ["top_info_gap"],
+                "quality": {
+                    "blocking_source_gaps": ["nested_blocking_gap"],
+                    "informational_source_gaps": ["nested_info_gap"],
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (dossier_dir / "quality.json").write_text(
+        json.dumps(
+            {
+                "blocking_source_gaps": ["quality_blocking_gap"],
+                "informational_source_gaps": ["quality_info_gap"],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return root


### PR DESCRIPTION
## Summary
- Adds the Texas RRC field-architecture portfolio package: source loading, action queue model, rollups, quality, HTML, staged IO, and CLI support.
- Publishes portfolio artifacts under /mnt/ace/worldenergydata/data/modules/texas_rrc/curated/analysis/field_architecture_portfolio/.
- Adds operator docs and code-stage review/legal evidence for #707.

## Validation
- Targeted TDD suite: 12 passed.
- black --check over src/, tests/, and architecture_portfolio: pass.
- isort --check-only over src/, tests/, and architecture_portfolio: pass.
- flake8 src/: pass.
- ruff check touched paths: pass.
- scripts/legal/legal-sanity-scan.sh: PASS.
- /mnt/ace smoke: 37 rows, no blocking gaps, 5 upstream manifests, 8 dossier input paths, 6 action specs.

## Review
- Codex code review: APPROVE.
- Claude code review r2: APPROVE.
- Gemini unavailable: IneligibleTierError.

## Caveat
- uv sync --all-packages --all-extras resolved 357 packages but hung twice in uv pip_compileall.py; exact pytest/lint/legal gates ran successfully with uv run --no-sync.