### PR TITLE
feat(texas-rrc): build pressure observations

### DIFF
--- a/docs/data-sources/onshore/texas-rrc/pressure-observations.md
+++ b/docs/data-sources/onshore/texas-rrc/pressure-observations.md
@@ -1,0 +1,147 @@
+# Texas RRC Pressure Observations
+
+Texas RRC pressure observations extract structured pressure-like fields from
+official completion packet data and join them to Wellbore Query depth context.
+The output supports the under-pressured well and field screen in
+[#708](https://github.com/vamseeachanta/worldenergydata/issues/708) and feeds
+downstream ranking work in
+[#710](https://github.com/vamseeachanta/worldenergydata/issues/710).
+
+## Source Of Record
+
+The command uses local snapshots of official Texas RRC bulk data only.
+PatchOps, Collide, EWA web-form flows, and historical scraper repositories are
+validation or endpoint-intelligence surfaces; they are not durable inputs for
+this product.
+
+| Input | Official source | Refresh cycle | Local path |
+| --- | --- | --- | --- |
+| `completion_data` | `https://www.rrc.texas.gov/resource-center/research/data-sets-available-for-download/#completion-data-table` | Nightly | `/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/completions/` |
+| `wellbore_query` | `https://www.rrc.texas.gov/media/kywh5qsj/wellboredump.zip` | Monthly, beginning of month | `/mnt/ace/worldenergydata/data/modules/texas_rrc/raw/wellbore/query/` |
+
+The loader also reads raw refresh manifests under
+`/mnt/ace/worldenergydata/data/modules/texas_rrc/manifests/`. If a completion
+ZIP exists but the newest `completion_data-*` manifest has `status=error`, the
+run proceeds and records a `raw_manifest_warning` in quality and manifest JSON.
+
+## Command
+
+Refresh source snapshots first when needed:
+
+```bash
+uv run worldenergydata texas-rrc refresh --source completion_data
+uv run worldenergydata texas-rrc refresh --source wellbore_query
+```
+
+Build the pressure outputs:
+
+```bash
+uv run worldenergydata texas-rrc build-pressure-observations \
+  --raw-root /mnt/ace/worldenergydata/data/modules/texas_rrc \
+  --output-root /mnt/ace/worldenergydata/data/modules/texas_rrc \
+  --require-sources
+```
+
+Use `--dry-run` to inspect counts and source warnings without writing outputs:
+
+```bash
+uv run worldenergydata texas-rrc build-pressure-observations --dry-run
+```
+
+Sandbox runs must opt into non-ACE outputs:
+
+```bash
+uv run worldenergydata texas-rrc build-pressure-observations \
+  --raw-root /tmp/texas_rrc \
+  --output-root /tmp/texas_rrc_out \
+  --allow-non-ace-output
+```
+
+## Output Contract
+
+The command writes normalized candidates and curated pressure observations:
+
+```text
+/mnt/ace/worldenergydata/data/modules/texas_rrc/
++-- normalized/pressure/
+|   +-- texas_rrc_pressure_candidates.csv
+|   +-- texas_rrc_pressure_candidates.parquet
++-- curated/pressure/well_pressure_observations/
+    +-- texas_rrc_well_pressure_observations.csv
+    +-- texas_rrc_well_pressure_observations.parquet
+    +-- coverage_by_district_decade.csv
+    +-- coverage_by_district_decade.parquet
+    +-- coverage_by_field_decade.csv
+    +-- coverage_by_field_decade.parquet
+    +-- texas_rrc_pressure_observation_quality.json
+    +-- manifest.json
+```
+
+Writes are staged under `.staging-pressure-*` directories before promotion. By
+default, writes outside `/mnt/ace/worldenergydata/data/modules/texas_rrc` are
+rejected.
+
+## Curated Schema
+
+Curated observation columns include:
+
+```text
+api14, api10, district, field_no, field_name, test_date, test_year,
+source_record_type, source_pressure_field, pressure_raw_psi,
+pressure_unit_basis, pressure_psia, atmospheric_pressure_psi,
+pressure_kind, pressure_method, reference_depth_ft, reference_depth_method,
+gradient_psi_ft, gradient_method, source_file, source_tracking_no,
+source_packet_id, source_form_id, source_row_no, source_row_id,
+usable_for_virgin_pressure_proxy, is_earliest_observation_for_well,
+virgin_pressure_proxy_method, quality_flags, limitations
+```
+
+Normalized candidates retain source pressure fields that are not yet defensible
+as curated observations. This is deliberate: W-2 casing, flowing, and fracturing
+pressures are preserved as candidates but are not silently represented as BHP.
+
+## Pressure Semantics
+
+- `G-1.BOTTOM_HOLE_PRESS` becomes `pressure_kind=BHP_measured` with
+  `pressure_method=source_reported_bottom_hole_pressure`.
+- `G-1 Field Data.WELLHEAD_PRESS` and `G-10.SIWH_PRESSURE` become
+  `pressure_kind=WHP_shut_in`.
+- Surface wellhead pressure uses `pressure_raw_psi + 14.7` for
+  `pressure_psia`, with `pressure_unit_basis=psig_assumed` and a screening
+  limitation.
+- Unclassified G-1 measurement, G-10 flowing, and W-2 pressure-like fields
+  remain normalized candidates until source semantics justify a curated kind.
+
+Reference depth priority is linked production interval midpoint, G-1
+bottom-hole depth, G-1 vertical depth, G-1 measured depth, G-1 plug-back depth,
+then unique Wellbore Query total depth. Gradients are only emitted for positive
+pressure, positive depth, and unambiguous linkage.
+
+`is_earliest_observation_for_well` marks the earliest usable pressure row by
+API14 and test date. WHP-derived gradients remain screening-only until #710
+performs or explicitly declines a gas-column correction.
+
+## Coverage And Quality
+
+Coverage tables report how many distinct wells have at least one curated
+pressure observation by:
+
+- district and decade
+- district, field, and decade
+
+Quality JSON includes parser counts, candidate and curated row counts, W-2
+candidate counts not curated, uncurated candidate counts, ambiguous depth
+counts, source gaps, and raw manifest warnings.
+
+## Known Caveats
+
+- The structured completion ZIP available in `/mnt/ace` is a daily packet, not
+  a full historical pressure archive.
+- Some G-10/W-10 status and historical pressure evidence lives only in PDFs or
+  imaged records; that extraction is outside this structured bulk-data scope.
+- Source pressure units are not always explicit in packet data. Raw values,
+  unit basis, and limitations are preserved so downstream ranking does not
+  confuse source-reported psi, assumed psig, and screening psia.
+- This product does not classify hydrostatic tiers, make reserves claims, or
+  produce field architecture recommendations; those remain downstream analysis
+  tasks.

--- a/docs/plans/2026-07-03-issue-709-texas-rrc-pressure-observations.md
+++ b/docs/plans/2026-07-03-issue-709-texas-rrc-pressure-observations.md
@@ -1,7 +1,7 @@
 # Plan: Issue #709 - Texas RRC well pressure observations
 
 **Issue:** https://github.com/vamseeachanta/worldenergydata/issues/709
-**Status:** plan-review
+**Status:** implemented
 **Tier:** T2 (existing Texas RRC package, direct-source packet parser extension, curated pressure table, CLI, tests, docs)
 **Client:** N/A
 **Project:** worldenergydata onshore pressure screen
@@ -570,46 +570,46 @@ will remain outside git.
 
 ## Acceptance Criteria
 
-- [ ] `worldenergydata.texas_rrc.pressure_observations` imports cleanly.
-- [ ] Official RRC completion packet and wellbore sources are loaded from the
+- [x] `worldenergydata.texas_rrc.pressure_observations` imports cleanly.
+- [x] Official RRC completion packet and wellbore sources are loaded from the
       existing `/mnt/ace` storage contract.
-- [ ] Completion raw manifest warnings are surfaced when a ZIP exists but the
+- [x] Completion raw manifest warnings are surfaced when a ZIP exists but the
       latest manifest status is `error`.
-- [ ] Structured G-1, G-1 Field Data, G-1 Measurement Data, G-10, W-2,
+- [x] Structured G-1, G-1 Field Data, G-1 Measurement Data, G-10, W-2,
       production interval, and formation rows are parsed into normalized
       pressure candidates.
-- [ ] Curated pressure observations are written under
+- [x] Curated pressure observations are written under
       `/mnt/ace/worldenergydata/data/modules/texas_rrc/curated/pressure/well_pressure_observations/`.
-- [ ] Normalized pressure candidates are written under
+- [x] Normalized pressure candidates are written under
       `/mnt/ace/worldenergydata/data/modules/texas_rrc/normalized/pressure/`.
-- [ ] Curated rows preserve raw pressure, source pressure field, unit basis,
+- [x] Curated rows preserve raw pressure, source pressure field, unit basis,
       pressure kind, pressure method, and limitations.
-- [ ] Wellhead/casing gauge-pressure conversions to `pressure_psia` use an
+- [x] Wellhead/casing gauge-pressure conversions to `pressure_psia` use an
       explicit atmospheric-pressure assumption and limitation.
-- [ ] W-2 pressure candidates are not silently represented as BHP.
-- [ ] Gradient computation is guarded by positive pressure, positive reference
+- [x] W-2 pressure candidates are not silently represented as BHP.
+- [x] Gradient computation is guarded by positive pressure, positive reference
       depth, defensible pressure kind, and unambiguous source/depth linkage.
-- [ ] Earliest usable pressure per well is flagged as the virgin-pressure proxy
+- [x] Earliest usable pressure per well is flagged as the virgin-pressure proxy
       for #710, with method and eligibility fields.
-- [ ] Coverage stats report how many wells have at least one pressure
+- [x] Coverage stats report how many wells have at least one pressure
       observation by district and decade, and by field and decade.
-- [ ] Quality output reports candidate counts, curated counts, pressure-kind
+- [x] Quality output reports candidate counts, curated counts, pressure-kind
       counts, uncurated candidate reasons, missing API, missing depth,
       ambiguous linkage, unit assumptions, manifest warnings, and source gaps.
-- [ ] Documentation explains source URLs, refresh cadences, storage layout,
+- [x] Documentation explains source URLs, refresh cadences, storage layout,
       schema, command usage, and WHP/BHP limitations.
-- [ ] Focused tests pass:
+- [x] Focused tests pass:
       `PYTHONPATH="$(printf '%s:' packages/*/src)src" uv run --no-sync pytest tests/unit/texas_rrc/test_pressure_observation_packet_schema.py tests/unit/texas_rrc/test_pressure_observation_packets.py tests/unit/texas_rrc/test_pressure_observation_sources.py tests/unit/texas_rrc/test_pressure_observations.py tests/unit/texas_rrc/test_pressure_observation_io.py tests/unit/texas_rrc/test_pressure_observation_cli.py -q`
-- [ ] Formatting/lint pass for touched Python:
+- [x] Formatting/lint pass for touched Python:
       `uv run --no-sync black --check --diff packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations src/worldenergydata/cli/commands/texas_rrc.py tests/unit/texas_rrc/test_pressure_observation*.py`
       and
       `uv run --no-sync isort --check-only --diff packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations src/worldenergydata/cli/commands/texas_rrc.py tests/unit/texas_rrc/test_pressure_observation*.py`
       and
       `uv run --no-sync ruff check packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations src/worldenergydata/cli/commands/texas_rrc.py tests/unit/texas_rrc/test_pressure_observation*.py`
-- [ ] `scripts/legal/legal-sanity-scan.sh` passes before commit.
-- [ ] Heavy raw, normalized, and curated data stays under `/mnt/ace` and is not
+- [x] `scripts/legal/legal-sanity-scan.sh` passes before commit.
+- [x] Heavy raw, normalized, and curated data stays under `/mnt/ace` and is not
       committed to git.
-- [ ] Code-stage adversarial review is recorded before closeout.
+- [x] Code-stage adversarial review is recorded before closeout.
 
 ## Adversarial Review Summary
 
@@ -620,9 +620,60 @@ Plan-stage inline review is recorded at
 |---|---|---|
 | Codex inline | MINOR | Plan includes source-of-record guardrails, manifest reconciliation, pressure-unit provenance, W-2 non-BHP guardrails, depth/gradient gating, virgin-proxy fields, and code-stage review acceptance. |
 
-Implementation remains blocked until explicit user approval moves
-[#709](https://github.com/vamseeachanta/worldenergydata/issues/709) to
-`status:plan-approved`.
+Code-stage review is recorded at
+`scripts/review/results/2026-07-03-code-709-codex-inline.md`.
+
+## Implementation Evidence
+
+The implemented slice wrote direct-source Texas RRC pressure outputs under
+`/mnt/ace/worldenergydata/data/modules/texas_rrc`:
+
+- 360 normalized pressure candidates
+- 48 curated pressure observations
+- 6 district/decade coverage rows
+- 8 field/decade coverage rows
+- no source gaps
+- expected warning:
+  `raw_manifest_warning:completion_data:error:2026-07-01T00:36:55Z`
+- 2 hashed input artifacts: completion ZIP and Wellbore Query CSV
+
+Focused tests passed:
+
+```bash
+PYTHONPATH="$(printf '%s:' packages/*/src)src" \
+  uv run --no-sync pytest --no-cov \
+    tests/unit/texas_rrc/test_pressure_observation*.py -q
+```
+
+Adjacent lifecycle/source tests passed:
+
+```bash
+PYTHONPATH="$(printf '%s:' packages/*/src)src" \
+  uv run --no-sync pytest --no-cov \
+    tests/unit/texas_rrc/test_lifecycle_keys.py \
+    tests/unit/texas_rrc/test_lifecycle_sources.py \
+    tests/unit/texas_rrc/test_lifecycle_io.py \
+    tests/unit/texas_rrc/test_source_catalog.py -q
+```
+
+Formatting, import sorting, lint, whitespace, and legal checks passed:
+
+```bash
+uv run --no-sync black --check --diff \
+  packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations \
+  tests/unit/texas_rrc/test_pressure_observation*.py \
+  src/worldenergydata/cli/commands/texas_rrc.py
+uv run --no-sync isort --check-only --diff \
+  packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations \
+  tests/unit/texas_rrc/test_pressure_observation*.py \
+  src/worldenergydata/cli/commands/texas_rrc.py
+uv run --no-sync ruff check \
+  packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations \
+  tests/unit/texas_rrc/test_pressure_observation*.py \
+  src/worldenergydata/cli/commands/texas_rrc.py
+git diff --check
+scripts/legal/legal-sanity-scan.sh
+```
 
 ## Risks and Open Questions
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -82,7 +82,7 @@ This directory contains issue-plan artifacts created during the issue-planning-m
 | [#695](https://github.com/vamseeachanta/worldenergydata/issues/695) | [texas-rrc-field-opportunity-architecture-ranking](2026-07-02-issue-695-texas-rrc-field-opportunity-architecture-ranking.md) | implemented | 2026-07-02 |
 | [#702](https://github.com/vamseeachanta/worldenergydata/issues/702) | [texas-rrc-field-architecture-dossiers](2026-07-02-issue-702-texas-rrc-field-architecture-dossiers.md) | implemented | 2026-07-02 |
 | [#707](https://github.com/vamseeachanta/worldenergydata/issues/707) | [texas-rrc-field-architecture-portfolio](2026-07-02-issue-707-texas-rrc-field-architecture-portfolio.md) | plan-approved | 2026-07-02 |
-| [#709](https://github.com/vamseeachanta/worldenergydata/issues/709) | [texas-rrc-pressure-observations](2026-07-03-issue-709-texas-rrc-pressure-observations.md) | plan-review | 2026-07-03 |
+| [#709](https://github.com/vamseeachanta/worldenergydata/issues/709) | [texas-rrc-pressure-observations](2026-07-03-issue-709-texas-rrc-pressure-observations.md) | implemented | 2026-07-03 |
 
 ## Closed / superseded plans
 

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations/__init__.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations/__init__.py
@@ -1,0 +1,13 @@
+"""Texas RRC pressure-observation extraction helpers."""
+
+from worldenergydata.texas_rrc.pressure_observations.packet_schema import (
+    PRESSURE_RECORD_SCHEMAS,
+    field_index,
+    pressure_fields_for,
+)
+
+__all__ = [
+    "PRESSURE_RECORD_SCHEMAS",
+    "field_index",
+    "pressure_fields_for",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations/cli_support.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations/cli_support.py
@@ -1,0 +1,189 @@
+"""CLI support for Texas RRC pressure-observation publishing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from worldenergydata.texas_rrc.pressure_observations.io import (
+    PressureObservationOutputManifest,
+    write_pressure_observation_outputs,
+)
+from worldenergydata.texas_rrc.pressure_observations.observations import (
+    build_pressure_observations,
+)
+from worldenergydata.texas_rrc.pressure_observations.quality import (
+    build_pressure_coverage,
+)
+from worldenergydata.texas_rrc.pressure_observations.sources import (
+    load_pressure_observation_inputs,
+)
+from worldenergydata.texas_rrc.source_catalog import SOURCE_CATALOG_ROOT
+
+
+@dataclass(frozen=True)
+class PressureObservationBuildResult:
+    """Result returned by the pressure-observation publisher."""
+
+    row_count: int
+    candidate_count: int
+    source_gaps: tuple[str, ...]
+    source_warnings: tuple[str, ...]
+    dry_run: bool
+    manifest: PressureObservationOutputManifest | None
+
+
+def run_build_pressure_observations(
+    raw_root: Path | str = SOURCE_CATALOG_ROOT,
+    output_root: Path | str = SOURCE_CATALOG_ROOT,
+    dry_run: bool = False,
+    require_sources: bool = False,
+    allow_non_ace_output: bool = False,
+) -> PressureObservationBuildResult:
+    """Build and optionally write Texas RRC pressure-observation outputs."""
+    source_root = Path(raw_root)
+    target_root = Path(output_root)
+    inputs = load_pressure_observation_inputs(source_root)
+    if inputs.source_gaps and (require_sources or not dry_run):
+        raise ValueError(
+            "Cannot build pressure observations with missing sources: "
+            + ", ".join(inputs.source_gaps)
+        )
+
+    observation_result, coverage, quality = _prepare_pressure_outputs(inputs)
+    if dry_run:
+        return PressureObservationBuildResult(
+            row_count=len(observation_result.observations),
+            candidate_count=len(inputs.candidates),
+            source_gaps=inputs.source_gaps,
+            source_warnings=inputs.source_warnings,
+            dry_run=True,
+            manifest=None,
+        )
+
+    manifest = _write_outputs(
+        source_root=source_root,
+        target_root=target_root,
+        inputs=inputs,
+        observations=observation_result.observations,
+        coverage=coverage,
+        quality=quality,
+        allow_non_ace_output=allow_non_ace_output,
+        require_sources=require_sources,
+    )
+    return PressureObservationBuildResult(
+        row_count=len(observation_result.observations),
+        candidate_count=len(inputs.candidates),
+        source_gaps=inputs.source_gaps,
+        source_warnings=inputs.source_warnings,
+        dry_run=False,
+        manifest=manifest,
+    )
+
+
+def _prepare_pressure_outputs(inputs):
+    wellbore = _wellbore_for_candidates(inputs.wellbore, inputs.candidates)
+    observation_result = build_pressure_observations(inputs.candidates, wellbore)
+    coverage = build_pressure_coverage(observation_result.observations)
+    quality = _quality_payload(
+        inputs.parser_quality,
+        observation_result.quality,
+        observation_result.observations,
+    )
+    return observation_result, coverage, quality
+
+
+def _quality_payload(
+    parser_quality: dict[str, int],
+    observation_quality: dict[str, int],
+    observations,
+) -> dict[str, object]:
+    quality: dict[str, object] = {}
+    quality.update(parser_quality)
+    quality.update(observation_quality)
+    quality.update(_observation_quality_counts(observations))
+    return quality
+
+
+def _observation_quality_counts(observations) -> dict[str, object]:
+    return {
+        "pressure_kind_counts": _column_counts(observations, "pressure_kind"),
+        "pressure_unit_basis_counts": _column_counts(
+            observations, "pressure_unit_basis"
+        ),
+        "reference_depth_method_counts": _column_counts(
+            observations, "reference_depth_method"
+        ),
+        "gradient_method_counts": _column_counts(observations, "gradient_method"),
+    }
+
+
+def _column_counts(frame, column: str) -> dict[str, int]:
+    if frame.empty or column not in frame:
+        return {}
+    values = frame[column].dropna().astype(str).str.strip()
+    values = values[values.ne("")]
+    counts = values.value_counts(sort=False).sort_index()
+    return {str(key): int(value) for key, value in counts.items()}
+
+
+def _write_outputs(
+    *,
+    source_root: Path,
+    target_root: Path,
+    inputs,
+    observations,
+    coverage,
+    quality: dict[str, object],
+    allow_non_ace_output: bool,
+    require_sources: bool,
+) -> PressureObservationOutputManifest:
+    return write_pressure_observation_outputs(
+        observations=observations,
+        candidates=inputs.candidates,
+        coverage_by_district_decade=coverage.by_district_decade,
+        coverage_by_field_decade=coverage.by_field_decade,
+        quality=quality,
+        output_root=target_root,
+        input_paths=inputs.input_paths,
+        input_artifacts=inputs.input_artifacts,
+        source_gaps=inputs.source_gaps,
+        source_warnings=inputs.source_warnings,
+        allow_non_ace_root=allow_non_ace_output,
+        command=_command(source_root, target_root, require_sources),
+    )
+
+
+def _wellbore_for_candidates(candidates_wellbore, candidates):
+    if (
+        candidates_wellbore.empty
+        or candidates.empty
+        or "api14" not in candidates_wellbore
+        or "api14" not in candidates
+    ):
+        return candidates_wellbore
+    api14s = set(candidates["api14"].dropna().astype(str))
+    if not api14s:
+        return candidates_wellbore.iloc[0:0].copy()
+    return candidates_wellbore[candidates_wellbore["api14"].astype(str).isin(api14s)]
+
+
+def _command(root: Path, output_root: Path, require_sources: bool) -> str:
+    parts = [
+        "worldenergydata",
+        "texas-rrc",
+        "build-pressure-observations",
+        "--raw-root",
+        str(root),
+        "--output-root",
+        str(output_root),
+    ]
+    if require_sources:
+        parts.append("--require-sources")
+    return " ".join(parts)
+
+
+__all__ = [
+    "PressureObservationBuildResult",
+    "run_build_pressure_observations",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations/io.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations/io.py
@@ -1,0 +1,376 @@
+"""Persist Texas RRC pressure-observation outputs."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.source_catalog import SOURCE_CATALOG_ROOT
+
+PRESSURE_OBSERVATION_DIR = Path("curated") / "pressure" / "well_pressure_observations"
+NORMALIZED_PRESSURE_DIR = Path("normalized") / "pressure"
+OBSERVATIONS_CSV_FILENAME = "texas_rrc_well_pressure_observations.csv"
+OBSERVATIONS_PARQUET_FILENAME = "texas_rrc_well_pressure_observations.parquet"
+CANDIDATES_CSV_FILENAME = "texas_rrc_pressure_candidates.csv"
+CANDIDATES_PARQUET_FILENAME = "texas_rrc_pressure_candidates.parquet"
+COVERAGE_BY_DISTRICT_DECADE_CSV_FILENAME = "coverage_by_district_decade.csv"
+COVERAGE_BY_DISTRICT_DECADE_PARQUET_FILENAME = "coverage_by_district_decade.parquet"
+COVERAGE_BY_FIELD_DECADE_CSV_FILENAME = "coverage_by_field_decade.csv"
+COVERAGE_BY_FIELD_DECADE_PARQUET_FILENAME = "coverage_by_field_decade.parquet"
+QUALITY_FILENAME = "texas_rrc_pressure_observation_quality.json"
+MANIFEST_FILENAME = "manifest.json"
+PRESSURE_DTYPES = {
+    "api14": "string",
+    "api10": "string",
+    "district": "string",
+    "field_no": "string",
+    "field_name": "string",
+    "lease_number": "string",
+    "operator_number": "string",
+    "source_tracking_no": "string",
+    "source_packet_id": "string",
+    "source_form_id": "string",
+}
+
+
+@dataclass(frozen=True)
+class PressureObservationOutputManifest:
+    """Paths and metadata for one pressure-observation output batch."""
+
+    generated_at: str
+    output_root: Path
+    observations_csv_path: Path
+    observations_parquet_path: Path
+    candidates_csv_path: Path
+    candidates_parquet_path: Path
+    coverage_by_district_decade_csv_path: Path
+    coverage_by_district_decade_parquet_path: Path
+    coverage_by_field_decade_csv_path: Path
+    coverage_by_field_decade_parquet_path: Path
+    quality_path: Path
+    manifest_path: Path
+    row_count: int
+    candidate_count: int
+    input_paths: tuple[str, ...]
+    input_artifacts: tuple[dict[str, object], ...]
+    source_gaps: tuple[str, ...]
+    source_warnings: tuple[str, ...]
+    command: str | None
+    code_revision: str | None
+
+
+def write_pressure_observation_outputs(
+    observations: pd.DataFrame,
+    candidates: pd.DataFrame,
+    coverage_by_district_decade: pd.DataFrame,
+    coverage_by_field_decade: pd.DataFrame,
+    quality: dict[str, object],
+    output_root: Path | str = SOURCE_CATALOG_ROOT,
+    generated_at: datetime | None = None,
+    input_paths: Iterable[str | Path] = (),
+    input_artifacts: Sequence[dict[str, object]] = (),
+    source_gaps: Sequence[str] = (),
+    source_warnings: Sequence[str] = (),
+    allow_non_ace_root: bool = False,
+    command: str | None = None,
+    code_revision: str | None = None,
+) -> PressureObservationOutputManifest:
+    """Write curated observations, normalized candidates, quality, and manifest."""
+    root = Path(output_root)
+    _validate_output_root(root, allow_non_ace_root)
+    stamp = _timestamp(generated_at)
+    manifest = _build_manifest(
+        root=root,
+        stamp=stamp,
+        observations=observations,
+        candidates=candidates,
+        input_paths=input_paths,
+        input_artifacts=input_artifacts,
+        source_gaps=source_gaps,
+        source_warnings=source_warnings,
+        command=command,
+        code_revision=code_revision,
+    )
+    _write_with_staging(
+        observations,
+        candidates,
+        coverage_by_district_decade,
+        coverage_by_field_decade,
+        quality,
+        manifest,
+        stamp,
+    )
+    return manifest
+
+
+def _build_manifest(
+    *,
+    root: Path,
+    stamp: str,
+    observations: pd.DataFrame,
+    candidates: pd.DataFrame,
+    input_paths: Iterable[str | Path],
+    input_artifacts: Sequence[dict[str, object]],
+    source_gaps: Sequence[str],
+    source_warnings: Sequence[str],
+    command: str | None,
+    code_revision: str | None,
+) -> PressureObservationOutputManifest:
+    curated_dir = root / PRESSURE_OBSERVATION_DIR
+    normalized_dir = root / NORMALIZED_PRESSURE_DIR
+    return PressureObservationOutputManifest(
+        generated_at=stamp,
+        output_root=root,
+        observations_csv_path=curated_dir / OBSERVATIONS_CSV_FILENAME,
+        observations_parquet_path=curated_dir / OBSERVATIONS_PARQUET_FILENAME,
+        candidates_csv_path=normalized_dir / CANDIDATES_CSV_FILENAME,
+        candidates_parquet_path=normalized_dir / CANDIDATES_PARQUET_FILENAME,
+        coverage_by_district_decade_csv_path=_curated_path(
+            curated_dir, COVERAGE_BY_DISTRICT_DECADE_CSV_FILENAME
+        ),
+        coverage_by_district_decade_parquet_path=_curated_path(
+            curated_dir, COVERAGE_BY_DISTRICT_DECADE_PARQUET_FILENAME
+        ),
+        coverage_by_field_decade_csv_path=_curated_path(
+            curated_dir, COVERAGE_BY_FIELD_DECADE_CSV_FILENAME
+        ),
+        coverage_by_field_decade_parquet_path=_curated_path(
+            curated_dir, COVERAGE_BY_FIELD_DECADE_PARQUET_FILENAME
+        ),
+        quality_path=curated_dir / QUALITY_FILENAME,
+        manifest_path=curated_dir / MANIFEST_FILENAME,
+        row_count=len(observations),
+        candidate_count=len(candidates),
+        input_paths=tuple(str(path) for path in input_paths),
+        input_artifacts=tuple(dict(artifact) for artifact in input_artifacts),
+        source_gaps=tuple(source_gaps),
+        source_warnings=tuple(source_warnings),
+        command=command,
+        code_revision=code_revision or _git_revision(),
+    )
+
+
+def _curated_path(curated_dir: Path, filename: str) -> Path:
+    return curated_dir / filename
+
+
+def load_pressure_observations(path: Path | str) -> pd.DataFrame:
+    """Load persisted pressure observations from CSV or Parquet."""
+    pressure_path = Path(path)
+    if pressure_path.suffix.lower() == ".parquet":
+        return pd.read_parquet(pressure_path)
+    return pd.read_csv(pressure_path, dtype=PRESSURE_DTYPES)
+
+
+def _write_with_staging(
+    observations: pd.DataFrame,
+    candidates: pd.DataFrame,
+    coverage_by_district_decade: pd.DataFrame,
+    coverage_by_field_decade: pd.DataFrame,
+    quality: dict[str, object],
+    manifest: PressureObservationOutputManifest,
+    stamp: str,
+) -> None:
+    curated_dir = manifest.observations_csv_path.parent
+    normalized_dir = manifest.candidates_csv_path.parent
+    curated_staging = (
+        curated_dir / f".staging-pressure-observations-{_compact_stamp(stamp)}"
+    )
+    normalized_staging = (
+        normalized_dir / f".staging-pressure-candidates-{_compact_stamp(stamp)}"
+    )
+    shutil.rmtree(curated_staging, ignore_errors=True)
+    shutil.rmtree(normalized_staging, ignore_errors=True)
+    try:
+        curated_staging.mkdir(parents=True, exist_ok=False)
+        normalized_staging.mkdir(parents=True, exist_ok=False)
+        _write_curated_staging(
+            curated_staging,
+            observations,
+            coverage_by_district_decade,
+            coverage_by_field_decade,
+            quality,
+            manifest,
+        )
+        _write_normalized_staging(normalized_staging, candidates)
+        _promote(curated_staging, curated_dir, _curated_filenames())
+        _promote(normalized_staging, normalized_dir, _normalized_filenames())
+    finally:
+        shutil.rmtree(curated_staging, ignore_errors=True)
+        shutil.rmtree(normalized_staging, ignore_errors=True)
+
+
+def _write_curated_staging(
+    staging: Path,
+    observations: pd.DataFrame,
+    coverage_by_district_decade: pd.DataFrame,
+    coverage_by_field_decade: pd.DataFrame,
+    quality: dict[str, object],
+    manifest: PressureObservationOutputManifest,
+) -> None:
+    observations.to_csv(staging / OBSERVATIONS_CSV_FILENAME, index=False)
+    observations.to_parquet(staging / OBSERVATIONS_PARQUET_FILENAME, index=False)
+    coverage_by_district_decade.to_csv(
+        staging / COVERAGE_BY_DISTRICT_DECADE_CSV_FILENAME, index=False
+    )
+    coverage_by_district_decade.to_parquet(
+        staging / COVERAGE_BY_DISTRICT_DECADE_PARQUET_FILENAME, index=False
+    )
+    coverage_by_field_decade.to_csv(
+        staging / COVERAGE_BY_FIELD_DECADE_CSV_FILENAME, index=False
+    )
+    coverage_by_field_decade.to_parquet(
+        staging / COVERAGE_BY_FIELD_DECADE_PARQUET_FILENAME, index=False
+    )
+    _write_json(staging / QUALITY_FILENAME, _quality_payload(manifest, quality))
+    _write_json(staging / MANIFEST_FILENAME, _manifest_payload(manifest, quality))
+
+
+def _write_normalized_staging(staging: Path, candidates: pd.DataFrame) -> None:
+    candidates.to_csv(staging / CANDIDATES_CSV_FILENAME, index=False)
+    candidates.to_parquet(staging / CANDIDATES_PARQUET_FILENAME, index=False)
+
+
+def _promote(staging: Path, target_dir: Path, filenames: tuple[str, ...]) -> None:
+    target_dir.mkdir(parents=True, exist_ok=True)
+    for filename in filenames:
+        (staging / filename).replace(target_dir / filename)
+
+
+def _curated_filenames() -> tuple[str, ...]:
+    return (
+        OBSERVATIONS_CSV_FILENAME,
+        OBSERVATIONS_PARQUET_FILENAME,
+        COVERAGE_BY_DISTRICT_DECADE_CSV_FILENAME,
+        COVERAGE_BY_DISTRICT_DECADE_PARQUET_FILENAME,
+        COVERAGE_BY_FIELD_DECADE_CSV_FILENAME,
+        COVERAGE_BY_FIELD_DECADE_PARQUET_FILENAME,
+        QUALITY_FILENAME,
+        MANIFEST_FILENAME,
+    )
+
+
+def _normalized_filenames() -> tuple[str, ...]:
+    return (CANDIDATES_CSV_FILENAME, CANDIDATES_PARQUET_FILENAME)
+
+
+def _validate_output_root(root: Path, allow_non_ace_root: bool) -> None:
+    if allow_non_ace_root:
+        return
+    if not root.resolve().is_relative_to(SOURCE_CATALOG_ROOT.resolve()):
+        raise ValueError(
+            "Pressure-observation output_root must stay under "
+            f"{SOURCE_CATALOG_ROOT}; pass allow_non_ace_root=True only for "
+            "isolated tests or sandbox runs"
+        )
+
+
+def _quality_payload(
+    manifest: PressureObservationOutputManifest,
+    quality: dict[str, object],
+) -> dict[str, object]:
+    payload = dict(quality)
+    payload.update(
+        {
+            "row_count": manifest.row_count,
+            "candidate_count": manifest.candidate_count,
+            "source_gaps": list(manifest.source_gaps),
+            "source_warnings": list(manifest.source_warnings),
+        }
+    )
+    return payload
+
+
+def _manifest_payload(
+    manifest: PressureObservationOutputManifest,
+    quality: dict[str, object],
+) -> dict[str, object]:
+    return {
+        "generated_at": manifest.generated_at,
+        "output_root": str(manifest.output_root),
+        "observations_csv_path": str(manifest.observations_csv_path),
+        "observations_parquet_path": str(manifest.observations_parquet_path),
+        "candidates_csv_path": str(manifest.candidates_csv_path),
+        "candidates_parquet_path": str(manifest.candidates_parquet_path),
+        "coverage_by_district_decade_csv_path": str(
+            manifest.coverage_by_district_decade_csv_path
+        ),
+        "coverage_by_district_decade_parquet_path": str(
+            manifest.coverage_by_district_decade_parquet_path
+        ),
+        "coverage_by_field_decade_csv_path": str(
+            manifest.coverage_by_field_decade_csv_path
+        ),
+        "coverage_by_field_decade_parquet_path": str(
+            manifest.coverage_by_field_decade_parquet_path
+        ),
+        "quality_path": str(manifest.quality_path),
+        "manifest_path": str(manifest.manifest_path),
+        "row_count": manifest.row_count,
+        "candidate_count": manifest.candidate_count,
+        "input_paths": list(manifest.input_paths),
+        "input_artifacts": list(manifest.input_artifacts),
+        "source_gaps": list(manifest.source_gaps),
+        "source_warnings": list(manifest.source_warnings),
+        "command": manifest.command,
+        "code_revision": manifest.code_revision,
+        "quality": _quality_payload(manifest, quality),
+    }
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _timestamp(value: datetime | None) -> str:
+    timestamp = value or datetime.now(timezone.utc)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _compact_stamp(stamp: str) -> str:
+    return stamp.replace("-", "").replace(":", "")
+
+
+def _git_revision() -> str | None:
+    repo_root = Path(__file__).resolve().parents[5]
+    try:
+        revision = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+        )
+        status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    suffix = "+dirty" if status.stdout.strip() else ""
+    value = revision.stdout.strip()
+    return f"{value}{suffix}" if value else None
+
+
+__all__ = [
+    "NORMALIZED_PRESSURE_DIR",
+    "PRESSURE_OBSERVATION_DIR",
+    "PressureObservationOutputManifest",
+    "load_pressure_observations",
+    "write_pressure_observation_outputs",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations/observations.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations/observations.py
@@ -1,0 +1,333 @@
+"""Build curated Texas RRC pressure observations from packet candidates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pandas as pd
+
+ATMOSPHERIC_PRESSURE_PSI = 14.7
+SURFACE_PRESSURE_FIELDS = {
+    ("G-1 Field Data", "WELLHEAD_PRESS"),
+    ("G-10", "SIWH_PRESSURE"),
+}
+BOTTOM_HOLE_PRESSURE_FIELDS = {
+    ("G-1", "BOTTOM_HOLE_PRESS"),
+}
+W2_RECORD_TYPE = "W-2"
+
+OUTPUT_COLUMNS = (
+    "api14",
+    "api10",
+    "district",
+    "field_no",
+    "field_name",
+    "test_date",
+    "test_year",
+    "source_record_type",
+    "source_pressure_field",
+    "pressure_raw_psi",
+    "pressure_unit_basis",
+    "pressure_psia",
+    "atmospheric_pressure_psi",
+    "pressure_kind",
+    "pressure_method",
+    "reference_depth_ft",
+    "reference_depth_method",
+    "gradient_psi_ft",
+    "gradient_method",
+    "source_file",
+    "source_tracking_no",
+    "source_packet_id",
+    "source_form_id",
+    "source_row_no",
+    "source_row_id",
+    "usable_for_virgin_pressure_proxy",
+    "is_earliest_observation_for_well",
+    "virgin_pressure_proxy_method",
+    "quality_flags",
+    "limitations",
+)
+
+
+@dataclass(frozen=True)
+class PressureObservationResult:
+    """Curated observations plus summary quality counters."""
+
+    observations: pd.DataFrame
+    quality: dict[str, int]
+
+
+def build_pressure_observations(
+    candidates: pd.DataFrame,
+    wellbore: pd.DataFrame | None = None,
+) -> PressureObservationResult:
+    """Return curated pressure observations from normalized candidates."""
+    rows = []
+    quality = {
+        "candidate_count": len(candidates),
+        "curated_count": 0,
+        "w2_pressure_candidates_not_curated": 0,
+        "uncurated_pressure_candidates": 0,
+        "missing_api": 0,
+        "ambiguous_depth_reference": 0,
+    }
+    wellbore_index = _wellbore_index(wellbore)
+
+    for _, candidate in candidates.iterrows():
+        row = _candidate_observation(candidate, wellbore_index, quality)
+        if row is not None:
+            rows.append(row)
+
+    observations = pd.DataFrame(rows, columns=OUTPUT_COLUMNS)
+    if not observations.empty:
+        observations = _mark_earliest_proxy(observations)
+    quality["curated_count"] = len(observations)
+    return PressureObservationResult(observations=observations, quality=quality)
+
+
+def _candidate_observation(
+    candidate: pd.Series,
+    wellbore_index: dict[str, dict[str, Any]],
+    quality: dict[str, int],
+) -> dict[str, Any] | None:
+    if not _valid_api14(candidate.get("api14")):
+        quality["missing_api"] += 1
+        return None
+    classification = _classify_pressure(candidate)
+    if classification is None:
+        if str(candidate.get("source_record_type", "")) == W2_RECORD_TYPE:
+            quality["w2_pressure_candidates_not_curated"] += 1
+        else:
+            quality["uncurated_pressure_candidates"] += 1
+        return None
+    if not _positive(candidate.get("pressure_raw_psi")):
+        quality["uncurated_pressure_candidates"] += 1
+        return None
+
+    depth = _reference_depth(candidate, wellbore_index)
+    flags = list(depth["quality_flags"])
+    if "ambiguous_depth_reference" in flags:
+        quality["ambiguous_depth_reference"] += 1
+    gradient = _gradient(classification["pressure_psia"], depth["reference_depth_ft"])
+    usable_proxy = _usable_for_proxy(candidate, depth, gradient)
+    return _observation_row(
+        candidate,
+        classification,
+        depth,
+        gradient,
+        usable_proxy,
+        flags,
+    )
+
+
+def _usable_for_proxy(candidate: pd.Series, depth: dict[str, Any], gradient) -> bool:
+    return bool(
+        candidate.get("api14")
+        and candidate.get("test_date")
+        and _positive(depth["reference_depth_ft"])
+        and gradient is not None
+    )
+
+
+def _classify_pressure(row: pd.Series) -> dict[str, Any] | None:
+    key = (
+        str(row.get("source_record_type", "")),
+        str(row.get("source_pressure_field", "")),
+    )
+    raw_pressure = float(row["pressure_raw_psi"])
+    if key in BOTTOM_HOLE_PRESSURE_FIELDS:
+        return {
+            "pressure_kind": "BHP_measured",
+            "pressure_method": "source_reported_bottom_hole_pressure",
+            "pressure_psia": raw_pressure,
+            "pressure_unit_basis": "source_psi_unspecified",
+            "atmospheric_pressure_psi": None,
+            "limitations": "source-reported bottom-hole pressure; units carried as source psi",
+        }
+    if key in SURFACE_PRESSURE_FIELDS and _valid_surface_pressure_context(row, key):
+        return {
+            "pressure_kind": "WHP_shut_in",
+            "pressure_method": "source_reported_shut_in_wellhead_pressure",
+            "pressure_psia": raw_pressure + ATMOSPHERIC_PRESSURE_PSI,
+            "pressure_unit_basis": "psig_assumed",
+            "atmospheric_pressure_psi": ATMOSPHERIC_PRESSURE_PSI,
+            "limitations": "screening conversion from assumed gauge pressure",
+        }
+    return None
+
+
+def _valid_surface_pressure_context(row: pd.Series, key: tuple[str, str]) -> bool:
+    if key == ("G-1 Field Data", "WELLHEAD_PRESS"):
+        return str(row.get("source_row_no", "")).strip().upper() == "SHUT-IN"
+    return True
+
+
+def _reference_depth(
+    candidate: pd.Series,
+    wellbore_index: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    interval_depth = _interval_midpoint(candidate)
+    if interval_depth is not None:
+        return {
+            "reference_depth_ft": interval_depth,
+            "reference_depth_method": "production_interval_midpoint",
+            "quality_flags": (),
+        }
+
+    for column, method in (
+        ("bottom_hole_depth_ft", "bottom_hole_depth"),
+        ("vertical_depth_ft", "vertical_depth"),
+        ("measured_depth_ft", "measured_depth"),
+        ("plug_back_depth_ft", "plug_back_depth"),
+    ):
+        value = _as_float(candidate.get(column))
+        if _positive(value):
+            return {
+                "reference_depth_ft": value,
+                "reference_depth_method": method,
+                "quality_flags": (),
+            }
+
+    api14 = str(candidate.get("api14", ""))
+    wellbore = wellbore_index.get(api14)
+    if wellbore is None:
+        return {
+            "reference_depth_ft": None,
+            "reference_depth_method": "",
+            "quality_flags": (),
+        }
+    if wellbore.get("ambiguous"):
+        return {
+            "reference_depth_ft": None,
+            "reference_depth_method": "",
+            "quality_flags": ("ambiguous_depth_reference",),
+        }
+    return {
+        "reference_depth_ft": wellbore.get("total_depth"),
+        "reference_depth_method": "wellbore_total_depth",
+        "quality_flags": (),
+    }
+
+
+def _wellbore_index(wellbore: pd.DataFrame | None) -> dict[str, dict[str, Any]]:
+    if wellbore is None or wellbore.empty or "api14" not in wellbore:
+        return {}
+    result: dict[str, dict[str, Any]] = {}
+    for api14, group in wellbore.groupby("api14", dropna=True):
+        depths = [
+            _as_float(value)
+            for value in group.get("total_depth", pd.Series(dtype=object)).tolist()
+        ]
+        depths = [value for value in depths if _positive(value)]
+        result[str(api14)] = {
+            "ambiguous": len(group) != 1,
+            "total_depth": depths[0] if len(group) == 1 and depths else None,
+        }
+    return result
+
+
+def _interval_midpoint(candidate: pd.Series) -> float | None:
+    top = _as_float(candidate.get("production_interval_from_ft"))
+    bottom = _as_float(candidate.get("production_interval_to_ft"))
+    if _positive(top) and _positive(bottom) and bottom >= top:
+        return (top + bottom) / 2.0
+    return None
+
+
+def _observation_row(
+    candidate: pd.Series,
+    classification: dict[str, Any],
+    depth: dict[str, Any],
+    gradient: float | None,
+    usable_proxy: bool,
+    flags: list[str],
+) -> dict[str, Any]:
+    row = {column: candidate.get(column, None) for column in OUTPUT_COLUMNS}
+    row.update(classification)
+    row.update(
+        {
+            "reference_depth_ft": depth["reference_depth_ft"],
+            "reference_depth_method": depth["reference_depth_method"],
+            "gradient_psi_ft": gradient,
+            "gradient_method": _gradient_method(classification, gradient),
+            "usable_for_virgin_pressure_proxy": usable_proxy,
+            "is_earliest_observation_for_well": False,
+            "virgin_pressure_proxy_method": "not_eligible",
+            "quality_flags": "|".join(flags),
+        }
+    )
+    return row
+
+
+def _gradient_method(
+    classification: dict[str, Any],
+    gradient: float | None,
+) -> str:
+    if gradient is None:
+        return ""
+    if classification["pressure_kind"] == "BHP_measured":
+        return "reported_bhp_over_reference_depth"
+    return "surface_pressure_over_reference_depth_screening_only"
+
+
+def _gradient(pressure: float, depth: Any) -> float | None:
+    depth_value = _as_float(depth)
+    if _positive(pressure) and _positive(depth_value):
+        return pressure / depth_value
+    return None
+
+
+def _mark_earliest_proxy(observations: pd.DataFrame) -> pd.DataFrame:
+    result = observations.copy()
+    result["usable_for_virgin_pressure_proxy"] = result[
+        "usable_for_virgin_pressure_proxy"
+    ].astype(object)
+    result["is_earliest_observation_for_well"] = result[
+        "is_earliest_observation_for_well"
+    ].astype(object)
+    eligible_mask = result["usable_for_virgin_pressure_proxy"].map(
+        lambda value: bool(value) if pd.notna(value) else False
+    )
+    eligible = result[eligible_mask].copy()
+    if eligible.empty:
+        return result
+    sort_columns = ["api14", "test_date", "source_row_id"]
+    eligible = eligible.sort_values(sort_columns)
+    first_indices = eligible.groupby("api14", sort=True).head(1).index
+    result.loc[first_indices, "is_earliest_observation_for_well"] = True
+    result.loc[first_indices, "virgin_pressure_proxy_method"] = result.loc[
+        first_indices, "pressure_kind"
+    ].map(
+        {
+            "BHP_measured": "earliest_reported_bhp",
+            "WHP_shut_in": "earliest_shut_in_whp_screening",
+        }
+    )
+    return result
+
+
+def _positive(value: Any) -> bool:
+    number = _as_float(value)
+    return number is not None and number > 0
+
+
+def _valid_api14(value: Any) -> bool:
+    text = str(value or "").strip()
+    return len(text) == 14 and text.isdigit()
+
+
+def _as_float(value: Any) -> float | None:
+    if value is None or value != value:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+__all__ = [
+    "PressureObservationResult",
+    "build_pressure_observations",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations/packet_schema.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations/packet_schema.py
@@ -1,0 +1,266 @@
+"""Official Texas RRC completion-packet schema maps used for pressure rows."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+PACKET_COLUMNS = (
+    "PACKET",
+    "TRACKING_NO",
+    "PACKET_ID",
+    "SUBMITTED_DT",
+    "OPERATOR_NO",
+    "API_NUMBER",
+    "LEASE_NO",
+    "WELL_NO",
+    "FIELD_NO",
+    "DISTRICT",
+    "FIELD_NAME",
+)
+
+G1_COLUMNS = (
+    "G-1",
+    "TRACKING_NO",
+    "PACKET_ID",
+    "G1_ID",
+    "DATE_OF_TEST",
+    "TEST_GAS_PRODUCTION",
+    "IS_DRY_GAS_WELL",
+    "GRAVITY_DRY_GAS",
+    "GAS_HYDRO_RATIO",
+    "AVG_SHUTIN_TEMP",
+    "GRAVITY_HYDROCARBON",
+    "GRAVITY_OF_MIXTURE",
+    "BOTTOM_HOLE_TEMP",
+    "BOTTOM_HOLE_DEPTH",
+    "NOTICE_OF_INTENTION",
+    "NUMBER_OF_PRODUCING_WELLS",
+    "ACRES_IN_LEASE",
+    "WORK_COMMENCED_DT",
+    "WORK_COMPLETED_DT",
+    "DISTANCE_TO_NEAREST_WELL",
+    "DISTANCE_TO_BNDRY_A",
+    "DIRECTION_TO_BNDRY_A_CODE",
+    "DISTANCE_TO_BNDRY_B",
+    "DIRECTION_TO_BNDRY_B_CODE",
+    "BOUNDARY_LEASE_NAME",
+    "ELEVATION",
+    "ELEVATION_CODE",
+    "WAS_DIRECT_SURVEY_MADE",
+    "TOP_OF_PAY",
+    "MEASURED_DEPTH",
+    "VERTICAL_DEPTH",
+    "PLUG_BACK_DEPTH",
+    "CASING_DETR_FIELD_RULES",
+    "CASING_DETR_RECOMMEND_DT",
+    "CASING_DETR_RRC_DT",
+    "DRILLING_CONTRACTOR_NM",
+    "IS_MULTIPLE_COMPLETION",
+    "DID_PREFLOW_48_HOURS",
+    "PIPELINE_CONNECTION",
+    "ANY_CONDENSATE",
+    "REMARKS",
+    "INTERVALS_DRILLED_BY_CODE",
+    "SECTION_ONE_REMARKS",
+    "CEMENTING_AFFIDAVIT_ATTACHED",
+    "AMOUNT_MATERIAL_REMARKS",
+    "FORM_CERTIFICATION",
+    "TESTER_NAME",
+    "TESTER_COMPANY",
+    "INTERVALS_DRILLED_BY_OTHER",
+    "PROD_INTV_REMARK",
+    "TESTER_PHONE",
+    "OP_IS_TESTER",
+    "GMM_ORIFICE_METER",
+    "GMM_FLANGE_TAPS",
+    "GMM_POS_CHOKE",
+    "GMM_PIPE_TAPS",
+    "GMM_ORIFICE_VENT",
+    "GMM_PITOT_TUBE",
+    "GMM_CRITICAL_FLOW",
+    "BOTTOM_HOLE_PRESS",
+    "IS_UNPERFORATED_CMPL",
+    "PLUG_BACK_DEPTH_TMD",
+    "TOP_OF_PAY_TMD",
+    "OFF_LEASE",
+    "COMMINGLED",
+    "INTERVAL_HYDROGEN_SULFIDE",
+    "HYDRAULIC_FRACKING_USED",
+    "HAS_FRACKING_DISCLOSURE",
+    "TUBING_REC_REMARKS",
+    "SURFACE_CASING_ROTATION_TIME",
+    "CASING_DETR_RECOMMEND_DEPTH",
+    "CASING_DETR_SWR_13_DEPTH",
+    "IS_ACTUATION_VALVE_ON_WELL",
+    "PROD_CASE_PSIG_BEF_FRACK_TREAT",
+    "HYDRAULIC_FRACKING_MAX_PSIG",
+    "CASING_DETR_SWR_13_EXCEP",
+    "CASING_DETR_RECOMMEND_GAU_GPD",
+    "ACTUATION_VALVE_ON_WELL_PSIG",
+    "GMM_MASS_FLOW_METER",
+    "GMM_OTHER",
+    "MEASUREMENT_DATA_ROW_CNT",
+    "AMOUNT_AND_MATERIAL_ROW_CNT",
+    "FIELD_DATA_ROW_CNT",
+    "MULTI_CMPL_ROW_COUNT",
+    "CASING_DATA_ROW_COUNT",
+    "LINER_DATA_ROW_COUNT",
+    "TUBING_DATA_ROW_COUNT",
+    "PROD_INTRVL_DATA_ROW_CNT",
+    "FORMATION_DATA_ROW_CNT",
+)
+
+G1_MEASUREMENT_COLUMNS = (
+    "G-1 Measurement Data",
+    "TRACKING_NO",
+    "PACKET_ID",
+    "G1_ID",
+    "ROW_NO",
+    "LINE_SIZE",
+    "ORIFICE_CHOKE_SIZE",
+    "TWENTYFOUR_HOUR_COEFF",
+    "STATIC_CHOKE_PRESS",
+    "DIFF",
+    "FLOW_TEMP",
+    "TEMP_FACTOR",
+    "GRAVITY_FACTOR",
+    "COMPRESS_FACTOR",
+    "VOLUME",
+)
+
+G1_FIELD_COLUMNS = (
+    "G-1 Field Data",
+    "TRACKING_NO",
+    "PACKET_ID",
+    "G1_ID",
+    "ROW_NO",
+    "TIME_OF_RUN",
+    "CHOKE_SIZE",
+    "WELLHEAD_PRESS",
+    "WELLHEAD_FLOW_TEMP",
+)
+
+G10_COLUMNS = (
+    "G-10",
+    "TRACKING_NO",
+    "PACKET_ID",
+    "G10_ID",
+    "REASON_CODE",
+    "DUE_DT",
+    "EFFECTIVE_DT",
+    "COND_PRODUCED",
+    "COND_GRAVITY",
+    "WATER_PRODUCED",
+    "XBHOLE_PRESSURE",
+    "FORM_CERTIFICATION",
+    "DATE_TESTED",
+    "TESTER_NAME",
+    "TESTER_COMPANY",
+    "GAS_PROD_DURING_TEST",
+    "GRAVITY_DRY_GAS",
+    "SIWH_PRESSURE",
+    "FLOWING_PRESSURE",
+    "TESTER_PHONE",
+)
+
+W2_COLUMNS = (
+    "W-2",
+    "TRACKING_NO",
+    "PACKET_ID",
+    "W2_ID",
+    "DATE_OF_TEST",
+    "OIL_PROD_DURING_TEST",
+    "GAS_PROD_DURING_TEST",
+    "CHOKE_SIZE",
+    "FLOW_TUBING_PRESS",
+    "CASING_PRESS",
+    "CALC_CASING_PRESS",
+    "PROD_CASE_PSIG_BEF_FRACK_TREAT",
+    "HYDRAULIC_FRACKING_MAX_PSIG",
+    "ACTUATION_VALVE_ON_WELL_PSIG",
+)
+
+PRODUCTION_INTERVAL_COLUMNS = (
+    "RECORD_TYPE",
+    "TRACKING_NO",
+    "PACKET_ID",
+    "FORM_ID",
+    "ROW_NO",
+    "FROM",
+    "TO",
+    "BOTTOM_HOLE_LABEL",
+    "LATERAL_LABEL",
+    "OPEN_HOLE",
+)
+
+FORMATION_COLUMNS = (
+    "RECORD_TYPE",
+    "TRACKING_NO",
+    "PACKET_ID",
+    "FORM_ID",
+    "ROW_NO",
+    "FORMATION",
+    "DEPTH",
+    "DEPTH_TMD",
+    "USER_ENCOUNTERED",
+    "USER_REMARK",
+    "USER_ISOLATED",
+)
+
+PRESSURE_RECORD_SCHEMAS: Mapping[str, tuple[str, ...]] = {
+    "PACKET": PACKET_COLUMNS,
+    "G-1": G1_COLUMNS,
+    "G-1 Measurement Data": G1_MEASUREMENT_COLUMNS,
+    "G-1 Field Data": G1_FIELD_COLUMNS,
+    "G-10": G10_COLUMNS,
+    "W-2": W2_COLUMNS,
+    "G-1 Production Interval Data": (
+        "G-1 Production Interval Data",
+        *PRODUCTION_INTERVAL_COLUMNS[1:],
+    ),
+    "W-2 Production Interval Data": (
+        "W-2 Production Interval Data",
+        *PRODUCTION_INTERVAL_COLUMNS[1:],
+    ),
+    "G-1 Formation Data": ("G-1 Formation Data", *FORMATION_COLUMNS[1:]),
+    "W-2 Formation Data": ("W-2 Formation Data", *FORMATION_COLUMNS[1:]),
+}
+
+PRESSURE_FIELDS: Mapping[str, tuple[str, ...]] = {
+    "G-1": ("BOTTOM_HOLE_PRESS",),
+    "G-1 Measurement Data": ("STATIC_CHOKE_PRESS",),
+    "G-1 Field Data": ("WELLHEAD_PRESS",),
+    "G-10": ("XBHOLE_PRESSURE", "SIWH_PRESSURE", "FLOWING_PRESSURE"),
+    "W-2": (
+        "FLOW_TUBING_PRESS",
+        "CASING_PRESS",
+        "CALC_CASING_PRESS",
+        "PROD_CASE_PSIG_BEF_FRACK_TREAT",
+        "HYDRAULIC_FRACKING_MAX_PSIG",
+        "ACTUATION_VALVE_ON_WELL_PSIG",
+    ),
+}
+
+
+def field_index(record_type: str, field_name: str) -> int:
+    """Return the brace-delimited field index for a named packet field."""
+    try:
+        columns = PRESSURE_RECORD_SCHEMAS[record_type]
+    except KeyError as exc:
+        raise KeyError(f"Unknown Texas RRC packet record type: {record_type}") from exc
+    try:
+        return columns.index(field_name)
+    except ValueError as exc:
+        raise KeyError(f"{field_name} is not defined for {record_type}") from exc
+
+
+def pressure_fields_for(record_type: str) -> tuple[str, ...]:
+    """Return pressure-bearing source fields for a packet record type."""
+    return PRESSURE_FIELDS.get(record_type, ())
+
+
+__all__ = [
+    "PRESSURE_RECORD_SCHEMAS",
+    "field_index",
+    "pressure_fields_for",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations/packets.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations/packets.py
@@ -1,0 +1,344 @@
+"""Parse Texas RRC brace-delimited completion packet pressure candidates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.lifecycle.keys import derive_api10, normalize_api14
+from worldenergydata.texas_rrc.pressure_observations.packet_schema import (
+    field_index,
+    pressure_fields_for,
+)
+
+PACKET_CONTEXT_INDEXES = {
+    "source_tracking_no": 1,
+    "source_packet_id": 2,
+    "operator_number": 5,
+    "api_number": 6,
+    "lease_number": 8,
+    "packet_completion_date": 21,
+    "field_no": 25,
+    "district": 27,
+    "field_name": 29,
+}
+
+BASE_COLUMNS = (
+    "api14",
+    "api10",
+    "district",
+    "field_no",
+    "field_name",
+    "lease_number",
+    "operator_number",
+    "test_date",
+    "test_year",
+    "source_record_type",
+    "source_pressure_field",
+    "pressure_raw_psi",
+    "source_tracking_no",
+    "source_packet_id",
+    "source_form_id",
+    "source_row_no",
+    "source_file",
+    "source_row_id",
+    "bottom_hole_depth_ft",
+    "vertical_depth_ft",
+    "measured_depth_ft",
+    "plug_back_depth_ft",
+    "production_interval_from_ft",
+    "production_interval_to_ft",
+    "reference_formation",
+)
+
+
+@dataclass(frozen=True)
+class PacketParseResult:
+    """Pressure candidates and parser quality counts from one packet text."""
+
+    candidates: pd.DataFrame
+    malformed_row_count: int = 0
+    unlinked_row_count: int = 0
+
+
+def read_packet_pressure_candidates(
+    text: str,
+    source_file: str = "",
+) -> PacketParseResult:
+    """Read brace-delimited packet text into normalized pressure candidates."""
+    packet_contexts: dict[tuple[str, str], dict[str, str]] = {}
+    form_contexts: dict[tuple[str, str, str], dict[str, str]] = {}
+    rows: list[dict[str, Any]] = []
+    malformed_count = 0
+    unlinked_count = 0
+
+    for line_number, raw_line in enumerate(text.splitlines(), start=1):
+        fields = [part.strip() for part in raw_line.rstrip("\r\n").split("{")]
+        record_type = fields[0] if fields else ""
+        if not record_type:
+            continue
+        if record_type == "PACKET":
+            context = _packet_context(fields)
+            if context:
+                packet_contexts[
+                    (context["source_tracking_no"], context["source_packet_id"])
+                ] = context
+            continue
+        if record_type in {
+            "G-1 Production Interval Data",
+            "W-2 Production Interval Data",
+        }:
+            form_key = (_field(fields, 1), _field(fields, 2), _field(fields, 3))
+            form = form_contexts.setdefault(form_key, {"source_form_id": form_key[2]})
+            form.update(_interval_context(record_type, fields))
+            _apply_form_context_to_existing_rows(rows, form_key, form)
+            continue
+        if record_type in {"G-1 Formation Data", "W-2 Formation Data"}:
+            form_key = (_field(fields, 1), _field(fields, 2), _field(fields, 3))
+            form = form_contexts.setdefault(form_key, {"source_form_id": form_key[2]})
+            form.update(_formation_context(record_type, fields))
+            _apply_form_context_to_existing_rows(rows, form_key, form)
+            continue
+        if not _pressure_relevant(record_type):
+            continue
+        if len(fields) < 4:
+            malformed_count += 1
+            continue
+
+        key = (_field(fields, 1), _field(fields, 2))
+        packet = packet_contexts.get(key)
+        if packet is None:
+            unlinked_count += 1
+            continue
+
+        if record_type in {"G-1", "G-10", "W-2"}:
+            form = _form_context(record_type, fields)
+            form_key = (key[0], key[1], form["source_form_id"])
+            form_contexts.setdefault(form_key, {}).update(form)
+        else:
+            form_id = _field(fields, 3)
+            form = form_contexts.get((key[0], key[1], form_id), {})
+
+        rows.extend(
+            _candidate_rows(
+                fields,
+                packet=packet,
+                form=form,
+                record_type=record_type,
+                source_file=source_file,
+                line_number=line_number,
+            )
+        )
+
+    return PacketParseResult(
+        candidates=pd.DataFrame(rows, columns=BASE_COLUMNS),
+        malformed_row_count=malformed_count,
+        unlinked_row_count=unlinked_count,
+    )
+
+
+def _pressure_relevant(record_type: str) -> bool:
+    return bool(pressure_fields_for(record_type))
+
+
+def _packet_context(fields: list[str]) -> dict[str, str]:
+    context = {
+        key: _field(fields, index) for key, index in PACKET_CONTEXT_INDEXES.items()
+    }
+    if not context["source_tracking_no"] or not context["source_packet_id"]:
+        return {}
+    api14 = normalize_api14(context["api_number"])
+    context["api14"] = api14 or ""
+    context["api10"] = derive_api10(api14) or ""
+    return context
+
+
+def _form_context(record_type: str, fields: list[str]) -> dict[str, str]:
+    form_id_name = {
+        "G-1": "G1_ID",
+        "G-10": "G10_ID",
+        "W-2": "W2_ID",
+    }[record_type]
+    form = {
+        "source_form_id": _field(fields, field_index(record_type, form_id_name)),
+        "test_date": _form_test_date(record_type, fields),
+    }
+    if record_type == "G-1":
+        form.update(
+            {
+                "bottom_hole_depth_ft": _numeric(
+                    _field(fields, field_index(record_type, "BOTTOM_HOLE_DEPTH"))
+                ),
+                "vertical_depth_ft": _numeric(
+                    _field(fields, field_index(record_type, "VERTICAL_DEPTH"))
+                ),
+                "measured_depth_ft": _numeric(
+                    _field(fields, field_index(record_type, "MEASURED_DEPTH"))
+                ),
+                "plug_back_depth_ft": _numeric(
+                    _field(fields, field_index(record_type, "PLUG_BACK_DEPTH"))
+                ),
+            }
+        )
+    return form
+
+
+def _interval_context(record_type: str, fields: list[str]) -> dict[str, float | None]:
+    return {
+        "production_interval_from_ft": _numeric(
+            _field(fields, field_index(record_type, "FROM"))
+        ),
+        "production_interval_to_ft": _numeric(
+            _field(fields, field_index(record_type, "TO"))
+        ),
+    }
+
+
+def _formation_context(record_type: str, fields: list[str]) -> dict[str, str]:
+    formation = _field(fields, field_index(record_type, "FORMATION"))
+    return {"reference_formation": formation}
+
+
+def _form_test_date(record_type: str, fields: list[str]) -> str:
+    for name in ("DATE_OF_TEST", "DATE_TESTED", "EFFECTIVE_DT"):
+        try:
+            value = _parse_date(_field(fields, field_index(record_type, name)))
+        except KeyError:
+            continue
+        if value:
+            return value
+    return ""
+
+
+def _candidate_rows(
+    fields: list[str],
+    *,
+    packet: dict[str, str],
+    form: dict[str, str],
+    record_type: str,
+    source_file: str,
+    line_number: int,
+) -> list[dict[str, Any]]:
+    rows = []
+    for pressure_field in pressure_fields_for(record_type):
+        raw_value = _field(fields, field_index(record_type, pressure_field))
+        pressure = _numeric(raw_value)
+        if pressure is None:
+            continue
+        test_date = form.get("test_date", "")
+        row = {
+            "api14": packet.get("api14", ""),
+            "api10": packet.get("api10", ""),
+            "district": packet.get("district", ""),
+            "field_no": packet.get("field_no", ""),
+            "field_name": packet.get("field_name", ""),
+            "lease_number": packet.get("lease_number", ""),
+            "operator_number": packet.get("operator_number", ""),
+            "test_date": test_date,
+            "test_year": _test_year(test_date),
+            "source_record_type": record_type,
+            "source_pressure_field": pressure_field,
+            "pressure_raw_psi": pressure,
+            "source_tracking_no": _field(fields, 1),
+            "source_packet_id": _field(fields, 2),
+            "source_form_id": _field(fields, 3),
+            "source_row_no": _source_row_no(record_type, fields),
+            "source_file": source_file,
+            "source_row_id": f"{source_file}:{line_number}:{pressure_field}",
+        }
+        row.update(_candidate_context(form))
+        rows.append(row)
+    return rows
+
+
+def _candidate_context(form: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "bottom_hole_depth_ft": form.get("bottom_hole_depth_ft"),
+        "vertical_depth_ft": form.get("vertical_depth_ft"),
+        "measured_depth_ft": form.get("measured_depth_ft"),
+        "plug_back_depth_ft": form.get("plug_back_depth_ft"),
+        "production_interval_from_ft": form.get("production_interval_from_ft"),
+        "production_interval_to_ft": form.get("production_interval_to_ft"),
+        "reference_formation": form.get("reference_formation", ""),
+    }
+
+
+def _apply_form_context_to_existing_rows(
+    rows: list[dict[str, Any]],
+    form_key: tuple[str, str, str],
+    form: dict[str, Any],
+) -> None:
+    tracking_no, packet_id, form_id = form_key
+    context = _candidate_context(form)
+    for row in rows:
+        if (
+            row["source_tracking_no"] == tracking_no
+            and row["source_packet_id"] == packet_id
+            and row["source_form_id"] == form_id
+        ):
+            row.update(context)
+
+
+def _source_row_no(record_type: str, fields: list[str]) -> str:
+    try:
+        return _field(fields, field_index(record_type, "ROW_NO"))
+    except KeyError:
+        return ""
+
+
+def _field(fields: list[str], index: int) -> str:
+    if index >= len(fields):
+        return ""
+    return fields[index].strip()
+
+
+def _parse_date(value: str) -> str:
+    text = value.strip()
+    if not text or text == "00000000":
+        return ""
+    if len(text) == 8 and text.isdigit():
+        try:
+            return date(int(text[:4]), int(text[4:6]), int(text[6:8])).isoformat()
+        except ValueError:
+            return ""
+    if "/" in text:
+        parts = text.split("/")
+        if len(parts) != 3:
+            return ""
+        try:
+            month, day, year = (int(part) for part in parts)
+            return date(year, month, day).isoformat()
+        except ValueError:
+            return ""
+    try:
+        return date.fromisoformat(text).isoformat()
+    except ValueError:
+        return ""
+
+
+def _numeric(value: str) -> float | None:
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def _test_year(test_date: str) -> int | None:
+    if not test_date:
+        return None
+    try:
+        return int(test_date[:4])
+    except ValueError:
+        return None
+
+
+__all__ = [
+    "PacketParseResult",
+    "read_packet_pressure_candidates",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations/quality.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations/quality.py
@@ -1,0 +1,94 @@
+"""Quality and coverage summaries for Texas RRC pressure observations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+DISTRICT_COVERAGE_COLUMNS = (
+    "district",
+    "test_decade",
+    "pressure_observation_well_count",
+    "pressure_observation_count",
+)
+FIELD_COVERAGE_COLUMNS = (
+    "district",
+    "field_no",
+    "field_name",
+    "test_decade",
+    "pressure_observation_well_count",
+    "pressure_observation_count",
+)
+
+
+@dataclass(frozen=True)
+class PressureCoverage:
+    """Coverage tables for pressure-observation availability."""
+
+    by_district_decade: pd.DataFrame
+    by_field_decade: pd.DataFrame
+
+
+def build_pressure_coverage(observations: pd.DataFrame) -> PressureCoverage:
+    """Return district/decade and field/decade pressure coverage summaries."""
+    if observations.empty:
+        return PressureCoverage(
+            by_district_decade=pd.DataFrame(columns=DISTRICT_COVERAGE_COLUMNS),
+            by_field_decade=pd.DataFrame(columns=FIELD_COVERAGE_COLUMNS),
+        )
+
+    frame = observations.copy()
+    frame["test_decade"] = _test_decades(frame)
+    frame = frame[frame["test_decade"].notna()].copy()
+    if frame.empty:
+        return PressureCoverage(
+            by_district_decade=pd.DataFrame(columns=DISTRICT_COVERAGE_COLUMNS),
+            by_field_decade=pd.DataFrame(columns=FIELD_COVERAGE_COLUMNS),
+        )
+
+    return PressureCoverage(
+        by_district_decade=_coverage(
+            frame,
+            keys=("district", "test_decade"),
+            columns=DISTRICT_COVERAGE_COLUMNS,
+        ),
+        by_field_decade=_coverage(
+            frame,
+            keys=("district", "field_no", "field_name", "test_decade"),
+            columns=FIELD_COVERAGE_COLUMNS,
+        ),
+    )
+
+
+def _coverage(
+    frame: pd.DataFrame,
+    keys: tuple[str, ...],
+    columns: tuple[str, ...],
+) -> pd.DataFrame:
+    grouped = (
+        frame.groupby(list(keys), dropna=False, sort=True)
+        .agg(
+            pressure_observation_well_count=("api14", "nunique"),
+            pressure_observation_count=("api14", "size"),
+        )
+        .reset_index()
+    )
+    return grouped.loc[:, list(columns)]
+
+
+def _test_decades(frame: pd.DataFrame) -> pd.Series:
+    years = pd.Series(pd.NA, index=frame.index, dtype="Int64")
+    if "test_year" in frame:
+        years = pd.to_numeric(frame["test_year"], errors="coerce").astype("Int64")
+    if "test_date" in frame:
+        date_years = pd.to_datetime(frame["test_date"], errors="coerce").dt.year
+        years = years.fillna(date_years.astype("Int64"))
+    decades = (years // 10) * 10
+    return decades.map(lambda value: f"{int(value)}s" if pd.notna(value) else pd.NA)
+
+
+__all__ = [
+    "PressureCoverage",
+    "build_pressure_coverage",
+]

--- a/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations/sources.py
+++ b/packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations/sources.py
@@ -1,0 +1,277 @@
+"""Load local official Texas RRC inputs for pressure observations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import zipfile
+from dataclasses import dataclass
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.lifecycle.keys import derive_api10, normalize_api14
+from worldenergydata.texas_rrc.pressure_observations.packets import (
+    read_packet_pressure_candidates,
+)
+
+COMPLETION_DIR = Path("raw") / "completions"
+WELLBORE_DIR = Path("raw") / "wellbore" / "query"
+MANIFEST_DIR = Path("manifests")
+TABLE_SUFFIXES = {".csv", ".dat", ".txt"}
+
+
+@dataclass(frozen=True)
+class PressureObservationInputs:
+    """Local pressure-observation source frames and source evidence."""
+
+    candidates: pd.DataFrame
+    wellbore: pd.DataFrame
+    input_paths: tuple[str, ...]
+    input_artifacts: tuple[dict[str, object], ...]
+    source_gaps: tuple[str, ...]
+    source_warnings: tuple[str, ...]
+    parser_quality: dict[str, int]
+
+
+def load_pressure_observation_inputs(raw_root: Path | str) -> PressureObservationInputs:
+    """Load pressure candidates and wellbore reference from local RRC snapshots."""
+    root = _local_root(raw_root)
+    candidate_frames, completion_paths, parser_quality = _completion_candidates(root)
+    wellbore, wellbore_paths = _wellbore_reference(root)
+
+    source_gaps = []
+    if not completion_paths:
+        source_gaps.append("completion_data")
+    if not wellbore_paths:
+        source_gaps.append("wellbore_query")
+
+    candidates = _candidate_frame(candidate_frames)
+    input_paths = tuple(str(path) for path in (*completion_paths, *wellbore_paths))
+    input_artifacts = tuple(
+        _artifact_payload(path) for path in (*completion_paths, *wellbore_paths)
+    )
+
+    return PressureObservationInputs(
+        candidates=candidates,
+        wellbore=wellbore,
+        input_paths=input_paths,
+        input_artifacts=input_artifacts,
+        source_gaps=tuple(source_gaps),
+        source_warnings=_raw_manifest_warnings(root),
+        parser_quality=parser_quality,
+    )
+
+
+def _candidate_frame(frames: list[pd.DataFrame]) -> pd.DataFrame:
+    if not frames:
+        return pd.DataFrame()
+    rows: list[dict[str, Any]] = []
+    for frame in frames:
+        rows.extend(frame.to_dict("records"))
+    return pd.DataFrame.from_records(rows, columns=frames[0].columns)
+
+
+def _local_root(raw_root: Path | str) -> Path:
+    value = str(raw_root)
+    if "://" in value:
+        raise ValueError("Pressure-observation inputs must be local filesystem paths")
+    return Path(raw_root)
+
+
+def _completion_candidates(
+    root: Path,
+) -> tuple[list[pd.DataFrame], list[Path], dict[str, int]]:
+    source_dir = root / COMPLETION_DIR
+    quality = {
+        "candidate_count": 0,
+        "malformed_row_count": 0,
+        "unlinked_row_count": 0,
+    }
+    if not source_dir.exists():
+        return [], [], quality
+
+    frames = []
+    paths = [path for path in sorted(source_dir.glob("*.zip")) if path.is_file()]
+    for path in paths:
+        with zipfile.ZipFile(path) as archive:
+            for member in sorted(archive.namelist()):
+                if Path(member).suffix.lower() not in TABLE_SUFFIXES:
+                    continue
+                text = archive.read(member).decode("utf-8", errors="replace")
+                parsed = read_packet_pressure_candidates(
+                    text,
+                    source_file=f"{path}!{member}",
+                )
+                quality["candidate_count"] += len(parsed.candidates)
+                quality["malformed_row_count"] += parsed.malformed_row_count
+                quality["unlinked_row_count"] += parsed.unlinked_row_count
+                if not parsed.candidates.empty:
+                    frames.append(parsed.candidates)
+    return frames, paths, quality
+
+
+def _wellbore_reference(root: Path) -> tuple[pd.DataFrame, list[Path]]:
+    source_dir = root / WELLBORE_DIR
+    if not source_dir.exists():
+        return pd.DataFrame(), []
+
+    frames = []
+    paths = [
+        path
+        for path in sorted(source_dir.rglob("*"))
+        if path.is_file() and path.suffix.lower() in TABLE_SUFFIXES.union({".zip"})
+    ]
+    for path in paths:
+        frame = _read_wellbore_path(path)
+        if not frame.empty:
+            frames.append(frame)
+    if not frames:
+        return pd.DataFrame(), paths
+    combined = pd.concat(frames, ignore_index=True)
+    return _normalize_wellbore_reference(combined), paths
+
+
+def _read_wellbore_path(path: Path) -> pd.DataFrame:
+    if path.suffix.lower() == ".zip":
+        frames = []
+        with zipfile.ZipFile(path) as archive:
+            for member in sorted(archive.namelist()):
+                if Path(member).suffix.lower() not in TABLE_SUFFIXES:
+                    continue
+                text = archive.read(member).decode("utf-8", errors="replace")
+                frame = _read_wellbore_text(text)
+                if not frame.empty:
+                    frames.append(frame)
+        return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+    first_line = _first_line(path)
+    if _looks_like_header(first_line):
+        return pd.read_csv(
+            path,
+            dtype=str,
+            keep_default_na=False,
+            low_memory=False,
+        )
+    return pd.read_csv(
+        path,
+        header=None,
+        names=["api_number", "total_depth"],
+        usecols=[2, 15],
+        dtype=str,
+        keep_default_na=False,
+        on_bad_lines="skip",
+    )
+
+
+def _read_wellbore_text(text: str) -> pd.DataFrame:
+    if not text.strip():
+        return pd.DataFrame()
+    first_line = text.splitlines()[0]
+    if _looks_like_header(first_line):
+        return pd.read_csv(
+            StringIO(text),
+            dtype=str,
+            keep_default_na=False,
+            low_memory=False,
+        )
+    return pd.read_csv(
+        StringIO(text),
+        header=None,
+        names=["api_number", "total_depth"],
+        usecols=[2, 15],
+        engine="python",
+        dtype=str,
+        keep_default_na=False,
+        on_bad_lines="skip",
+    )
+
+
+def _looks_like_header(first_line: str) -> bool:
+    keys = {_column_key(part) for part in first_line.split(",")}
+    return bool(keys.intersection({"API_NO", "API_NUMBER", "TOTAL_DEPTH"}))
+
+
+def _first_line(path: Path) -> str:
+    with path.open(encoding="utf-8", errors="replace") as handle:
+        return handle.readline()
+
+
+def _normalize_wellbore_reference(frame: pd.DataFrame) -> pd.DataFrame:
+    renamed = frame.rename(
+        columns={column: _wellbore_alias(column) for column in frame}
+    )
+    if "api_number" not in renamed or "total_depth" not in renamed:
+        return pd.DataFrame()
+    result = renamed.loc[:, ["api_number", "total_depth"]].copy()
+    result["api14"] = result["api_number"].map(normalize_api14)
+    result = result[result["api14"].notna()].copy()
+    result["api10"] = result["api14"].map(derive_api10)
+    result["total_depth"] = result["total_depth"].astype(str).str.strip()
+    return result.loc[:, ["api14", "api10", "total_depth"]].reset_index(drop=True)
+
+
+def _wellbore_alias(column: str) -> str:
+    aliases = {
+        "API_NO": "api_number",
+        "API_NUMBER": "api_number",
+        "API": "api_number",
+        "TOTAL_DEPTH": "total_depth",
+        "TOTAL_DEPTH_FT": "total_depth",
+    }
+    return aliases.get(_column_key(column), str(column).lower())
+
+
+def _raw_manifest_warnings(root: Path) -> tuple[str, ...]:
+    warnings = []
+    manifest_dir = root / MANIFEST_DIR
+    if not manifest_dir.exists():
+        return ()
+    for source_id in ("completion_data", "wellbore_query"):
+        manifest = _latest_manifest(manifest_dir, source_id)
+        if not manifest:
+            continue
+        status = str(manifest.get("status", ""))
+        if status and status != "downloaded":
+            retrieved_at = str(manifest.get("retrieved_at", ""))
+            warnings.append(f"raw_manifest_warning:{source_id}:{status}:{retrieved_at}")
+    return tuple(warnings)
+
+
+def _latest_manifest(manifest_dir: Path, source_id: str) -> dict[str, Any]:
+    paths = sorted(manifest_dir.glob(f"{source_id}-*.json"))
+    for path in reversed(paths):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(payload, dict):
+            return payload
+    return {}
+
+
+def _artifact_payload(path: Path) -> dict[str, object]:
+    return {
+        "path": str(path),
+        "byte_size": path.stat().st_size,
+        "sha256": _sha256(path),
+    }
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _column_key(column: object) -> str:
+    return str(column).strip().upper().replace(" ", "_")
+
+
+__all__ = [
+    "PressureObservationInputs",
+    "load_pressure_observation_inputs",
+]

--- a/scripts/review/results/2026-07-03-code-709-codex-inline.md
+++ b/scripts/review/results/2026-07-03-code-709-codex-inline.md
@@ -1,0 +1,88 @@
+# Codex adversarial code review - Issue #709
+
+Implementation reviewed: Texas RRC pressure observations
+Review time: 2026-07-03
+
+## Verdict
+
+MINOR after remediation - implementation is acceptable for the approved #709
+scope.
+
+No blocking defects remain after the live `/mnt/ace` smoke, parser/coverage
+performance fixes, and the T2 adversarial review remediation pass.
+
+## Findings
+
+No unresolved blocking findings.
+
+Resolved blocking findings from the T2 adversarial review:
+
+1. `G-1 Field Data.WELLHEAD_PRESS` was initially curated as `WHP_shut_in`
+   without requiring `source_row_no=SHUT-IN`. Fixed by requiring the SHUT-IN
+   row context; added regression tests for SHUT-IN accepted and blank/FLOWING
+   row numbers rejected.
+2. Candidates with blank/invalid `api14` could initially become curated
+   observations. Fixed by rejecting invalid API14 before curation and counting
+   `missing_api`; added a regression test.
+3. Source artifact hashing initially covered completion ZIPs only. Fixed by
+   including Wellbore Query files in `input_artifacts`; added a regression
+   assertion for completion and wellbore SHA256/byte-size payloads.
+
+Minor residual caveats:
+
+1. The command-line console script path imports the broader `worldenergydata`
+   CLI and stalled in an unrelated `torch` import path from `safety_analysis`
+   during smoke. The pressure build support layer itself completed and wrote
+   `/mnt/ace` outputs. A separate CLI-startup issue should handle lazy-loading
+   unrelated heavy modules.
+2. The live run still reads the full Wellbore Query CSV before filtering to
+   pressure-candidate API14s. The post-load filter prevents statewide groupby
+   cost, but a future optimization could push candidate-API filtering into the
+   wellbore read path.
+3. WHP-derived rows remain screening-only and do not perform a static gas-column
+   BHP correction in this slice. That matches the approved plan's downstream
+   #710 policy gate, but consumers must not treat WHP gradients as measured BHP.
+
+## Checks Performed
+
+- Reviewed pressure classification, W-2 non-BHP handling, unit-basis fields,
+  source warning propagation, depth priority, gradient gating, earliest-proxy
+  selection, coverage aggregation, `/mnt/ace` output guard, staged writes, and
+  manifest payloads.
+- Ran focused tests:
+  `PYTHONPATH="$(printf '%s:' packages/*/src)src" uv run --no-sync pytest --no-cov tests/unit/texas_rrc/test_pressure_observation*.py -q`
+  -> 28 passed after the T2 review fixes.
+- Ran remediation-focused tests:
+  `PYTHONPATH="$(printf '%s:' packages/*/src)src" uv run --no-sync pytest --no-cov tests/unit/texas_rrc/test_pressure_observation_cli.py tests/unit/texas_rrc/test_pressure_observations.py tests/unit/texas_rrc/test_pressure_observation_sources.py -q`
+  -> 15 passed after the T2 review fixes.
+- Ran adjacent tests:
+  `PYTHONPATH="$(printf '%s:' packages/*/src)src" uv run --no-sync pytest --no-cov tests/unit/texas_rrc/test_lifecycle_keys.py tests/unit/texas_rrc/test_lifecycle_sources.py tests/unit/texas_rrc/test_lifecycle_io.py tests/unit/texas_rrc/test_source_catalog.py -q`
+  -> 31 passed after the final CLI helper split.
+- Ran formatting/lint:
+  `black --check --diff`, `isort --check-only --diff`, and `ruff check` on the
+  touched pressure package, Texas RRC CLI command, and pressure tests -> clean.
+- Ran `git diff --check` and `scripts/legal/legal-sanity-scan.sh` -> clean/PASS.
+- Checked newly added pressure persistence and CLI helper function lengths
+  against the local 50-line rule -> all pressure-related additions are <= 50
+  lines per function.
+- Ran live support-layer build against
+  `/mnt/ace/worldenergydata/data/modules/texas_rrc` -> 360 candidates, 48
+  curated observations, no source gaps, 2 hashed input artifacts, expected
+  `raw_manifest_warning:completion_data:error:2026-07-01T00:36:55Z`.
+- Wrote live `/mnt/ace` outputs:
+  - `curated/pressure/well_pressure_observations/texas_rrc_well_pressure_observations.csv`
+  - `curated/pressure/well_pressure_observations/texas_rrc_well_pressure_observations.parquet`
+  - `normalized/pressure/texas_rrc_pressure_candidates.csv`
+  - `normalized/pressure/texas_rrc_pressure_candidates.parquet`
+  - `curated/pressure/well_pressure_observations/coverage_by_district_decade.csv`
+  - `curated/pressure/well_pressure_observations/coverage_by_field_decade.csv`
+  - `curated/pressure/well_pressure_observations/texas_rrc_pressure_observation_quality.json`
+  - `curated/pressure/well_pressure_observations/manifest.json`
+- Reloaded live CSV/JSON outputs and confirmed 48 observation rows, 360
+  candidate rows, 6 district/decade coverage rows, 8 field/decade coverage
+  rows, pressure/unit quality counts, no source gaps, 2 input artifacts, and
+  the expected completion manifest warning.
+
+## Required Changes Before Closeout
+
+None for #709.

--- a/src/worldenergydata/cli/commands/texas_rrc.py
+++ b/src/worldenergydata/cli/commands/texas_rrc.py
@@ -606,6 +606,128 @@ def normalize_lifecycle(
         raise typer.Exit(1)
 
 
+def _print_pressure_observation_summary(
+    row_count: int,
+    candidate_count: int,
+    source_gaps,
+    source_warnings,
+) -> None:
+    table = Table(
+        title="Texas RRC Pressure Observations",
+        show_header=True,
+        header_style="bold cyan",
+    )
+    table.add_column("Metric", style="dim")
+    table.add_column("Value")
+    table.add_row("Curated observations", str(row_count))
+    table.add_row("Normalized candidates", str(candidate_count))
+    table.add_row("Source gaps", ", ".join(source_gaps) if source_gaps else "None")
+    table.add_row(
+        "Source warnings",
+        ", ".join(source_warnings) if source_warnings else "None",
+    )
+    console.print(table)
+    for warning in source_warnings:
+        console.print(f"[yellow]Source warning:[/yellow] {warning}")
+
+
+def _print_pressure_observation_outputs(manifest) -> None:
+    console.print(
+        "[green]Wrote pressure observations[/green] "
+        f"{manifest.row_count} rows -> {manifest.observations_csv_path}"
+    )
+    console.print(f"[dim]Parquet: {manifest.observations_parquet_path}[/dim]")
+    console.print(f"[dim]Candidates CSV: {manifest.candidates_csv_path}[/dim]")
+    console.print(f"[dim]Candidates Parquet: {manifest.candidates_parquet_path}[/dim]")
+    console.print(
+        "[dim]District/decade coverage: "
+        f"{manifest.coverage_by_district_decade_csv_path}[/dim]"
+    )
+    console.print(
+        "[dim]Field/decade coverage: "
+        f"{manifest.coverage_by_field_decade_csv_path}[/dim]"
+    )
+    console.print(f"[dim]Quality report: {manifest.quality_path}[/dim]")
+    console.print(f"[dim]Manifest: {manifest.manifest_path}[/dim]")
+
+
+@app.command("build-pressure-observations")
+def build_pressure_observations_command(
+    raw_root: Path = typer.Option(
+        Path("/mnt/ace/worldenergydata/data/modules/texas_rrc"),
+        "--raw-root",
+        help="Root containing Texas RRC raw completion and wellbore snapshots",
+    ),
+    output_root: Path = typer.Option(
+        Path("/mnt/ace/worldenergydata/data/modules/texas_rrc"),
+        "--output-root",
+        help="Root for curated pressure-observation outputs",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Build the pressure-observation summary without writing outputs",
+    ),
+    require_sources: bool = typer.Option(
+        False,
+        "--require-sources",
+        help="Fail when completion or wellbore pressure inputs are missing",
+    ),
+    allow_non_ace_output: bool = typer.Option(
+        False,
+        "--allow-non-ace-output",
+        help="Allow non-/mnt/ace output roots for isolated tests or sandboxes",
+    ),
+) -> None:
+    """Build Texas RRC well pressure observations from local official data."""
+    _run_pressure_observation_build(
+        raw_root=raw_root,
+        output_root=output_root,
+        dry_run=dry_run,
+        require_sources=require_sources,
+        allow_non_ace_output=allow_non_ace_output,
+    )
+
+
+def _run_pressure_observation_build(
+    raw_root: Path,
+    output_root: Path,
+    dry_run: bool,
+    require_sources: bool,
+    allow_non_ace_output: bool,
+) -> None:
+    from worldenergydata.texas_rrc.pressure_observations.cli_support import (
+        run_build_pressure_observations,
+    )
+
+    try:
+        result = run_build_pressure_observations(
+            raw_root=raw_root,
+            output_root=output_root,
+            dry_run=dry_run,
+            require_sources=require_sources,
+            allow_non_ace_output=allow_non_ace_output,
+        )
+        _print_pressure_observation_summary(
+            result.row_count,
+            result.candidate_count,
+            result.source_gaps,
+            result.source_warnings,
+        )
+        if dry_run:
+            console.print(
+                "[yellow]Dry run:[/yellow] no pressure-observation outputs written"
+            )
+            return
+        if result.manifest is not None:
+            _print_pressure_observation_outputs(result.manifest)
+    except typer.Exit:
+        raise
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+
+
 def _print_production_atlas_summary(row_count: int, source_gaps) -> None:
     table = Table(
         title="Texas RRC Production Field Atlas",

--- a/tests/unit/texas_rrc/test_pressure_observation_cli.py
+++ b/tests/unit/texas_rrc/test_pressure_observation_cli.py
@@ -1,0 +1,227 @@
+"""Tests for Texas RRC pressure-observation CLI support."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from worldenergydata.cli.commands.texas_rrc import app
+from worldenergydata.texas_rrc.pressure_observations.cli_support import (
+    PressureObservationBuildResult,
+    run_build_pressure_observations,
+)
+from worldenergydata.texas_rrc.pressure_observations.io import (
+    PressureObservationOutputManifest,
+)
+
+
+def test_build_pressure_observations_cli_calls_support_layer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_run_build_pressure_observations(**kwargs):
+        calls.append(kwargs)
+        return _Result(
+            row_count=1,
+            candidate_count=3,
+            source_gaps=(),
+            source_warnings=("raw_manifest_warning:completion_data:error:2026-07-01",),
+            dry_run=False,
+            manifest=_manifest(tmp_path),
+        )
+
+    monkeypatch.setattr(
+        "worldenergydata.texas_rrc.pressure_observations.cli_support."
+        "run_build_pressure_observations",
+        fake_run_build_pressure_observations,
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "build-pressure-observations",
+            "--raw-root",
+            str(tmp_path),
+            "--output-root",
+            str(tmp_path),
+            "--allow-non-ace-output",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        {
+            "raw_root": tmp_path,
+            "output_root": tmp_path,
+            "dry_run": False,
+            "require_sources": False,
+            "allow_non_ace_output": True,
+        }
+    ]
+    assert "Wrote pressure observations" in result.output
+    assert "raw_manifest_warning:completion_data:error:2026-07-01" in result.output
+
+
+def test_run_build_pressure_observations_dry_run_reports_missing_sources(
+    tmp_path: Path,
+) -> None:
+    result = run_build_pressure_observations(
+        raw_root=tmp_path,
+        output_root=tmp_path,
+        dry_run=True,
+        require_sources=False,
+        allow_non_ace_output=True,
+    )
+
+    assert isinstance(result, PressureObservationBuildResult)
+    assert result.dry_run is True
+    assert result.row_count == 0
+    assert result.candidate_count == 0
+    assert result.source_gaps == ("completion_data", "wellbore_query")
+    assert result.manifest is None
+
+
+def test_run_build_pressure_observations_writes_coverage_outputs(
+    tmp_path: Path,
+) -> None:
+    _write_pressure_raw_fixture(tmp_path)
+
+    result = run_build_pressure_observations(
+        raw_root=tmp_path,
+        output_root=tmp_path,
+        allow_non_ace_output=True,
+    )
+
+    assert result.row_count == 1
+    assert result.candidate_count == 1
+    assert result.manifest is not None
+    assert result.manifest.coverage_by_district_decade_csv_path.exists()
+    assert result.manifest.coverage_by_field_decade_csv_path.exists()
+    quality = json.loads(result.manifest.quality_path.read_text(encoding="utf-8"))
+    assert quality["pressure_kind_counts"] == {"BHP_measured": 1}
+    assert quality["pressure_unit_basis_counts"] == {"source_psi_unspecified": 1}
+
+
+def test_run_build_pressure_observations_requires_sources(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="completion_data"):
+        run_build_pressure_observations(
+            raw_root=tmp_path,
+            output_root=tmp_path,
+            dry_run=True,
+            require_sources=True,
+            allow_non_ace_output=True,
+        )
+
+
+@dataclass(frozen=True)
+class _Result:
+    row_count: int
+    candidate_count: int
+    source_gaps: tuple[str, ...]
+    source_warnings: tuple[str, ...]
+    dry_run: bool
+    manifest: PressureObservationOutputManifest | None
+
+
+def _manifest(tmp_path: Path) -> PressureObservationOutputManifest:
+    curated = tmp_path / "curated" / "pressure" / "well_pressure_observations"
+    normalized = tmp_path / "normalized" / "pressure"
+    return PressureObservationOutputManifest(
+        generated_at="2026-07-03T12:00:00Z",
+        output_root=tmp_path,
+        observations_csv_path=curated / "texas_rrc_well_pressure_observations.csv",
+        observations_parquet_path=curated
+        / "texas_rrc_well_pressure_observations.parquet",
+        candidates_csv_path=normalized / "texas_rrc_pressure_candidates.csv",
+        candidates_parquet_path=normalized / "texas_rrc_pressure_candidates.parquet",
+        coverage_by_district_decade_csv_path=curated
+        / "coverage_by_district_decade.csv",
+        coverage_by_district_decade_parquet_path=curated
+        / "coverage_by_district_decade.parquet",
+        coverage_by_field_decade_csv_path=curated / "coverage_by_field_decade.csv",
+        coverage_by_field_decade_parquet_path=curated
+        / "coverage_by_field_decade.parquet",
+        quality_path=curated / "texas_rrc_pressure_observation_quality.json",
+        manifest_path=curated / "manifest.json",
+        row_count=1,
+        candidate_count=3,
+        input_paths=(),
+        input_artifacts=(),
+        source_gaps=(),
+        source_warnings=("raw_manifest_warning:completion_data:error:2026-07-01",),
+        command=None,
+        code_revision="test-rev",
+    )
+
+
+def _write_pressure_raw_fixture(root: Path) -> None:
+    completion_zip = root / "raw" / "completions" / "06-29-2026.zip"
+    completion_zip.parent.mkdir(parents=True)
+    with zipfile.ZipFile(completion_zip, "w") as archive:
+        archive.writestr(
+            "completion.dat",
+            "\n".join(
+                [
+                    _packet_line(
+                        {
+                            1: "123456",
+                            2: "654321",
+                            5: "456789",
+                            6: "00100001",
+                            8: "98765",
+                            25: "12345678",
+                            27: "08",
+                            29: "SPRABERRY",
+                        }
+                    ),
+                    _record_line(
+                        "G-1",
+                        {
+                            1: "123456",
+                            2: "654321",
+                            3: "999",
+                            4: "03/01/2024",
+                            59: "2500",
+                        },
+                    ),
+                    _record_line(
+                        "G-1 Production Interval Data",
+                        {
+                            1: "123456",
+                            2: "654321",
+                            3: "999",
+                            4: "1",
+                            5: "1000",
+                            6: "1200",
+                        },
+                        length=10,
+                    ),
+                ]
+            ),
+        )
+    wellbore = root / "raw" / "wellbore" / "query" / "wellbore.csv"
+    wellbore.parent.mkdir(parents=True)
+    wellbore.write_text("API_NO,TOTAL_DEPTH\n4200100001,1200\n", encoding="utf-8")
+
+
+def _packet_line(values: dict[int, str], length: int = 61) -> str:
+    columns = [""] * length
+    columns[0] = "PACKET"
+    for index, value in values.items():
+        columns[index] = value
+    return "{".join(columns)
+
+
+def _record_line(record_type: str, values: dict[int, str], length: int = 90) -> str:
+    columns = [""] * length
+    columns[0] = record_type
+    for index, value in values.items():
+        columns[index] = value
+    return "{".join(columns)

--- a/tests/unit/texas_rrc/test_pressure_observation_io.py
+++ b/tests/unit/texas_rrc/test_pressure_observation_io.py
@@ -1,0 +1,143 @@
+"""Tests for Texas RRC pressure-observation output persistence."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pandas as pd
+import pytest
+
+from worldenergydata.texas_rrc.pressure_observations.io import (
+    load_pressure_observations,
+    write_pressure_observation_outputs,
+)
+
+
+def test_write_pressure_observation_outputs_persists_tables_quality_and_manifest(
+    tmp_path,
+) -> None:
+    observations = pd.DataFrame(
+        [
+            {
+                "api14": "42001000010000",
+                "api10": "4200100001",
+                "pressure_kind": "BHP_measured",
+                "pressure_psia": 2500.0,
+            }
+        ]
+    )
+    candidates = pd.DataFrame(
+        [
+            {
+                "api14": "42001000010000",
+                "api10": "4200100001",
+                "source_record_type": "G-1",
+                "source_pressure_field": "BOTTOM_HOLE_PRESS",
+                "pressure_raw_psi": 2500.0,
+            }
+        ]
+    )
+    coverage_by_district_decade = pd.DataFrame(
+        [
+            {
+                "district": "08",
+                "test_decade": "2020s",
+                "pressure_observation_well_count": 1,
+                "pressure_observation_count": 1,
+            }
+        ]
+    )
+    coverage_by_field_decade = pd.DataFrame(
+        [
+            {
+                "district": "08",
+                "field_no": "12345678",
+                "field_name": "SPRABERRY",
+                "test_decade": "2020s",
+                "pressure_observation_well_count": 1,
+                "pressure_observation_count": 1,
+            }
+        ]
+    )
+
+    manifest = write_pressure_observation_outputs(
+        observations,
+        candidates,
+        coverage_by_district_decade,
+        coverage_by_field_decade,
+        quality={"w2_pressure_candidates_not_curated": 0},
+        output_root=tmp_path,
+        generated_at=datetime(2026, 7, 3, 12, 0, tzinfo=timezone.utc),
+        input_paths=["raw/completions/06-29-2026.zip"],
+        input_artifacts=[
+            {
+                "path": "raw/completions/06-29-2026.zip",
+                "byte_size": 123,
+                "sha256": "a" * 64,
+            }
+        ],
+        source_gaps=(),
+        source_warnings=("raw_manifest_warning:completion_data:error:2026-07-01",),
+        allow_non_ace_root=True,
+        command="worldenergydata texas-rrc build-pressure-observations",
+        code_revision="abc123",
+    )
+
+    assert manifest.row_count == 1
+    assert manifest.candidate_count == 1
+    assert manifest.observations_csv_path.exists()
+    assert manifest.observations_parquet_path.exists()
+    assert manifest.candidates_csv_path.exists()
+    assert manifest.candidates_parquet_path.exists()
+    assert manifest.coverage_by_district_decade_csv_path.exists()
+    assert manifest.coverage_by_district_decade_parquet_path.exists()
+    assert manifest.coverage_by_field_decade_csv_path.exists()
+    assert manifest.coverage_by_field_decade_parquet_path.exists()
+    assert manifest.quality_path.exists()
+    assert manifest.manifest_path.exists()
+    assert (
+        load_pressure_observations(manifest.observations_csv_path).loc[0, "api14"]
+        == "42001000010000"
+    )
+
+    quality_payload = json.loads(manifest.quality_path.read_text(encoding="utf-8"))
+    assert quality_payload["row_count"] == 1
+    assert quality_payload["candidate_count"] == 1
+    assert quality_payload["source_warnings"] == [
+        "raw_manifest_warning:completion_data:error:2026-07-01"
+    ]
+    assert quality_payload["w2_pressure_candidates_not_curated"] == 0
+
+    manifest_payload = json.loads(manifest.manifest_path.read_text(encoding="utf-8"))
+    assert manifest_payload["generated_at"] == "2026-07-03T12:00:00Z"
+    assert manifest_payload["observations_csv_path"] == str(
+        manifest.observations_csv_path
+    )
+    assert manifest_payload["candidates_csv_path"] == str(manifest.candidates_csv_path)
+    assert manifest_payload["coverage_by_district_decade_csv_path"] == str(
+        manifest.coverage_by_district_decade_csv_path
+    )
+    assert manifest_payload["coverage_by_field_decade_csv_path"] == str(
+        manifest.coverage_by_field_decade_csv_path
+    )
+    assert manifest_payload["input_artifacts"][0]["sha256"] == "a" * 64
+    assert manifest_payload["command"] == (
+        "worldenergydata texas-rrc build-pressure-observations"
+    )
+    assert manifest_payload["code_revision"] == "abc123"
+    assert not list(tmp_path.rglob(".staging-*"))
+
+
+def test_write_pressure_observation_outputs_rejects_non_ace_root_without_override(
+    tmp_path,
+) -> None:
+    with pytest.raises(ValueError, match="/mnt/ace"):
+        write_pressure_observation_outputs(
+            pd.DataFrame(),
+            pd.DataFrame(),
+            pd.DataFrame(),
+            pd.DataFrame(),
+            quality={},
+            output_root=tmp_path,
+        )

--- a/tests/unit/texas_rrc/test_pressure_observation_packet_schema.py
+++ b/tests/unit/texas_rrc/test_pressure_observation_packet_schema.py
@@ -1,0 +1,46 @@
+"""Tests for Texas RRC pressure-observation packet schema maps."""
+
+from __future__ import annotations
+
+from worldenergydata.texas_rrc.pressure_observations.packet_schema import (
+    PRESSURE_RECORD_SCHEMAS,
+    field_index,
+    pressure_fields_for,
+)
+
+
+def test_packet_schema_maps_g1_pressure_fields():
+    assert "G-1" in PRESSURE_RECORD_SCHEMAS
+    assert field_index("G-1", "BOTTOM_HOLE_PRESS") > 0
+    assert field_index("G-1", "BOTTOM_HOLE_DEPTH") > 0
+    assert field_index("G-1", "DATE_OF_TEST") > 0
+
+
+def test_packet_schema_maps_g1_field_pressure_rows():
+    assert pressure_fields_for("G-1 Field Data") == ("WELLHEAD_PRESS",)
+    assert field_index("G-1 Field Data", "ROW_NO") > 0
+    assert field_index("G-1 Field Data", "WELLHEAD_PRESS") > 0
+
+
+def test_packet_schema_maps_g10_pressure_fields():
+    assert pressure_fields_for("G-10") == (
+        "XBHOLE_PRESSURE",
+        "SIWH_PRESSURE",
+        "FLOWING_PRESSURE",
+    )
+    assert field_index("G-10", "DATE_TESTED") > 0
+    assert field_index("G-10", "REASON_CODE") > 0
+
+
+def test_packet_schema_maps_interval_and_formation_rows():
+    assert field_index("G-1 Production Interval Data", "FROM") > 0
+    assert field_index("G-1 Production Interval Data", "TO") > 0
+    assert field_index("W-2 Production Interval Data", "BOTTOM_HOLE_LABEL") > 0
+    assert field_index("G-1 Formation Data", "FORMATION") > 0
+    assert field_index("W-2 Formation Data", "DEPTH") > 0
+
+
+def test_w2_pressure_like_fields_are_candidates_not_bhp_fields():
+    assert "W-2" in PRESSURE_RECORD_SCHEMAS
+    assert "CALC_CASING_PRESS" in pressure_fields_for("W-2")
+    assert "BOTTOM_HOLE_PRESS" not in pressure_fields_for("W-2")

--- a/tests/unit/texas_rrc/test_pressure_observation_packets.py
+++ b/tests/unit/texas_rrc/test_pressure_observation_packets.py
@@ -1,0 +1,198 @@
+"""Tests for parsing Texas RRC pressure-observation packet rows."""
+
+from __future__ import annotations
+
+from worldenergydata.texas_rrc.pressure_observations.packets import (
+    read_packet_pressure_candidates,
+)
+
+
+def _packet_line(values: dict[int, str], length: int = 61) -> str:
+    columns = [""] * length
+    columns[0] = "PACKET"
+    for index, value in values.items():
+        columns[index] = value
+    return "{".join(columns)
+
+
+def _record_line(record_type: str, values: dict[int, str], length: int = 90) -> str:
+    columns = [""] * length
+    columns[0] = record_type
+    for index, value in values.items():
+        columns[index] = value
+    return "{".join(columns)
+
+
+def _packet_context() -> str:
+    return _packet_line(
+        {
+            1: "123456",
+            2: "654321",
+            5: "456789",
+            6: "00100001",
+            8: "98765",
+            25: "12345678",
+            27: "08",
+            29: "SPRABERRY",
+        }
+    )
+
+
+def test_packet_parser_links_g1_pressure_to_packet_context():
+    text = "\n".join(
+        [
+            "123456{G-1{Packet Data(1)",
+            _packet_context(),
+            _record_line(
+                "G-1",
+                {
+                    1: "123456",
+                    2: "654321",
+                    3: "999",
+                    4: "03/01/2024",
+                    13: "10000",
+                    59: "2500",
+                },
+            ),
+        ]
+    )
+
+    result = read_packet_pressure_candidates(text, source_file="packet.dat")
+
+    assert result.malformed_row_count == 0
+    assert result.unlinked_row_count == 0
+    row = result.candidates.iloc[0].to_dict()
+    assert row["api14"] == "42001000010000"
+    assert row["api10"] == "4200100001"
+    assert row["district"] == "08"
+    assert row["field_no"] == "12345678"
+    assert row["field_name"] == "SPRABERRY"
+    assert row["test_date"] == "2024-03-01"
+    assert row["source_record_type"] == "G-1"
+    assert row["source_pressure_field"] == "BOTTOM_HOLE_PRESS"
+    assert row["pressure_raw_psi"] == 2500.0
+    assert row["source_tracking_no"] == "123456"
+    assert row["source_packet_id"] == "654321"
+    assert row["source_form_id"] == "999"
+    assert row["source_file"] == "packet.dat"
+
+
+def test_packet_parser_links_g1_interval_depth_to_pressure_candidate():
+    text = "\n".join(
+        [
+            _packet_context(),
+            _record_line(
+                "G-1",
+                {
+                    1: "123456",
+                    2: "654321",
+                    3: "999",
+                    4: "03/01/2024",
+                    13: "10000",
+                    59: "2500",
+                },
+            ),
+            _record_line(
+                "G-1 Production Interval Data",
+                {
+                    1: "123456",
+                    2: "654321",
+                    3: "999",
+                    4: "1",
+                    5: "1000",
+                    6: "1200",
+                },
+                length=10,
+            ),
+        ]
+    )
+
+    result = read_packet_pressure_candidates(text, source_file="packet.dat")
+
+    row = result.candidates.iloc[0].to_dict()
+    assert row["production_interval_from_ft"] == 1000.0
+    assert row["production_interval_to_ft"] == 1200.0
+    assert row["reference_formation"] == ""
+
+
+def test_packet_parser_links_g1_field_shut_in_wellhead_pressure():
+    text = "\n".join(
+        [
+            _packet_context(),
+            _record_line(
+                "G-1",
+                {1: "123456", 2: "654321", 3: "999", 4: "03/01/2024"},
+            ),
+            _record_line(
+                "G-1 Field Data",
+                {
+                    1: "123456",
+                    2: "654321",
+                    3: "999",
+                    4: "SHUT-IN",
+                    7: "1032",
+                },
+                length=9,
+            ),
+        ]
+    )
+
+    result = read_packet_pressure_candidates(text, source_file="packet.dat")
+
+    row = result.candidates.iloc[0].to_dict()
+    assert row["source_record_type"] == "G-1 Field Data"
+    assert row["source_pressure_field"] == "WELLHEAD_PRESS"
+    assert row["pressure_raw_psi"] == 1032.0
+    assert row["source_row_no"] == "SHUT-IN"
+    assert row["test_date"] == "2024-03-01"
+
+
+def test_packet_parser_links_g10_pressure_rows_to_packet_context():
+    text = "\n".join(
+        [
+            _packet_context(),
+            _record_line(
+                "G-10",
+                {
+                    1: "123456",
+                    2: "654321",
+                    3: "777",
+                    4: "2",
+                    10: "2500",
+                    12: "04/15/2024",
+                    17: "1200",
+                    18: "950",
+                },
+                length=20,
+            ),
+        ]
+    )
+
+    result = read_packet_pressure_candidates(text, source_file="packet.dat")
+
+    assert list(result.candidates["source_pressure_field"]) == [
+        "XBHOLE_PRESSURE",
+        "SIWH_PRESSURE",
+        "FLOWING_PRESSURE",
+    ]
+    assert set(result.candidates["source_form_id"]) == {"777"}
+    assert set(result.candidates["test_date"]) == {"2024-04-15"}
+
+
+def test_packet_parser_counts_unlinked_and_malformed_rows():
+    text = "\n".join(
+        [
+            "G-1{123456",
+            _record_line(
+                "G-1 Field Data",
+                {1: "999999", 2: "888888", 3: "777", 4: "SHUT-IN", 7: "1000"},
+                length=9,
+            ),
+        ]
+    )
+
+    result = read_packet_pressure_candidates(text, source_file="bad.dat")
+
+    assert result.candidates.empty
+    assert result.malformed_row_count == 1
+    assert result.unlinked_row_count == 1

--- a/tests/unit/texas_rrc/test_pressure_observation_quality.py
+++ b/tests/unit/texas_rrc/test_pressure_observation_quality.py
@@ -1,0 +1,61 @@
+"""Tests for Texas RRC pressure-observation quality summaries."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.pressure_observations.quality import (
+    build_pressure_coverage,
+)
+
+
+def test_coverage_groups_wells_by_district_and_decade_and_field() -> None:
+    observations = pd.DataFrame(
+        [
+            {
+                "api14": "42001000010000",
+                "district": "08",
+                "field_no": "12345678",
+                "field_name": "SPRABERRY",
+                "test_date": "2024-03-01",
+            },
+            {
+                "api14": "42001000010000",
+                "district": "08",
+                "field_no": "12345678",
+                "field_name": "SPRABERRY",
+                "test_date": "2025-03-01",
+            },
+            {
+                "api14": "42001000020000",
+                "district": "7C",
+                "field_no": "87654321",
+                "field_name": "WOLFBONE",
+                "test_year": 2018,
+            },
+        ]
+    )
+
+    coverage = build_pressure_coverage(observations)
+
+    district_2020 = coverage.by_district_decade[
+        coverage.by_district_decade["district"].eq("08")
+    ].iloc[0]
+    assert district_2020.to_dict() == {
+        "district": "08",
+        "test_decade": "2020s",
+        "pressure_observation_well_count": 1,
+        "pressure_observation_count": 2,
+    }
+
+    field_2010 = coverage.by_field_decade[
+        coverage.by_field_decade["field_no"].eq("87654321")
+    ].iloc[0]
+    assert field_2010.to_dict() == {
+        "district": "7C",
+        "field_no": "87654321",
+        "field_name": "WOLFBONE",
+        "test_decade": "2010s",
+        "pressure_observation_well_count": 1,
+        "pressure_observation_count": 1,
+    }

--- a/tests/unit/texas_rrc/test_pressure_observation_sources.py
+++ b/tests/unit/texas_rrc/test_pressure_observation_sources.py
@@ -1,0 +1,127 @@
+"""Tests for Texas RRC pressure-observation source discovery."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+from worldenergydata.texas_rrc.pressure_observations.sources import (
+    load_pressure_observation_inputs,
+)
+
+
+def _packet_line(values: dict[int, str], length: int = 61) -> str:
+    columns = [""] * length
+    columns[0] = "PACKET"
+    for index, value in values.items():
+        columns[index] = value
+    return "{".join(columns)
+
+
+def _record_line(record_type: str, values: dict[int, str], length: int = 90) -> str:
+    columns = [""] * length
+    columns[0] = record_type
+    for index, value in values.items():
+        columns[index] = value
+    return "{".join(columns)
+
+
+def _write_zip(path: Path, member_name: str, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr(member_name, content)
+
+
+def test_load_pressure_observation_inputs_parses_completion_zip_and_wellbore(
+    tmp_path: Path,
+) -> None:
+    completion_zip = tmp_path / "raw" / "completions" / "06-29-2026.zip"
+    _write_zip(
+        completion_zip,
+        "completion.dat",
+        "\n".join(
+            [
+                _packet_line(
+                    {
+                        1: "123456",
+                        2: "654321",
+                        5: "456789",
+                        6: "00100001",
+                        8: "98765",
+                        25: "12345678",
+                        27: "08",
+                        29: "SPRABERRY",
+                    }
+                ),
+                _record_line(
+                    "G-1",
+                    {
+                        1: "123456",
+                        2: "654321",
+                        3: "999",
+                        4: "03/01/2024",
+                        13: "10000",
+                        59: "2500",
+                    },
+                ),
+            ]
+        ),
+    )
+    wellbore = tmp_path / "raw" / "wellbore" / "query" / "wellbore.csv"
+    wellbore.parent.mkdir(parents=True)
+    wellbore.write_text(
+        "API_NO,TOTAL_DEPTH\n4200100001,10000\n",
+        encoding="utf-8",
+    )
+    manifest = tmp_path / "manifests" / "completion_data-20260701T003655Z.json"
+    manifest.parent.mkdir()
+    manifest.write_text(
+        json.dumps(
+            {
+                "source_id": "completion_data",
+                "status": "error",
+                "retrieved_at": "2026-07-01T00:36:55Z",
+                "raw_path": str(completion_zip.parent),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    inputs = load_pressure_observation_inputs(tmp_path)
+
+    assert inputs.source_gaps == ()
+    assert inputs.candidates.iloc[0]["api14"] == "42001000010000"
+    assert inputs.wellbore.iloc[0].to_dict() == {
+        "api14": "42001000010000",
+        "api10": "4200100001",
+        "total_depth": "10000",
+    }
+    assert inputs.parser_quality == {
+        "candidate_count": 1,
+        "malformed_row_count": 0,
+        "unlinked_row_count": 0,
+    }
+    assert str(completion_zip) in inputs.input_paths
+    assert str(wellbore) in inputs.input_paths
+    artifacts_by_path = {
+        str(artifact["path"]): artifact for artifact in inputs.input_artifacts
+    }
+    assert set(artifacts_by_path) == {str(completion_zip), str(wellbore)}
+    assert artifacts_by_path[str(completion_zip)]["byte_size"] > 0
+    assert len(artifacts_by_path[str(completion_zip)]["sha256"]) == 64
+    assert artifacts_by_path[str(wellbore)]["byte_size"] > 0
+    assert len(artifacts_by_path[str(wellbore)]["sha256"]) == 64
+    assert inputs.source_warnings == (
+        "raw_manifest_warning:completion_data:error:" "2026-07-01T00:36:55Z",
+    )
+
+
+def test_load_pressure_observation_inputs_reports_missing_sources(
+    tmp_path: Path,
+) -> None:
+    inputs = load_pressure_observation_inputs(tmp_path)
+
+    assert inputs.candidates.empty
+    assert inputs.wellbore.empty
+    assert inputs.source_gaps == ("completion_data", "wellbore_query")

--- a/tests/unit/texas_rrc/test_pressure_observations.py
+++ b/tests/unit/texas_rrc/test_pressure_observations.py
@@ -1,0 +1,206 @@
+"""Tests for building curated Texas RRC pressure observations."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from worldenergydata.texas_rrc.pressure_observations.observations import (
+    build_pressure_observations,
+)
+
+
+def _candidate(**overrides) -> dict[str, object]:
+    row: dict[str, object] = {
+        "api14": "42001000010000",
+        "api10": "4200100001",
+        "district": "08",
+        "field_no": "12345678",
+        "field_name": "SPRABERRY",
+        "test_date": "2024-03-01",
+        "test_year": 2024,
+        "source_record_type": "G-1",
+        "source_pressure_field": "BOTTOM_HOLE_PRESS",
+        "pressure_raw_psi": 2500.0,
+        "source_row_id": "fixture:1:BOTTOM_HOLE_PRESS",
+        "source_file": "fixture.dat",
+        "source_tracking_no": "123456",
+        "source_packet_id": "654321",
+        "source_form_id": "999",
+        "source_row_no": "",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_g1_bottom_hole_pressure_builds_reported_bhp_row():
+    result = build_pressure_observations(pd.DataFrame([_candidate()]))
+
+    row = result.observations.iloc[0].to_dict()
+    assert row["pressure_kind"] == "BHP_measured"
+    assert row["pressure_method"] == "source_reported_bottom_hole_pressure"
+    assert row["pressure_psia"] == 2500.0
+    assert row["pressure_unit_basis"] == "source_psi_unspecified"
+    assert row["usable_for_virgin_pressure_proxy"] is False
+
+
+def test_shut_in_surface_pressure_psig_converts_to_psia_with_limitation():
+    result = build_pressure_observations(
+        pd.DataFrame(
+            [
+                _candidate(
+                    source_record_type="G-1 Field Data",
+                    source_pressure_field="WELLHEAD_PRESS",
+                    source_row_no="SHUT-IN",
+                    pressure_raw_psi=100.0,
+                    production_interval_from_ft=1000,
+                    production_interval_to_ft=1200,
+                )
+            ]
+        )
+    )
+
+    row = result.observations.iloc[0].to_dict()
+    assert row["pressure_kind"] == "WHP_shut_in"
+    assert row["pressure_psia"] == 114.7
+    assert row["atmospheric_pressure_psi"] == 14.7
+    assert row["pressure_unit_basis"] == "psig_assumed"
+    assert "screening" in row["limitations"]
+
+
+def test_g1_field_wellhead_pressure_without_shut_in_row_is_not_curated():
+    result = build_pressure_observations(
+        pd.DataFrame(
+            [
+                _candidate(
+                    source_record_type="G-1 Field Data",
+                    source_pressure_field="WELLHEAD_PRESS",
+                    source_row_no="FLOWING",
+                    pressure_raw_psi=100.0,
+                    production_interval_from_ft=1000,
+                    production_interval_to_ft=1200,
+                )
+            ]
+        )
+    )
+
+    assert result.observations.empty
+    assert result.quality["uncurated_pressure_candidates"] == 1
+
+
+def test_g1_field_wellhead_pressure_with_blank_row_no_is_not_curated():
+    result = build_pressure_observations(
+        pd.DataFrame(
+            [
+                _candidate(
+                    source_record_type="G-1 Field Data",
+                    source_pressure_field="WELLHEAD_PRESS",
+                    source_row_no="",
+                    pressure_raw_psi=100.0,
+                    production_interval_from_ft=1000,
+                    production_interval_to_ft=1200,
+                )
+            ]
+        )
+    )
+
+    assert result.observations.empty
+    assert result.quality["uncurated_pressure_candidates"] == 1
+
+
+def test_candidate_missing_api14_is_not_curated():
+    result = build_pressure_observations(
+        pd.DataFrame(
+            [
+                _candidate(
+                    api14="",
+                    api10="",
+                    production_interval_from_ft=1000,
+                    production_interval_to_ft=1200,
+                )
+            ]
+        )
+    )
+
+    assert result.observations.empty
+    assert result.quality["missing_api"] == 1
+
+
+def test_w2_pressure_candidates_are_not_misclassified_as_bhp():
+    result = build_pressure_observations(
+        pd.DataFrame(
+            [
+                _candidate(
+                    source_record_type="W-2",
+                    source_pressure_field="CALC_CASING_PRESS",
+                    pressure_raw_psi=500.0,
+                )
+            ]
+        )
+    )
+
+    assert result.observations.empty
+    assert result.quality["w2_pressure_candidates_not_curated"] == 1
+
+
+def test_gradient_prefers_producing_interval_midpoint():
+    result = build_pressure_observations(
+        pd.DataFrame(
+            [
+                _candidate(
+                    production_interval_from_ft=1000,
+                    production_interval_to_ft=1200,
+                )
+            ]
+        )
+    )
+
+    row = result.observations.iloc[0].to_dict()
+    assert row["reference_depth_ft"] == 1100.0
+    assert row["reference_depth_method"] == "production_interval_midpoint"
+    assert row["gradient_psi_ft"] == 2500.0 / 1100.0
+    assert row["gradient_method"] == "reported_bhp_over_reference_depth"
+
+
+def test_gradient_suppressed_for_ambiguous_depth_join():
+    wellbore = pd.DataFrame(
+        [
+            {"api14": "42001000010000", "total_depth": 9000},
+            {"api14": "42001000010000", "total_depth": 9100},
+        ]
+    )
+
+    result = build_pressure_observations(pd.DataFrame([_candidate()]), wellbore)
+
+    row = result.observations.iloc[0].to_dict()
+    assert pd.isna(row["reference_depth_ft"])
+    assert pd.isna(row["gradient_psi_ft"])
+    assert "ambiguous_depth_reference" in row["quality_flags"]
+
+
+def test_earliest_usable_observation_is_virgin_proxy():
+    result = build_pressure_observations(
+        pd.DataFrame(
+            [
+                _candidate(
+                    test_date="2024-03-01",
+                    test_year=2024,
+                    production_interval_from_ft=1000,
+                    production_interval_to_ft=1200,
+                ),
+                _candidate(
+                    test_date="2025-03-01",
+                    test_year=2025,
+                    source_row_id="fixture:2:BOTTOM_HOLE_PRESS",
+                    production_interval_from_ft=1000,
+                    production_interval_to_ft=1200,
+                ),
+            ]
+        )
+    )
+
+    observations = result.observations.sort_values("test_date")
+    assert observations.iloc[0]["is_earliest_observation_for_well"] is True
+    assert observations.iloc[0]["virgin_pressure_proxy_method"] == (
+        "earliest_reported_bhp"
+    )
+    assert observations.iloc[1]["is_earliest_observation_for_well"] is False


### PR DESCRIPTION
## Summary

Implements #709: direct-source Texas RRC pressure observation extraction from official completion packets plus Wellbore Query depth context.

## Outputs

Live `/mnt/ace` build wrote:
- 360 normalized pressure candidates
- 48 curated pressure observations
- 6 district/decade coverage rows
- 8 field/decade coverage rows
- 2 hashed input artifacts: completion ZIP and Wellbore Query CSV
- no source gaps
- expected source warning: `raw_manifest_warning:completion_data:error:2026-07-01T00:36:55Z`

Output root:
`/mnt/ace/worldenergydata/data/modules/texas_rrc`

## Verification

- `PYTHONPATH="$(printf '%s:' packages/*/src)src" uv run --no-sync pytest --no-cov tests/unit/texas_rrc/test_pressure_observation*.py -q` -> 28 passed
- `PYTHONPATH="$(printf '%s:' packages/*/src)src" uv run --no-sync pytest --no-cov tests/unit/texas_rrc/test_lifecycle_keys.py tests/unit/texas_rrc/test_lifecycle_sources.py tests/unit/texas_rrc/test_lifecycle_io.py tests/unit/texas_rrc/test_source_catalog.py -q` -> 31 passed
- `uv run --no-sync black --check --diff packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations tests/unit/texas_rrc/test_pressure_observation*.py src/worldenergydata/cli/commands/texas_rrc.py`
- `uv run --no-sync isort --check-only --diff packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations tests/unit/texas_rrc/test_pressure_observation*.py src/worldenergydata/cli/commands/texas_rrc.py`
- `uv run --no-sync ruff check packages/worldenergydata-texas_rrc/src/worldenergydata/texas_rrc/pressure_observations tests/unit/texas_rrc/test_pressure_observation*.py src/worldenergydata/cli/commands/texas_rrc.py`
- `git diff --cached --check`
- `scripts/legal/legal-sanity-scan.sh` -> PASS

## Review

Code-stage review recorded at `scripts/review/results/2026-07-03-code-709-codex-inline.md`.
A T2 adversarial review found blocking issues in SHUT-IN row semantics, missing API curation, and wellbore artifact hashing; all were remediated with regression tests.

Closes #709.
