### PR TITLE
feat: add Texas pressure screen integration

### DIFF
--- a/config/underpressured_screen.yml
+++ b/config/underpressured_screen.yml
@@ -1,6 +1,7 @@
 # Under-pressured gas/condensate screen configuration (issue #710, epic #708).
-# Consumes per-well pressure-observation tables in the shared #709 schema
-# (Kansas from #725 today; Texas RRC joins via #709 once its extraction lands).
+# Consumes per-well pressure-observation tables through the screen contract.
+# Kansas validates the Hugoton/Panoma analog gate; Texas RRC adds #709 packet
+# coverage as screening-only WHP observations.
 module: underpressured_screen
 
 inputs:
@@ -9,7 +10,16 @@ inputs:
   # outputs so the screen never silently conflates the two.
   - name: kansas_kgs_proration
     path: /mnt/ace/worldenergydata/data/modules/kansas_kgs/curated/pressure/well_pressure_observations.parquet
+    schema: screen_v1
+    state: KS
     era: depleted  # program starts 1996; Hugoton discovered 1922
+  - name: texas_rrc_completion_packets
+    path: /mnt/ace/worldenergydata/data/modules/texas_rrc/curated/pressure/well_pressure_observations/texas_rrc_well_pressure_observations.parquet
+    quality_path: /mnt/ace/worldenergydata/data/modules/texas_rrc/curated/pressure/well_pressure_observations/texas_rrc_pressure_observation_quality.json
+    schema: texas_rrc_pressure_v1
+    state: TX
+    era: completion_packet_screening
+    require_usable_proxy: true
 
 output:
   base_dir: /mnt/ace/worldenergydata/data/modules/pressure_screen/curated
@@ -38,3 +48,10 @@ validation_gate:
     - HUGOTON GAS AREA
     - PANOMA GAS AREA
   required_tier: severely_underpressured
+
+participation_gate:
+  # Texas #709 is a narrow daily completion packet today, so require
+  # participation without forcing a false West Panhandle analog recovery gate.
+  required_states:
+    TX:
+      min_wells: 1

--- a/docs/data-sources/onshore/state-well-databases/underpressured-gas-fields.md
+++ b/docs/data-sources/onshore/state-well-databases/underpressured-gas-fields.md
@@ -1,12 +1,15 @@
-# Under-Pressured Gas Fields — Screen Results (Kansas First Cut)
+# Under-Pressured Gas Fields - Multi-State Screen Results
 
 Issue: [#710](https://github.com/vamseeachanta/worldenergydata/issues/710)
-(parent epic [#708](https://github.com/vamseeachanta/worldenergydata/issues/708)).
+(parent epic [#708](https://github.com/vamseeachanta/worldenergydata/issues/708);
+Texas integration [#732](https://github.com/vamseeachanta/worldenergydata/issues/732)).
 
 The screen answers the epic's motivating question — *which wells and fields
 actually produced from very low bottom-hole pressure?* — from state-regulator
-data. This first cut runs on the Kansas KGS ingest (#725); Texas RRC joins
-through the same observation schema once #709's extraction lands.
+data. The current run combines Kansas KGS proration pressure observations
+([#725](https://github.com/vamseeachanta/worldenergydata/issues/725)) with
+Texas RRC completion-packet pressure observations
+([#709](https://github.com/vamseeachanta/worldenergydata/issues/709)).
 
 ## Method
 
@@ -23,24 +26,48 @@ PYTHONPATH=src python -m worldenergydata.analysis.underpressured_screen.screen \
    under-pressured 0.35–0.433; severely under-pressured < 0.35. A separate
    **near-vacuum flag** marks shut-in wellhead pressure < 50 psia — the West
    Panhandle vacuum-operations regime.
-3. **Earliest observation per well** is the virgin-pressure proxy; the source
-   `era` label (depleted for the 1996+ Kansas proration program) rides along
-   so depleted-era pressures are never presented as virgin.
-4. **Field ranking** (≥5 wells) plus a **validation gate**: the run fails
+3. **Source normalization** adapts state-specific physical schemas into the
+   screen contract. Kansas already emits `well_key` and `field`; Texas maps
+   `api14` to `well_key`, `field_name` to `field`, injects `state=TX`, and
+   filters to rows marked `usable_for_virgin_pressure_proxy`.
+4. **Earliest observation per well** is the screening proxy; the source `era`
+   label rides along so depleted-era Kansas proration pressures and Texas
+   completion-packet screening pressures are not presented as measured virgin
+   BHP. Source-provided earliest-observation flags break same-year duplicate
+   ties, such as Texas G-1/G-10 rows for the same API14.
+5. **Field ranking** (>=5 wells) plus a **validation gate**: the run fails
    unless Hugoton and Panoma appear in the top 10 classified severely
    under-pressured.
+6. **Participation gate**: Texas must be loaded and screened, but the current
+   daily completion packet is too narrow to require West Panhandle analog
+   recovery.
 
 Outputs: `/mnt/ace/worldenergydata/data/modules/pressure_screen/curated/`
 (`well_screen_earliest.parquet`, `underpressured_field_ranking.parquet`,
 `screen_summary.json`).
 
-## Results (Kansas, run 2026-07-02)
+## Results (run 2026-07-03)
 
-10,103 wells screened — **all severely under-pressured** (expected: the
-proration program observed Hugoton-trend gas seven decades into depletion).
-Median estimated-BHP gradient **0.0304 psi/ft ≈ 7% of hydrostatic**.
-**264 wells were at near-vacuum** shut-in wellhead pressure. Validation gate:
-**PASSED**.
+10,128 wells screened: **10,103 Kansas** wells and **25 Texas** wells after
+earliest-observation selection. The screen loaded 39,134 Kansas pressure rows
+and 43 usable Texas pressure rows from 48 curated Texas observations. Median
+estimated-BHP gradient remains **0.0304 psi/ft**, with **264 near-vacuum**
+shut-in wellhead-pressure wells. Validation gate: **PASSED**. Texas
+participation gate: **PASSED**.
+
+Tier counts:
+
+| Tier | Wells |
+| --- | ---: |
+| Severely under-pressured | 10,126 |
+| Normal | 2 |
+
+Source counts after earliest-observation selection:
+
+| Source | State | Wells | Era |
+| --- | --- | ---: | --- |
+| `kansas_kgs_proration` | KS | 10,103 | depleted |
+| `texas_rrc_completion_packets` | TX | 25 | completion_packet_screening |
 
 | Field | Wells | Median gradient (psi/ft) | P10–P90 | Near-vacuum wells |
 | --- | --- | --- | --- | --- |
@@ -50,11 +77,18 @@ Median estimated-BHP gradient **0.0304 psi/ft ≈ 7% of hydrostatic**.
 | HUGOTON | 200 | 0.0352 | 0.020–0.068 | 12 |
 | PANOMA | 60 | 0.0232 | 0.015–0.033 | 15 |
 | GREENWOOD | 17 | 0.0212 | 0.015–0.031 | 1 |
+| BRISCOE RANCH (EAGLEFORD) | 16 | 0.1361 | 0.094–0.205 | 0 |
 
-Notable beyond the analogs: **Greenwood Gas Area** (Morton County, KS) is the
-most extreme entry — median gradient under 2% of hydrostatic with 22% of its
-tested wells at near-vacuum, i.e., wells literally being sucked dry and still
-on the annual test rolls.
+Notable beyond the analogs:
+
+- **Greenwood Gas Area** (Morton County, KS) remains the most extreme entry:
+  median gradient under 2% of hydrostatic with 22% of tested wells at
+  near-vacuum.
+- **Briscoe Ranch (Eagleford)** enters as the first Texas ranked field: 16
+  earliest wells, all screening-only WHP-derived observations, median estimated
+  gradient 0.1361 psi/ft.
+- Two Texas wells classify normal after the gas-column correction:
+  `CARTHAGE (HAYNESVILLE SHALE)` and `HAWKVILLE (AUSTIN CHALK)`.
 
 ## Caveats
 
@@ -65,6 +99,13 @@ on the annual test rolls.
 - Gradients use wells-master total depth as the reference depth and an
   average-z̄T̄ gas column; both are approximations flagged in the data
   (`bhp_method`, `gradient_method`).
-- Single-source run: tier boundaries (0.433/0.35) only become discriminating
-  once normally-pressured populations (TX #709, OK completions) enter the
-  same table.
+- Texas RRC #709 rows in this run are all **shut-in wellhead pressure** rows,
+  not measured bottom-hole pressure. They remain screening-only until a source
+  provides measured BHP or a better calibrated gas-column correction.
+- The Texas input is a narrow daily completion packet, not a full historical
+  pressure archive. It is useful for proving the multi-state screen path and
+  finding current low-gradient examples, but it is not yet a West Panhandle
+  analog recovery dataset.
+- The Texas quality sidecar currently carries
+  `raw_manifest_warning:completion_data:error:2026-07-01T00:36:55Z`; the
+  screen propagates that warning into `screen_summary.json`.

--- a/docs/plans/2026-07-03-issue-732-texas-rrc-underpressured-screen.md
+++ b/docs/plans/2026-07-03-issue-732-texas-rrc-underpressured-screen.md
@@ -1,7 +1,7 @@
 # Plan: Issue #732 - Texas RRC pressure-screen integration
 
 **Issue:** https://github.com/vamseeachanta/worldenergydata/issues/732
-**Status:** plan-review
+**Status:** implemented
 **Tier:** T2 (multi-source analysis adapter, config update, live `/mnt/ace` run, tests, docs)
 **Client:** N/A
 **Project:** worldenergydata onshore pressure screen

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -83,7 +83,7 @@ This directory contains issue-plan artifacts created during the issue-planning-m
 | [#702](https://github.com/vamseeachanta/worldenergydata/issues/702) | [texas-rrc-field-architecture-dossiers](2026-07-02-issue-702-texas-rrc-field-architecture-dossiers.md) | implemented | 2026-07-02 |
 | [#707](https://github.com/vamseeachanta/worldenergydata/issues/707) | [texas-rrc-field-architecture-portfolio](2026-07-02-issue-707-texas-rrc-field-architecture-portfolio.md) | plan-approved | 2026-07-02 |
 | [#709](https://github.com/vamseeachanta/worldenergydata/issues/709) | [texas-rrc-pressure-observations](2026-07-03-issue-709-texas-rrc-pressure-observations.md) | implemented | 2026-07-03 |
-| [#732](https://github.com/vamseeachanta/worldenergydata/issues/732) | [texas-rrc-underpressured-screen](2026-07-03-issue-732-texas-rrc-underpressured-screen.md) | plan-review | 2026-07-03 |
+| [#732](https://github.com/vamseeachanta/worldenergydata/issues/732) | [texas-rrc-underpressured-screen](2026-07-03-issue-732-texas-rrc-underpressured-screen.md) | implemented | 2026-07-03 |
 
 ## Closed / superseded plans
 

--- a/scripts/review/results/2026-07-03-code-732-codex-inline.md
+++ b/scripts/review/results/2026-07-03-code-732-codex-inline.md
@@ -1,0 +1,65 @@
+# Codex Inline Code Review - Issue #732
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/732
+**Branch:** `feature/issue-732-texas-pressure-screen`
+**Reviewer:** Codex inline adversarial review
+**Date:** 2026-07-03
+**Verdict:** APPROVE AFTER FIXES
+
+## Findings
+
+1. **MAJOR - Same-year Texas G-1/G-10 duplicates were selected by input order,
+   not by #709's source earliest-observation flag.**
+
+   The first implementation normalized Texas rows and then reused the existing
+   `earliest_per_well()` sort of `well_key, test_year`. This was insufficient
+   for Texas #709 because an API14 can have both G-1 Field Data and G-10
+   shut-in WHP observations in the same test year, with different depth
+   denominators. In live output, that could choose the G-1 row even when #709
+   had marked the G-10 row as the earliest usable observation for that API14.
+
+   **Fix:** Added `screen_observation_priority`, populated it from
+   `is_earliest_observation_for_well` for Texas rows, and changed
+   `earliest_per_well()` to sort by `well_key`, `test_year`, and
+   `screen_observation_priority`. Added
+   `test_earliest_per_well_uses_source_priority_for_same_year_ties`.
+
+2. **MINOR - Report table initially used pre-fix Briscoe Ranch gradients.**
+
+   After the priority fix, the live ranked-field parquet changed Briscoe Ranch
+   median estimated gradient from 0.0918 to 0.1361 psi/ft.
+
+   **Fix:** Reran the live `/mnt/ace` screen and updated the report table and
+   narrative to match the regenerated parquet.
+
+3. **MINOR - Markdown caveat indentation drifted during report rewrite.**
+
+   **Fix:** Restored normal two-space continuation indentation.
+
+## Verification Evidence
+
+- RED test observed before fix:
+  - `test_earliest_per_well_uses_source_priority_for_same_year_ties` failed by
+    selecting `reference_depth_ft=15150.5` instead of `7394.0`.
+- Focused tests after fixes:
+  - `PYTHONPATH="$(printf '%s:' packages/*/src)src" uv run --no-sync pytest tests/unit/analysis/test_underpressured_observations.py tests/unit/analysis/test_underpressured_screen.py -q`
+  - Result: 23 passed.
+- Lint/format:
+  - `uv run --no-sync ruff check ...`
+  - `uv run --no-sync ruff format --check ...`
+  - Result: passed.
+- Live screen:
+  - `PYTHONPATH="$(printf '%s:' packages/*/src)src" uv run --no-sync python -m worldenergydata.analysis.underpressured_screen.screen --config config/underpressured_screen.yml`
+  - Result: validation gate passed, Texas participation gate passed, 10,128
+    wells screened, state counts `KS=10103`, `TX=25`.
+- Legal scan:
+  - `scripts/legal/legal-sanity-scan.sh`
+  - Result: PASS.
+
+## Residual Risk
+
+- Texas #709 remains a narrow daily completion-packet sample, not a full Texas
+  historical pressure archive. The implementation intentionally uses a Texas
+  participation gate rather than a West Panhandle analog recovery gate.
+- Texas WHP gradients remain screening-only. The docs and summary preserve that
+  caveat.

--- a/src/worldenergydata/analysis/underpressured_screen/observations.py
+++ b/src/worldenergydata/analysis/underpressured_screen/observations.py
@@ -1,0 +1,117 @@
+"""Observation normalization for the under-pressured screen."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+REQUIRED_SCREEN_COLUMNS = (
+    "well_key",
+    "state",
+    "field",
+    "test_year",
+    "pressure_kind",
+    "pressure_psia",
+    "reference_depth_ft",
+)
+
+TEXAS_COLUMN_MAP = {
+    "api14": "well_key",
+    "field_name": "field",
+}
+
+
+def normalize_observations(frame: pd.DataFrame, input_config: dict) -> pd.DataFrame:
+    """Normalize one source-specific pressure table to the screen contract."""
+    schema = input_config.get("schema", "screen_v1")
+    if schema == "screen_v1":
+        normalized = frame.copy()
+    elif schema == "texas_rrc_pressure_v1":
+        normalized = _normalize_texas_pressure(frame, input_config)
+    else:
+        raise ValueError(f"Unsupported pressure screen input schema: {schema}")
+
+    normalized["source_name"] = input_config["name"]
+    normalized["era"] = input_config["era"]
+    if "state" in input_config:
+        if "state" not in normalized:
+            normalized["state"] = input_config["state"]
+        else:
+            normalized["state"] = normalized["state"].fillna(input_config["state"])
+    if "screen_observation_priority" not in normalized:
+        normalized["screen_observation_priority"] = 0
+    _validate_required_columns(normalized, input_config["name"])
+    return normalized
+
+
+def load_observations(inputs: list[dict]) -> tuple[pd.DataFrame, dict]:
+    """Load and normalize all configured pressure-observation inputs."""
+    frames = []
+    summary = {
+        "input_row_counts": {},
+        "loaded_row_counts": {},
+        "source_warnings": {},
+    }
+    for entry in inputs:
+        frame = pd.read_parquet(entry["path"])
+        summary["input_row_counts"][entry["name"]] = int(len(frame))
+        normalized = normalize_observations(frame, entry)
+        summary["loaded_row_counts"][entry["name"]] = int(len(normalized))
+        warnings = _read_source_warnings(entry.get("quality_path"))
+        if warnings:
+            summary["source_warnings"][entry["name"]] = warnings
+        frames.append(normalized)
+    return pd.concat(frames, ignore_index=True), summary
+
+
+def _normalize_texas_pressure(frame: pd.DataFrame, input_config: dict) -> pd.DataFrame:
+    required = set(TEXAS_COLUMN_MAP) | {
+        "test_year",
+        "pressure_kind",
+        "pressure_psia",
+        "reference_depth_ft",
+    }
+    _validate_columns(frame, required, input_config["name"])
+    normalized = frame.rename(columns=TEXAS_COLUMN_MAP).copy()
+    normalized["well_key"] = normalized["well_key"].astype("string")
+    if "is_earliest_observation_for_well" in normalized:
+        earliest = _truthy(normalized["is_earliest_observation_for_well"])
+        normalized["screen_observation_priority"] = (~earliest).astype(int)
+    if input_config.get("require_usable_proxy"):
+        _validate_columns(
+            normalized, {"usable_for_virgin_pressure_proxy"}, input_config["name"]
+        )
+        usable = _truthy(normalized["usable_for_virgin_pressure_proxy"])
+        normalized = normalized[usable].copy()
+    return normalized
+
+
+def _validate_required_columns(frame: pd.DataFrame, source_name: str) -> None:
+    _validate_columns(frame, set(REQUIRED_SCREEN_COLUMNS), source_name)
+
+
+def _validate_columns(
+    frame: pd.DataFrame, required: set[str], source_name: str
+) -> None:
+    missing = sorted(required - set(frame.columns))
+    if missing:
+        missing_text = ", ".join(missing)
+        raise ValueError(f"{source_name} missing required columns: {missing_text}")
+
+
+def _read_source_warnings(quality_path: str | None) -> list[str]:
+    if not quality_path:
+        return []
+    path = Path(quality_path)
+    if not path.exists():
+        return [f"missing_quality_path:{path}"]
+    quality = json.loads(path.read_text(encoding="utf-8"))
+    return [str(item) for item in quality.get("source_warnings", [])]
+
+
+def _truthy(series: pd.Series) -> pd.Series:
+    if pd.api.types.is_bool_dtype(series):
+        return series.fillna(False)
+    return series.fillna("").astype(str).str.lower().isin({"1", "true", "yes"})

--- a/src/worldenergydata/analysis/underpressured_screen/screen.py
+++ b/src/worldenergydata/analysis/underpressured_screen/screen.py
@@ -23,6 +23,10 @@ import numpy as np
 import pandas as pd
 import yaml
 
+from worldenergydata.analysis.underpressured_screen.observations import (
+    load_observations,
+)
+
 TIER_NORMAL = "normal"
 TIER_MILD = "mildly_underpressured"
 TIER_SEVERE = "severely_underpressured"
@@ -31,16 +35,6 @@ TIER_SEVERE = "severely_underpressured"
 def load_config(config_path: str | Path) -> dict:
     with Path(config_path).open("r", encoding="utf-8") as handle:
         return yaml.safe_load(handle)
-
-
-def load_observations(inputs: list[dict]) -> pd.DataFrame:
-    frames = []
-    for entry in inputs:
-        frame = pd.read_parquet(entry["path"])
-        frame["source_name"] = entry["name"]
-        frame["era"] = entry["era"]
-        frames.append(frame)
-    return pd.concat(frames, ignore_index=True)
 
 
 def estimate_bhp(observations: pd.DataFrame, settings: dict) -> pd.DataFrame:
@@ -90,7 +84,10 @@ def classify_tiers(frame: pd.DataFrame, tiers: dict) -> pd.DataFrame:
 def earliest_per_well(frame: pd.DataFrame) -> pd.DataFrame:
     """One row per well: its earliest test with a usable gradient."""
     usable = frame[frame["bhp_gradient_psi_ft"].notna()].copy()
-    usable = usable.sort_values(["well_key", "test_year"])
+    sort_columns = ["well_key", "test_year"]
+    if "screen_observation_priority" in usable:
+        sort_columns.append("screen_observation_priority")
+    usable = usable.sort_values(sort_columns)
     return usable.groupby("well_key", as_index=False).first()
 
 
@@ -103,8 +100,8 @@ def rank_fields(wells: pd.DataFrame, settings: dict) -> pd.DataFrame:
         p90_gradient_psi_ft=("bhp_gradient_psi_ft", lambda s: s.quantile(0.9)),
         near_vacuum_wells=("near_vacuum", "sum"),
         earliest_test_year=("test_year", "min"),
-        states=("state", lambda s: ",".join(sorted(s.unique()))),
-        era=("era", lambda s: ",".join(sorted(s.unique()))),
+        states=("state", lambda s: ",".join(sorted(s.dropna().unique()))),
+        era=("era", lambda s: ",".join(sorted(s.dropna().unique()))),
     ).reset_index()
     ranking = ranking[ranking["well_count"] >= settings["min_wells_per_field"]]
     return ranking.sort_values("well_count", ascending=False).reset_index(drop=True)
@@ -139,9 +136,52 @@ def run_validation_gate(ranking: pd.DataFrame, gate: dict) -> dict:
     return {"passed": passed, "fields": results}
 
 
+def run_participation_gate(wells: pd.DataFrame, gate: dict) -> dict:
+    """Verify configured state/source participation without tier claims."""
+    results = {}
+    for state, rules in gate.get("required_states", {}).items():
+        state_wells = wells[wells["state"] == state]
+        min_wells = int(rules.get("min_wells", 1))
+        well_count = int(state_wells["well_key"].nunique())
+        results[state] = {
+            "well_count": well_count,
+            "min_wells": min_wells,
+            "passed": well_count >= min_wells,
+        }
+    return {
+        "passed": all(item["passed"] for item in results.values()),
+        "states": results,
+    }
+
+
+def build_screen_summary(
+    wells: pd.DataFrame,
+    ranking: pd.DataFrame,
+    validation_gate: dict,
+    participation_gate: dict,
+    load_summary: dict,
+) -> dict:
+    tier_counts = wells["pressure_tier"].value_counts().to_dict()
+    return {
+        "wells_screened": int(len(wells)),
+        "tier_counts": {k: int(v) for k, v in tier_counts.items()},
+        "near_vacuum_wells": int(wells["near_vacuum"].sum()),
+        "fields_ranked": int(len(ranking)),
+        "median_gradient_psi_ft": _median_gradient(wells),
+        "validation_gate": validation_gate,
+        "participation_gate": participation_gate,
+        "era_note": _unique_values(wells["era"]),
+        "state_counts": _counts(wells["state"]),
+        "source_counts": _counts(wells["source_name"]),
+        "input_row_counts": load_summary.get("input_row_counts", {}),
+        "loaded_row_counts": load_summary.get("loaded_row_counts", {}),
+        "source_warnings": load_summary.get("source_warnings", {}),
+    }
+
+
 def run_screen(config_path: str | Path) -> dict:
     config = load_config(config_path)
-    observations = load_observations(config["inputs"])
+    observations, load_summary = load_observations(config["inputs"])
     enriched = classify_tiers(
         estimate_bhp(observations, config["bhp_estimate"]), config["tiers"]
     )
@@ -150,19 +190,12 @@ def run_screen(config_path: str | Path) -> dict:
         rank_fields(wells, config["field_ranking"]), config["tiers"]
     )
     gate = run_validation_gate(ranking, config["validation_gate"])
-
-    tier_counts = wells["pressure_tier"].value_counts().to_dict()
-    summary = {
-        "wells_screened": int(len(wells)),
-        "tier_counts": {k: int(v) for k, v in tier_counts.items()},
-        "near_vacuum_wells": int(wells["near_vacuum"].sum()),
-        "fields_ranked": int(len(ranking)),
-        "median_gradient_psi_ft": round(
-            float(wells["bhp_gradient_psi_ft"].median()), 4
-        ),
-        "validation_gate": gate,
-        "era_note": sorted(wells["era"].unique().tolist()),
-    }
+    participation_gate = run_participation_gate(
+        wells, config.get("participation_gate", {})
+    )
+    summary = build_screen_summary(
+        wells, ranking, gate, participation_gate, load_summary
+    )
 
     out_dir = Path(config["output"]["base_dir"])
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -174,7 +207,25 @@ def run_screen(config_path: str | Path) -> dict:
 
     if not gate["passed"]:
         raise RuntimeError(f"Validation gate failed: {gate['fields']}")
+    if not participation_gate["passed"]:
+        raise RuntimeError(f"Participation gate failed: {participation_gate['states']}")
     return summary
+
+
+def _counts(series: pd.Series) -> dict:
+    counts = series.dropna().value_counts().to_dict()
+    return {str(key): int(value) for key, value in counts.items()}
+
+
+def _median_gradient(wells: pd.DataFrame) -> float | None:
+    median = wells["bhp_gradient_psi_ft"].median()
+    if pd.isna(median):
+        return None
+    return round(float(median), 4)
+
+
+def _unique_values(series: pd.Series) -> list[str]:
+    return sorted(str(value) for value in series.dropna().unique().tolist())
 
 
 def main() -> None:

--- a/tests/unit/analysis/test_underpressured_observations.py
+++ b/tests/unit/analysis/test_underpressured_observations.py
@@ -1,0 +1,135 @@
+"""Unit tests for under-pressured screen observation loading (#732)."""
+
+import json
+
+import pandas as pd
+
+from worldenergydata.analysis.underpressured_screen.observations import (
+    load_observations,
+    normalize_observations,
+)
+
+
+def test_normalizes_texas_pressure_schema_to_screen_contract():
+    frame = pd.DataFrame(
+        [
+            {
+                "api14": "42127373050000",
+                "field_name": "BRISCOE RANCH (EAGLEFORD)",
+                "test_year": 2017,
+                "pressure_kind": "WHP_shut_in",
+                "pressure_psia": 1046.7,
+                "reference_depth_ft": 7394.0,
+                "usable_for_virgin_pressure_proxy": True,
+                "is_earliest_observation_for_well": True,
+                "gradient_method": "surface_pressure_over_reference_depth_screening_only",
+            }
+        ]
+    )
+
+    result = normalize_observations(
+        frame,
+        {
+            "name": "texas_rrc_completion_packets",
+            "schema": "texas_rrc_pressure_v1",
+            "state": "TX",
+            "era": "completion_packet_screening",
+            "require_usable_proxy": True,
+        },
+    )
+
+    assert result.loc[0, "well_key"] == "42127373050000"
+    assert result.loc[0, "field"] == "BRISCOE RANCH (EAGLEFORD)"
+    assert result.loc[0, "state"] == "TX"
+    assert result.loc[0, "source_name"] == "texas_rrc_completion_packets"
+    assert result.loc[0, "era"] == "completion_packet_screening"
+    assert result.loc[0, "pressure_kind"] == "WHP_shut_in"
+
+
+def test_filters_texas_unusable_rows_when_required():
+    frame = pd.DataFrame(
+        [
+            {
+                "api14": "42127373050000",
+                "field_name": "BRISCOE RANCH (EAGLEFORD)",
+                "test_year": 2017,
+                "pressure_kind": "WHP_shut_in",
+                "pressure_psia": 1046.7,
+                "reference_depth_ft": 7394.0,
+                "usable_for_virgin_pressure_proxy": True,
+            },
+            {
+                "api14": "42127373100000",
+                "field_name": "BRISCOE RANCH (EAGLEFORD)",
+                "test_year": 2017,
+                "pressure_kind": "WHP_shut_in",
+                "pressure_psia": 788.7,
+                "reference_depth_ft": 12740.5,
+                "usable_for_virgin_pressure_proxy": False,
+            },
+        ]
+    )
+
+    result = normalize_observations(
+        frame,
+        {
+            "name": "texas_rrc_completion_packets",
+            "schema": "texas_rrc_pressure_v1",
+            "state": "TX",
+            "era": "completion_packet_screening",
+            "require_usable_proxy": True,
+        },
+    )
+
+    assert list(result["well_key"]) == ["42127373050000"]
+
+
+def test_load_observations_collects_input_counts_and_quality_warnings(tmp_path):
+    observations_path = tmp_path / "texas.parquet"
+    quality_path = tmp_path / "quality.json"
+    pd.DataFrame(
+        [
+            {
+                "api14": "42127373050000",
+                "field_name": "BRISCOE RANCH (EAGLEFORD)",
+                "test_year": 2017,
+                "pressure_kind": "WHP_shut_in",
+                "pressure_psia": 1046.7,
+                "reference_depth_ft": 7394.0,
+                "usable_for_virgin_pressure_proxy": True,
+            }
+        ]
+    ).to_parquet(observations_path)
+    quality_path.write_text(
+        json.dumps(
+            {
+                "source_warnings": [
+                    "raw_manifest_warning:completion_data:error:2026-07-01T00:36:55Z"
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    observations, summary = load_observations(
+        [
+            {
+                "name": "texas_rrc_completion_packets",
+                "path": str(observations_path),
+                "quality_path": str(quality_path),
+                "schema": "texas_rrc_pressure_v1",
+                "state": "TX",
+                "era": "completion_packet_screening",
+                "require_usable_proxy": True,
+            }
+        ]
+    )
+
+    assert len(observations) == 1
+    assert summary["input_row_counts"] == {"texas_rrc_completion_packets": 1}
+    assert summary["loaded_row_counts"] == {"texas_rrc_completion_packets": 1}
+    assert summary["source_warnings"] == {
+        "texas_rrc_completion_packets": [
+            "raw_manifest_warning:completion_data:error:2026-07-01T00:36:55Z"
+        ]
+    }

--- a/tests/unit/analysis/test_underpressured_screen.py
+++ b/tests/unit/analysis/test_underpressured_screen.py
@@ -11,10 +11,12 @@ from worldenergydata.analysis.underpressured_screen.screen import (
     TIER_NORMAL,
     TIER_SEVERE,
     apply_field_tier,
+    build_screen_summary,
     classify_tiers,
     earliest_per_well,
     estimate_bhp,
     rank_fields,
+    run_participation_gate,
     run_validation_gate,
 )
 
@@ -32,6 +34,7 @@ def make_observations(rows):
         "pressure_kind": "WHP_shut_in",
         "era": "depleted",
         "field": "HUGOTON GAS AREA",
+        "source_name": "kansas_kgs_proration",
     }
     return pd.DataFrame([{**defaults, **row} for row in rows])
 
@@ -192,6 +195,62 @@ class TestEarliestAndRanking:
         ranking = rank_fields(wells, {"min_wells_per_field": 5})
         assert "DEEP NORMAL" not in set(ranking["field"])
 
+    def test_earliest_per_well_uses_texas_api14_well_key(self):
+        obs = make_observations(
+            [
+                {
+                    "well_key": "42127373050000",
+                    "state": "TX",
+                    "test_year": 2018,
+                    "pressure_psia": 1000.0,
+                    "reference_depth_ft": 7000.0,
+                    "source_name": "texas_rrc_completion_packets",
+                },
+                {
+                    "well_key": "42127373050000",
+                    "state": "TX",
+                    "test_year": 2017,
+                    "pressure_psia": 900.0,
+                    "reference_depth_ft": 7000.0,
+                    "source_name": "texas_rrc_completion_packets",
+                },
+            ]
+        )
+        wells = earliest_per_well(
+            classify_tiers(estimate_bhp(obs, BHP_SETTINGS), TIERS)
+        )
+        assert len(wells) == 1
+        assert int(wells.loc[0, "test_year"]) == 2017
+
+    def test_earliest_per_well_uses_source_priority_for_same_year_ties(self):
+        obs = make_observations(
+            [
+                {
+                    "well_key": "42127373050000",
+                    "state": "TX",
+                    "test_year": 2017,
+                    "pressure_psia": 1046.7,
+                    "reference_depth_ft": 15150.5,
+                    "screen_observation_priority": 1,
+                },
+                {
+                    "well_key": "42127373050000",
+                    "state": "TX",
+                    "test_year": 2017,
+                    "pressure_psia": 1046.7,
+                    "reference_depth_ft": 7394.0,
+                    "screen_observation_priority": 0,
+                },
+            ]
+        )
+
+        wells = earliest_per_well(
+            classify_tiers(estimate_bhp(obs, BHP_SETTINGS), TIERS)
+        )
+
+        assert len(wells) == 1
+        assert wells.loc[0, "reference_depth_ft"] == 7394.0
+
 
 class TestValidationGate:
     def _ranking(self, tier):
@@ -234,3 +293,77 @@ class TestValidationGate:
             },
         )
         assert not gate["passed"]
+
+
+class TestSummaryAndParticipationGate:
+    def test_summary_reports_state_source_and_era_counts(self):
+        wells = pd.DataFrame(
+            {
+                "well_key": ["ks-1", "tx-1"],
+                "state": ["KS", "TX"],
+                "source_name": [
+                    "kansas_kgs_proration",
+                    "texas_rrc_completion_packets",
+                ],
+                "era": ["depleted", "completion_packet_screening"],
+                "pressure_tier": [TIER_SEVERE, TIER_MILD],
+                "near_vacuum": [False, False],
+                "bhp_gradient_psi_ft": [0.03, 0.40],
+            }
+        )
+        ranking = pd.DataFrame({"field": ["HUGOTON GAS AREA", "BRISCOE RANCH"]})
+
+        summary = build_screen_summary(
+            wells,
+            ranking,
+            {"passed": True},
+            {"passed": True},
+            {
+                "input_row_counts": {
+                    "kansas_kgs_proration": 2,
+                    "texas_rrc_completion_packets": 3,
+                },
+                "loaded_row_counts": {
+                    "kansas_kgs_proration": 1,
+                    "texas_rrc_completion_packets": 1,
+                },
+                "source_warnings": {"texas_rrc_completion_packets": ["warning"]},
+            },
+        )
+
+        assert summary["state_counts"] == {"KS": 1, "TX": 1}
+        assert summary["source_counts"] == {
+            "kansas_kgs_proration": 1,
+            "texas_rrc_completion_packets": 1,
+        }
+        assert summary["era_note"] == ["completion_packet_screening", "depleted"]
+        assert summary["source_warnings"] == {
+            "texas_rrc_completion_packets": ["warning"]
+        }
+
+    def test_participation_gate_requires_state_well_count(self):
+        wells = pd.DataFrame(
+            {
+                "well_key": ["ks-1", "tx-1"],
+                "state": ["KS", "TX"],
+            }
+        )
+
+        gate = run_participation_gate(
+            wells,
+            {"required_states": {"TX": {"min_wells": 1}}},
+        )
+
+        assert gate["passed"]
+        assert gate["states"]["TX"]["well_count"] == 1
+
+    def test_participation_gate_fails_when_state_missing(self):
+        wells = pd.DataFrame({"well_key": ["ks-1"], "state": ["KS"]})
+
+        gate = run_participation_gate(
+            wells,
+            {"required_states": {"TX": {"min_wells": 1}}},
+        )
+
+        assert not gate["passed"]
+        assert gate["states"]["TX"]["well_count"] == 0


### PR DESCRIPTION
## Summary

- normalizes Texas RRC #709 pressure observations into the existing under-pressured screen contract
- adds source/state summary counts, Texas participation gate, and #709 quality-warning propagation
- refreshes `/mnt/ace/worldenergydata/data/modules/pressure_screen/curated` outputs with Kansas + Texas inputs
- updates the multi-state pressure-screen report and marks the #732 plan implemented

## Gates

- Issue: #732
- Plan: `docs/plans/2026-07-03-issue-732-texas-rrc-underpressured-screen.md`
- Code review: `scripts/review/results/2026-07-03-code-732-codex-inline.md`

## Verification

- RED observed: same-year duplicate test failed before the priority fix
- `PYTHONPATH="$(printf '%s:' packages/*/src)src" uv run --no-sync pytest tests/unit/analysis/test_underpressured_observations.py tests/unit/analysis/test_underpressured_screen.py -q` -> 23 passed
- `uv run --no-sync ruff check ...` -> passed
- `uv run --no-sync ruff format --check ...` -> passed
- `PYTHONPATH="$(printf '%s:' packages/*/src)src" uv run --no-sync python -m worldenergydata.analysis.underpressured_screen.screen --config config/underpressured_screen.yml` -> validation and participation gates passed
- `scripts/legal/legal-sanity-scan.sh` -> PASS

## Live `/mnt/ace` output

- wells screened: 10,128
- state counts: KS 10,103; TX 25
- source counts: Kansas KGS 10,103; Texas RRC 25
- validation gate: passed for Hugoton/Panoma
- Texas participation gate: passed
- Texas source warning propagated: `raw_manifest_warning:completion_data:error:2026-07-01T00:36:55Z`
