### PR TITLE
feat(colorado_ecmc): scout FacilityDetail pressure sources

### DIFF
--- a/config/colorado_ecmc_source_discovery.yml
+++ b/config/colorado_ecmc_source_discovery.yml
@@ -1,0 +1,16 @@
+# Colorado ECMC official pressure-source discovery (#749).
+# Heavy raw/parsed/report evidence stays under /mnt/ace.
+module: colorado_ecmc_source_discovery
+
+storage:
+  base_dir: /mnt/ace/worldenergydata/data/modules/colorado_ecmc/source_discovery
+
+facility_detail:
+  base_url: https://ecmc.state.co.us/cogisdb/Facility/FacilityDetail.aspx
+  sample_apis:
+    - "12339345"
+  max_requests: 1
+  request_delay_seconds: 1
+  timeout_seconds: 60
+  source_role: candidate_pressure_observation
+  refresh: live_database

--- a/docs/data-sources/onshore/state-well-databases/colorado-ecmc-pressure-source-discovery.md
+++ b/docs/data-sources/onshore/state-well-databases/colorado-ecmc-pressure-source-discovery.md
@@ -1,0 +1,116 @@
+# Colorado ECMC Pressure-Source Discovery
+
+Issue: [#749](https://github.com/vamseeachanta/worldenergydata/issues/749)
+
+Follow-up ingest issue:
+[#751](https://github.com/vamseeachanta/worldenergydata/issues/751)
+
+Survey and live-scout date: 2026-07-04.
+
+## Decision
+
+The official ECMC FacilityDetail endpoint is a viable candidate for a
+production-grade Form 5A / Initial Test Data pressure ingest, but it is not yet
+a screen-ready Colorado pressure source.
+
+The approved [#749](https://github.com/vamseeachanta/worldenergydata/issues/749)
+scout proved that the public FacilityDetail HTML contains structured initial
+test rows with `CASING_PRESS` and `TUBING_PRESS`. It intentionally used a
+single configured API sample and did not attempt statewide iteration. A
+production ingest now needs a separate reviewed plan under
+[#751](https://github.com/vamseeachanta/worldenergydata/issues/751) covering
+source-list construction, throttling, retry/resume, coverage accounting, parser
+drift checks, and pressure interpretation.
+
+Colorado therefore remains excluded from underpressured-screen participation
+gates until that follow-up ingest is approved, implemented, and reviewed.
+
+## Official Source Matrix
+
+| Source | Official URL | Role | Refresh / access | Pressure relevance |
+|---|---|---|---|---|
+| ECMC download catalog | https://ecmc.state.co.us/appAssets/data/downloadsExt.txt | `approved_spine` | Public catalog; direct JSON/text asset | Lists official bulk datasets and landing pages |
+| ECMC data page | https://ecmc.state.co.us/data2.html | `context_only` | Public app; newer state landing page may reject non-browser access | Navigation source only |
+| Production data dictionary | https://ecmc.state.co.us/documents/data/downloads/production/production_record_data_dictionary.htm | `approved_spine` | Public HTML | Defines Form 7 pressure columns used by [#745](https://github.com/vamseeachanta/worldenergydata/issues/745) |
+| Form 7 production CSVs | https://ecmc.state.co.us/documents/data/downloads/production/{YYYY}_prod_reports.csv and `monthly_prod.csv` | `approved_spine` | Annual static + monthly rolling | Carries pressure columns, but [#745](https://github.com/vamseeachanta/worldenergydata/issues/745) live slice had zero positive pressure values |
+| Wells GIS | https://ecmc.state.co.us/documents/data/downloads/gis/WELLS_SHP.ZIP | `approved_spine` | Daily static HTTPS ZIP | API, facility, field, location, MD/TVD join spine |
+| Facilities GIS | https://ecmc.state.co.us/documents/data/downloads/gis/Facilities.ZIP | `context_only` | Daily static HTTPS ZIP; 169,504,664 bytes on 2026-07-04 check | Candidate facility/well crosswalk and scout seed source |
+| FacilityDetail | https://ecmc.state.co.us/cogisdb/Facility/FacilityDetail.aspx?api=12339345 | `candidate_pressure_observation` | Public live COGIS page by county+sequence API fragment | Exposes Form 5A-like Initial Test Data including `CASING_PRESS` and `TUBING_PRESS` |
+| COA page | https://ecmc.state.co.us/cogisdb/Resources/COAs?facid=12339345 | `context_only` | Public live COGIS page by facility id | Mentions Form 5A/Form 17 obligations; not a pressure-observation table |
+| Imaged document search | https://ecmc.state.co.us/cogisdb/ImagedDocToolMenu | `requires_data_request` / manual fallback | Public document-search landing page | Form attachments and Laserfiche route; not preferred for automated source of record |
+| MIT/Form 21 | https://ecmc.state.co.us/documents/data/downloads/Engineering/MechIntegrityDownload.html | `excluded_integrity_pressure` | Monthly bulk MIT ZIP | Engineering integrity pressure, not reservoir or production-test pressure |
+| Field inspections | https://ecmc.state.co.us/documents/data/downloads/Field/FieldDownload.html | `context_only` | Monthly bulk field-inspection export | Compliance/operations context only |
+| ECMC download guide | https://ecmc.state.co.us/documents/data/downloads/ECMC_Download_Guidance_v2_ada.pdf | `context_only` | Public PDF | Confirms SQL-backed form data/attachments exist and supports data-request framing |
+
+## Live Scout Evidence
+
+The approved scout used:
+
+```text
+config/colorado_ecmc_source_discovery.yml
+```
+
+and wrote:
+
+```text
+/mnt/ace/worldenergydata/data/modules/colorado_ecmc/source_discovery/
+  raw/facility_detail/12339345.html
+  raw/facility_detail/manifest.json
+  parsed/facility_detail_initial_tests.parquet
+  parsed/facility_detail_initial_tests.json
+  reports/colorado_ecmc_pressure_source_discovery.json
+```
+
+Live result:
+
+| Metric | Value |
+|---|---:|
+| FacilityDetail request count | 1 |
+| API fragment | `12339345` |
+| HTTP status | 200 |
+| Raw HTML size | 50,740 bytes |
+| Parsed initial-test rows | 11 |
+| Candidate pressure rows | 2 |
+| Candidate pressure kinds | `WHP_casing_initial_test`, `WHP_flowing_tubing_initial_test` |
+| Report decision | `facility_detail_candidate_for_follow_up` |
+| Screen status | `source_discovery_not_screen_ready` |
+
+The sampled page is for API `05-123-39345`, facility `436953`, Wattenberg
+field, NIOBRARA formation (`NBRR`). The parsed initial-test pressure rows are:
+
+| Test type | Measure | Candidate kind |
+|---|---:|---|
+| `CASING_PRESS` | 1700 | `WHP_casing_initial_test` |
+| `TUBING_PRESS` | 1300 | `WHP_flowing_tubing_initial_test` |
+
+Other initial-test rows (`BBLS_H2O`, `BBLS_OIL`, `BTU_GAS`, `MCF_GAS`,
+calculated rates, and gravity) are retained as rates/properties, not pressure
+observations.
+
+## Interpretation Boundary
+
+The discovery parser classifies pressure-like values before any screen use:
+
+| Lane | Classification | Screen use |
+|---|---|---|
+| FacilityDetail Initial Test Data `CASING_PRESS` | Candidate pressure observation | Not eligible until [#751](https://github.com/vamseeachanta/worldenergydata/issues/751) approves ingest + interpretation |
+| FacilityDetail Initial Test Data `TUBING_PRESS` | Candidate pressure observation | Not eligible until [#751](https://github.com/vamseeachanta/worldenergydata/issues/751) approves ingest + interpretation |
+| FacilityDetail treatment pressure | Excluded engineering pressure | Never screen evidence without a later explicit contract change |
+| MIT/Form 21 pressures | Excluded integrity pressure | Never screen evidence without a later explicit contract change |
+| Form 17/bradenhead pressures | Excluded annulus/compliance pressure | Never screen evidence without a later explicit contract change |
+| Form 7 production pressure columns | Implemented spine source | Empty in [#745](https://github.com/vamseeachanta/worldenergydata/issues/745) 2025+monthly live slice |
+
+## Follow-Up Requirements
+
+[#751](https://github.com/vamseeachanta/worldenergydata/issues/751) should plan
+the production ingest before any statewide run. Required controls:
+
+- use an approved source list from the wells/facilities spine;
+- carry a hard throttle and retry/backoff policy;
+- write raw HTML and manifests under `/mnt/ace`;
+- support resume after interruption;
+- count coverage by API/facility and parse status;
+- fail closed on parser drift;
+- keep MIT/Form 21, treatment pressure, and Form 17/bradenhead lanes excluded;
+- update the underpressured-screen contract only after pressure kind, gauge
+  handling, depth reference, field join, and quality sidecars are reviewed.

--- a/docs/data-sources/onshore/state-well-databases/source-catalog.md
+++ b/docs/data-sources/onshore/state-well-databases/source-catalog.md
@@ -151,7 +151,7 @@ No initial/shut-in BHP, shut-in wellhead pressure, or deliverability-test values
 | Daily Activity Dashboard full export | 9 activity datasets (pending/approved permits Form 2/2A, spuds, completions activity, etc.) | https://ecmc.state.co.us/documents/data/downloads/Dashboard/DAD_Export.zip (26 MB) | Zip of tables | Daily (verified last-mod 2026-07-02) | Free | VERIFIED |
 | Well analytical (chemistry) data | Gas/produced-water analytical sample data (useful for gas composition, not pressure) | https://ecmc.state.co.us/documents/data/downloads/environmental/ProdWellDownLoad.zip | .mdb in zip | Labeled "Updated Monthly" but last-mod 2024-03-01 (stale) | Free | VERIFIED (staleness noted) |
 | Spacing orders | Section/twp/range, cause/order number, well density, unit size, formation code | CauseOrderTabl_Download.zip via spacing-download page | Access .mdb | Post-hearings | Free | Landing page verified; zip path UNVERIFIED |
-| Formation tops / initial completion tests | Tops (with logged/cored/DST flags), casing/cement, completed-interval and **Initial Test Data** — per-well COGIS scout pages only, not bulk | https://ecmc.state.co.us/cogisdb/Facility/FacilityDetail?api={CCSSSSS}&type=WELL (verified rendering tops + initial test block) | HTML (structured, scrapeable) | Live DB | Free | VERIFIED (no bulk download exists) |
+| Formation tops / initial completion tests | Tops (with logged/cored/DST flags), casing/cement, completed-interval and **Initial Test Data** — per-well COGIS scout pages only, not bulk | https://ecmc.state.co.us/cogisdb/Facility/FacilityDetail.aspx?api={CCSSSSS} (verified rendering tops + initial test block) | HTML (structured, scrapeable) | Live DB | Free | VERIFIED + SCOUTED ([#749](https://github.com/vamseeachanta/worldenergydata/issues/749)); production ingest deferred to [#751](https://github.com/vamseeachanta/worldenergydata/issues/751) |
 
 Master index: https://ecmc.colorado.gov/data-maps-reports/downloadable-data-documents (403 to non-browser user agents). Download guide: https://ecmc.state.co.us/documents/data/downloads/ECMC_Download_Guidance_v2_ada.pdf.
 
@@ -168,18 +168,43 @@ Colorado pressure evidence into the screen.
 
 Initial completion test data comes from Form 5A (Completed Interval Report)
 and is stored structured in COGIS: the per-well scout card renders an "Initial
-Test Data" block (test date, method, hours tested, choke, test-type/measure
-pairs — verified on an oil-well example showing BBLS_OIL/GRAVITY_OIL; whether
-gas-well records carry SITP/CAOF measures is UNVERIFIED) plus formation tops
-with a DSTs column. There is still **no bulk download of the Form 5A test or
-tops tables**; getting reservoir-relevant Colorado pressure requires a
-polite per-API FacilityDetail scrape or an ECMC data request. Bradenhead
-(Form 17) annulus-pressure tests exist as imaged forms only. MIT (Form 21)
-test data is a genuine structured monthly bulk download, but it is engineering
-integrity pressure, not reservoir/wellhead production pressure.
+Test Data" block (test date, method, hours tested, gas type, test-type/measure
+pairs) plus formation tops with a DSTs column. The [#749](https://github.com/vamseeachanta/worldenergydata/issues/749)
+live scout on 2026-07-04 fetched one official FacilityDetail page
+(`api=12339345`, 50,740 bytes), parsed 11 initial-test rows, and found two
+candidate pressure observations: `CASING_PRESS=1700` and `TUBING_PRESS=1300`
+for the NIOBRARA (`NBRR`) interval. The sample output lives under
+`/mnt/ace/worldenergydata/data/modules/colorado_ecmc/source_discovery/`.
+
+There is still **no bulk download of the Form 5A test or tops tables**; a
+statewide automated ingest now requires the separate [#751](https://github.com/vamseeachanta/worldenergydata/issues/751)
+plan for source-list construction, throttling, retry/resume, coverage
+accounting, and parser drift checks. Bradenhead (Form 17) annulus-pressure
+tests exist as imaged forms only. MIT (Form 21) test data is a genuine
+structured monthly bulk download, but it is engineering integrity pressure, not
+reservoir/wellhead production pressure.
 
 ### Ingestion effort estimate
-**Low** for wells master, production CSVs, MIT, and DAD exports: static HTTPS files with stable URL patterns, no auth — gotchas: ecmc.colorado.gov landing pages 403 without a browser User-Agent, annual summary files are Access .mdb (need mdbtools/UCanAccess), 2023 production file has a nonstandard name (`2023_prod_reports_20240903.csv`). Initial-test/tops data is **medium-high**: a ~100k-page scrape of COGIS FacilityDetail (simple `api=` parameter, HTML parse; throttle politely).
+**Low** for wells master, production CSVs, MIT, and DAD exports: static HTTPS files with stable URL patterns, no auth — gotchas: ecmc.colorado.gov landing pages 403 without a browser User-Agent, annual summary files are Access .mdb (need mdbtools/UCanAccess), 2023 production file has a nonstandard name (`2023_prod_reports_20240903.csv`). Initial-test/tops data is **medium-high**: FacilityDetail is structured enough for a direct-source parser, but a production run must be throttled, resumable, and coverage-audited before any statewide crawl.
+
+### Implemented [#749](https://github.com/vamseeachanta/worldenergydata/issues/749) source-discovery snapshot
+
+The bounded source-discovery lane now writes:
+
+```text
+/mnt/ace/worldenergydata/data/modules/colorado_ecmc/source_discovery/
+  raw/facility_detail/12339345.html
+  raw/facility_detail/manifest.json
+  parsed/facility_detail_initial_tests.parquet
+  parsed/facility_detail_initial_tests.json
+  reports/colorado_ecmc_pressure_source_discovery.json
+```
+
+The live scout fetched one official FacilityDetail page and produced
+`parsed_row_count: 11`, `candidate_pressure_count: 2`, and
+`decision: facility_detail_candidate_for_follow_up`. The candidate rows remain
+`source_discovery_not_screen_ready`; [#751](https://github.com/vamseeachanta/worldenergydata/issues/751)
+is the gated follow-up for production ingest.
 
 ### Implemented [#745](https://github.com/vamseeachanta/worldenergydata/issues/745) snapshot
 

--- a/docs/plans/2026-07-04-issue-749-colorado-ecmc-pressure-source-discovery.md
+++ b/docs/plans/2026-07-04-issue-749-colorado-ecmc-pressure-source-discovery.md
@@ -1,7 +1,7 @@
 # Plan: Issue #749 - Colorado ECMC pressure-source discovery
 
 **Issue:** https://github.com/vamseeachanta/worldenergydata/issues/749
-**Status:** plan-review
+**Status:** implemented
 **Tier:** T2 (official source discovery, bounded live scout, parser fixture, docs, follow-up decision)
 **Client:** N/A
 **Project:** worldenergydata onshore pressure screen

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -86,7 +86,7 @@ This directory contains issue-plan artifacts created during the issue-planning-m
 | [#732](https://github.com/vamseeachanta/worldenergydata/issues/732) | [texas-rrc-underpressured-screen](2026-07-03-issue-732-texas-rrc-underpressured-screen.md) | implemented | 2026-07-03 |
 | [#740](https://github.com/vamseeachanta/worldenergydata/issues/740) | [oklahoma-occ-pressure-observations](2026-07-03-issue-740-oklahoma-occ-pressure-observations.md) | implemented | 2026-07-03 |
 | [#745](https://github.com/vamseeachanta/worldenergydata/issues/745) | [colorado-ecmc-wellhead-pressure-observations](2026-07-03-issue-745-colorado-ecmc-wellhead-pressure-observations.md) | implemented | 2026-07-03 |
-| [#749](https://github.com/vamseeachanta/worldenergydata/issues/749) | [colorado-ecmc-pressure-source-discovery](2026-07-04-issue-749-colorado-ecmc-pressure-source-discovery.md) | plan-review | 2026-07-04 |
+| [#749](https://github.com/vamseeachanta/worldenergydata/issues/749) | [colorado-ecmc-pressure-source-discovery](2026-07-04-issue-749-colorado-ecmc-pressure-source-discovery.md) | implemented | 2026-07-04 |
 
 ## Closed / superseded plans
 

--- a/scripts/review/results/2026-07-04-code-749-codex-inline.md
+++ b/scripts/review/results/2026-07-04-code-749-codex-inline.md
@@ -1,0 +1,87 @@
+# Codex Inline Code Review: Issue #749 Colorado ECMC pressure-source discovery
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/749
+**Branch:** `feat/colorado-ecmc-source-discovery-749`
+**Reviewer:** Codex inline
+**Date:** 2026-07-04
+**Posture:** adversarial defect hunt; default non-approval unless source,
+scope, interpretation, and refresh-output risks are controlled.
+
+## Dispatch Note
+
+This runtime exposed a subagent tool after tool discovery, but that tool's
+contract says not to spawn subagents unless the user explicitly asks for
+subagents, delegation, or parallel agent work. The code-stage review was
+therefore performed inline and this fallback is recorded here.
+
+## Verdict
+
+APPROVE for merge after verification remains green.
+
+## Review Findings
+
+### Finding 1: A generic "Formation Details" page title could be parsed as a formation code
+
+**Risk:** FacilityDetail pages include a section title like "Wellbore And
+Formation Details". A naive `Formation\s+...` regex could classify the
+formation code as `Details`, corrupting pressure-source context and downstream
+field/formation grouping.
+
+**Disposition:** Fixed. A regression fixture now includes the misleading title,
+and `facility_detail.py` anchors formation-code extraction on the actual
+FacilityDetail formation header:
+`Formation {code} Formation Classification`.
+
+### Finding 2: Pressure semantics could leak treatment or integrity pressures into the screen
+
+**Risk:** The source page contains treatment pressure fields and links to
+MIT/Form 21 and bradenhead/Form 17 lanes. Mixing these with initial-test casing
+or tubing pressure would create false underpressured-screen evidence.
+
+**Disposition:** Controlled. `classify_facility_detail_pressures` marks only
+Initial Test Data `CASING_PRESS` and `TUBING_PRESS` as candidate pressure
+observations, keeps `underpressured_screen_eligible=False`, and excludes
+formation-treatment and integrity lanes. Tests cover all three branches.
+
+### Finding 3: The scout could drift from source discovery into an unapproved statewide crawl
+
+**Risk:** A working FacilityDetail parser could be misused as a statewide scrape
+without an approved source-list, throttle, retry/resume policy, or coverage
+accounting.
+
+**Disposition:** Controlled for [#749](https://github.com/vamseeachanta/worldenergydata/issues/749).
+The config has one `sample_apis` entry, `max_requests: 1`, and a request delay.
+The production ingest has been split into follow-up
+[#751](https://github.com/vamseeachanta/worldenergydata/issues/751).
+
+### Finding 4: Live output could be unverifiable local residue
+
+**Risk:** Source discovery needs `/mnt/ace` evidence, but raw HTML and parsed
+heavy artifacts should not be committed to the repo or left without provenance.
+
+**Disposition:** Controlled. The live run writes raw HTML, parsed JSON/parquet,
+and manifest/report JSON under
+`/mnt/ace/worldenergydata/data/modules/colorado_ecmc/source_discovery/`.
+The repo carries only config, parser/scout code, tests, and docs.
+
+### Finding 5: Interpreter mismatch can break parquet output
+
+**Risk:** The shell's Miniforge `python` is Python 3.13 without `pyarrow`, so
+running the scout with `python -m ...` fails at parquet writing. The repo's
+pytest/runtime path uses `/usr/bin/python3` 3.12 with `pyarrow`.
+
+**Disposition:** Documented operational caveat, not a code blocker for this
+repo. The live source-discovery run was verified with `/usr/bin/python3`, which
+matches the test environment. This is consistent with existing Colorado and
+Oklahoma pipelines that also write parquet.
+
+## Verification Evidence
+
+- RED: new tests failed initially with missing `facility_detail` and
+  `source_discovery` modules.
+- REGRESSION RED: fixture with "Formation Details" failed with
+  `formation_code == Details`.
+- GREEN: focused Colorado source-discovery and existing Colorado tests passed
+  after implementation.
+- Live scout: one official ECMC FacilityDetail request wrote `/mnt/ace` outputs
+  with `parsed_row_count: 11` and `candidate_pressure_count: 2`.

--- a/src/worldenergydata/modules/state_regulators/colorado_ecmc/facility_detail.py
+++ b/src/worldenergydata/modules/state_regulators/colorado_ecmc/facility_detail.py
@@ -1,0 +1,236 @@
+"""Parse Colorado ECMC FacilityDetail initial-test source pages (#749)."""
+
+from __future__ import annotations
+
+import re
+
+import pandas as pd
+from bs4 import BeautifulSoup
+
+
+PRESSURE_KINDS = {
+    ("initial_test_data", "CASING_PRESS"): "WHP_casing_initial_test",
+    ("initial_test_data", "TUBING_PRESS"): "WHP_flowing_tubing_initial_test",
+}
+
+
+def parse_facility_detail_html(
+    html: str, source_url: str | None = None
+) -> pd.DataFrame:
+    """Extract long-form Initial Test Data rows from a COGIS scout page."""
+    soup = BeautifulSoup(html, "html.parser")
+    page_text = _normalize_space(soup.get_text(" ", strip=True))
+    context = _page_context(page_text)
+    initial_table = _find_initial_test_table(soup)
+    if initial_table is None:
+        return pd.DataFrame(columns=_columns())
+
+    fields = {**context, **_initial_test_fields(initial_table)}
+    rows = []
+    for test_type, measure in _initial_test_measures(initial_table):
+        rows.append(
+            {
+                **fields,
+                "source_url": source_url,
+                "source_section": "initial_test_data",
+                "test_type": test_type,
+                "measure_value": _number(measure),
+                "measure_raw": measure,
+            }
+        )
+    return pd.DataFrame(rows, columns=_columns())
+
+
+def classify_facility_detail_pressures(frame: pd.DataFrame) -> pd.DataFrame:
+    """Classify FacilityDetail measures before any screen use."""
+    result = frame.copy()
+    result["pressure_role"] = "test_rate_or_property"
+    result["pressure_kind"] = pd.NA
+    result["exclude_reason"] = pd.NA
+    result["underpressured_screen_eligible"] = False
+
+    for (section, test_type), pressure_kind in PRESSURE_KINDS.items():
+        use = (result["source_section"] == section) & (result["test_type"] == test_type)
+        result.loc[use, "pressure_role"] = "candidate_pressure_observation"
+        result.loc[use, "pressure_kind"] = pressure_kind
+        result.loc[use, "exclude_reason"] = "source_discovery_not_screen_ready"
+
+    treatment = result["source_section"].eq("formation_treatment")
+    result.loc[treatment, "pressure_role"] = "excluded_engineering_pressure"
+    result.loc[treatment, "exclude_reason"] = "formation_treatment_pressure"
+
+    integrity = result["source_section"].isin(["mit_form_21", "form_17_bradenhead"])
+    result.loc[integrity, "pressure_role"] = "excluded_integrity_pressure"
+    result.loc[integrity, "exclude_reason"] = "mechanical_integrity_pressure"
+    result["underpressured_screen_eligible"] = result[
+        "underpressured_screen_eligible"
+    ].astype(object)
+    return result
+
+
+def _page_context(page_text: str) -> dict:
+    api_fragment = _first_group(r"API#\s*05[-\s]?(\d{3})[-\s]?(\d{5})", page_text)
+    api_fragment = "".join(api_fragment) if isinstance(api_fragment, tuple) else None
+    return {
+        "api_fragment": api_fragment,
+        "api10": f"05{api_fragment}" if api_fragment else pd.NA,
+        "api12": f"05{api_fragment}00" if api_fragment else pd.NA,
+        "facility_id": _first_group(r"FacilityID:\s*(\d+)", page_text),
+        "field": _clean_field(_first_group(r"Field:\s*([A-Z0-9 ()/-]+)", page_text)),
+        "formation_code": _first_group(
+            r"Formation\s+([A-Z0-9]+)\s+Formation Classification", page_text
+        ),
+        "formation": _first_group(
+            r"Completed Information for Formation\s+([A-Z0-9 ]+?)"
+            r"(?:\s+1st Production Date|\s+Formation Name|$)",
+            page_text,
+        ),
+        "wellbore": _first_group(r"Wellbore\s+#(\d+)", page_text),
+        "measured_td_ft": _number(_first_group(r"Measured TD:\s*([\d,]+)\s*ft", page_text)),
+        "vertical_td_ft": _number(
+            _first_group(r"Vertical TD:\s*([\d,]+)\s*ft", page_text)
+        ),
+        "interval_top_ft": _number(
+            _first_group(r"Interval Top:\s*([\d,]+)\s*ft", page_text)
+        ),
+        "interval_bottom_ft": _number(
+            _first_group(r"Interval Bottom:\s*([\d,]+)\s*ft", page_text)
+        ),
+        "first_production_date": _date(
+            _first_group(r"1st Production Date:\s*([0-9/]+)", page_text)
+        ),
+    }
+
+
+def _find_initial_test_table(soup: BeautifulSoup):
+    marker = soup.find(string=lambda text: text and "Initial Test Data" in text)
+    if marker is None:
+        return None
+    return marker.find_parent("table")
+
+
+def _initial_test_fields(table) -> dict:
+    fields = {
+        "test_date": pd.NaT,
+        "test_method": pd.NA,
+        "hours_tested": pd.NA,
+        "gas_type": pd.NA,
+        "gas_disposal": pd.NA,
+    }
+    for row in table.find_all("tr"):
+        cells = _cells(row)
+        for label, value in _label_values(cells).items():
+            if label == "Test Date":
+                fields["test_date"] = _date(value)
+            elif label == "Test Method":
+                fields["test_method"] = value
+            elif label == "Hours Tested":
+                fields["hours_tested"] = _number(value)
+            elif label == "Gas Type":
+                fields["gas_type"] = value
+            elif label == "Gas Disposal":
+                fields["gas_disposal"] = value
+    return fields
+
+
+def _initial_test_measures(table) -> list[tuple[str, str]]:
+    rows = []
+    in_measures = False
+    for row in table.find_all("tr"):
+        cells = _cells(row)
+        joined = " ".join(cells)
+        if "Perforation Data" in joined:
+            break
+        if len(cells) >= 2 and cells[0] == "Test Type" and cells[1] == "Measure":
+            in_measures = True
+            continue
+        if in_measures and len(cells) >= 2 and _looks_like_measure(cells[0]):
+            rows.append((cells[0], cells[1]))
+    return rows
+
+
+def _label_values(cells: list[str]) -> dict[str, str]:
+    values = {}
+    index = 0
+    while index < len(cells) - 1:
+        label = cells[index].rstrip(":")
+        if cells[index].endswith(":"):
+            values[label] = cells[index + 1]
+            index += 2
+        else:
+            index += 1
+    return values
+
+
+def _cells(row) -> list[str]:
+    cells = row.find_all(["td", "th"], recursive=False)
+    if not cells:
+        cells = row.find_all(["td", "th"])
+    return [_normalize_space(cell.get_text(" ", strip=True)) for cell in cells]
+
+
+def _first_group(pattern: str, text: str):
+    match = re.search(pattern, text, flags=re.IGNORECASE)
+    if not match:
+        return pd.NA
+    if len(match.groups()) > 1:
+        return tuple(group.strip() for group in match.groups())
+    return match.group(1).strip()
+
+
+def _clean_field(value):
+    if pd.isna(value):
+        return pd.NA
+    return str(value).split("-", 1)[0].strip()
+
+
+def _number(value):
+    if pd.isna(value):
+        return pd.NA
+    match = re.search(r"-?\d+(?:,\d{3})*(?:\.\d+)?", str(value))
+    if not match:
+        return pd.NA
+    number = float(match.group(0).replace(",", ""))
+    return int(number) if number.is_integer() else number
+
+
+def _date(value):
+    if pd.isna(value):
+        return pd.NaT
+    return pd.to_datetime(value, errors="coerce")
+
+
+def _looks_like_measure(value: str) -> bool:
+    return bool(re.fullmatch(r"[A-Z0-9_]+", value.strip()))
+
+
+def _normalize_space(value: str) -> str:
+    return re.sub(r"\s+", " ", value.replace("\xa0", " ")).strip()
+
+
+def _columns() -> list[str]:
+    return [
+        "api_fragment",
+        "api10",
+        "api12",
+        "facility_id",
+        "field",
+        "formation_code",
+        "formation",
+        "wellbore",
+        "measured_td_ft",
+        "vertical_td_ft",
+        "interval_top_ft",
+        "interval_bottom_ft",
+        "first_production_date",
+        "test_date",
+        "test_method",
+        "hours_tested",
+        "gas_type",
+        "gas_disposal",
+        "source_url",
+        "source_section",
+        "test_type",
+        "measure_value",
+        "measure_raw",
+    ]

--- a/src/worldenergydata/modules/state_regulators/colorado_ecmc/facility_detail.py
+++ b/src/worldenergydata/modules/state_regulators/colorado_ecmc/facility_detail.py
@@ -7,7 +7,6 @@ import re
 import pandas as pd
 from bs4 import BeautifulSoup
 
-
 PRESSURE_KINDS = {
     ("initial_test_data", "CASING_PRESS"): "WHP_casing_initial_test",
     ("initial_test_data", "TUBING_PRESS"): "WHP_flowing_tubing_initial_test",

--- a/src/worldenergydata/modules/state_regulators/colorado_ecmc/facility_detail.py
+++ b/src/worldenergydata/modules/state_regulators/colorado_ecmc/facility_detail.py
@@ -86,7 +86,9 @@ def _page_context(page_text: str) -> dict:
             page_text,
         ),
         "wellbore": _first_group(r"Wellbore\s+#(\d+)", page_text),
-        "measured_td_ft": _number(_first_group(r"Measured TD:\s*([\d,]+)\s*ft", page_text)),
+        "measured_td_ft": _number(
+            _first_group(r"Measured TD:\s*([\d,]+)\s*ft", page_text)
+        ),
         "vertical_td_ft": _number(
             _first_group(r"Vertical TD:\s*([\d,]+)\s*ft", page_text)
         ),

--- a/src/worldenergydata/modules/state_regulators/colorado_ecmc/source_discovery.py
+++ b/src/worldenergydata/modules/state_regulators/colorado_ecmc/source_discovery.py
@@ -1,0 +1,165 @@
+"""Capped official-source scout for Colorado ECMC FacilityDetail pages (#749)."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from time import sleep
+from urllib.parse import urlencode
+from urllib.request import urlopen
+
+import pandas as pd
+import yaml
+
+from worldenergydata.modules.state_regulators.colorado_ecmc.facility_detail import (
+    classify_facility_detail_pressures,
+    parse_facility_detail_html,
+)
+
+BASE_URL = "https://ecmc.state.co.us/cogisdb/Facility/FacilityDetail.aspx"
+
+
+def load_source_discovery_config(path: str | Path) -> dict:
+    with Path(path).open("r", encoding="utf-8") as handle:
+        config = yaml.safe_load(handle)
+    scout = config["facility_detail"]
+    if int(scout["max_requests"]) > len(scout["sample_apis"]):
+        raise ValueError("ECMC source discovery max_requests exceeds sample_apis")
+    return config
+
+
+def build_facility_detail_url(api_fragment: str, base_url: str = BASE_URL) -> str:
+    digits = "".join(char for char in str(api_fragment) if char.isdigit())
+    if len(digits) == 12 and digits.startswith("05"):
+        digits = digits[2:10]
+    elif len(digits) == 10 and digits.startswith("05"):
+        digits = digits[2:10]
+    if len(digits) != 8:
+        raise ValueError(f"expected Colorado county+sequence API fragment: {api_fragment}")
+    return f"{base_url}?{urlencode({'api': digits})}"
+
+
+def fetch_facility_detail(
+    url: str, destination: str | Path, timeout: int = 60
+) -> dict:
+    path = Path(destination)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    digest = hashlib.sha256()
+    size = 0
+    with urlopen(url, timeout=timeout) as response, path.open("wb") as handle:
+        while True:
+            chunk = response.read(1 << 20)
+            if not chunk:
+                break
+            handle.write(chunk)
+            digest.update(chunk)
+            size += len(chunk)
+        headers = response.headers
+        return {
+            "source_url": url,
+            "raw_path": str(path),
+            "status_code": response.getcode(),
+            "size_bytes": size,
+            "sha256": digest.hexdigest(),
+            "last_modified": headers.get("Last-Modified"),
+            "etag": headers.get("ETag"),
+            "downloaded_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+
+def write_source_discovery_manifest(
+    base_dir: str | Path, downloads: list[dict]
+) -> dict:
+    base = Path(base_dir)
+    manifest_path = base / "raw" / "facility_detail" / "manifest.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "source": "colorado_ecmc_facility_detail",
+        "request_count": len(downloads),
+        "parsed_row_count": int(sum(item.get("parsed_row_count", 0) for item in downloads)),
+        "candidate_pressure_count": int(
+            sum(item.get("candidate_pressure_count", 0) for item in downloads)
+        ),
+        "manifest_written_at": datetime.now(timezone.utc).isoformat(),
+        "downloads": downloads,
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return manifest
+
+
+def run_source_discovery(config_path: str | Path) -> dict:
+    config = load_source_discovery_config(config_path)
+    base_dir = Path(config["storage"]["base_dir"])
+    scout = config["facility_detail"]
+    raw_dir = base_dir / "raw" / "facility_detail"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    downloads, frames = [], []
+    for index, api_fragment in enumerate(scout["sample_apis"][: scout["max_requests"]]):
+        url = build_facility_detail_url(api_fragment, scout["base_url"])
+        raw_path = raw_dir / f"{_api_fragment(api_fragment)}.html"
+        metadata = fetch_facility_detail(url, raw_path, scout.get("timeout_seconds", 60))
+        parsed = parse_facility_detail_html(raw_path.read_text(encoding="utf-8"), url)
+        classified = classify_facility_detail_pressures(parsed)
+        metadata["api_fragment"] = _api_fragment(api_fragment)
+        metadata["parsed_row_count"] = int(len(classified))
+        metadata["candidate_pressure_count"] = int(
+            classified["pressure_role"].eq("candidate_pressure_observation").sum()
+        )
+        downloads.append(metadata)
+        frames.append(classified)
+        if index < int(scout["max_requests"]) - 1:
+            sleep(float(scout["request_delay_seconds"]))
+    parsed_frame = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+    manifest = write_source_discovery_manifest(base_dir, downloads)
+    report = _write_outputs(base_dir, parsed_frame, manifest)
+    return {"manifest": manifest, "report": report, "parsed": parsed_frame}
+
+
+def _write_outputs(base_dir: Path, parsed: pd.DataFrame, manifest: dict) -> dict:
+    parsed_dir = base_dir / "parsed"
+    report_dir = base_dir / "reports"
+    parsed_dir.mkdir(parents=True, exist_ok=True)
+    report_dir.mkdir(parents=True, exist_ok=True)
+    parsed.to_parquet(parsed_dir / "facility_detail_initial_tests.parquet")
+    parsed_json = parsed.to_json(orient="records", date_format="iso")
+    (parsed_dir / "facility_detail_initial_tests.json").write_text(
+        parsed_json, encoding="utf-8"
+    )
+    report = {
+        "source": manifest["source"],
+        "request_count": manifest["request_count"],
+        "parsed_row_count": manifest["parsed_row_count"],
+        "candidate_pressure_count": manifest["candidate_pressure_count"],
+        "decision": "facility_detail_candidate_for_follow_up",
+        "automated_ingest_follow_up_recommended": True,
+        "screen_exclusion": "source_discovery_not_screen_ready",
+        "excluded_pressure_lanes": [
+            "formation_treatment_pressure",
+            "mechanical_integrity_pressure",
+            "form_17_bradenhead_pressure",
+        ],
+        "report_written_at": datetime.now(timezone.utc).isoformat(),
+    }
+    (report_dir / "colorado_ecmc_pressure_source_discovery.json").write_text(
+        json.dumps(report, indent=2), encoding="utf-8"
+    )
+    return report
+
+
+def _api_fragment(value: str) -> str:
+    return build_facility_detail_url(value).rsplit("=", 1)[1]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Colorado ECMC source scout (#749)")
+    parser.add_argument("--config", default="config/colorado_ecmc_source_discovery.yml")
+    args = parser.parse_args()
+    result = run_source_discovery(args.config)
+    print(json.dumps(result["report"], indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/worldenergydata/modules/state_regulators/colorado_ecmc/source_discovery.py
+++ b/src/worldenergydata/modules/state_regulators/colorado_ecmc/source_discovery.py
@@ -38,13 +38,13 @@ def build_facility_detail_url(api_fragment: str, base_url: str = BASE_URL) -> st
     elif len(digits) == 10 and digits.startswith("05"):
         digits = digits[2:10]
     if len(digits) != 8:
-        raise ValueError(f"expected Colorado county+sequence API fragment: {api_fragment}")
+        raise ValueError(
+            f"expected Colorado county+sequence API fragment: {api_fragment}"
+        )
     return f"{base_url}?{urlencode({'api': digits})}"
 
 
-def fetch_facility_detail(
-    url: str, destination: str | Path, timeout: int = 60
-) -> dict:
+def fetch_facility_detail(url: str, destination: str | Path, timeout: int = 60) -> dict:
     path = Path(destination)
     path.parent.mkdir(parents=True, exist_ok=True)
     digest = hashlib.sha256()
@@ -79,7 +79,9 @@ def write_source_discovery_manifest(
     manifest = {
         "source": "colorado_ecmc_facility_detail",
         "request_count": len(downloads),
-        "parsed_row_count": int(sum(item.get("parsed_row_count", 0) for item in downloads)),
+        "parsed_row_count": int(
+            sum(item.get("parsed_row_count", 0) for item in downloads)
+        ),
         "candidate_pressure_count": int(
             sum(item.get("candidate_pressure_count", 0) for item in downloads)
         ),
@@ -100,7 +102,9 @@ def run_source_discovery(config_path: str | Path) -> dict:
     for index, api_fragment in enumerate(scout["sample_apis"][: scout["max_requests"]]):
         url = build_facility_detail_url(api_fragment, scout["base_url"])
         raw_path = raw_dir / f"{_api_fragment(api_fragment)}.html"
-        metadata = fetch_facility_detail(url, raw_path, scout.get("timeout_seconds", 60))
+        metadata = fetch_facility_detail(
+            url, raw_path, scout.get("timeout_seconds", 60)
+        )
         parsed = parse_facility_detail_html(raw_path.read_text(encoding="utf-8"), url)
         classified = classify_facility_detail_pressures(parsed)
         metadata["api_fragment"] = _api_fragment(api_fragment)

--- a/tests/fixtures/colorado_ecmc/facility_detail_12339345_excerpt.html
+++ b/tests/fixtures/colorado_ecmc/facility_detail_12339345_excerpt.html
@@ -1,0 +1,74 @@
+<html>
+  <body>
+    <table>
+      <tr>
+        <td colspan="2">
+          <span class="labelMedBold"><font color="navy">&nbsp;Surface Location<br />&nbsp;API# 05-123-39345</font></span>
+        </td>
+      </tr>
+      <tr>
+        <td><span class="labelSmall">FacilityID:</span></td>
+        <td><span class="labelSmall"><strong>436953</strong></span></td>
+        <td><span class="labelSmall">Field:</span></td>
+        <td><span class="labelSmall">WATTENBERG - #90750</span></td>
+      </tr>
+    </table>
+    <h2>Wellbore And Formation Details -- select either a wellbore Or formation to expand.</h2>
+    <div class="accordion">
+      <div class="accordion-head">
+        <h3>Wellbore #00 Measured TD: 14829 ft. Vertical TD: 7041 ft.</h3>
+      </div>
+      <div class="accordion2">
+        <div class="accordion2-head">
+          <h4>Formation NBRR Formation Classification: OW Status: PR - 1/1/2026 Interval Top: 7397 ft. Interval Bottom: 14700 ft.</h4>
+        </div>
+        <table>
+          <tr>
+            <td bgcolor="#FFD700"><span class="labelMedBold"><font color="navy">&nbsp;Completed Information for Formation NIOBRARA</font></span></td>
+          </tr>
+          <tr>
+            <td><span class="labelSmall">1st Production Date:</span></td>
+            <td><span class="labelSmall">5/16/2017</span></td>
+          </tr>
+          <tr>
+            <td><span class="labelSmall">Formation Name:</span></td>
+            <td><span class="labelSmall">NIOBRARA</span></td>
+          </tr>
+          <tr>
+            <td><span class="labelSmall"><strong>Formation Treatment</strong></span></td>
+          </tr>
+          <tr>
+            <td><span class="labelSmall">Max pressure during treatment (psi):</span></td>
+            <td><span class="labelSmall">8871</span></td>
+          </tr>
+          <tr>
+            <td colspan="4" bgcolor="#FFD700"><span class="labelSmall"><strong>Initial Test Data:</strong></span></td>
+          </tr>
+          <tr>
+            <td><span class="labelSmall">Test Date:</span></td>
+            <td><span class="labelSmall">5/19/2017</span></td>
+            <td><span class="labelSmall">Test Method:</span></td>
+            <td><span class="labelSmall">Flowing</span></td>
+          </tr>
+          <tr>
+            <td><span class="labelSmall">Hours Tested:</span></td>
+            <td><span class="labelSmall">24</span></td>
+            <td><span class="labelSmall">Gas Type:</span></td>
+            <td><span class="labelSmall">WET</span></td>
+          </tr>
+          <tr>
+            <th><span class="labelSmall"><strong>Test Type</strong></span></th>
+            <th><span class="labelSmall"><strong>Measure</strong></span></th>
+          </tr>
+          <tr><td><span class="labelSmall">BBLS_H2O</span></td><td><span class="labelSmall">75</span></td></tr>
+          <tr><td><span class="labelSmall">BBLS_OIL</span></td><td><span class="labelSmall">336</span></td></tr>
+          <tr><td><span class="labelSmall">BTU_GAS</span></td><td><span class="labelSmall">1345</span></td></tr>
+          <tr><td><span class="labelSmall">CALC_MCF_GAS</span></td><td><span class="labelSmall">418</span></td></tr>
+          <tr><td><span class="labelSmall">CASING_PRESS</span></td><td><span class="labelSmall">1700</span></td></tr>
+          <tr><td><span class="labelSmall">MCF_GAS</span></td><td><span class="labelSmall">418</span></td></tr>
+          <tr><td><span class="labelSmall">TUBING_PRESS</span></td><td><span class="labelSmall">1300</span></td></tr>
+        </table>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tests/unit/modules/state_regulators/test_colorado_ecmc_facility_detail.py
+++ b/tests/unit/modules/state_regulators/test_colorado_ecmc_facility_detail.py
@@ -16,7 +16,9 @@ FIXTURE = (
     / "colorado_ecmc"
     / "facility_detail_12339345_excerpt.html"
 )
-SOURCE_URL = "https://ecmc.state.co.us/cogisdb/Facility/FacilityDetail.aspx?api=12339345"
+SOURCE_URL = (
+    "https://ecmc.state.co.us/cogisdb/Facility/FacilityDetail.aspx?api=12339345"
+)
 
 
 def test_parse_facility_detail_html_extracts_initial_test_rows():

--- a/tests/unit/modules/state_regulators/test_colorado_ecmc_facility_detail.py
+++ b/tests/unit/modules/state_regulators/test_colorado_ecmc_facility_detail.py
@@ -1,0 +1,108 @@
+"""Tests for Colorado ECMC FacilityDetail/Form 5A source discovery (#749)."""
+
+from pathlib import Path
+
+import pandas as pd
+
+from worldenergydata.modules.state_regulators.colorado_ecmc.facility_detail import (
+    classify_facility_detail_pressures,
+    parse_facility_detail_html,
+)
+
+
+FIXTURE = (
+    Path(__file__).parents[3]
+    / "fixtures"
+    / "colorado_ecmc"
+    / "facility_detail_12339345_excerpt.html"
+)
+SOURCE_URL = "https://ecmc.state.co.us/cogisdb/Facility/FacilityDetail.aspx?api=12339345"
+
+
+def test_parse_facility_detail_html_extracts_initial_test_rows():
+    rows = parse_facility_detail_html(
+        FIXTURE.read_text(encoding="utf-8"), source_url=SOURCE_URL
+    )
+
+    assert set(rows["test_type"]) == {
+        "BBLS_H2O",
+        "BBLS_OIL",
+        "BTU_GAS",
+        "CALC_MCF_GAS",
+        "CASING_PRESS",
+        "MCF_GAS",
+        "TUBING_PRESS",
+    }
+    casing = rows.set_index("test_type").loc["CASING_PRESS"]
+    tubing = rows.set_index("test_type").loc["TUBING_PRESS"]
+
+    assert casing["api10"] == "0512339345"
+    assert casing["api_fragment"] == "12339345"
+    assert casing["facility_id"] == "436953"
+    assert casing["field"] == "WATTENBERG"
+    assert casing["formation_code"] == "NBRR"
+    assert casing["formation"] == "NIOBRARA"
+    assert casing["interval_top_ft"] == 7397
+    assert casing["interval_bottom_ft"] == 14700
+    assert casing["measured_td_ft"] == 14829
+    assert casing["vertical_td_ft"] == 7041
+    assert casing["first_production_date"] == pd.Timestamp("2017-05-16")
+    assert casing["test_date"] == pd.Timestamp("2017-05-19")
+    assert casing["test_method"] == "Flowing"
+    assert casing["hours_tested"] == 24
+    assert casing["gas_type"] == "WET"
+    assert casing["measure_value"] == 1700
+    assert casing["source_section"] == "initial_test_data"
+    assert casing["source_url"] == SOURCE_URL
+    assert tubing["measure_value"] == 1300
+
+
+def test_classify_facility_detail_pressures_keeps_only_initial_test_candidates():
+    raw = pd.DataFrame(
+        [
+            {
+                "source_section": "initial_test_data",
+                "test_type": "CASING_PRESS",
+                "measure_value": 1700,
+            },
+            {
+                "source_section": "initial_test_data",
+                "test_type": "TUBING_PRESS",
+                "measure_value": 1300,
+            },
+            {
+                "source_section": "formation_treatment",
+                "test_type": "MAX_TREATMENT_PRESS",
+                "measure_value": 8871,
+            },
+            {
+                "source_section": "mit_form_21",
+                "test_type": "CASING_PRESS",
+                "measure_value": 500,
+            },
+            {
+                "source_section": "initial_test_data",
+                "test_type": "MCF_GAS",
+                "measure_value": 418,
+            },
+        ]
+    )
+
+    classified = classify_facility_detail_pressures(raw)
+    by_key = classified.set_index(["source_section", "test_type"])
+
+    casing = by_key.loc[("initial_test_data", "CASING_PRESS")]
+    tubing = by_key.loc[("initial_test_data", "TUBING_PRESS")]
+    treatment = by_key.loc[("formation_treatment", "MAX_TREATMENT_PRESS")]
+    mit = by_key.loc[("mit_form_21", "CASING_PRESS")]
+    gas_rate = by_key.loc[("initial_test_data", "MCF_GAS")]
+
+    assert casing["pressure_role"] == "candidate_pressure_observation"
+    assert casing["pressure_kind"] == "WHP_casing_initial_test"
+    assert casing["underpressured_screen_eligible"] is False
+    assert tubing["pressure_kind"] == "WHP_flowing_tubing_initial_test"
+    assert treatment["pressure_role"] == "excluded_engineering_pressure"
+    assert treatment["exclude_reason"] == "formation_treatment_pressure"
+    assert mit["pressure_role"] == "excluded_integrity_pressure"
+    assert mit["exclude_reason"] == "mechanical_integrity_pressure"
+    assert gas_rate["pressure_role"] == "test_rate_or_property"

--- a/tests/unit/modules/state_regulators/test_colorado_ecmc_facility_detail.py
+++ b/tests/unit/modules/state_regulators/test_colorado_ecmc_facility_detail.py
@@ -9,7 +9,6 @@ from worldenergydata.modules.state_regulators.colorado_ecmc.facility_detail impo
     parse_facility_detail_html,
 )
 
-
 FIXTURE = (
     Path(__file__).parents[3]
     / "fixtures"

--- a/tests/unit/modules/state_regulators/test_colorado_ecmc_source_discovery.py
+++ b/tests/unit/modules/state_regulators/test_colorado_ecmc_source_discovery.py
@@ -14,7 +14,6 @@ from worldenergydata.modules.state_regulators.colorado_ecmc.source_discovery imp
     write_source_discovery_manifest,
 )
 
-
 FIXTURE = (
     Path(__file__).parents[3]
     / "fixtures"

--- a/tests/unit/modules/state_regulators/test_colorado_ecmc_source_discovery.py
+++ b/tests/unit/modules/state_regulators/test_colorado_ecmc_source_discovery.py
@@ -190,12 +190,8 @@ def test_run_source_discovery_writes_raw_parsed_and_report_outputs(
 
     result = run_source_discovery(config_path)
 
-    parsed_json = (
-        base_dir / "parsed" / "facility_detail_initial_tests.json"
-    )
-    report_json = (
-        base_dir / "reports" / "colorado_ecmc_pressure_source_discovery.json"
-    )
+    parsed_json = base_dir / "parsed" / "facility_detail_initial_tests.json"
+    report_json = base_dir / "reports" / "colorado_ecmc_pressure_source_discovery.json"
     assert result["report"]["request_count"] == 1
     assert result["report"]["parsed_row_count"] == 7
     assert result["report"]["candidate_pressure_count"] == 2

--- a/tests/unit/modules/state_regulators/test_colorado_ecmc_source_discovery.py
+++ b/tests/unit/modules/state_regulators/test_colorado_ecmc_source_discovery.py
@@ -1,0 +1,206 @@
+"""Tests for capped Colorado ECMC source discovery scout (#749)."""
+
+import hashlib
+import json
+from pathlib import Path
+
+import yaml
+
+from worldenergydata.modules.state_regulators.colorado_ecmc.source_discovery import (
+    build_facility_detail_url,
+    fetch_facility_detail,
+    load_source_discovery_config,
+    run_source_discovery,
+    write_source_discovery_manifest,
+)
+
+
+FIXTURE = (
+    Path(__file__).parents[3]
+    / "fixtures"
+    / "colorado_ecmc"
+    / "facility_detail_12339345_excerpt.html"
+)
+
+
+def test_source_discovery_config_is_capped_and_direct_source():
+    config = load_source_discovery_config("config/colorado_ecmc_source_discovery.yml")
+
+    scout = config["facility_detail"]
+
+    assert config["storage"]["base_dir"] == (
+        "/mnt/ace/worldenergydata/data/modules/colorado_ecmc/source_discovery"
+    )
+    assert scout["base_url"] == (
+        "https://ecmc.state.co.us/cogisdb/Facility/FacilityDetail.aspx"
+    )
+    assert scout["sample_apis"] == ["12339345"]
+    assert scout["max_requests"] == 1
+    assert scout["request_delay_seconds"] >= 1
+    assert scout["max_requests"] <= len(scout["sample_apis"])
+
+
+def test_build_facility_detail_url_normalizes_api_fragment():
+    expected = (
+        "https://ecmc.state.co.us/cogisdb/Facility/FacilityDetail.aspx?api=12339345"
+    )
+
+    assert build_facility_detail_url("12339345") == expected
+    assert build_facility_detail_url("05-123-39345") == expected
+    assert build_facility_detail_url("0512339345") == expected
+    assert build_facility_detail_url("051233934500") == expected
+
+
+def test_fetch_facility_detail_writes_html_and_metadata(tmp_path, monkeypatch):
+    payload = b"<html>facility detail</html>"
+
+    class FakeResponse:
+        headers = {"Last-Modified": "Fri, 03 Jul 2026 12:05:27 GMT", "ETag": "abc"}
+
+        def __init__(self):
+            self._used = False
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self, size=-1):
+            if self._used:
+                return b""
+            self._used = True
+            return payload
+
+        def getcode(self):
+            return 200
+
+    def fake_urlopen(url, timeout):
+        assert url.endswith("?api=12339345")
+        assert timeout == 60
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        "worldenergydata.modules.state_regulators.colorado_ecmc."
+        "source_discovery.urlopen",
+        fake_urlopen,
+    )
+    destination = tmp_path / "raw" / "facility_detail" / "12339345.html"
+
+    metadata = fetch_facility_detail(
+        "https://ecmc.state.co.us/cogisdb/Facility/FacilityDetail.aspx?api=12339345",
+        destination,
+    )
+
+    assert destination.read_bytes() == payload
+    assert metadata["source_url"].endswith("?api=12339345")
+    assert metadata["raw_path"] == str(destination)
+    assert metadata["status_code"] == 200
+    assert metadata["size_bytes"] == len(payload)
+    assert metadata["sha256"] == hashlib.sha256(payload).hexdigest()
+    assert metadata["last_modified"] == "Fri, 03 Jul 2026 12:05:27 GMT"
+    assert metadata["etag"] == "abc"
+    assert metadata["downloaded_at"]
+
+
+def test_write_source_discovery_manifest_records_parser_counts(tmp_path):
+    base_dir = tmp_path / "source_discovery"
+    downloads = [
+        {
+            "api_fragment": "12339345",
+            "source_url": (
+                "https://ecmc.state.co.us/cogisdb/Facility/"
+                "FacilityDetail.aspx?api=12339345"
+            ),
+            "raw_path": str(base_dir / "raw" / "facility_detail" / "12339345.html"),
+            "status_code": 200,
+            "size_bytes": 17,
+            "sha256": "abc123",
+            "last_modified": "Fri, 03 Jul 2026 12:05:27 GMT",
+            "etag": "etag-1",
+            "downloaded_at": "2026-07-04T08:00:00+00:00",
+            "parsed_row_count": 7,
+            "candidate_pressure_count": 2,
+        }
+    ]
+
+    manifest = write_source_discovery_manifest(base_dir, downloads)
+
+    assert manifest["source"] == "colorado_ecmc_facility_detail"
+    assert manifest["request_count"] == 1
+    assert manifest["parsed_row_count"] == 7
+    assert manifest["candidate_pressure_count"] == 2
+    assert manifest["downloads"][0]["api_fragment"] == "12339345"
+    written = json.loads(
+        (base_dir / "raw" / "facility_detail" / "manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert written == manifest
+
+
+def test_run_source_discovery_writes_raw_parsed_and_report_outputs(
+    tmp_path, monkeypatch
+):
+    config_path = tmp_path / "colorado_ecmc_source_discovery.yml"
+    base_dir = tmp_path / "source_discovery"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "storage": {"base_dir": str(base_dir)},
+                "facility_detail": {
+                    "base_url": (
+                        "https://ecmc.state.co.us/cogisdb/Facility/"
+                        "FacilityDetail.aspx"
+                    ),
+                    "sample_apis": ["12339345"],
+                    "max_requests": 1,
+                    "request_delay_seconds": 1,
+                    "timeout_seconds": 60,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_fetch(url, destination, timeout=60):
+        destination.write_text(FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+        return {
+            "api_fragment": "12339345",
+            "source_url": url,
+            "raw_path": str(destination),
+            "status_code": 200,
+            "size_bytes": destination.stat().st_size,
+            "sha256": "sha",
+            "last_modified": "Fri, 03 Jul 2026 12:05:27 GMT",
+            "etag": "etag",
+            "downloaded_at": "2026-07-04T08:00:00+00:00",
+        }
+
+    monkeypatch.setattr(
+        "worldenergydata.modules.state_regulators.colorado_ecmc."
+        "source_discovery.fetch_facility_detail",
+        fake_fetch,
+    )
+    monkeypatch.setattr(
+        "worldenergydata.modules.state_regulators.colorado_ecmc."
+        "source_discovery.sleep",
+        lambda _: None,
+    )
+
+    result = run_source_discovery(config_path)
+
+    parsed_json = (
+        base_dir / "parsed" / "facility_detail_initial_tests.json"
+    )
+    report_json = (
+        base_dir / "reports" / "colorado_ecmc_pressure_source_discovery.json"
+    )
+    assert result["report"]["request_count"] == 1
+    assert result["report"]["parsed_row_count"] == 7
+    assert result["report"]["candidate_pressure_count"] == 2
+    assert result["report"]["decision"] == "facility_detail_candidate_for_follow_up"
+    assert parsed_json.exists()
+    assert report_json.exists()
+    parsed = json.loads(parsed_json.read_text(encoding="utf-8"))
+    assert {row["test_type"] for row in parsed} >= {"CASING_PRESS", "TUBING_PRESS"}


### PR DESCRIPTION
## Summary\n\nImplements [#749](https://github.com/vamseeachanta/worldenergydata/issues/749): official Colorado ECMC pressure-source discovery beyond Form 7 production pressure columns.\n\n## Changes\n\n- Adds a fixture-tested FacilityDetail/Form 5A initial-test parser.\n- Adds a capped source-discovery config and scout writer for official ECMC FacilityDetail pages.\n- Writes source-discovery evidence under `/mnt/ace/worldenergydata/data/modules/colorado_ecmc/source_discovery/`.\n- Adds source docs and updates the multi-state source catalog.\n- Records inline adversarial code review.\n- Creates follow-up [#751](https://github.com/vamseeachanta/worldenergydata/issues/751) for production-grade statewide ingest planning.\n\n## Live source-discovery result\n\n- Request count: 1\n- Parsed initial-test rows: 11\n- Candidate pressure rows: 2\n- Candidate pressure kinds: `WHP_casing_initial_test`, `WHP_flowing_tubing_initial_test`\n- Screen status: `source_discovery_not_screen_ready`\n\n## Verification\n\n- RED: new tests failed on missing `facility_detail` and `source_discovery` modules.\n- REGRESSION RED: fixture with "Formation Details" failed until formation-code extraction was anchored.\n- `PYTHONPATH=src:packages/worldenergydata-core/src /usr/bin/python3 -m pytest tests/unit/modules/state_regulators/test_colorado_ecmc_facility_detail.py tests/unit/modules/state_regulators/test_colorado_ecmc_source_discovery.py tests/unit/modules/state_regulators/test_colorado_ecmc_pipeline.py tests/unit/modules/state_regulators/test_colorado_ecmc_parsers.py tests/unit/modules/state_regulators/test_colorado_ecmc_observations.py -q` → 23 passed.\n- `ruff check ...` → passed.\n- `git diff --cached --check` → passed.\n- `scripts/legal/legal-sanity-scan.sh` → PASS.\n- Live scout with `/usr/bin/python3` wrote raw HTML, parsed JSON/parquet, manifest, and report under `/mnt/ace`.\n\nCloses [#749](https://github.com/vamseeachanta/worldenergydata/issues/749).