### PR TITLE
feat: ingest Oklahoma OCC completion pressures

### DIFF
--- a/config/oklahoma_occ.yml
+++ b/config/oklahoma_occ.yml
@@ -23,6 +23,8 @@ pressure_observations:
   pressure_kind: WHP_shut_in
   test_type: OCC Form 1002A initial completion test
   gradient_method: completion_pressure_over_reference_depth_screening_only
+  min_test_year: 2010
+  max_future_years: 0
   depth_priority:
     - True_Vertical_Depth
     - Formation_Depth

--- a/config/oklahoma_occ.yml
+++ b/config/oklahoma_occ.yml
@@ -1,0 +1,30 @@
+# Oklahoma Corporation Commission direct-source ingest (#740).
+# Heavy raw/normalized/curated data stays under /mnt/ace.
+module: oklahoma_occ
+
+storage:
+  base_dir: /mnt/ace/worldenergydata/data/modules/oklahoma_occ
+  raw_dir: raw
+  normalized_dir: normalized
+  curated_dir: curated
+
+sources:
+  completion_workbook:
+    url: https://oklahoma.gov/content/dam/ok/en/occ/documents/og/ogdatafiles/completions-wells-formations-base.xlsx
+    raw_path: completions-wells-formations-base.xlsx
+    refresh: daily
+  completion_dictionary:
+    url: https://oklahoma.gov/content/dam/ok/en/occ/documents/og/ogdatafiles/completions-wells-formations-data-dictionary.xlsx
+    raw_path: completions-wells-formations-data-dictionary.xlsx
+    refresh: occasional
+
+pressure_observations:
+  atmospheric_psi: 14.7
+  pressure_kind: WHP_shut_in
+  test_type: OCC Form 1002A initial completion test
+  gradient_method: completion_pressure_over_reference_depth_screening_only
+  depth_priority:
+    - True_Vertical_Depth
+    - Formation_Depth
+    - Measured_Total_Depth
+    - Total_Depth

--- a/config/underpressured_screen.yml
+++ b/config/underpressured_screen.yml
@@ -20,6 +20,12 @@ inputs:
     state: TX
     era: completion_packet_screening
     require_usable_proxy: true
+  - name: oklahoma_occ_completions
+    path: /mnt/ace/worldenergydata/data/modules/oklahoma_occ/curated/pressure/well_pressure_observations.parquet
+    quality_path: /mnt/ace/worldenergydata/data/modules/oklahoma_occ/curated/pressure/oklahoma_occ_pressure_observation_quality.json
+    schema: oklahoma_occ_completion_v1
+    state: OK
+    era: completion_test_2010_present
 
 output:
   base_dir: /mnt/ace/worldenergydata/data/modules/pressure_screen/curated
@@ -54,4 +60,6 @@ participation_gate:
   # participation without forcing a false West Panhandle analog recovery gate.
   required_states:
     TX:
+      min_wells: 1
+    OK:
       min_wells: 1

--- a/docs/data-sources/onshore/state-well-databases/source-catalog.md
+++ b/docs/data-sources/onshore/state-well-databases/source-catalog.md
@@ -71,7 +71,7 @@ KCC (the regulator) publishes essentially no bulk data itself; its filings are d
 | Dataset | Coverage/fields | URL | Format | Refresh cadence | License/cost | Status |
 |---|---|---|---|---|---|---|
 | Wells master (RBDMS) | All OK wells: API, name, operator, status, type, surface lat/lon, county, PLSS, footages, + deep-link to imaged well records | https://oklahoma.gov/occ/divisions/oil-gas/oil-gas-data.html → https://oklahoma.gov/content/dam/ok/en/occ/documents/og/ogdatafiles/rbdms-wells.csv (+ data dictionary `rbdms-wells-data-dictionary.xlsx`) | CSV (also shapefile: `.../og/esri/files/RBDMS_WELLS.zip`) | Nightly | Free, public | VERIFIED (sampled header + rows) |
-| **Completions (1002A extract), 2010-present** | Per completion/formation: API, dates (spud/completion/first prod), TD/TVD, BH location, formation name/code/depth, perf top/bottom, acid/frac, casing, and **initial test block: Test_Date, Oil_BBL_Per_Day, Oil_Gravity, Gas_MCF_Per_Day, GOR, Water_BBL_Per_Day, Pumping_Flowing, Shut_In_Pressure, Choke_Size, Flow_Tubing_Pressure** | `.../ogdatafiles/completions-wells-formations-base.xlsx` (76 MB) + `-daily.xlsx` + `-data-dictionary.xlsx` | XLSX | ~Daily (base last-mod 2026-06-30) | Free, public | VERIFIED (data dictionary downloaded; field list confirmed) |
+| **Completions (1002A extract), 2010-present** | Per completion/formation: API, dates (spud/completion/first prod), TD/TVD, BH location, formation name/code/depth, perf top/bottom, acid/frac, casing, and **initial test block: Test_Date, Oil_BBL_Per_Day, Oil_Gravity, Gas_MCF_Per_Day, GOR, Water_BBL_Per_Day, Pumping_Flowing, Shut_In_Pressure, Choke_Size, Flow_Tubing_Pressure** | `.../ogdatafiles/completions-wells-formations-base.xlsx` (76 MB) + `-daily.xlsx` + `-data-dictionary.xlsx` | XLSX | ~Daily (base last-mod 2026-06-30) | Free, public | VERIFIED + IMPLEMENTED ([#740](https://github.com/vamseeachanta/worldenergydata/issues/740); live `/mnt/ace` snapshot 2026-07-03) |
 | Completions legacy (pre-2010) | Historical completions from old Oracle DB (97 MB) | `.../ogdatafiles/completions-wells-legacy.xlsx` | XLSX | Static (last-mod 2025-07-15) | Free, public | VERIFIED file exists; **field list UNVERIFIED** (may or may not carry test pressures) |
 | Intent to Drill | Master (154 MB) + 7-day files, w/ formations | `.../ogdatafiles/ITD-wells-formations-base.xlsx`, `ITD-wells-formations-daily.xlsx`, dictionary | XLSX | Daily | Free, public | VERIFIED (HEAD 200) |
 | UIC injection volumes | Annual volumes 2006–2025 (+ Arbuckle daily 1012D 2012–2026) | `.../ogdatafiles/20XX-uic-injection-volumes.xlsx`, `dly1012d_20XX.xlsx` | XLSX | Weekly for recent years | Free, public | VERIFIED (links scraped) |
@@ -87,6 +87,36 @@ OGS (Oklahoma Geological Survey / OPIC well data library) is a physical archive 
 
 ### Ingestion effort estimate
 **Low-medium.** No auth/rate limits; single-URL downloads with published data dictionaries. Gotchas: workhorse files are large XLSX (76–154 MB — need streaming parse); completion records are one row per formation/test (dedupe by API+Completion_No); nightly overwrite means snapshotting for history; panhandle (Guymon-Hugoton) virgin-pressure work pre-1990 forces imaged Form 1016/1002A parsing (high-effort OCR lane). OTC production has no verified bulk endpoint (per-PUN lookup only).
+
+### Implemented [#740](https://github.com/vamseeachanta/worldenergydata/issues/740) snapshot
+
+The Oklahoma completion-pressure lane now has a direct-source pipeline:
+
+```text
+/mnt/ace/worldenergydata/data/modules/oklahoma_occ/
+  raw/
+    completions-wells-formations-base.xlsx
+    completions-wells-formations-data-dictionary.xlsx
+    manifest.json
+  normalized/completions/completion_pressure_rows.parquet
+  curated/pressure/well_pressure_observations.parquet
+  curated/pressure/oklahoma_occ_pressure_observation_quality.json
+```
+
+Live run 2026-07-03 against the OCC direct URLs downloaded the 76,131,895-byte
+base workbook (`Last-Modified: Tue, 30 Jun 2026 00:34:55 GMT`) and dictionary.
+The parser read 202,745 completion rows and emitted 108,518 curated pressure
+observations across 19,972 Oklahoma wells after filtering to `test_year`
+2010-2026. Source anomalies outside that window are counted in the quality
+sidecar (`filtered_out_of_window_test_year_count: 8,917`) rather than silently
+loaded into the screen.
+
+The pressure observation mix is 78,000 `WHP_shut_in` rows and 30,518
+`WHP_flowing_tubing` fallback rows. Both are treated as surface wellhead
+screening pressures in the multi-state screen, with the same static gas-column
+correction and `era: completion_test_2010_present`. This does not replace a
+Form 1016 back-pressure/deliverability lane for Guymon-Hugoton-style
+pre-2010/virgin-pressure evidence.
 
 ## New Mexico — EMNRD Oil Conservation Division (OCD)
 
@@ -293,12 +323,15 @@ Ranked by value-per-effort for the under-pressured screen (#708):
    `ks_wells.zip` (depth, formation, location) for gradient computation.
    One 14 MB file + one 44 MB wells file. The 2013 freeze does not hurt —
    the virgin-to-depleted pressure history is what the screen needs.
-2. **Oklahoma — GO, ingest second (effort: low-medium).** The OCC
+2. **Oklahoma — IMPLEMENTED ([#740](https://github.com/vamseeachanta/worldenergydata/issues/740); effort: low-medium).** The OCC
    completions extract (2010-present, dictionary-verified) provides
    `Shut_In_Pressure` and `Flow_Tubing_Pressure` per formation completion,
-   plus TD/TVD and formation depth for the gradient denominator — and covers
-   the Panhandle trend continuation. Pre-2010 (legacy XLSX field content
-   unverified; Form 1016 imaged) is a later OCR lane if needed.
+   plus TD/TVD and formation depth for the gradient denominator. The live
+   [#740](https://github.com/vamseeachanta/worldenergydata/issues/740)
+   pipeline writes `/mnt/ace/.../oklahoma_occ/` raw, normalized, curated,
+   and quality outputs and feeds the multi-state screen. Pre-2010 legacy XLSX
+   interpretation and Form 1016 image extraction remain later OCR/acquisition
+   lanes.
 3. **Colorado — GO, ingest third (effort: low for bulk).** Monthly wellhead
    tubing/casing pressures in the 1999+ production CSVs give a late-life
    pressure screen out of the box (and Piceance BCG coverage); virgin-test
@@ -319,7 +352,7 @@ Ranked by value-per-effort for the under-pressured screen (#708):
    but pressure evidence in all five is imaged (or paywalled + imaged, ND),
    i.e., an OCR/document-extraction program rather than an ingestion slice.
 
-Suggested follow-on issues once this survey is accepted: (a) Kansas
-KGS ingest + pressure-gradient table (mirrors #709 for TX), (b) Oklahoma OCC
-completions ingest, (c) extend the #710 screen to consume multi-state
-pressure observations through one normalized schema.
+Suggested follow-on issues once this survey is accepted: (a) Colorado ECMC
+wellhead-pressure ingest, (b) Oklahoma Form 1016 image/OCR acquisition for
+Panhandle deliverability tests, (c) Oklahoma OTC production acquisition if a
+sanctioned bulk path or data-request route is identified.

--- a/docs/data-sources/onshore/state-well-databases/underpressured-gas-fields.md
+++ b/docs/data-sources/onshore/state-well-databases/underpressured-gas-fields.md
@@ -2,23 +2,27 @@
 
 Issue: [#710](https://github.com/vamseeachanta/worldenergydata/issues/710)
 (parent epic [#708](https://github.com/vamseeachanta/worldenergydata/issues/708);
-Texas integration [#732](https://github.com/vamseeachanta/worldenergydata/issues/732)).
+Texas integration [#732](https://github.com/vamseeachanta/worldenergydata/issues/732);
+Oklahoma integration [#740](https://github.com/vamseeachanta/worldenergydata/issues/740)).
 
 The screen answers the epic's motivating question — *which wells and fields
 actually produced from very low bottom-hole pressure?* — from state-regulator
 data. The current run combines Kansas KGS proration pressure observations
 ([#725](https://github.com/vamseeachanta/worldenergydata/issues/725)) with
 Texas RRC completion-packet pressure observations
-([#709](https://github.com/vamseeachanta/worldenergydata/issues/709)).
+([#709](https://github.com/vamseeachanta/worldenergydata/issues/709)) and
+Oklahoma OCC Form 1002A completion pressure observations
+([#740](https://github.com/vamseeachanta/worldenergydata/issues/740)).
 
 ## Method
 
 ```bash
-PYTHONPATH=src python -m worldenergydata.analysis.underpressured_screen.screen \
+PYTHONPATH=src:packages/worldenergydata-core/src python3.12 \
+  -m worldenergydata.analysis.underpressured_screen.screen \
     --config config/underpressured_screen.yml
 ```
 
-1. **BHP estimate**: wellhead shut-in readings get the static gas-column
+1. **BHP estimate**: wellhead readings get the static gas-column
    correction `BHP = WHP_psia · exp(0.01875·γg·D / (z̄·T̄))` (γg 0.65,
    z̄ 0.95, T̄ 520 °R from config — a ~7% uplift at Hugoton depths);
    measured BHP values pass through unchanged.
@@ -29,18 +33,21 @@ PYTHONPATH=src python -m worldenergydata.analysis.underpressured_screen.screen \
 3. **Source normalization** adapts state-specific physical schemas into the
    screen contract. Kansas already emits `well_key` and `field`; Texas maps
    `api14` to `well_key`, `field_name` to `field`, injects `state=TX`, and
-   filters to rows marked `usable_for_virgin_pressure_proxy`.
+   filters to rows marked `usable_for_virgin_pressure_proxy`; Oklahoma maps
+   OCC completion observations into `well_key`, `field`, `pressure_kind`,
+   `pressure_psia`, and `reference_depth_ft`.
 4. **Earliest observation per well** is the screening proxy; the source `era`
    label rides along so depleted-era Kansas proration pressures and Texas
-   completion-packet screening pressures are not presented as measured virgin
-   BHP. Source-provided earliest-observation flags break same-year duplicate
-   ties, such as Texas G-1/G-10 rows for the same API14.
+   or Oklahoma completion-test screening pressures are not presented as
+   measured virgin BHP. Source-provided earliest-observation flags break
+   same-year duplicate ties, such as Texas G-1/G-10 rows for the same API14 or
+   Oklahoma multi-formation completion rows for the same API.
 5. **Field ranking** (>=5 wells) plus a **validation gate**: the run fails
    unless Hugoton and Panoma appear in the top 10 classified severely
    under-pressured.
-6. **Participation gate**: Texas must be loaded and screened, but the current
-   daily completion packet is too narrow to require West Panhandle analog
-   recovery.
+6. **Participation gate**: Texas and Oklahoma must be loaded and screened, but
+   neither completion-test lane is required to recover West Panhandle analogs
+   until a full historical or Form 1016 source is available.
 
 Outputs: `/mnt/ace/worldenergydata/data/modules/pressure_screen/curated/`
 (`well_screen_earliest.parquet`, `underpressured_field_ranking.parquet`,
@@ -48,19 +55,21 @@ Outputs: `/mnt/ace/worldenergydata/data/modules/pressure_screen/curated/`
 
 ## Results (run 2026-07-03)
 
-10,128 wells screened: **10,103 Kansas** wells and **25 Texas** wells after
-earliest-observation selection. The screen loaded 39,134 Kansas pressure rows
-and 43 usable Texas pressure rows from 48 curated Texas observations. Median
-estimated-BHP gradient remains **0.0304 psi/ft**, with **264 near-vacuum**
-shut-in wellhead-pressure wells. Validation gate: **PASSED**. Texas
-participation gate: **PASSED**.
+30,100 wells screened: **10,103 Kansas**, **25 Texas**, and **19,972
+Oklahoma** wells after earliest-observation selection. The screen loaded
+39,134 Kansas pressure rows, 43 usable Texas rows from 48 curated Texas
+observations, and 108,518 Oklahoma pressure rows from the OCC completion
+extract. Median estimated-BHP gradient is **0.0411 psi/ft**, with **697
+near-vacuum** shut-in wellhead-pressure wells. Validation gate: **PASSED**.
+Texas and Oklahoma participation gates: **PASSED**.
 
 Tier counts:
 
 | Tier | Wells |
 | --- | ---: |
-| Severely under-pressured | 10,126 |
-| Normal | 2 |
+| Severely under-pressured | 28,248 |
+| Mildly under-pressured | 855 |
+| Normal | 997 |
 
 Source counts after earliest-observation selection:
 
@@ -68,22 +77,29 @@ Source counts after earliest-observation selection:
 | --- | --- | ---: | --- |
 | `kansas_kgs_proration` | KS | 10,103 | depleted |
 | `texas_rrc_completion_packets` | TX | 25 | completion_packet_screening |
+| `oklahoma_occ_completions` | OK | 19,972 | completion_test_2010_present |
 
 | Field | Wells | Median gradient (psi/ft) | P10–P90 | Near-vacuum wells |
 | --- | --- | --- | --- | --- |
 | HUGOTON GAS AREA | 7,146 | 0.0316 | 0.022–0.056 | 159 |
+| MISSISSIPPIAN | 3,920 | 0.0667 | 0.015–0.332 | 24 |
+| WOODFORD | 3,705 | 0.1366 | 0.027–0.373 | 5 |
 | PANOMA GAS AREA | 2,342 | 0.0289 | 0.021–0.039 | 20 |
-| GREENWOOD GAS AREA | 233 | **0.0181** | 0.014–0.029 | **51 (22%)** |
-| HUGOTON | 200 | 0.0352 | 0.020–0.068 | 12 |
-| PANOMA | 60 | 0.0232 | 0.015–0.033 | 15 |
-| GREENWOOD | 17 | 0.0212 | 0.015–0.031 | 1 |
-| BRISCOE RANCH (EAGLEFORD) | 16 | 0.1361 | 0.094–0.205 | 0 |
+| (unmatched) | 1,306 | 0.0204 | 0.013–0.111 | 15 |
+| MISSISSIPPI LIME | 924 | 0.0279 | 0.013–0.244 | 7 |
+| CLEVELAND | 745 | 0.0990 | 0.018–0.302 | 7 |
+| HUNTON | 647 | 0.0736 | 0.009–0.250 | 25 |
+| TONKAWA | 466 | 0.0980 | 0.016–0.223 | 2 |
+| OSWEGO | 431 | 0.0416 | 0.013–0.163 | 4 |
 
 Notable beyond the analogs:
 
 - **Greenwood Gas Area** (Morton County, KS) remains the most extreme entry:
   median gradient under 2% of hydrostatic with 22% of tested wells at
   near-vacuum.
+- **Mississippian** and **Woodford** are the largest Oklahoma completion-test
+  entries. They are screening-only formation-name buckets, not yet a
+  field-development architecture model.
 - **Briscoe Ranch (Eagleford)** enters as the first Texas ranked field: 16
   earliest wells, all screening-only WHP-derived observations, median estimated
   gradient 0.1361 psi/ft.
@@ -96,16 +112,24 @@ Notable beyond the analogs:
   1922). They prove sustained economic production at extremely low BHP — the
   epic's question — but virgin-pressure claims need DST-era evidence (KGS DST
   records are a per-well scrape, catalogued in `source-catalog.md`).
-- Gradients use wells-master total depth as the reference depth and an
-  average-z̄T̄ gas column; both are approximations flagged in the data
-  (`bhp_method`, `gradient_method`).
-- Texas RRC #709 rows in this run are all **shut-in wellhead pressure** rows,
-  not measured bottom-hole pressure. They remain screening-only until a source
-  provides measured BHP or a better calibrated gas-column correction.
+- Gradients use source-provided TVD/depth fields and an average-z̄T̄ gas
+  column; both are approximations flagged in the data (`bhp_method`,
+  `gradient_method`).
+- Texas RRC [#709](https://github.com/vamseeachanta/worldenergydata/issues/709)
+  rows and Oklahoma OCC
+  [#740](https://github.com/vamseeachanta/worldenergydata/issues/740) rows are
+  **wellhead pressure**
+  rows, not measured bottom-hole pressure. Oklahoma uses `WHP_shut_in` first
+  and `WHP_flowing_tubing` as a fallback when shut-in pressure is missing.
+  Both remain screening-only until a source provides measured BHP or a better
+  calibrated gas-column correction.
 - The Texas input is a narrow daily completion packet, not a full historical
   pressure archive. It is useful for proving the multi-state screen path and
   finding current low-gradient examples, but it is not yet a West Panhandle
   analog recovery dataset.
+- The Oklahoma input covers structured Form 1002A completion records from
+  2010-present. Pre-2010 legacy completions and Form 1016 back-pressure tests
+  remain imaged/legacy lanes and are not in this run.
 - The Texas quality sidecar currently carries
   `raw_manifest_warning:completion_data:error:2026-07-01T00:36:55Z`; the
   screen propagates that warning into `screen_summary.json`.

--- a/docs/plans/2026-07-03-issue-740-oklahoma-occ-pressure-observations.md
+++ b/docs/plans/2026-07-03-issue-740-oklahoma-occ-pressure-observations.md
@@ -1,7 +1,7 @@
 # Plan: Issue #740 - Oklahoma OCC completion-pressure observations
 
 **Issue:** https://github.com/vamseeachanta/worldenergydata/issues/740
-**Status:** plan-review
+**Status:** implemented
 **Tier:** T2 (new direct-source state ingest, `/mnt/ace` raw snapshot, curated pressure observations, screen integration, docs)
 **Client:** N/A
 **Project:** worldenergydata onshore pressure screen

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -84,7 +84,7 @@ This directory contains issue-plan artifacts created during the issue-planning-m
 | [#707](https://github.com/vamseeachanta/worldenergydata/issues/707) | [texas-rrc-field-architecture-portfolio](2026-07-02-issue-707-texas-rrc-field-architecture-portfolio.md) | plan-approved | 2026-07-02 |
 | [#709](https://github.com/vamseeachanta/worldenergydata/issues/709) | [texas-rrc-pressure-observations](2026-07-03-issue-709-texas-rrc-pressure-observations.md) | implemented | 2026-07-03 |
 | [#732](https://github.com/vamseeachanta/worldenergydata/issues/732) | [texas-rrc-underpressured-screen](2026-07-03-issue-732-texas-rrc-underpressured-screen.md) | implemented | 2026-07-03 |
-| [#740](https://github.com/vamseeachanta/worldenergydata/issues/740) | [oklahoma-occ-pressure-observations](2026-07-03-issue-740-oklahoma-occ-pressure-observations.md) | plan-review | 2026-07-03 |
+| [#740](https://github.com/vamseeachanta/worldenergydata/issues/740) | [oklahoma-occ-pressure-observations](2026-07-03-issue-740-oklahoma-occ-pressure-observations.md) | implemented | 2026-07-03 |
 
 ## Closed / superseded plans
 

--- a/scripts/review/results/2026-07-03-code-740-codex-inline.md
+++ b/scripts/review/results/2026-07-03-code-740-codex-inline.md
@@ -1,0 +1,60 @@
+# Code Review: Issue #740 - Oklahoma OCC completion pressures
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/740
+**Mode:** Codex inline adversarial review
+**Date:** 2026-07-03
+**Scope reviewed:**
+
+- `src/worldenergydata/modules/state_regulators/oklahoma_occ/`
+- `src/worldenergydata/analysis/underpressured_screen/`
+- `config/oklahoma_occ.yml`
+- `config/underpressured_screen.yml`
+- focused unit tests
+- onshore source catalog and screen report docs
+
+## Routing Note
+
+The runtime exposed subagent tools, but their tool contract says not to spawn
+subagents unless the user explicitly asks for subagents/delegation/parallel
+agent work. No such explicit request was present in this closeout turn, so this
+review is an inline defect-hunting review rather than a dispatched multi-agent
+review.
+
+## Findings
+
+### R1 - Fixed: XLSX workbook handle could remain open on empty/error paths
+
+`_read_selected_columns()` originally called `workbook.close()` only after the
+normal row-iteration path. An empty workbook or exception while iterating rows
+could skip close and leak the file handle during large direct-source refreshes.
+
+Resolution: wrapped selected-column reading in `try/finally` so
+`workbook.close()` always runs after `load_workbook()`.
+
+## Post-Fix Review Result
+
+No open blocking findings remain in the reviewed diff.
+
+Residual risks:
+
+- OCC workbook schema drift is controlled by fail-closed required-column
+  validation, but semantic drift in optional columns still requires source
+  review.
+- `WHP_flowing_tubing` remains a screening-only fallback pressure. It is now
+  treated consistently as a surface wellhead pressure, but it is not measured
+  BHP and should not be presented as virgin pressure.
+- Form 1016 back-pressure/deliverability tests and Oklahoma Tax Commission
+  production data remain outside this issue.
+
+## Verification Evidence
+
+- Focused tests: `35 passed` with `--no-cov`.
+- Ruff check: pass.
+- Ruff format check: pass.
+- Direct OCC ingest: pass; workbook SHA256
+  `6d68d41320a6fcefd0b9973d544cf1c836de4c43a3cdeca0c9f58e74c2757e1f`.
+- OCC curated invariant check: 108,518 rows, 19,972 wells, test years
+  2010-2026.
+- Multi-state pressure screen: pass; 30,100 wells screened; validation and
+  participation gates passed.
+- Legal scan: `legal-sanity-scan: PASS`.

--- a/src/worldenergydata/analysis/underpressured_screen/observations.py
+++ b/src/worldenergydata/analysis/underpressured_screen/observations.py
@@ -22,6 +22,10 @@ TEXAS_COLUMN_MAP = {
     "field_name": "field",
 }
 
+OKLAHOMA_COLUMN_MAP = {
+    "formation_name": "field",
+}
+
 
 def normalize_observations(frame: pd.DataFrame, input_config: dict) -> pd.DataFrame:
     """Normalize one source-specific pressure table to the screen contract."""
@@ -30,6 +34,8 @@ def normalize_observations(frame: pd.DataFrame, input_config: dict) -> pd.DataFr
         normalized = frame.copy()
     elif schema == "texas_rrc_pressure_v1":
         normalized = _normalize_texas_pressure(frame, input_config)
+    elif schema == "oklahoma_occ_completion_v1":
+        normalized = _normalize_oklahoma_occ_completion(frame, input_config)
     else:
         raise ValueError(f"Unsupported pressure screen input schema: {schema}")
 
@@ -85,6 +91,29 @@ def _normalize_texas_pressure(frame: pd.DataFrame, input_config: dict) -> pd.Dat
         )
         usable = _truthy(normalized["usable_for_virgin_pressure_proxy"])
         normalized = normalized[usable].copy()
+    return normalized
+
+
+def _normalize_oklahoma_occ_completion(
+    frame: pd.DataFrame, input_config: dict
+) -> pd.DataFrame:
+    required = {
+        "well_key",
+        "test_year",
+        "pressure_kind",
+        "pressure_psia",
+        "reference_depth_ft",
+    }
+    if "field" not in frame:
+        required.add("formation_name")
+    _validate_columns(frame, required, input_config["name"])
+    normalized = frame.copy()
+    if "field" not in normalized:
+        normalized = normalized.rename(columns=OKLAHOMA_COLUMN_MAP)
+    normalized["well_key"] = normalized["well_key"].astype("string")
+    if "is_earliest_observation" in normalized:
+        earliest = _truthy(normalized["is_earliest_observation"])
+        normalized["screen_observation_priority"] = (~earliest).astype(int)
     return normalized
 
 

--- a/src/worldenergydata/analysis/underpressured_screen/screen.py
+++ b/src/worldenergydata/analysis/underpressured_screen/screen.py
@@ -40,8 +40,8 @@ def load_config(config_path: str | Path) -> dict:
 def estimate_bhp(observations: pd.DataFrame, settings: dict) -> pd.DataFrame:
     """Add ``bhp_psia_est`` and ``bhp_gradient_psi_ft``.
 
-    Wellhead shut-in readings get the average-temperature-and-z static
-    gas-column correction; measured BHP values pass through unchanged.
+    Wellhead readings get the average-temperature-and-z static gas-column
+    correction; measured BHP values pass through unchanged.
     """
     frame = observations.copy()
     exponent = (
@@ -51,7 +51,7 @@ def estimate_bhp(observations: pd.DataFrame, settings: dict) -> pd.DataFrame:
         / (settings["z_avg"] * settings["t_avg_rankine"])
     )
     multiplier = np.exp(exponent)
-    is_whp = frame["pressure_kind"] == "WHP_shut_in"
+    is_whp = frame["pressure_kind"].fillna("").astype(str).str.startswith("WHP_")
     frame["bhp_psia_est"] = frame["pressure_psia"].where(
         ~is_whp, frame["pressure_psia"] * multiplier
     )
@@ -199,8 +199,10 @@ def run_screen(config_path: str | Path) -> dict:
 
     out_dir = Path(config["output"]["base_dir"])
     out_dir.mkdir(parents=True, exist_ok=True)
-    wells.to_parquet(out_dir / "well_screen_earliest.parquet")
-    ranking.to_parquet(out_dir / "underpressured_field_ranking.parquet")
+    _parquet_safe_frame(wells).to_parquet(out_dir / "well_screen_earliest.parquet")
+    _parquet_safe_frame(ranking).to_parquet(
+        out_dir / "underpressured_field_ranking.parquet"
+    )
     (out_dir / "screen_summary.json").write_text(
         json.dumps(summary, indent=2), encoding="utf-8"
     )
@@ -226,6 +228,25 @@ def _median_gradient(wells: pd.DataFrame) -> float | None:
 
 def _unique_values(series: pd.Series) -> list[str]:
     return sorted(str(value) for value in series.dropna().unique().tolist())
+
+
+def _parquet_safe_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    """Normalize optional object metadata columns before parquet serialization."""
+    result = frame.copy()
+    for column in result.select_dtypes(include=["object"]).columns:
+        if column.endswith("_date"):
+            parsed = pd.to_datetime(result[column], errors="coerce")
+            if int(parsed.notna().sum()) == int(result[column].notna().sum()):
+                result[column] = parsed
+                continue
+        result[column] = result[column].map(_nullable_text).astype("string")
+    return result
+
+
+def _nullable_text(value: object) -> str | None:
+    if pd.isna(value):
+        return None
+    return str(value)
 
 
 def main() -> None:

--- a/src/worldenergydata/modules/state_regulators/oklahoma_occ/__init__.py
+++ b/src/worldenergydata/modules/state_regulators/oklahoma_occ/__init__.py
@@ -1,0 +1,1 @@
+"""Oklahoma OCC direct-source ingest helpers (#740)."""

--- a/src/worldenergydata/modules/state_regulators/oklahoma_occ/parsers.py
+++ b/src/worldenergydata/modules/state_regulators/oklahoma_occ/parsers.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
+from openpyxl import load_workbook
 
 CORE_COLUMNS = {
     "API_Number",
@@ -40,6 +42,13 @@ NUMERIC_COLUMNS = [
     "Perforated_Top_Depth",
     "Perforated_Bottom_Depth",
 ]
+
+READ_COLUMNS = sorted(CORE_COLUMNS | set(CONTEXT_COLUMNS) | set(NUMERIC_COLUMNS))
+TEXT_COLUMNS = sorted(
+    set(READ_COLUMNS)
+    - set(NUMERIC_COLUMNS)
+    - {"API_Number", "Completion_No", "Test_Date"}
+)
 
 OUTPUT_COLUMNS = [
     "state",
@@ -77,15 +86,45 @@ OUTPUT_COLUMNS = [
 
 def read_completion_workbook(path: str | Path) -> pd.DataFrame:
     """Read an OCC completion workbook into a typed DataFrame."""
-    frame = pd.read_excel(path, engine="openpyxl", dtype=str)
+    frame = _read_selected_columns(Path(path), READ_COLUMNS)
     _validate_columns(frame, CORE_COLUMNS, Path(path).name)
     for column in NUMERIC_COLUMNS:
         if column in frame:
             frame[column] = pd.to_numeric(frame[column], errors="coerce")
-    frame["API_Number"] = frame["API_Number"].map(_clean_identifier)
-    frame["Completion_No"] = frame["Completion_No"].map(_clean_completion_no)
+    for column in TEXT_COLUMNS:
+        if column in frame:
+            frame[column] = frame[column].map(_clean_text).astype("string")
+    frame["API_Number"] = frame["API_Number"].map(_clean_identifier).astype("string")
+    frame["Completion_No"] = (
+        frame["Completion_No"].map(_clean_completion_no).astype("string")
+    )
     frame["Test_Date"] = pd.to_datetime(frame["Test_Date"], errors="coerce")
     return frame
+
+
+def _read_selected_columns(path: Path, wanted_columns: list[str]) -> pd.DataFrame:
+    workbook = load_workbook(path, read_only=True, data_only=True)
+    try:
+        sheet = workbook.active
+        rows = sheet.iter_rows(values_only=True)
+        try:
+            header = next(rows)
+        except StopIteration:
+            return pd.DataFrame(columns=wanted_columns)
+        column_indexes = {
+            name: index for index, name in enumerate(header) if name in wanted_columns
+        }
+        records = []
+        for row in rows:
+            records.append(
+                {
+                    column: row[index] if index < len(row) else None
+                    for column, index in column_indexes.items()
+                }
+            )
+    finally:
+        workbook.close()
+    return pd.DataFrame.from_records(records, columns=list(column_indexes))
 
 
 def build_pressure_observations(
@@ -104,7 +143,12 @@ def build_pressure_observations(
     test_date = pd.to_datetime(frame["Test_Date"], errors="coerce")
     pressure = _select_pressure(frame)
     depth, depth_source = _select_reference_depth(frame, settings["depth_priority"])
-    usable = pressure["pressure_psig"].gt(0) & depth.gt(0) & test_date.notna()
+    test_year = test_date.dt.year
+    min_year, max_year = _year_window(settings)
+    in_window = test_year.between(min_year, max_year)
+    usable = (
+        pressure["pressure_psig"].gt(0) & depth.gt(0) & test_date.notna() & in_window
+    )
     filtered = frame[usable].copy()
     pressure = pressure[usable].reset_index(drop=True)
     depth = depth[usable].reset_index(drop=True)
@@ -139,9 +183,7 @@ def build_pressure_observations(
                 pressure["pressure_psig"] + settings["atmospheric_psi"]
             ).to_numpy(),
             "pressure_kind": pressure["pressure_kind"].to_numpy(),
-            "flow_tubing_pressure_psig": filtered[
-                "Flow_Tubing_Pressure"
-            ].to_numpy(),
+            "flow_tubing_pressure_psig": filtered["Flow_Tubing_Pressure"].to_numpy(),
             "gas_mcf_per_day": filtered["Gas_MCF_Per_Day"].to_numpy(),
             "oil_bbl_per_day": filtered["Oil_BBL_Per_Day"].to_numpy(),
             "water_bbl_per_day": filtered["Water_BBL_Per_Day"].to_numpy(),
@@ -165,7 +207,7 @@ def build_pressure_observations(
 
 
 def build_quality_stats(
-    completions: pd.DataFrame, observations: pd.DataFrame
+    completions: pd.DataFrame, observations: pd.DataFrame, settings: dict | None = None
 ) -> dict:
     pressure = _select_pressure(completions)
     depth, _ = _select_reference_depth(
@@ -178,6 +220,9 @@ def build_quality_stats(
         ],
     )
     test_date = pd.to_datetime(completions["Test_Date"], errors="coerce")
+    test_year = test_date.dt.year
+    min_year, max_year = _year_window(settings or {})
+    in_window = test_year.between(min_year, max_year)
     has_pressure = pressure["pressure_psig"].gt(0)
     has_depth = depth.gt(0)
     return {
@@ -188,6 +233,10 @@ def build_quality_stats(
         "filtered_missing_test_date_count": int(
             (has_pressure & has_depth & test_date.isna()).sum()
         ),
+        "filtered_out_of_window_test_year_count": int(
+            (has_pressure & has_depth & test_date.notna() & ~in_window).sum()
+        ),
+        "test_year_window": [int(min_year), int(max_year)],
         "wells_with_pressure_observation": int(observations["well_key"].nunique()),
         "completion_observation_count": int(
             observations[["well_key", "completion_no"]].drop_duplicates().shape[0]
@@ -254,6 +303,15 @@ def _clean_completion_no(value: object) -> str | None:
     return text.zfill(2) if text else None
 
 
+def _clean_text(value: object) -> str | None:
+    if pd.isna(value):
+        return None
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    text = str(value).strip()
+    return text[:-2] if text.endswith(".0") else text
+
+
 def _api14(api_number: str | None, completion_no: str | None) -> str | None:
     if not api_number or not completion_no:
         return None
@@ -282,3 +340,14 @@ def _year_range(observations: pd.DataFrame) -> list[int] | None:
         int(observations["test_year"].min()),
         int(observations["test_year"].max()),
     ]
+
+
+def _year_window(settings: dict) -> tuple[int, int]:
+    min_year = int(settings.get("min_test_year", 1900))
+    if "max_test_year" in settings:
+        max_year = int(settings["max_test_year"])
+    else:
+        max_year = datetime.now(timezone.utc).year + int(
+            settings.get("max_future_years", 0)
+        )
+    return min_year, max_year

--- a/src/worldenergydata/modules/state_regulators/oklahoma_occ/parsers.py
+++ b/src/worldenergydata/modules/state_regulators/oklahoma_occ/parsers.py
@@ -1,0 +1,284 @@
+"""Parsers for Oklahoma OCC completion workbooks (#740)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+CORE_COLUMNS = {
+    "API_Number",
+    "Completion_No",
+    "Test_Date",
+    "Shut_In_Pressure",
+    "Flow_Tubing_Pressure",
+}
+
+CONTEXT_COLUMNS = [
+    "Well_Name",
+    "Well_Number",
+    "Operator_Name",
+    "Operator_Number",
+    "County",
+    "Formation_Name",
+    "Formation_Code",
+]
+
+NUMERIC_COLUMNS = [
+    "Shut_In_Pressure",
+    "Flow_Tubing_Pressure",
+    "Gas_MCF_Per_Day",
+    "Oil_BBL_Per_Day",
+    "Water_BBL_Per_Day",
+    "Gas_Oil_Ratio",
+    "Oil_Gravity",
+    "Measured_Total_Depth",
+    "True_Vertical_Depth",
+    "Total_Depth",
+    "Formation_Depth",
+    "Perforated_Top_Depth",
+    "Perforated_Bottom_Depth",
+]
+
+OUTPUT_COLUMNS = [
+    "state",
+    "well_key",
+    "api_number",
+    "api14",
+    "completion_no",
+    "well_name",
+    "well_number",
+    "operator",
+    "operator_number",
+    "county",
+    "field",
+    "formation_name",
+    "formation_code",
+    "test_date",
+    "test_year",
+    "test_type",
+    "pressure_psig_reported",
+    "pressure_psia",
+    "pressure_kind",
+    "flow_tubing_pressure_psig",
+    "gas_mcf_per_day",
+    "oil_bbl_per_day",
+    "water_bbl_per_day",
+    "reference_depth_ft",
+    "reference_depth_source",
+    "gradient_psi_ft",
+    "gradient_method",
+    "is_earliest_observation",
+    "screen_observation_priority",
+    "source_file",
+]
+
+
+def read_completion_workbook(path: str | Path) -> pd.DataFrame:
+    """Read an OCC completion workbook into a typed DataFrame."""
+    frame = pd.read_excel(path, engine="openpyxl", dtype=str)
+    _validate_columns(frame, CORE_COLUMNS, Path(path).name)
+    for column in NUMERIC_COLUMNS:
+        if column in frame:
+            frame[column] = pd.to_numeric(frame[column], errors="coerce")
+    frame["API_Number"] = frame["API_Number"].map(_clean_identifier)
+    frame["Completion_No"] = frame["Completion_No"].map(_clean_completion_no)
+    frame["Test_Date"] = pd.to_datetime(frame["Test_Date"], errors="coerce")
+    return frame
+
+
+def build_pressure_observations(
+    completions: pd.DataFrame, settings: dict
+) -> pd.DataFrame:
+    """Build curated pressure observations from structured OCC completions."""
+    frame = completions.copy()
+    _validate_columns(frame, CORE_COLUMNS, "OCC completions")
+    for column in CONTEXT_COLUMNS + NUMERIC_COLUMNS:
+        if column not in frame:
+            frame[column] = pd.NA
+    for column in NUMERIC_COLUMNS:
+        frame[column] = pd.to_numeric(frame[column], errors="coerce")
+    frame["API_Number"] = frame["API_Number"].map(_clean_identifier)
+    frame["Completion_No"] = frame["Completion_No"].map(_clean_completion_no)
+    test_date = pd.to_datetime(frame["Test_Date"], errors="coerce")
+    pressure = _select_pressure(frame)
+    depth, depth_source = _select_reference_depth(frame, settings["depth_priority"])
+    usable = pressure["pressure_psig"].gt(0) & depth.gt(0) & test_date.notna()
+    filtered = frame[usable].copy()
+    pressure = pressure[usable].reset_index(drop=True)
+    depth = depth[usable].reset_index(drop=True)
+    depth_source = depth_source[usable].reset_index(drop=True)
+    test_date = test_date[usable].reset_index(drop=True)
+
+    observations = pd.DataFrame(
+        {
+            "state": "OK",
+            "well_key": filtered["API_Number"].to_numpy(),
+            "api_number": filtered["API_Number"].to_numpy(),
+            "api14": [
+                _api14(api, completion)
+                for api, completion in zip(
+                    filtered["API_Number"], filtered["Completion_No"], strict=False
+                )
+            ],
+            "completion_no": filtered["Completion_No"].to_numpy(),
+            "well_name": filtered["Well_Name"].to_numpy(),
+            "well_number": filtered["Well_Number"].to_numpy(),
+            "operator": filtered["Operator_Name"].to_numpy(),
+            "operator_number": filtered["Operator_Number"].to_numpy(),
+            "county": filtered["County"].to_numpy(),
+            "field": filtered["Formation_Name"].to_numpy(),
+            "formation_name": filtered["Formation_Name"].to_numpy(),
+            "formation_code": filtered["Formation_Code"].to_numpy(),
+            "test_date": test_date,
+            "test_year": test_date.dt.year.astype("Int64"),
+            "test_type": settings["test_type"],
+            "pressure_psig_reported": pressure["pressure_psig"].to_numpy(),
+            "pressure_psia": (
+                pressure["pressure_psig"] + settings["atmospheric_psi"]
+            ).to_numpy(),
+            "pressure_kind": pressure["pressure_kind"].to_numpy(),
+            "flow_tubing_pressure_psig": filtered[
+                "Flow_Tubing_Pressure"
+            ].to_numpy(),
+            "gas_mcf_per_day": filtered["Gas_MCF_Per_Day"].to_numpy(),
+            "oil_bbl_per_day": filtered["Oil_BBL_Per_Day"].to_numpy(),
+            "water_bbl_per_day": filtered["Water_BBL_Per_Day"].to_numpy(),
+            "reference_depth_ft": depth.to_numpy(),
+            "reference_depth_source": depth_source.to_numpy(),
+            "gradient_psi_ft": (
+                (pressure["pressure_psig"] + settings["atmospheric_psi"]) / depth
+            ).to_numpy(),
+            "gradient_method": settings["gradient_method"],
+            "source_file": "completions-wells-formations-base.xlsx",
+        }
+    )
+    observations["is_earliest_observation"] = _earliest_flags(observations)
+    observations["screen_observation_priority"] = (
+        ~observations["is_earliest_observation"].astype(bool)
+    ).astype(int)
+    observations["is_earliest_observation"] = observations[
+        "is_earliest_observation"
+    ].astype(object)
+    return observations[OUTPUT_COLUMNS]
+
+
+def build_quality_stats(
+    completions: pd.DataFrame, observations: pd.DataFrame
+) -> dict:
+    pressure = _select_pressure(completions)
+    depth, _ = _select_reference_depth(
+        completions,
+        [
+            "True_Vertical_Depth",
+            "Formation_Depth",
+            "Measured_Total_Depth",
+            "Total_Depth",
+        ],
+    )
+    test_date = pd.to_datetime(completions["Test_Date"], errors="coerce")
+    has_pressure = pressure["pressure_psig"].gt(0)
+    has_depth = depth.gt(0)
+    return {
+        "input_rows": int(len(completions)),
+        "curated_count": int(len(observations)),
+        "filtered_missing_pressure_count": int((~has_pressure).sum()),
+        "filtered_missing_depth_count": int((has_pressure & ~has_depth).sum()),
+        "filtered_missing_test_date_count": int(
+            (has_pressure & has_depth & test_date.isna()).sum()
+        ),
+        "wells_with_pressure_observation": int(observations["well_key"].nunique()),
+        "completion_observation_count": int(
+            observations[["well_key", "completion_no"]].drop_duplicates().shape[0]
+        ),
+        "pressure_kind_counts": _counts(observations["pressure_kind"]),
+        "reference_depth_source_counts": _counts(
+            observations["reference_depth_source"]
+        ),
+        "test_year_range": _year_range(observations),
+    }
+
+
+def _select_pressure(frame: pd.DataFrame) -> pd.DataFrame:
+    shut_in = pd.to_numeric(frame["Shut_In_Pressure"], errors="coerce")
+    flowing = pd.to_numeric(frame["Flow_Tubing_Pressure"], errors="coerce")
+    uses_shut_in = shut_in.gt(0)
+    pressure = shut_in.where(uses_shut_in, flowing)
+    kind = pd.Series(
+        np.where(uses_shut_in, "WHP_shut_in", "WHP_flowing_tubing"),
+        index=frame.index,
+    )
+    return pd.DataFrame({"pressure_psig": pressure, "pressure_kind": kind})
+
+
+def _select_reference_depth(
+    frame: pd.DataFrame, depth_priority: list[str]
+) -> tuple[pd.Series, pd.Series]:
+    depth = pd.Series(np.nan, index=frame.index, dtype="float64")
+    source = pd.Series(pd.NA, index=frame.index, dtype="object")
+    for column in depth_priority:
+        if column in frame:
+            values = pd.to_numeric(frame[column], errors="coerce")
+        else:
+            values = pd.Series(np.nan, index=frame.index, dtype="float64")
+        use = depth.isna() & values.gt(0)
+        depth.loc[use] = values.loc[use]
+        source.loc[use] = column
+    return depth, source
+
+
+def _earliest_flags(observations: pd.DataFrame) -> pd.Series:
+    order = observations.sort_values(["well_key", "test_date", "completion_no"])
+    first_index = order.groupby("well_key", sort=False).head(1).index
+    flags = pd.Series(False, index=observations.index, dtype=object)
+    flags.loc[first_index] = True
+    return flags
+
+
+def _clean_identifier(value: object) -> str | None:
+    if pd.isna(value):
+        return None
+    text = str(value).strip()
+    if text.endswith(".0"):
+        text = text[:-2]
+    return text.zfill(10) if text else None
+
+
+def _clean_completion_no(value: object) -> str | None:
+    if pd.isna(value):
+        return None
+    text = str(value).strip()
+    if text.endswith(".0"):
+        text = text[:-2]
+    return text.zfill(2) if text else None
+
+
+def _api14(api_number: str | None, completion_no: str | None) -> str | None:
+    if not api_number or not completion_no:
+        return None
+    return f"{api_number}00{completion_no}"
+
+
+def _validate_columns(
+    frame: pd.DataFrame, required: set[str], source_name: str
+) -> None:
+    missing = sorted(required - set(frame.columns))
+    if missing:
+        raise ValueError(
+            f"{source_name} missing required OCC completion columns: "
+            + ", ".join(missing)
+        )
+
+
+def _counts(series: pd.Series) -> dict:
+    return {str(key): int(value) for key, value in series.value_counts().items()}
+
+
+def _year_range(observations: pd.DataFrame) -> list[int] | None:
+    if observations.empty:
+        return None
+    return [
+        int(observations["test_year"].min()),
+        int(observations["test_year"].max()),
+    ]

--- a/src/worldenergydata/modules/state_regulators/oklahoma_occ/pipeline.py
+++ b/src/worldenergydata/modules/state_regulators/oklahoma_occ/pipeline.py
@@ -11,6 +11,12 @@ from urllib.request import urlopen
 
 import yaml
 
+from worldenergydata.modules.state_regulators.oklahoma_occ.parsers import (
+    build_pressure_observations,
+    build_quality_stats,
+    read_completion_workbook,
+)
+
 
 def load_config(config_path: str | Path) -> dict:
     with Path(config_path).open("r", encoding="utf-8") as handle:
@@ -74,13 +80,35 @@ def run_pipeline(config_path: str | Path) -> dict:
     config = load_config(config_path)
     base_dir = Path(config["storage"]["base_dir"])
     raw_dir = base_dir / config["storage"]["raw_dir"]
+    normalized_dir = base_dir / config["storage"]["normalized_dir"]
+    curated_dir = base_dir / config["storage"]["curated_dir"]
     downloads = []
     for source in config["sources"].values():
         downloads.append(
             download_source(source["url"], raw_dir / source["raw_path"])
         )
     manifest = write_manifest(config, base_dir, downloads)
-    return {"manifest": manifest}
+
+    completions = read_completion_workbook(
+        raw_dir / config["sources"]["completion_workbook"]["raw_path"]
+    )
+    observations = build_pressure_observations(
+        completions, config["pressure_observations"]
+    )
+    quality = build_quality_stats(completions, observations)
+    quality["manifest_sources"] = sorted(manifest)
+
+    completions_dir = normalized_dir / "completions"
+    completions_dir.mkdir(parents=True, exist_ok=True)
+    completions.to_parquet(completions_dir / "completion_pressure_rows.parquet")
+
+    pressure_dir = curated_dir / "pressure"
+    pressure_dir.mkdir(parents=True, exist_ok=True)
+    observations.to_parquet(pressure_dir / "well_pressure_observations.parquet")
+    (pressure_dir / "oklahoma_occ_pressure_observation_quality.json").write_text(
+        json.dumps(quality, indent=2), encoding="utf-8"
+    )
+    return {"manifest": manifest, "quality": quality}
 
 
 def _sha256(path: Path) -> str:

--- a/src/worldenergydata/modules/state_regulators/oklahoma_occ/pipeline.py
+++ b/src/worldenergydata/modules/state_regulators/oklahoma_occ/pipeline.py
@@ -84,9 +84,7 @@ def run_pipeline(config_path: str | Path) -> dict:
     curated_dir = base_dir / config["storage"]["curated_dir"]
     downloads = []
     for source in config["sources"].values():
-        downloads.append(
-            download_source(source["url"], raw_dir / source["raw_path"])
-        )
+        downloads.append(download_source(source["url"], raw_dir / source["raw_path"]))
     manifest = write_manifest(config, base_dir, downloads)
 
     completions = read_completion_workbook(
@@ -95,7 +93,9 @@ def run_pipeline(config_path: str | Path) -> dict:
     observations = build_pressure_observations(
         completions, config["pressure_observations"]
     )
-    quality = build_quality_stats(completions, observations)
+    quality = build_quality_stats(
+        completions, observations, config["pressure_observations"]
+    )
     quality["manifest_sources"] = sorted(manifest)
 
     completions_dir = normalized_dir / "completions"

--- a/src/worldenergydata/modules/state_regulators/oklahoma_occ/pipeline.py
+++ b/src/worldenergydata/modules/state_regulators/oklahoma_occ/pipeline.py
@@ -1,0 +1,103 @@
+"""Raw -> normalized -> curated pipeline for Oklahoma OCC data (#740)."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.request import urlopen
+
+import yaml
+
+
+def load_config(config_path: str | Path) -> dict:
+    with Path(config_path).open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def download_source(url: str, destination: str | Path, timeout: int = 120) -> dict:
+    """Download one direct-source file and return response/file metadata."""
+    path = Path(destination)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    digest = hashlib.sha256()
+    size = 0
+    with urlopen(url, timeout=timeout) as response, path.open("wb") as handle:
+        while True:
+            chunk = response.read(1 << 20)
+            if not chunk:
+                break
+            handle.write(chunk)
+            digest.update(chunk)
+            size += len(chunk)
+        headers = response.headers
+        return {
+            "url": url,
+            "path": str(path),
+            "size_bytes": size,
+            "sha256": digest.hexdigest(),
+            "last_modified": headers.get("Last-Modified"),
+            "etag": headers.get("ETag"),
+            "downloaded_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+
+def write_manifest(config: dict, base_dir: str | Path, downloads: list[dict]) -> dict:
+    """Write raw/source provenance for configured OCC files."""
+    base = Path(base_dir)
+    raw_dir = base / config["storage"]["raw_dir"]
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    by_url = {item["url"]: item for item in downloads}
+    entries = {}
+    for name, source in config["sources"].items():
+        raw_path = raw_dir / source["raw_path"]
+        downloaded = by_url.get(source["url"], {})
+        entries[name] = {
+            "source_url": source["url"],
+            "raw_path": str(raw_path),
+            "sha256": downloaded.get("sha256") or _sha256(raw_path),
+            "size_bytes": downloaded.get("size_bytes") or raw_path.stat().st_size,
+            "refresh": source["refresh"],
+            "last_modified": downloaded.get("last_modified"),
+            "etag": downloaded.get("etag"),
+            "downloaded_at": downloaded.get("downloaded_at"),
+            "manifest_written_at": datetime.now(timezone.utc).isoformat(),
+        }
+    (raw_dir / "manifest.json").write_text(
+        json.dumps(entries, indent=2), encoding="utf-8"
+    )
+    return entries
+
+
+def run_pipeline(config_path: str | Path) -> dict:
+    config = load_config(config_path)
+    base_dir = Path(config["storage"]["base_dir"])
+    raw_dir = base_dir / config["storage"]["raw_dir"]
+    downloads = []
+    for source in config["sources"].values():
+        downloads.append(
+            download_source(source["url"], raw_dir / source["raw_path"])
+        )
+    manifest = write_manifest(config, base_dir, downloads)
+    return {"manifest": manifest}
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Oklahoma OCC ingest (#740)")
+    parser.add_argument("--config", default="config/oklahoma_occ.yml")
+    args = parser.parse_args()
+    result = run_pipeline(args.config)
+    print(json.dumps(result["manifest"], indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/analysis/test_underpressured_observations.py
+++ b/tests/unit/analysis/test_underpressured_observations.py
@@ -84,6 +84,54 @@ def test_filters_texas_unusable_rows_when_required():
     assert list(result["well_key"]) == ["42127373050000"]
 
 
+def test_normalizes_oklahoma_occ_completion_schema_to_screen_contract():
+    frame = pd.DataFrame(
+        [
+            {
+                "well_key": "3500323456",
+                "formation_name": "MORROW",
+                "test_year": 2024,
+                "pressure_kind": "WHP_shut_in",
+                "pressure_psia": 139.7,
+                "reference_depth_ft": 5100.0,
+                "is_earliest_observation": True,
+            },
+            {
+                "well_key": "3500323456",
+                "formation_name": "MORROW",
+                "test_year": 2025,
+                "pressure_kind": "WHP_shut_in",
+                "pressure_psia": 120.0,
+                "reference_depth_ft": 5100.0,
+                "is_earliest_observation": False,
+            },
+        ]
+    )
+
+    result = normalize_observations(
+        frame,
+        {
+            "name": "oklahoma_occ_completions",
+            "schema": "oklahoma_occ_completion_v1",
+            "state": "OK",
+            "era": "completion_test_2010_present",
+        },
+    )
+
+    assert list(result["well_key"]) == ["3500323456", "3500323456"]
+    assert list(result["field"]) == ["MORROW", "MORROW"]
+    assert list(result["state"]) == ["OK", "OK"]
+    assert list(result["source_name"]) == [
+        "oklahoma_occ_completions",
+        "oklahoma_occ_completions",
+    ]
+    assert list(result["era"]) == [
+        "completion_test_2010_present",
+        "completion_test_2010_present",
+    ]
+    assert list(result["screen_observation_priority"]) == [0, 1]
+
+
 def test_load_observations_collects_input_counts_and_quality_warnings(tmp_path):
     observations_path = tmp_path / "texas.parquet"
     quality_path = tmp_path / "quality.json"

--- a/tests/unit/analysis/test_underpressured_screen.py
+++ b/tests/unit/analysis/test_underpressured_screen.py
@@ -299,16 +299,21 @@ class TestSummaryAndParticipationGate:
     def test_summary_reports_state_source_and_era_counts(self):
         wells = pd.DataFrame(
             {
-                "well_key": ["ks-1", "tx-1"],
-                "state": ["KS", "TX"],
+                "well_key": ["ks-1", "tx-1", "ok-1"],
+                "state": ["KS", "TX", "OK"],
                 "source_name": [
                     "kansas_kgs_proration",
                     "texas_rrc_completion_packets",
+                    "oklahoma_occ_completions",
                 ],
-                "era": ["depleted", "completion_packet_screening"],
-                "pressure_tier": [TIER_SEVERE, TIER_MILD],
-                "near_vacuum": [False, False],
-                "bhp_gradient_psi_ft": [0.03, 0.40],
+                "era": [
+                    "depleted",
+                    "completion_packet_screening",
+                    "completion_test_2010_present",
+                ],
+                "pressure_tier": [TIER_SEVERE, TIER_MILD, TIER_MILD],
+                "near_vacuum": [False, False, False],
+                "bhp_gradient_psi_ft": [0.03, 0.40, 0.39],
             }
         )
         ranking = pd.DataFrame({"field": ["HUGOTON GAS AREA", "BRISCOE RANCH"]})
@@ -322,21 +327,28 @@ class TestSummaryAndParticipationGate:
                 "input_row_counts": {
                     "kansas_kgs_proration": 2,
                     "texas_rrc_completion_packets": 3,
+                    "oklahoma_occ_completions": 4,
                 },
                 "loaded_row_counts": {
                     "kansas_kgs_proration": 1,
                     "texas_rrc_completion_packets": 1,
+                    "oklahoma_occ_completions": 1,
                 },
                 "source_warnings": {"texas_rrc_completion_packets": ["warning"]},
             },
         )
 
-        assert summary["state_counts"] == {"KS": 1, "TX": 1}
+        assert summary["state_counts"] == {"KS": 1, "TX": 1, "OK": 1}
         assert summary["source_counts"] == {
             "kansas_kgs_proration": 1,
             "texas_rrc_completion_packets": 1,
+            "oklahoma_occ_completions": 1,
         }
-        assert summary["era_note"] == ["completion_packet_screening", "depleted"]
+        assert summary["era_note"] == [
+            "completion_packet_screening",
+            "completion_test_2010_present",
+            "depleted",
+        ]
         assert summary["source_warnings"] == {
             "texas_rrc_completion_packets": ["warning"]
         }

--- a/tests/unit/analysis/test_underpressured_screen.py
+++ b/tests/unit/analysis/test_underpressured_screen.py
@@ -16,8 +16,8 @@ from worldenergydata.analysis.underpressured_screen.screen import (
     earliest_per_well,
     estimate_bhp,
     rank_fields,
-    run_screen,
     run_participation_gate,
+    run_screen,
     run_validation_gate,
 )
 

--- a/tests/unit/analysis/test_underpressured_screen.py
+++ b/tests/unit/analysis/test_underpressured_screen.py
@@ -16,6 +16,7 @@ from worldenergydata.analysis.underpressured_screen.screen import (
     earliest_per_well,
     estimate_bhp,
     rank_fields,
+    run_screen,
     run_participation_gate,
     run_validation_gate,
 )
@@ -48,6 +49,23 @@ class TestEstimateBhp:
                     "test_year": 1997,
                     "pressure_psia": 100.0,
                     "reference_depth_ft": 2800.0,
+                }
+            ]
+        )
+        result = estimate_bhp(obs, BHP_SETTINGS)
+        expected = 100.0 * math.exp(0.01875 * 0.65 * 2800.0 / (0.95 * 520.0))
+        assert result["bhp_psia_est"].iloc[0] == pytest.approx(expected)
+        assert result["bhp_method"].iloc[0] == "static_gas_column_avg_zt"
+
+    def test_flowing_tubing_whp_gets_static_column_screening_correction(self):
+        obs = make_observations(
+            [
+                {
+                    "well_key": "w1",
+                    "test_year": 2024,
+                    "pressure_psia": 100.0,
+                    "reference_depth_ft": 2800.0,
+                    "pressure_kind": "WHP_flowing_tubing",
                 }
             ]
         )
@@ -379,3 +397,80 @@ class TestSummaryAndParticipationGate:
 
         assert not gate["passed"]
         assert gate["states"]["TX"]["well_count"] == 0
+
+    def test_screen_outputs_are_parquet_safe_with_mixed_optional_metadata(
+        self, tmp_path
+    ):
+        first = make_observations(
+            [
+                {
+                    "well_key": "ks-1",
+                    "test_year": 2020,
+                    "pressure_psia": 100.0,
+                    "reference_depth_ft": 2800.0,
+                    "test_date": pd.Timestamp("2020-01-01"),
+                }
+            ]
+        )
+        second = make_observations(
+            [
+                {
+                    "well_key": "ok-1",
+                    "state": "OK",
+                    "test_year": 2021,
+                    "pressure_psia": 120.0,
+                    "reference_depth_ft": 3200.0,
+                    "test_date": "2021-01-01",
+                    "source_name": "oklahoma_occ_completions",
+                    "era": "completion_test_2010_present",
+                }
+            ]
+        )
+        first_path = tmp_path / "first.parquet"
+        second_path = tmp_path / "second.parquet"
+        first.to_parquet(first_path)
+        second.to_parquet(second_path)
+        config_path = tmp_path / "screen.yml"
+        output_dir = tmp_path / "out"
+        config_path.write_text(
+            f"""
+inputs:
+  - name: kansas_kgs_proration
+    path: {first_path}
+    schema: screen_v1
+    era: depleted
+  - name: oklahoma_occ_completions
+    path: {second_path}
+    schema: screen_v1
+    era: completion_test_2010_present
+bhp_estimate:
+  gas_sg: 0.65
+  z_avg: 0.95
+  t_avg_rankine: 520.0
+tiers:
+  hydrostatic_normal_min: 0.433
+  mild_underpressure_min: 0.35
+  near_vacuum_whp_psia: 50.0
+field_ranking:
+  min_wells_per_field: 1
+validation_gate:
+  required_fields_in_top10: []
+  required_tier: severely_underpressured
+participation_gate:
+  required_states:
+    KS:
+      min_wells: 1
+    OK:
+      min_wells: 1
+output:
+  base_dir: {output_dir}
+""",
+            encoding="utf-8",
+        )
+
+        summary = run_screen(config_path)
+
+        assert summary["state_counts"] == {"KS": 1, "OK": 1}
+        assert (
+            pd.read_parquet(output_dir / "well_screen_earliest.parquet").shape[0] == 2
+        )

--- a/tests/unit/modules/state_regulators/test_oklahoma_occ_parsers.py
+++ b/tests/unit/modules/state_regulators/test_oklahoma_occ_parsers.py
@@ -9,7 +9,6 @@ from worldenergydata.modules.state_regulators.oklahoma_occ.parsers import (
     read_completion_workbook,
 )
 
-
 SETTINGS = {
     "atmospheric_psi": 14.7,
     "test_type": "OCC Form 1002A initial completion test",

--- a/tests/unit/modules/state_regulators/test_oklahoma_occ_parsers.py
+++ b/tests/unit/modules/state_regulators/test_oklahoma_occ_parsers.py
@@ -14,6 +14,8 @@ SETTINGS = {
     "atmospheric_psi": 14.7,
     "test_type": "OCC Form 1002A initial completion test",
     "gradient_method": "completion_pressure_over_reference_depth_screening_only",
+    "min_test_year": 2010,
+    "max_test_year": 2026,
     "depth_priority": [
         "True_Vertical_Depth",
         "Formation_Depth",
@@ -49,6 +51,39 @@ def test_read_completion_workbook_preserves_required_occ_columns(tmp_path):
     assert frame.loc[0, "Completion_No"] == "01"
     assert frame.loc[0, "Shut_In_Pressure"] == 125
     assert frame.loc[0, "True_Vertical_Depth"] == 5100
+
+
+def test_read_completion_workbook_keeps_mixed_well_numbers_parquet_safe(tmp_path):
+    workbook = tmp_path / "completions.xlsx"
+    output = tmp_path / "normalized.parquet"
+    pd.DataFrame(
+        [
+            {
+                "API_Number": "3500323456",
+                "Completion_No": "01",
+                "Well_Number": 1,
+                "Test_Date": "2024-01-15",
+                "Shut_In_Pressure": "125",
+                "Flow_Tubing_Pressure": None,
+                "True_Vertical_Depth": "5100",
+            },
+            {
+                "API_Number": "3500323457",
+                "Completion_No": "01",
+                "Well_Number": "1-21",
+                "Test_Date": "2024-01-15",
+                "Shut_In_Pressure": "125",
+                "Flow_Tubing_Pressure": None,
+                "True_Vertical_Depth": "5100",
+            },
+        ]
+    ).to_excel(workbook, index=False)
+
+    frame = read_completion_workbook(workbook)
+    frame.to_parquet(output)
+    round_trip = pd.read_parquet(output)
+
+    assert list(round_trip["Well_Number"]) == ["1", "1-21"]
 
 
 def test_build_pressure_observations_coerces_pressure_depth_and_test_year():
@@ -183,3 +218,40 @@ def test_build_pressure_observations_filters_unusable_rows_and_flags_earliest():
     assert quality["filtered_missing_pressure_count"] == 1
     assert quality["filtered_missing_depth_count"] == 1
     assert quality["wells_with_pressure_observation"] == 1
+
+
+def test_build_pressure_observations_filters_out_of_window_test_years():
+    completions = pd.DataFrame(
+        [
+            {
+                "API_Number": "3500323456",
+                "Completion_No": "01",
+                "Test_Date": "1900-01-01",
+                "Shut_In_Pressure": "100",
+                "Flow_Tubing_Pressure": None,
+                "True_Vertical_Depth": "5000",
+            },
+            {
+                "API_Number": "3500323457",
+                "Completion_No": "01",
+                "Test_Date": "2024-01-01",
+                "Shut_In_Pressure": "100",
+                "Flow_Tubing_Pressure": None,
+                "True_Vertical_Depth": "5000",
+            },
+            {
+                "API_Number": "3500323458",
+                "Completion_No": "01",
+                "Test_Date": "2205-01-01",
+                "Shut_In_Pressure": "100",
+                "Flow_Tubing_Pressure": None,
+                "True_Vertical_Depth": "5000",
+            },
+        ]
+    )
+
+    observations = build_pressure_observations(completions, SETTINGS)
+    quality = build_quality_stats(completions, observations, SETTINGS)
+
+    assert list(observations["well_key"]) == ["3500323457"]
+    assert quality["filtered_out_of_window_test_year_count"] == 2

--- a/tests/unit/modules/state_regulators/test_oklahoma_occ_parsers.py
+++ b/tests/unit/modules/state_regulators/test_oklahoma_occ_parsers.py
@@ -1,0 +1,185 @@
+"""Tests for Oklahoma OCC completion-pressure parsing (#740)."""
+
+import pandas as pd
+import pytest
+
+from worldenergydata.modules.state_regulators.oklahoma_occ.parsers import (
+    build_pressure_observations,
+    build_quality_stats,
+    read_completion_workbook,
+)
+
+
+SETTINGS = {
+    "atmospheric_psi": 14.7,
+    "test_type": "OCC Form 1002A initial completion test",
+    "gradient_method": "completion_pressure_over_reference_depth_screening_only",
+    "depth_priority": [
+        "True_Vertical_Depth",
+        "Formation_Depth",
+        "Measured_Total_Depth",
+        "Total_Depth",
+    ],
+}
+
+
+def test_read_completion_workbook_preserves_required_occ_columns(tmp_path):
+    workbook = tmp_path / "completions.xlsx"
+    pd.DataFrame(
+        [
+            {
+                "API_Number": "3500323456",
+                "Completion_No": "01",
+                "Well_Name": "PANHANDLE TEST",
+                "Operator_Name": "DIRECT SOURCE ENERGY",
+                "County": "TEXAS",
+                "Formation_Name": "MORROW",
+                "Test_Date": "2024-01-15",
+                "Shut_In_Pressure": "125",
+                "Flow_Tubing_Pressure": "80",
+                "True_Vertical_Depth": "5100",
+                "Measured_Total_Depth": "5400",
+            }
+        ]
+    ).to_excel(workbook, index=False)
+
+    frame = read_completion_workbook(workbook)
+
+    assert frame.loc[0, "API_Number"] == "3500323456"
+    assert frame.loc[0, "Completion_No"] == "01"
+    assert frame.loc[0, "Shut_In_Pressure"] == 125
+    assert frame.loc[0, "True_Vertical_Depth"] == 5100
+
+
+def test_build_pressure_observations_coerces_pressure_depth_and_test_year():
+    completions = pd.DataFrame(
+        [
+            {
+                "API_Number": "3500323456",
+                "Completion_No": "01",
+                "Well_Name": "PANHANDLE TEST",
+                "Operator_Name": "DIRECT SOURCE ENERGY",
+                "County": "TEXAS",
+                "Formation_Name": "MORROW",
+                "Test_Date": "2024-01-15",
+                "Shut_In_Pressure": "125",
+                "Flow_Tubing_Pressure": "80",
+                "Gas_MCF_Per_Day": "2500",
+                "Oil_BBL_Per_Day": "12",
+                "Water_BBL_Per_Day": "3",
+                "True_Vertical_Depth": "5100",
+                "Formation_Depth": "5050",
+                "Measured_Total_Depth": "5400",
+                "Total_Depth": "5450",
+            }
+        ]
+    )
+
+    observations = build_pressure_observations(completions, SETTINGS)
+
+    assert len(observations) == 1
+    row = observations.iloc[0]
+    assert row["state"] == "OK"
+    assert row["well_key"] == "3500323456"
+    assert row["api_number"] == "3500323456"
+    assert row["completion_no"] == "01"
+    assert row["test_year"] == 2024
+    assert row["pressure_kind"] == "WHP_shut_in"
+    assert row["pressure_psig_reported"] == 125
+    assert row["pressure_psia"] == pytest.approx(139.7)
+    assert row["reference_depth_ft"] == 5100
+    assert row["reference_depth_source"] == "True_Vertical_Depth"
+    assert row["gas_mcf_per_day"] == 2500
+    assert row["is_earliest_observation"] is True
+
+
+def test_build_pressure_observations_uses_flowing_pressure_when_shut_in_missing():
+    completions = pd.DataFrame(
+        [
+            {
+                "API_Number": "3500323456",
+                "Completion_No": "02",
+                "Well_Name": "PANHANDLE TEST",
+                "Operator_Name": "DIRECT SOURCE ENERGY",
+                "County": "TEXAS",
+                "Formation_Name": "MORROW",
+                "Test_Date": "2024-02-15",
+                "Shut_In_Pressure": None,
+                "Flow_Tubing_Pressure": "80",
+                "True_Vertical_Depth": None,
+                "Formation_Depth": "5050",
+            }
+        ]
+    )
+
+    observations = build_pressure_observations(completions, SETTINGS)
+
+    assert len(observations) == 1
+    row = observations.iloc[0]
+    assert row["pressure_kind"] == "WHP_flowing_tubing"
+    assert row["pressure_psig_reported"] == 80
+    assert row["reference_depth_ft"] == 5050
+    assert row["reference_depth_source"] == "Formation_Depth"
+
+
+def test_build_pressure_observations_filters_unusable_rows_and_flags_earliest():
+    completions = pd.DataFrame(
+        [
+            {
+                "API_Number": "3500323456",
+                "Completion_No": "02",
+                "Well_Name": "SECOND",
+                "Operator_Name": "DIRECT SOURCE ENERGY",
+                "County": "TEXAS",
+                "Formation_Name": "MORROW",
+                "Test_Date": "2024-02-15",
+                "Shut_In_Pressure": "90",
+                "True_Vertical_Depth": "5000",
+            },
+            {
+                "API_Number": "3500323456",
+                "Completion_No": "01",
+                "Well_Name": "FIRST",
+                "Operator_Name": "DIRECT SOURCE ENERGY",
+                "County": "TEXAS",
+                "Formation_Name": "MORROW",
+                "Test_Date": "2023-12-31",
+                "Shut_In_Pressure": "100",
+                "True_Vertical_Depth": "5000",
+            },
+            {
+                "API_Number": "3509923456",
+                "Completion_No": "01",
+                "Well_Name": "NO PRESSURE",
+                "Operator_Name": "DIRECT SOURCE ENERGY",
+                "County": "BEAVER",
+                "Formation_Name": "MORROW",
+                "Test_Date": "2024-01-01",
+                "Shut_In_Pressure": None,
+                "Flow_Tubing_Pressure": None,
+                "True_Vertical_Depth": "5000",
+            },
+            {
+                "API_Number": "3513923456",
+                "Completion_No": "01",
+                "Well_Name": "NO DEPTH",
+                "Operator_Name": "DIRECT SOURCE ENERGY",
+                "County": "TEXAS",
+                "Formation_Name": "MORROW",
+                "Test_Date": "2024-01-01",
+                "Shut_In_Pressure": "100",
+                "True_Vertical_Depth": None,
+            },
+        ]
+    )
+
+    observations = build_pressure_observations(completions, SETTINGS)
+    quality = build_quality_stats(completions, observations)
+
+    assert list(observations["completion_no"]) == ["02", "01"]
+    assert list(observations["is_earliest_observation"]) == [False, True]
+    assert quality["input_rows"] == 4
+    assert quality["curated_count"] == 2
+    assert quality["filtered_missing_pressure_count"] == 1
+    assert quality["filtered_missing_depth_count"] == 1
+    assert quality["wells_with_pressure_observation"] == 1

--- a/tests/unit/modules/state_regulators/test_oklahoma_occ_pipeline.py
+++ b/tests/unit/modules/state_regulators/test_oklahoma_occ_pipeline.py
@@ -1,0 +1,123 @@
+"""Tests for Oklahoma OCC source manifesting (#740)."""
+
+import hashlib
+import json
+from pathlib import Path
+
+import yaml
+
+from worldenergydata.modules.state_regulators.oklahoma_occ.pipeline import (
+    download_source,
+    load_config,
+    write_manifest,
+)
+
+
+def test_load_config_reads_yaml(tmp_path):
+    config_path = tmp_path / "oklahoma_occ.yml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "storage": {
+                    "base_dir": str(tmp_path / "oklahoma_occ"),
+                    "raw_dir": "raw",
+                },
+                "sources": {
+                    "completion_dictionary": {
+                        "url": "https://example.test/dictionary.xlsx",
+                        "raw_path": "dictionary.xlsx",
+                        "refresh": "occasional",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path)
+
+    assert config["storage"]["raw_dir"] == "raw"
+    assert config["sources"]["completion_dictionary"]["raw_path"] == "dictionary.xlsx"
+
+
+def test_download_source_writes_bytes_and_response_metadata(tmp_path, monkeypatch):
+    payload = b"oklahoma completion dictionary"
+
+    class FakeResponse:
+        headers = {"Last-Modified": "Tue, 26 Aug 2025 15:33:40 GMT", "ETag": "abc"}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self, size=-1):
+            if self._used:
+                return b""
+            self._used = True
+            return payload
+
+        def __init__(self):
+            self._used = False
+
+    def fake_urlopen(url, timeout):
+        assert url == "https://example.test/dictionary.xlsx"
+        assert timeout == 120
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        "worldenergydata.modules.state_regulators.oklahoma_occ.pipeline.urlopen",
+        fake_urlopen,
+    )
+    destination = tmp_path / "raw" / "dictionary.xlsx"
+
+    metadata = download_source("https://example.test/dictionary.xlsx", destination)
+
+    assert destination.read_bytes() == payload
+    assert metadata["url"] == "https://example.test/dictionary.xlsx"
+    assert metadata["path"] == str(destination)
+    assert metadata["size_bytes"] == len(payload)
+    assert metadata["sha256"] == hashlib.sha256(payload).hexdigest()
+    assert metadata["last_modified"] == "Tue, 26 Aug 2025 15:33:40 GMT"
+    assert metadata["etag"] == "abc"
+
+
+def test_write_manifest_records_source_hashes_and_refresh(tmp_path):
+    base_dir = tmp_path / "oklahoma_occ"
+    raw_dir = base_dir / "raw"
+    raw_dir.mkdir(parents=True)
+    workbook = raw_dir / "completions.xlsx"
+    dictionary = raw_dir / "dictionary.xlsx"
+    workbook.write_bytes(b"workbook")
+    dictionary.write_bytes(b"dictionary")
+    config = {
+        "storage": {"raw_dir": "raw"},
+        "sources": {
+            "completion_workbook": {
+                "url": "https://example.test/completions.xlsx",
+                "raw_path": "completions.xlsx",
+                "refresh": "daily",
+            },
+            "completion_dictionary": {
+                "url": "https://example.test/dictionary.xlsx",
+                "raw_path": "dictionary.xlsx",
+                "refresh": "occasional",
+            },
+        },
+    }
+
+    manifest = write_manifest(config, base_dir, downloads=[])
+
+    assert set(manifest) == {"completion_workbook", "completion_dictionary"}
+    assert manifest["completion_workbook"]["source_url"] == (
+        "https://example.test/completions.xlsx"
+    )
+    assert manifest["completion_workbook"]["size_bytes"] == len(b"workbook")
+    assert manifest["completion_workbook"]["sha256"] == hashlib.sha256(
+        b"workbook"
+    ).hexdigest()
+    assert manifest["completion_workbook"]["refresh"] == "daily"
+    assert "manifest_written_at" in manifest["completion_workbook"]
+    written = json.loads((raw_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert written == manifest

--- a/tests/unit/modules/state_regulators/test_oklahoma_occ_pipeline.py
+++ b/tests/unit/modules/state_regulators/test_oklahoma_occ_pipeline.py
@@ -2,7 +2,6 @@
 
 import hashlib
 import json
-from pathlib import Path
 
 import yaml
 
@@ -114,9 +113,10 @@ def test_write_manifest_records_source_hashes_and_refresh(tmp_path):
         "https://example.test/completions.xlsx"
     )
     assert manifest["completion_workbook"]["size_bytes"] == len(b"workbook")
-    assert manifest["completion_workbook"]["sha256"] == hashlib.sha256(
-        b"workbook"
-    ).hexdigest()
+    assert (
+        manifest["completion_workbook"]["sha256"]
+        == hashlib.sha256(b"workbook").hexdigest()
+    )
     assert manifest["completion_workbook"]["refresh"] == "daily"
     assert "manifest_written_at" in manifest["completion_workbook"]
     written = json.loads((raw_dir / "manifest.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

Closes #740.

- Adds direct-source Oklahoma OCC completion workbook ingest with raw manifesting, normalized completion pressure rows, curated pressure observations, and quality stats under `/mnt/ace/worldenergydata/data/modules/oklahoma_occ`.
- Adds `oklahoma_occ_completion_v1` support to the under-pressured screen and updates the screen config/docs to include Oklahoma alongside Kansas and Texas.
- Hardens the screen output path for mixed optional metadata and treats all `WHP_*` pressures consistently as surface wellhead screening pressures.

## Live outputs

- OCC raw workbook: 76,131,895 bytes, SHA256 `6d68d41320a6fcefd0b9973d544cf1c836de4c43a3cdeca0c9f58e74c2757e1f`, Last-Modified `Tue, 30 Jun 2026 00:34:55 GMT`.
- OCC curated pressure observations: 108,518 rows, 19,972 wells, test years 2010-2026, 8,917 out-of-window source rows filtered.
- Multi-state screen: 30,100 wells screened; state counts OK 19,972 / KS 10,103 / TX 25; validation and participation gates passed.

## Verification

- `PYTHONPATH=src:packages/worldenergydata-core/src pytest tests/unit/modules/state_regulators/test_oklahoma_occ_pipeline.py tests/unit/modules/state_regulators/test_oklahoma_occ_parsers.py tests/unit/analysis/test_underpressured_observations.py tests/unit/analysis/test_underpressured_screen.py -q --no-cov` -> 35 passed
- `ruff check src/worldenergydata/modules/state_regulators/oklahoma_occ src/worldenergydata/analysis/underpressured_screen tests/unit/modules/state_regulators tests/unit/analysis` -> pass
- `ruff format --check src/worldenergydata/modules/state_regulators/oklahoma_occ src/worldenergydata/analysis/underpressured_screen tests/unit/modules/state_regulators tests/unit/analysis` -> pass
- `PYTHONPATH=src:packages/worldenergydata-core/src python3.12 -m worldenergydata.modules.state_regulators.oklahoma_occ.pipeline --config config/oklahoma_occ.yml` -> pass
- `PYTHONPATH=src:packages/worldenergydata-core/src python3.12 -m worldenergydata.analysis.underpressured_screen.screen --config config/underpressured_screen.yml` -> pass
- `bash scripts/legal/legal-sanity-scan.sh` -> pass

## Review

- Inline adversarial code review artifact: `scripts/review/results/2026-07-03-code-740-codex-inline.md`.
- Subagent dispatch was not used because the available tool contract forbids spawning agents unless the user explicitly requests subagents/delegation.
