### PR TITLE
feat(hub): well-level granular timelines + canonical field crosswalk (#758, #755)

### DIFF
--- a/config/fields.yml
+++ b/config/fields.yml
@@ -1,0 +1,99 @@
+# ABOUTME: Canonical field registry + crosswalk for the field-centric hub (epic #754, issue #755).
+# ABOUTME: Resolves each field by ONE canonical id (== lifecycle _facts.json id) to its BSEE block/lease,
+#          FDP portfolio slug, and which per-field surfaces exist. Externalized per repo config rule.
+#
+# has_* flags reflect what is actually built today (not a roadmap).
+# FDP portfolio pages that map to NO canonical lifecycle field (Miocene/other-play tiebacks) are listed
+# under `unmapped_fdp_pages` so the crosswalk stays honest.
+
+fields:
+  - canonical_id: big_foot
+    display_name: "Big Foot"
+    region: "US Gulf of Mexico"
+    play: "Wilcox / Lower Tertiary"
+    bsee_block: "Walker Ridge 29"
+    lease_number: "G16942"
+    fdp_slug: null
+    surfaces: {lifecycle_poster: true, economics_page: true, fdp_page: false}
+  - canonical_id: anchor
+    display_name: "Anchor"
+    region: "US Gulf of Mexico"
+    play: "Lower Tertiary Wilcox"
+    bsee_block: "Green Canyon 807"
+    lease_number: null
+    fdp_slug: null
+    surfaces: {lifecycle_poster: true, economics_page: true, fdp_page: false}
+  - canonical_id: cascade_chinook
+    display_name: "Cascade/Chinook"
+    region: "US Gulf of Mexico"
+    play: "Lower Tertiary (Wilcox)"
+    bsee_block: "Walker Ridge 206/250 (Cascade), 425/469 (Chinook)"
+    lease_number: null
+    fdp_slug: chinook   # NOTE: portfolio has only chinook.html — covers the Chinook half of the field
+    surfaces: {lifecycle_poster: true, economics_page: true, fdp_page: true}
+  - canonical_id: jack_st_malo
+    display_name: "Jack/St. Malo"
+    region: "US Gulf of Mexico"
+    play: "Lower Tertiary (Wilcox)"
+    bsee_block: "Walker Ridge 678 (St. Malo) / 758-759 (Jack)"
+    lease_number: null
+    fdp_slug: null
+    surfaces: {lifecycle_poster: true, economics_page: true, fdp_page: false}
+  - canonical_id: julia
+    display_name: "Julia"
+    region: "US Gulf of Mexico"
+    play: "Lower Tertiary Wilcox"
+    bsee_block: "Walker Ridge 627 (WR 540/583/584/627/628)"
+    lease_number: null
+    fdp_slug: julia
+    surfaces: {lifecycle_poster: true, economics_page: true, fdp_page: true}
+  - canonical_id: kaskida
+    display_name: "Kaskida"
+    region: "US Gulf of Mexico"
+    play: "Lower Tertiary (Wilcox)"
+    bsee_block: "Keathley Canyon 292"
+    lease_number: null
+    fdp_slug: null
+    surfaces: {lifecycle_poster: true, economics_page: false, fdp_page: false}
+  - canonical_id: north_platte
+    display_name: "North Platte (renamed Sparta)"
+    region: "US Gulf of Mexico"
+    play: "Wilcox (Lower Tertiary / Paleogene)"
+    bsee_block: "Garden Banks 959 (straddles GB 915/916/958/959)"
+    lease_number: null
+    fdp_slug: null
+    surfaces: {lifecycle_poster: true, economics_page: false, fdp_page: false}
+  - canonical_id: shenandoah
+    display_name: "Shenandoah"
+    region: "US Gulf of Mexico"
+    play: "Wilcox (Lower Tertiary)"
+    bsee_block: "Walker Ridge 52 (blocks 51, 52, N/2 53)"
+    lease_number: null
+    fdp_slug: null
+    surfaces: {lifecycle_poster: true, economics_page: true, fdp_page: false}
+  - canonical_id: stones
+    display_name: "Stones"
+    region: "US Gulf of Mexico"
+    play: "Lower Tertiary Wilcox"
+    bsee_block: "Walker Ridge 508"
+    lease_number: null
+    fdp_slug: stones
+    surfaces: {lifecycle_poster: true, economics_page: true, fdp_page: true}
+  - canonical_id: tiber
+    display_name: "Tiber"
+    region: "US Gulf of Mexico"
+    play: "Wilcox (Lower Tertiary / Paleogene)"
+    bsee_block: "Keathley Canyon 102"
+    lease_number: null
+    fdp_slug: null
+    surfaces: {lifecycle_poster: true, economics_page: false, fdp_page: false}
+
+# FDP portfolio pages with no canonical lifecycle field (out of scope for the hub join):
+unmapped_fdp_pages:
+  - {slug: aconcagua, block: MC305}
+  - {slug: camden-hills, block: MC348}
+  - {slug: cheyenne, block: LL399}
+  - {slug: coulomb, block: MC657}
+  - {slug: great-white, block: AC857}
+  - {slug: king, block: MC84}
+  - {slug: tobago, block: AC859}

--- a/reports/lower_tertiary/lifecycle/anchor_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/anchor_lifecycle.html
@@ -207,6 +207,7 @@
     </header>
 
     <div class="metrics" id="f-metrics"></div>
+    <div id="f-wells"></div>
 
     <div class="body">
       <section>
@@ -290,6 +291,8 @@ const MODEL = {
    ============================================================ */
 const FIELD = {
   "id": "anchor",
+  "wellsHref": null,
+  "wellsCount": 0,
   "name": "Anchor",
   "operator": "Chevron",
   "region": "Green Canyon 807 · US Gulf of Mexico",
@@ -427,13 +430,19 @@ const FIELD = {
 
 /* ---------------- render ---------------- */
 const $ = (id) => document.getElementById(id);
-const pos = (yr) => ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 100;
+// inset to 3–97% so the first/last gate flags aren't clipped at the container edges
+const pos = (yr) => 3 + ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 94;
 const curIdx = MODEL.phases.findIndex(p => p.key === FIELD.currentPhase);
 
 document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.wellsHref) $("f-wells").innerHTML =
+  `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
+  + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`
+  + `border-bottom:1px solid var(--line);color:var(--accent-ink);font-weight:700;font-size:13.5px;text-decoration:none">`
+  + `<span>▾ Deep-dive · well-level life-cycle timelines (${FIELD.wellsCount} wells)</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
 

--- a/reports/lower_tertiary/lifecycle/big_foot_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/big_foot_lifecycle.html
@@ -207,6 +207,7 @@
     </header>
 
     <div class="metrics" id="f-metrics"></div>
+    <div id="f-wells"></div>
 
     <div class="body">
       <section>
@@ -290,6 +291,8 @@ const MODEL = {
    ============================================================ */
 const FIELD = {
   "id": "big_foot",
+  "wellsHref": "wells/",
+  "wellsCount": 5,
   "name": "Big Foot",
   "operator": "Chevron",
   "region": "Walker Ridge 29 (G16942) · US Gulf of Mexico",
@@ -440,13 +443,19 @@ const FIELD = {
 
 /* ---------------- render ---------------- */
 const $ = (id) => document.getElementById(id);
-const pos = (yr) => ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 100;
+// inset to 3–97% so the first/last gate flags aren't clipped at the container edges
+const pos = (yr) => 3 + ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 94;
 const curIdx = MODEL.phases.findIndex(p => p.key === FIELD.currentPhase);
 
 document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.wellsHref) $("f-wells").innerHTML =
+  `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
+  + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`
+  + `border-bottom:1px solid var(--line);color:var(--accent-ink);font-weight:700;font-size:13.5px;text-decoration:none">`
+  + `<span>▾ Deep-dive · well-level life-cycle timelines (${FIELD.wellsCount} wells)</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
 

--- a/reports/lower_tertiary/lifecycle/cascade_chinook_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/cascade_chinook_lifecycle.html
@@ -207,6 +207,7 @@
     </header>
 
     <div class="metrics" id="f-metrics"></div>
+    <div id="f-wells"></div>
 
     <div class="body">
       <section>
@@ -290,6 +291,8 @@ const MODEL = {
    ============================================================ */
 const FIELD = {
   "id": "cascade_chinook",
+  "wellsHref": null,
+  "wellsCount": 0,
   "name": "Cascade/Chinook",
   "operator": "MP Gulf of Mexico LLC (Murphy EXPRO)",
   "region": "Walker Ridge 206/250 (Cascade), 425/469 (Chinook) · US Gulf of Mexico",
@@ -405,13 +408,19 @@ const FIELD = {
 
 /* ---------------- render ---------------- */
 const $ = (id) => document.getElementById(id);
-const pos = (yr) => ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 100;
+// inset to 3–97% so the first/last gate flags aren't clipped at the container edges
+const pos = (yr) => 3 + ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 94;
 const curIdx = MODEL.phases.findIndex(p => p.key === FIELD.currentPhase);
 
 document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.wellsHref) $("f-wells").innerHTML =
+  `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
+  + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`
+  + `border-bottom:1px solid var(--line);color:var(--accent-ink);font-weight:700;font-size:13.5px;text-decoration:none">`
+  + `<span>▾ Deep-dive · well-level life-cycle timelines (${FIELD.wellsCount} wells)</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
 

--- a/reports/lower_tertiary/lifecycle/jack_st_malo_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/jack_st_malo_lifecycle.html
@@ -207,6 +207,7 @@
     </header>
 
     <div class="metrics" id="f-metrics"></div>
+    <div id="f-wells"></div>
 
     <div class="body">
       <section>
@@ -290,6 +291,8 @@ const MODEL = {
    ============================================================ */
 const FIELD = {
   "id": "jack_st_malo",
+  "wellsHref": null,
+  "wellsCount": 0,
   "name": "Jack/St. Malo",
   "operator": "Chevron",
   "region": "Walker Ridge 678 (St. Malo) / 758-759 (Jack) · US Gulf of Mexico",
@@ -427,13 +430,19 @@ const FIELD = {
 
 /* ---------------- render ---------------- */
 const $ = (id) => document.getElementById(id);
-const pos = (yr) => ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 100;
+// inset to 3–97% so the first/last gate flags aren't clipped at the container edges
+const pos = (yr) => 3 + ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 94;
 const curIdx = MODEL.phases.findIndex(p => p.key === FIELD.currentPhase);
 
 document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.wellsHref) $("f-wells").innerHTML =
+  `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
+  + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`
+  + `border-bottom:1px solid var(--line);color:var(--accent-ink);font-weight:700;font-size:13.5px;text-decoration:none">`
+  + `<span>▾ Deep-dive · well-level life-cycle timelines (${FIELD.wellsCount} wells)</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
 

--- a/reports/lower_tertiary/lifecycle/julia_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/julia_lifecycle.html
@@ -207,6 +207,7 @@
     </header>
 
     <div class="metrics" id="f-metrics"></div>
+    <div id="f-wells"></div>
 
     <div class="body">
       <section>
@@ -290,6 +291,8 @@ const MODEL = {
    ============================================================ */
 const FIELD = {
   "id": "julia",
+  "wellsHref": null,
+  "wellsCount": 0,
   "name": "Julia",
   "operator": "ExxonMobil",
   "region": "Walker Ridge 627 (WR 540/583/584/627/628) · US Gulf of Mexico",
@@ -430,13 +433,19 @@ const FIELD = {
 
 /* ---------------- render ---------------- */
 const $ = (id) => document.getElementById(id);
-const pos = (yr) => ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 100;
+// inset to 3–97% so the first/last gate flags aren't clipped at the container edges
+const pos = (yr) => 3 + ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 94;
 const curIdx = MODEL.phases.findIndex(p => p.key === FIELD.currentPhase);
 
 document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.wellsHref) $("f-wells").innerHTML =
+  `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
+  + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`
+  + `border-bottom:1px solid var(--line);color:var(--accent-ink);font-weight:700;font-size:13.5px;text-decoration:none">`
+  + `<span>▾ Deep-dive · well-level life-cycle timelines (${FIELD.wellsCount} wells)</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
 

--- a/reports/lower_tertiary/lifecycle/kaskida_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/kaskida_lifecycle.html
@@ -207,6 +207,7 @@
     </header>
 
     <div class="metrics" id="f-metrics"></div>
+    <div id="f-wells"></div>
 
     <div class="body">
       <section>
@@ -290,6 +291,8 @@ const MODEL = {
    ============================================================ */
 const FIELD = {
   "id": "kaskida",
+  "wellsHref": null,
+  "wellsCount": 0,
   "name": "Kaskida",
   "operator": "BP",
   "region": "Keathley Canyon 292 · US Gulf of Mexico",
@@ -403,13 +406,19 @@ const FIELD = {
 
 /* ---------------- render ---------------- */
 const $ = (id) => document.getElementById(id);
-const pos = (yr) => ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 100;
+// inset to 3–97% so the first/last gate flags aren't clipped at the container edges
+const pos = (yr) => 3 + ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 94;
 const curIdx = MODEL.phases.findIndex(p => p.key === FIELD.currentPhase);
 
 document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.wellsHref) $("f-wells").innerHTML =
+  `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
+  + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`
+  + `border-bottom:1px solid var(--line);color:var(--accent-ink);font-weight:700;font-size:13.5px;text-decoration:none">`
+  + `<span>▾ Deep-dive · well-level life-cycle timelines (${FIELD.wellsCount} wells)</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
 

--- a/reports/lower_tertiary/lifecycle/lifecycle_template.html
+++ b/reports/lower_tertiary/lifecycle/lifecycle_template.html
@@ -207,6 +207,7 @@
     </header>
 
     <div class="metrics" id="f-metrics"></div>
+    <div id="f-wells"></div>
 
     <div class="body">
       <section>
@@ -292,13 +293,19 @@ const FIELD = __FIELD_JSON__;
 
 /* ---------------- render ---------------- */
 const $ = (id) => document.getElementById(id);
-const pos = (yr) => ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 100;
+// inset to 3–97% so the first/last gate flags aren't clipped at the container edges
+const pos = (yr) => 3 + ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 94;
 const curIdx = MODEL.phases.findIndex(p => p.key === FIELD.currentPhase);
 
 document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.wellsHref) $("f-wells").innerHTML =
+  `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
+  + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`
+  + `border-bottom:1px solid var(--line);color:var(--accent-ink);font-weight:700;font-size:13.5px;text-decoration:none">`
+  + `<span>▾ Deep-dive · well-level life-cycle timelines (${FIELD.wellsCount} wells)</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
 

--- a/reports/lower_tertiary/lifecycle/north_platte_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/north_platte_lifecycle.html
@@ -207,6 +207,7 @@
     </header>
 
     <div class="metrics" id="f-metrics"></div>
+    <div id="f-wells"></div>
 
     <div class="body">
       <section>
@@ -290,6 +291,8 @@ const MODEL = {
    ============================================================ */
 const FIELD = {
   "id": "north_platte",
+  "wellsHref": null,
+  "wellsCount": 0,
   "name": "North Platte (renamed Sparta)",
   "operator": "Shell",
   "region": "Garden Banks 959 (straddles GB 915/916/958/959) · US Gulf of Mexico",
@@ -399,13 +402,19 @@ const FIELD = {
 
 /* ---------------- render ---------------- */
 const $ = (id) => document.getElementById(id);
-const pos = (yr) => ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 100;
+// inset to 3–97% so the first/last gate flags aren't clipped at the container edges
+const pos = (yr) => 3 + ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 94;
 const curIdx = MODEL.phases.findIndex(p => p.key === FIELD.currentPhase);
 
 document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.wellsHref) $("f-wells").innerHTML =
+  `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
+  + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`
+  + `border-bottom:1px solid var(--line);color:var(--accent-ink);font-weight:700;font-size:13.5px;text-decoration:none">`
+  + `<span>▾ Deep-dive · well-level life-cycle timelines (${FIELD.wellsCount} wells)</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
 

--- a/reports/lower_tertiary/lifecycle/shenandoah_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/shenandoah_lifecycle.html
@@ -207,6 +207,7 @@
     </header>
 
     <div class="metrics" id="f-metrics"></div>
+    <div id="f-wells"></div>
 
     <div class="body">
       <section>
@@ -290,6 +291,8 @@ const MODEL = {
    ============================================================ */
 const FIELD = {
   "id": "shenandoah",
+  "wellsHref": null,
+  "wellsCount": 0,
   "name": "Shenandoah",
   "operator": "Beacon Offshore Energy",
   "region": "Walker Ridge 52 (blocks 51, 52, N/2 53) · US Gulf of Mexico",
@@ -423,13 +426,19 @@ const FIELD = {
 
 /* ---------------- render ---------------- */
 const $ = (id) => document.getElementById(id);
-const pos = (yr) => ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 100;
+// inset to 3–97% so the first/last gate flags aren't clipped at the container edges
+const pos = (yr) => 3 + ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 94;
 const curIdx = MODEL.phases.findIndex(p => p.key === FIELD.currentPhase);
 
 document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.wellsHref) $("f-wells").innerHTML =
+  `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
+  + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`
+  + `border-bottom:1px solid var(--line);color:var(--accent-ink);font-weight:700;font-size:13.5px;text-decoration:none">`
+  + `<span>▾ Deep-dive · well-level life-cycle timelines (${FIELD.wellsCount} wells)</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
 

--- a/reports/lower_tertiary/lifecycle/stones_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/stones_lifecycle.html
@@ -207,6 +207,7 @@
     </header>
 
     <div class="metrics" id="f-metrics"></div>
+    <div id="f-wells"></div>
 
     <div class="body">
       <section>
@@ -290,6 +291,8 @@ const MODEL = {
    ============================================================ */
 const FIELD = {
   "id": "stones",
+  "wellsHref": null,
+  "wellsCount": 0,
   "name": "Stones",
   "operator": "Shell",
   "region": "Walker Ridge 508 · US Gulf of Mexico",
@@ -420,13 +423,19 @@ const FIELD = {
 
 /* ---------------- render ---------------- */
 const $ = (id) => document.getElementById(id);
-const pos = (yr) => ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 100;
+// inset to 3–97% so the first/last gate flags aren't clipped at the container edges
+const pos = (yr) => 3 + ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 94;
 const curIdx = MODEL.phases.findIndex(p => p.key === FIELD.currentPhase);
 
 document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.wellsHref) $("f-wells").innerHTML =
+  `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
+  + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`
+  + `border-bottom:1px solid var(--line);color:var(--accent-ink);font-weight:700;font-size:13.5px;text-decoration:none">`
+  + `<span>▾ Deep-dive · well-level life-cycle timelines (${FIELD.wellsCount} wells)</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
 

--- a/reports/lower_tertiary/lifecycle/tiber_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/tiber_lifecycle.html
@@ -207,6 +207,7 @@
     </header>
 
     <div class="metrics" id="f-metrics"></div>
+    <div id="f-wells"></div>
 
     <div class="body">
       <section>
@@ -290,6 +291,8 @@ const MODEL = {
    ============================================================ */
 const FIELD = {
   "id": "tiber",
+  "wellsHref": null,
+  "wellsCount": 0,
   "name": "Tiber",
   "operator": "BP",
   "region": "Keathley Canyon 102 · US Gulf of Mexico",
@@ -395,13 +398,19 @@ const FIELD = {
 
 /* ---------------- render ---------------- */
 const $ = (id) => document.getElementById(id);
-const pos = (yr) => ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 100;
+// inset to 3–97% so the first/last gate flags aren't clipped at the container edges
+const pos = (yr) => 3 + ((yr - FIELD.axis.start) / (FIELD.axis.end - FIELD.axis.start)) * 94;
 const curIdx = MODEL.phases.findIndex(p => p.key === FIELD.currentPhase);
 
 document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.wellsHref) $("f-wells").innerHTML =
+  `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
+  + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`
+  + `border-bottom:1px solid var(--line);color:var(--accent-ink);font-weight:700;font-size:13.5px;text-decoration:none">`
+  + `<span>▾ Deep-dive · well-level life-cycle timelines (${FIELD.wellsCount} wells)</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
 

--- a/reports/lower_tertiary/lifecycle/wells/_wells.json
+++ b/reports/lower_tertiary/lifecycle/wells/_wells.json
@@ -1,0 +1,19 @@
+{
+  "fields": {
+    "big_foot": {
+      "display_name": "Big Foot",
+      "operator": "Chevron",
+      "host": "Extended Tension-Leg Platform (eTLP)",
+      "lease": "G16942",
+      "block": "Walker Ridge 29",
+      "play": "Wilcox / Lower Tertiary"
+    }
+  },
+  "wells": [
+    {"api": "608124006001", "slot": "A004", "field_id": "big_foot", "spud_date": "2019-03-10", "td_date": "2019-03-25", "drilling_rig_days": 15, "completion_rig_days": 156, "max_tvd_ft": 22253, "mud_weight_ppg": 16.4, "first_oil": "2019-06-01", "workovers": [{"date": "2020-08-30", "type": "Workover"}], "cum_oil_mmbbl": 32.2, "uptime_pct": 93.7, "status": "producing"},
+    {"api": "608124006603", "slot": "A006", "field_id": "big_foot", "spud_date": "2020-02-12", "td_date": "2020-03-01", "drilling_rig_days": 18, "completion_rig_days": 224, "max_tvd_ft": 21395, "mud_weight_ppg": 16.4, "first_oil": "2020-09-01", "workovers": [{"date": "2022-03-16", "type": "Workover"}], "cum_oil_mmbbl": 21.3, "uptime_pct": 92.2, "status": "producing"},
+    {"api": "608124006200", "slot": "A001", "field_id": "big_foot", "spud_date": "2012-04-03", "td_date": "2012-08-07", "drilling_rig_days": 126, "completion_rig_days": 265, "max_tvd_ft": 23187, "mud_weight_ppg": 16.4, "first_oil": "2018-11-01", "workovers": [{"date": "2021-07-15", "type": "Workover"}], "cum_oil_mmbbl": 14.9, "uptime_pct": 94.6, "status": "producing"},
+    {"api": "608124006800", "slot": "A008", "field_id": "big_foot", "spud_date": "2013-01-22", "td_date": "2021-12-02", "drilling_rig_days": 118, "completion_rig_days": 164, "max_tvd_ft": 21801, "mud_weight_ppg": 17, "first_oil": "2022-07-01", "workovers": [{"date": "2025-10-03", "type": "Workover"}], "cum_oil_mmbbl": 4.7, "uptime_pct": 92.4, "status": "producing"},
+    {"api": "608124006302", "slot": "A002", "field_id": "big_foot", "spud_date": "2024-07-11", "td_date": "2024-07-24", "drilling_rig_days": 13, "completion_rig_days": 168, "max_tvd_ft": 21830, "mud_weight_ppg": 14, "first_oil": "2025-01-01", "workovers": [], "cum_oil_mmbbl": 1.5, "uptime_pct": 96.3, "status": "producing"}
+  ]
+}

--- a/reports/lower_tertiary/lifecycle/wells/big_foot_A001_well.html
+++ b/reports/lower_tertiary/lifecycle/wells/big_foot_A001_well.html
@@ -329,7 +329,7 @@ $("spine").innerHTML=WELL.phases.map((p,i)=>{
   return `<div class="phase ${c}">${here}<div class="pk">Stage ${i+1}</div><div class="pn">${p.n}</div></div>`;
 }).join("");
 function renderTL(el,axis,gates,spans){
-  const pos=v=>((v-axis.start)/(axis.end-axis.start))*100;
+  const pos=v=>3+((v-axis.start)/(axis.end-axis.start))*94;  // inset so edge flags aren't clipped
   let h=`<div class="tl-axis"></div>`;
   h+=axis.ticks.map(t=>`<div class="tl-tick" style="left:${pos(t.v)}%">${t.t}</div>`).join("");
   h+=spans.map(s=>{const l=pos(s.from),w=pos(s.to)-pos(s.from);return `<div class="tl-span" style="left:${l}%;width:${w}%"><div class="bar"></div><span class="txt">${s.txt}</span></div>`;}).join("");

--- a/reports/lower_tertiary/lifecycle/wells/big_foot_A001_well.html
+++ b/reports/lower_tertiary/lifecycle/wells/big_foot_A001_well.html
@@ -1,0 +1,345 @@
+<meta charset="utf-8">
+<title>Well Life-Cycle</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root {
+    --bg:#eef2f6; --panel:#fff; --panel-2:#f6f9fc; --ink:#0c1a28; --muted:#5a6b7b; --line:#d6e0ea;
+    --accent:#d9822b; --accent-ink:#7a4410; --done:#1d5fa8; --done-deep:#10365e; --future:#a9bccd;
+    --good:#2e9e6b; --alert:#c0453b; --primary-gate:#1d5fa8;
+    --shadow:0 1px 2px rgba(12,26,40,.06),0 8px 24px rgba(12,26,40,.06);
+    --mono:ui-monospace,"SF Mono","Cascadia Code",Consolas,monospace;
+    --sans:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#0a141f;--panel:#10202f;--panel-2:#0d1b28;--ink:#e8eef4;--muted:#8ca0b3;--line:#24384b;
+    --accent:#f0a24a;--accent-ink:#f7c489;--done:#4d91d6;--done-deep:#2f6ba8;--future:#3a5064;
+    --good:#43b982;--alert:#e0685e;--primary-gate:#5b9de0;--shadow:0 1px 2px rgba(0,0,0,.4),0 10px 30px rgba(0,0,0,.35);}}
+  :root[data-theme="dark"]{--bg:#0a141f;--panel:#10202f;--panel-2:#0d1b28;--ink:#e8eef4;--muted:#8ca0b3;--line:#24384b;
+    --accent:#f0a24a;--accent-ink:#f7c489;--done:#4d91d6;--done-deep:#2f6ba8;--future:#3a5064;--good:#43b982;--alert:#e0685e;--primary-gate:#5b9de0;}
+  :root[data-theme="light"]{--bg:#eef2f6;--panel:#fff;--panel-2:#f6f9fc;--ink:#0c1a28;--muted:#5a6b7b;--line:#d6e0ea;
+    --accent:#d9822b;--accent-ink:#7a4410;--done:#1d5fa8;--done-deep:#10365e;--future:#a9bccd;--good:#2e9e6b;--alert:#c0453b;--primary-gate:#1d5fa8;}
+  *{box-sizing:border-box} body{margin:0}
+  .wrap{background:var(--bg);color:var(--ink);font-family:var(--sans);padding:clamp(16px,3vw,40px);min-height:100%}
+  .sheet{max-width:1180px;margin:0 auto;background:var(--panel);border:1px solid var(--line);border-radius:14px;box-shadow:var(--shadow);overflow:hidden}
+  .head{padding:clamp(18px,2.4vw,30px);border-bottom:1px solid var(--line);display:grid;grid-template-columns:1fr auto;gap:20px;align-items:start}
+  .eyebrow{font-family:var(--mono);font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--muted);margin:0 0 6px}
+  .title{font-size:clamp(26px,4vw,40px);font-weight:800;letter-spacing:-.02em;margin:0;line-height:1.02}
+  .sub{color:var(--muted);margin:8px 0 0;font-size:14.5px;max-width:66ch}
+  .sub a{color:var(--accent-ink)} :root[data-theme="dark"] .sub a,@media(prefers-color-scheme:dark){.sub a{color:var(--accent)}}
+  .status{display:inline-flex;align-items:center;gap:7px;font-family:var(--mono);font-size:12px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;
+    color:var(--good);background:color-mix(in srgb,var(--good) 14%,transparent);border:1px solid color-mix(in srgb,var(--good) 40%,transparent);padding:6px 12px;border-radius:999px;white-space:nowrap}
+  .status .dot{width:8px;height:8px;border-radius:50%;background:var(--good);box-shadow:0 0 0 4px color-mix(in srgb,var(--good) 22%,transparent)}
+  .draft{display:inline-block;font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--alert);
+    border:1px solid color-mix(in srgb,var(--alert) 45%,transparent);padding:3px 8px;border-radius:5px}
+  .metrics{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:1px;background:var(--line);border-top:1px solid var(--line)}
+  .metric{background:var(--panel-2);padding:14px 18px}
+  .metric .k{font-family:var(--mono);font-size:10.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted)}
+  .metric .v{font-family:var(--mono);font-size:20px;font-weight:700;font-variant-numeric:tabular-nums;margin-top:4px}
+  .metric .v small{font-size:12px;color:var(--muted);font-weight:500}
+  .body{padding:clamp(18px,2.4vw,30px);display:grid;gap:30px}
+  .lane-label{font-family:var(--mono);font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:var(--muted);margin:0 0 12px;font-weight:600}
+  .lane-label b{color:var(--accent-ink)} :root[data-theme="dark"] .lane-label b,@media(prefers-color-scheme:dark){.lane-label b{color:var(--accent)}}
+  .scrollx{overflow-x:auto;padding-bottom:4px}
+  .spine{display:flex;min-width:640px;gap:4px}
+  .phase{position:relative;flex:1 1 0;min-width:96px;padding:14px 14px 14px 26px;color:#fff;
+    clip-path:polygon(0 0,calc(100% - 16px) 0,100% 50%,calc(100% - 16px) 100%,0 100%,16px 50%);background:var(--future)}
+  .phase:first-child{padding-left:16px;clip-path:polygon(0 0,calc(100% - 16px) 0,100% 50%,calc(100% - 16px) 100%,0 100%)}
+  .phase.done{background:var(--done)} .phase.done.deep{background:var(--done-deep)}
+  .phase.current{background:var(--accent);color:#1c1206;box-shadow:0 6px 20px color-mix(in srgb,var(--accent) 45%,transparent);z-index:3}
+  .phase.future{background:color-mix(in srgb,var(--future) 55%,var(--panel));color:var(--muted)}
+  .phase .pn{font-weight:800;font-size:15px} .phase .pk{font-family:var(--mono);font-size:9.5px;letter-spacing:.12em;text-transform:uppercase;opacity:.8;margin-bottom:2px}
+  .youhere{position:absolute;top:-30px;left:50%;transform:translateX(-50%);font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--accent-ink);white-space:nowrap}
+  :root[data-theme="dark"] .youhere,@media(prefers-color-scheme:dark){.youhere{color:var(--accent)}}
+  .youhere::after{content:"▼";display:block;text-align:center;margin-top:2px;color:var(--accent)}
+  .tl{position:relative;min-width:640px;height:120px;margin-top:6px}
+  .tl-axis{position:absolute;left:0;right:0;top:82px;height:2px;background:linear-gradient(90deg,var(--future),var(--done) 55%,var(--accent))}
+  .tl-tick{position:absolute;top:90px;transform:translateX(-50%);font-family:var(--mono);font-size:10.5px;color:var(--muted);font-variant-numeric:tabular-nums}
+  .tl-tick::before{content:"";position:absolute;top:-10px;left:50%;width:1px;height:7px;background:var(--line)}
+  .tl-gate{position:absolute;top:82px;transform:translate(-50%,-50%);width:13px;height:13px;border-radius:50%;background:var(--primary-gate);border:2.5px solid var(--panel);box-shadow:0 0 0 1px var(--primary-gate);z-index:2}
+  .tl-gate.sec{background:var(--alert);box-shadow:0 0 0 1px var(--alert)}
+  .tl-gate.now{background:var(--accent);box-shadow:0 0 0 1px var(--accent),0 0 0 6px color-mix(in srgb,var(--accent) 22%,transparent)}
+  .tl-flag{position:absolute;bottom:42px;transform:translateX(-50%);text-align:center;width:120px}
+  .tl-flag .lab{font-size:12px;font-weight:700;line-height:1.15} .tl-flag .dt{font-family:var(--mono);font-size:11px;color:var(--accent-ink);font-variant-numeric:tabular-nums}
+  :root[data-theme="dark"] .tl-flag .dt,@media(prefers-color-scheme:dark){.tl-flag .dt{color:var(--accent)}}
+  .tl-flag .stem{position:absolute;left:50%;bottom:-14px;width:1.5px;height:14px;background:var(--line)}
+  .tl-span{position:absolute;top:68px;height:22px;display:flex;align-items:center;justify-content:center}
+  .tl-span .bar{position:absolute;left:0;right:0;top:9px;height:3px;border-radius:2px;background:color-mix(in srgb,var(--done) 45%,transparent)}
+  .tl-span .txt{position:relative;font-family:var(--mono);font-size:10px;color:var(--muted);background:var(--panel);padding:0 6px;white-space:nowrap}
+  .cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px}
+  .card{background:var(--panel-2);border:1px solid var(--line);border-radius:10px;padding:14px 16px}
+  .card h4{margin:0 0 6px;font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--done)}
+  .card.cur h4{color:var(--accent-ink)} :root[data-theme="dark"] .card.cur h4,@media(prefers-color-scheme:dark){.card.cur h4{color:var(--accent)}}
+  .card .big{font-family:var(--mono);font-size:19px;font-weight:700;font-variant-numeric:tabular-nums}
+  .card ul{margin:6px 0 0;padding-left:15px} .card li{font-size:12.5px;color:var(--muted);margin-bottom:2px}
+  .foot{border-top:1px solid var(--line);padding:16px clamp(18px,2.4vw,30px);display:flex;flex-wrap:wrap;gap:6px 18px;justify-content:space-between;font-size:11px;color:var(--muted);font-family:var(--mono)}
+</style>
+
+<div class="wrap"><div class="sheet">
+  <header class="head">
+    <div>
+      <p class="eyebrow">Well life-cycle · deep-dive</p>
+      <h1 class="title" id="t">—</h1>
+      <p class="sub" id="s">—</p>
+    </div>
+    <div style="display:flex;flex-direction:column;align-items:flex-end;gap:10px">
+      <span class="status"><span class="dot"></span><span id="st">—</span></span>
+      <span class="draft">Draft tracer · #758</span>
+    </div>
+  </header>
+  <div class="metrics" id="m"></div>
+  <div class="body">
+    <section><p class="lane-label">Well stages · <b>you are here</b></p><div class="scrollx"><div class="spine" id="spine"></div></div></section>
+    <section><p class="lane-label">Well construction · rig-day scale</p><div class="scrollx"><div class="tl" id="tlc"></div></div></section>
+    <section><p class="lane-label">Production life · calendar years</p><div class="scrollx"><div class="tl" id="tlp"></div></div></section>
+    <section><p class="lane-label">Stage detail</p><div class="cards" id="cards"></div></section>
+  </div>
+  <footer class="foot">
+    <span>Data: BSEE WAR (spud/complete/workover milestones) + V30 drilling workbook (native rig-days, TD, mud wt) + OGOR-A (first oil, cum, uptime). Draft tracer — refs #758/#754.</span>
+    <span id="gen">original artwork</span>
+  </footer>
+</div></div>
+
+<script>
+const WELL = {
+  "title": "Big Foot · A001",
+  "sub": "API 608124006200 · Walker Ridge 29 · Chevron · Wilcox / Lower Tertiary — nested under the <a href=\"../big_foot_lifecycle.html\">Big Foot field life-cycle</a>",
+  "statusLabel": "Producing",
+  "generated": "Generated 2026-07-04",
+  "phases": [
+    {
+      "k": "spud",
+      "n": "Spud"
+    },
+    {
+      "k": "drill",
+      "n": "Drill"
+    },
+    {
+      "k": "complete",
+      "n": "Complete"
+    },
+    {
+      "k": "produce",
+      "n": "Produce"
+    },
+    {
+      "k": "abandon",
+      "n": "Abandon"
+    }
+  ],
+  "current": "produce",
+  "metrics": [
+    {
+      "k": "Drilling",
+      "v": "126",
+      "u": "rig-days"
+    },
+    {
+      "k": "Completion",
+      "v": "265",
+      "u": "rig-days"
+    },
+    {
+      "k": "Max TVD",
+      "v": "23,187",
+      "u": "ft"
+    },
+    {
+      "k": "Mud weight",
+      "v": "16.4",
+      "u": "ppg"
+    },
+    {
+      "k": "Cum oil",
+      "v": "14.9",
+      "u": "MMbbl"
+    },
+    {
+      "k": "Uptime",
+      "v": "94.6",
+      "u": "%"
+    }
+  ],
+  "cAxis": {
+    "start": 0,
+    "end": 391,
+    "ticks": [
+      {
+        "v": 0,
+        "t": "0"
+      },
+      {
+        "v": 100,
+        "t": "100"
+      },
+      {
+        "v": 200,
+        "t": "200"
+      },
+      {
+        "v": 300,
+        "t": "300"
+      },
+      {
+        "v": 391,
+        "t": "391"
+      }
+    ]
+  },
+  "cGates": [
+    {
+      "x": 0,
+      "lab": "Spud",
+      "dt": "Apr 2012",
+      "kind": ""
+    },
+    {
+      "x": 126,
+      "lab": "TD reached",
+      "dt": "Aug 2012",
+      "kind": ""
+    },
+    {
+      "x": 391,
+      "lab": "Completed",
+      "dt": "Nov 2018",
+      "kind": "now"
+    }
+  ],
+  "cSpans": [
+    {
+      "from": 0,
+      "to": 126,
+      "txt": "Drill · 126 rig-days"
+    },
+    {
+      "from": 126,
+      "to": 391,
+      "txt": "Complete · 265 rig-days"
+    }
+  ],
+  "pAxis": {
+    "start": 2015,
+    "end": 2040,
+    "ticks": [
+      {
+        "v": 2020,
+        "t": "2020"
+      },
+      {
+        "v": 2025,
+        "t": "2025"
+      },
+      {
+        "v": 2030,
+        "t": "2030"
+      },
+      {
+        "v": 2035,
+        "t": "2035"
+      },
+      {
+        "v": 2040,
+        "t": "2040"
+      }
+    ]
+  },
+  "pGates": [
+    {
+      "x": 2018.875,
+      "lab": "First oil",
+      "dt": "Nov 2018",
+      "kind": "now"
+    },
+    {
+      "x": 2021.5416666666667,
+      "lab": "Workover",
+      "dt": "Jul 2021",
+      "kind": "sec"
+    },
+    {
+      "x": 2026.5,
+      "lab": "Today",
+      "dt": "2026",
+      "kind": "nowmark"
+    }
+  ],
+  "pSpans": [
+    {
+      "from": 2018.875,
+      "to": 2038,
+      "txt": "Producing · 14.9 MMbbl · 94.6% uptime"
+    }
+  ],
+  "cards": [
+    {
+      "t": "Drill · done",
+      "big": "126 rig-days",
+      "li": [
+        "TD 23,187 ft",
+        "16.4 ppg mud",
+        "spud Apr 2012"
+      ]
+    },
+    {
+      "t": "Complete · done",
+      "big": "265 rig-days",
+      "li": [
+        "first oil Nov 2018",
+        "Wilcox / Lower Tertiary"
+      ]
+    },
+    {
+      "t": "Produce · now",
+      "big": "14.9 MMbbl",
+      "li": [
+        "94.6% uptime",
+        "Big Foot · Extended Tension-Leg Platform (eTLP)"
+      ],
+      "cur": true
+    },
+    {
+      "t": "Workover",
+      "big": "1 event",
+      "li": [
+        "Jul 2021 · Workover"
+      ]
+    },
+    {
+      "t": "Abandon",
+      "big": "—",
+      "li": [
+        "still producing",
+        "no P&A"
+      ]
+    }
+  ]
+};
+const $=id=>document.getElementById(id);
+document.title = WELL.title + " — Well Life-Cycle";
+$("t").textContent = WELL.title;
+$("s").innerHTML = WELL.sub;
+$("st").textContent = WELL.statusLabel;
+$("gen").textContent = WELL.generated + " · original artwork";
+const curIdx=WELL.phases.findIndex(p=>p.k===WELL.current);
+$("m").innerHTML=WELL.metrics.map(m=>`<div class="metric"><div class="k">${m.k}</div><div class="v">${m.v} <small>${m.u}</small></div></div>`).join("");
+$("spine").innerHTML=WELL.phases.map((p,i)=>{
+  let c="future"; if(i<curIdx)c="done"; else if(i===curIdx)c="current";
+  const here=i===curIdx?'<div class="youhere">You are here</div>':"";
+  return `<div class="phase ${c}">${here}<div class="pk">Stage ${i+1}</div><div class="pn">${p.n}</div></div>`;
+}).join("");
+function renderTL(el,axis,gates,spans){
+  const pos=v=>((v-axis.start)/(axis.end-axis.start))*100;
+  let h=`<div class="tl-axis"></div>`;
+  h+=axis.ticks.map(t=>`<div class="tl-tick" style="left:${pos(t.v)}%">${t.t}</div>`).join("");
+  h+=spans.map(s=>{const l=pos(s.from),w=pos(s.to)-pos(s.from);return `<div class="tl-span" style="left:${l}%;width:${w}%"><div class="bar"></div><span class="txt">${s.txt}</span></div>`;}).join("");
+  h+=gates.map(g=>{
+    const cls=g.kind==="sec"?"sec":((g.kind==="now"||g.kind==="nowmark")?"now":"");
+    return `<div class="tl-gate ${cls}" style="left:${pos(g.x)}%"></div><div class="tl-flag" style="left:${pos(g.x)}%"><div class="lab">${g.lab}</div><div class="dt">${g.dt}</div><div class="stem"></div></div>`;
+  }).join("");
+  el.innerHTML=h;
+}
+renderTL($("tlc"),WELL.cAxis,WELL.cGates,WELL.cSpans);
+renderTL($("tlp"),WELL.pAxis,WELL.pGates,WELL.pSpans);
+$("cards").innerHTML=WELL.cards.map(c=>`<div class="card${c.cur?' cur':''}"><h4>${c.t}</h4><div class="big">${c.big}</div><ul>${c.li.map(x=>`<li>${x}</li>`).join("")}</ul></div>`).join("");
+</script>

--- a/reports/lower_tertiary/lifecycle/wells/big_foot_A002_well.html
+++ b/reports/lower_tertiary/lifecycle/wells/big_foot_A002_well.html
@@ -323,7 +323,7 @@ $("spine").innerHTML=WELL.phases.map((p,i)=>{
   return `<div class="phase ${c}">${here}<div class="pk">Stage ${i+1}</div><div class="pn">${p.n}</div></div>`;
 }).join("");
 function renderTL(el,axis,gates,spans){
-  const pos=v=>((v-axis.start)/(axis.end-axis.start))*100;
+  const pos=v=>3+((v-axis.start)/(axis.end-axis.start))*94;  // inset so edge flags aren't clipped
   let h=`<div class="tl-axis"></div>`;
   h+=axis.ticks.map(t=>`<div class="tl-tick" style="left:${pos(t.v)}%">${t.t}</div>`).join("");
   h+=spans.map(s=>{const l=pos(s.from),w=pos(s.to)-pos(s.from);return `<div class="tl-span" style="left:${l}%;width:${w}%"><div class="bar"></div><span class="txt">${s.txt}</span></div>`;}).join("");

--- a/reports/lower_tertiary/lifecycle/wells/big_foot_A002_well.html
+++ b/reports/lower_tertiary/lifecycle/wells/big_foot_A002_well.html
@@ -1,0 +1,339 @@
+<meta charset="utf-8">
+<title>Well Life-Cycle</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root {
+    --bg:#eef2f6; --panel:#fff; --panel-2:#f6f9fc; --ink:#0c1a28; --muted:#5a6b7b; --line:#d6e0ea;
+    --accent:#d9822b; --accent-ink:#7a4410; --done:#1d5fa8; --done-deep:#10365e; --future:#a9bccd;
+    --good:#2e9e6b; --alert:#c0453b; --primary-gate:#1d5fa8;
+    --shadow:0 1px 2px rgba(12,26,40,.06),0 8px 24px rgba(12,26,40,.06);
+    --mono:ui-monospace,"SF Mono","Cascadia Code",Consolas,monospace;
+    --sans:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#0a141f;--panel:#10202f;--panel-2:#0d1b28;--ink:#e8eef4;--muted:#8ca0b3;--line:#24384b;
+    --accent:#f0a24a;--accent-ink:#f7c489;--done:#4d91d6;--done-deep:#2f6ba8;--future:#3a5064;
+    --good:#43b982;--alert:#e0685e;--primary-gate:#5b9de0;--shadow:0 1px 2px rgba(0,0,0,.4),0 10px 30px rgba(0,0,0,.35);}}
+  :root[data-theme="dark"]{--bg:#0a141f;--panel:#10202f;--panel-2:#0d1b28;--ink:#e8eef4;--muted:#8ca0b3;--line:#24384b;
+    --accent:#f0a24a;--accent-ink:#f7c489;--done:#4d91d6;--done-deep:#2f6ba8;--future:#3a5064;--good:#43b982;--alert:#e0685e;--primary-gate:#5b9de0;}
+  :root[data-theme="light"]{--bg:#eef2f6;--panel:#fff;--panel-2:#f6f9fc;--ink:#0c1a28;--muted:#5a6b7b;--line:#d6e0ea;
+    --accent:#d9822b;--accent-ink:#7a4410;--done:#1d5fa8;--done-deep:#10365e;--future:#a9bccd;--good:#2e9e6b;--alert:#c0453b;--primary-gate:#1d5fa8;}
+  *{box-sizing:border-box} body{margin:0}
+  .wrap{background:var(--bg);color:var(--ink);font-family:var(--sans);padding:clamp(16px,3vw,40px);min-height:100%}
+  .sheet{max-width:1180px;margin:0 auto;background:var(--panel);border:1px solid var(--line);border-radius:14px;box-shadow:var(--shadow);overflow:hidden}
+  .head{padding:clamp(18px,2.4vw,30px);border-bottom:1px solid var(--line);display:grid;grid-template-columns:1fr auto;gap:20px;align-items:start}
+  .eyebrow{font-family:var(--mono);font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--muted);margin:0 0 6px}
+  .title{font-size:clamp(26px,4vw,40px);font-weight:800;letter-spacing:-.02em;margin:0;line-height:1.02}
+  .sub{color:var(--muted);margin:8px 0 0;font-size:14.5px;max-width:66ch}
+  .sub a{color:var(--accent-ink)} :root[data-theme="dark"] .sub a,@media(prefers-color-scheme:dark){.sub a{color:var(--accent)}}
+  .status{display:inline-flex;align-items:center;gap:7px;font-family:var(--mono);font-size:12px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;
+    color:var(--good);background:color-mix(in srgb,var(--good) 14%,transparent);border:1px solid color-mix(in srgb,var(--good) 40%,transparent);padding:6px 12px;border-radius:999px;white-space:nowrap}
+  .status .dot{width:8px;height:8px;border-radius:50%;background:var(--good);box-shadow:0 0 0 4px color-mix(in srgb,var(--good) 22%,transparent)}
+  .draft{display:inline-block;font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--alert);
+    border:1px solid color-mix(in srgb,var(--alert) 45%,transparent);padding:3px 8px;border-radius:5px}
+  .metrics{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:1px;background:var(--line);border-top:1px solid var(--line)}
+  .metric{background:var(--panel-2);padding:14px 18px}
+  .metric .k{font-family:var(--mono);font-size:10.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted)}
+  .metric .v{font-family:var(--mono);font-size:20px;font-weight:700;font-variant-numeric:tabular-nums;margin-top:4px}
+  .metric .v small{font-size:12px;color:var(--muted);font-weight:500}
+  .body{padding:clamp(18px,2.4vw,30px);display:grid;gap:30px}
+  .lane-label{font-family:var(--mono);font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:var(--muted);margin:0 0 12px;font-weight:600}
+  .lane-label b{color:var(--accent-ink)} :root[data-theme="dark"] .lane-label b,@media(prefers-color-scheme:dark){.lane-label b{color:var(--accent)}}
+  .scrollx{overflow-x:auto;padding-bottom:4px}
+  .spine{display:flex;min-width:640px;gap:4px}
+  .phase{position:relative;flex:1 1 0;min-width:96px;padding:14px 14px 14px 26px;color:#fff;
+    clip-path:polygon(0 0,calc(100% - 16px) 0,100% 50%,calc(100% - 16px) 100%,0 100%,16px 50%);background:var(--future)}
+  .phase:first-child{padding-left:16px;clip-path:polygon(0 0,calc(100% - 16px) 0,100% 50%,calc(100% - 16px) 100%,0 100%)}
+  .phase.done{background:var(--done)} .phase.done.deep{background:var(--done-deep)}
+  .phase.current{background:var(--accent);color:#1c1206;box-shadow:0 6px 20px color-mix(in srgb,var(--accent) 45%,transparent);z-index:3}
+  .phase.future{background:color-mix(in srgb,var(--future) 55%,var(--panel));color:var(--muted)}
+  .phase .pn{font-weight:800;font-size:15px} .phase .pk{font-family:var(--mono);font-size:9.5px;letter-spacing:.12em;text-transform:uppercase;opacity:.8;margin-bottom:2px}
+  .youhere{position:absolute;top:-30px;left:50%;transform:translateX(-50%);font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--accent-ink);white-space:nowrap}
+  :root[data-theme="dark"] .youhere,@media(prefers-color-scheme:dark){.youhere{color:var(--accent)}}
+  .youhere::after{content:"▼";display:block;text-align:center;margin-top:2px;color:var(--accent)}
+  .tl{position:relative;min-width:640px;height:120px;margin-top:6px}
+  .tl-axis{position:absolute;left:0;right:0;top:82px;height:2px;background:linear-gradient(90deg,var(--future),var(--done) 55%,var(--accent))}
+  .tl-tick{position:absolute;top:90px;transform:translateX(-50%);font-family:var(--mono);font-size:10.5px;color:var(--muted);font-variant-numeric:tabular-nums}
+  .tl-tick::before{content:"";position:absolute;top:-10px;left:50%;width:1px;height:7px;background:var(--line)}
+  .tl-gate{position:absolute;top:82px;transform:translate(-50%,-50%);width:13px;height:13px;border-radius:50%;background:var(--primary-gate);border:2.5px solid var(--panel);box-shadow:0 0 0 1px var(--primary-gate);z-index:2}
+  .tl-gate.sec{background:var(--alert);box-shadow:0 0 0 1px var(--alert)}
+  .tl-gate.now{background:var(--accent);box-shadow:0 0 0 1px var(--accent),0 0 0 6px color-mix(in srgb,var(--accent) 22%,transparent)}
+  .tl-flag{position:absolute;bottom:42px;transform:translateX(-50%);text-align:center;width:120px}
+  .tl-flag .lab{font-size:12px;font-weight:700;line-height:1.15} .tl-flag .dt{font-family:var(--mono);font-size:11px;color:var(--accent-ink);font-variant-numeric:tabular-nums}
+  :root[data-theme="dark"] .tl-flag .dt,@media(prefers-color-scheme:dark){.tl-flag .dt{color:var(--accent)}}
+  .tl-flag .stem{position:absolute;left:50%;bottom:-14px;width:1.5px;height:14px;background:var(--line)}
+  .tl-span{position:absolute;top:68px;height:22px;display:flex;align-items:center;justify-content:center}
+  .tl-span .bar{position:absolute;left:0;right:0;top:9px;height:3px;border-radius:2px;background:color-mix(in srgb,var(--done) 45%,transparent)}
+  .tl-span .txt{position:relative;font-family:var(--mono);font-size:10px;color:var(--muted);background:var(--panel);padding:0 6px;white-space:nowrap}
+  .cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px}
+  .card{background:var(--panel-2);border:1px solid var(--line);border-radius:10px;padding:14px 16px}
+  .card h4{margin:0 0 6px;font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--done)}
+  .card.cur h4{color:var(--accent-ink)} :root[data-theme="dark"] .card.cur h4,@media(prefers-color-scheme:dark){.card.cur h4{color:var(--accent)}}
+  .card .big{font-family:var(--mono);font-size:19px;font-weight:700;font-variant-numeric:tabular-nums}
+  .card ul{margin:6px 0 0;padding-left:15px} .card li{font-size:12.5px;color:var(--muted);margin-bottom:2px}
+  .foot{border-top:1px solid var(--line);padding:16px clamp(18px,2.4vw,30px);display:flex;flex-wrap:wrap;gap:6px 18px;justify-content:space-between;font-size:11px;color:var(--muted);font-family:var(--mono)}
+</style>
+
+<div class="wrap"><div class="sheet">
+  <header class="head">
+    <div>
+      <p class="eyebrow">Well life-cycle · deep-dive</p>
+      <h1 class="title" id="t">—</h1>
+      <p class="sub" id="s">—</p>
+    </div>
+    <div style="display:flex;flex-direction:column;align-items:flex-end;gap:10px">
+      <span class="status"><span class="dot"></span><span id="st">—</span></span>
+      <span class="draft">Draft tracer · #758</span>
+    </div>
+  </header>
+  <div class="metrics" id="m"></div>
+  <div class="body">
+    <section><p class="lane-label">Well stages · <b>you are here</b></p><div class="scrollx"><div class="spine" id="spine"></div></div></section>
+    <section><p class="lane-label">Well construction · rig-day scale</p><div class="scrollx"><div class="tl" id="tlc"></div></div></section>
+    <section><p class="lane-label">Production life · calendar years</p><div class="scrollx"><div class="tl" id="tlp"></div></div></section>
+    <section><p class="lane-label">Stage detail</p><div class="cards" id="cards"></div></section>
+  </div>
+  <footer class="foot">
+    <span>Data: BSEE WAR (spud/complete/workover milestones) + V30 drilling workbook (native rig-days, TD, mud wt) + OGOR-A (first oil, cum, uptime). Draft tracer — refs #758/#754.</span>
+    <span id="gen">original artwork</span>
+  </footer>
+</div></div>
+
+<script>
+const WELL = {
+  "title": "Big Foot · A002",
+  "sub": "API 608124006302 · Walker Ridge 29 · Chevron · Wilcox / Lower Tertiary — nested under the <a href=\"../big_foot_lifecycle.html\">Big Foot field life-cycle</a>",
+  "statusLabel": "Producing",
+  "generated": "Generated 2026-07-04",
+  "phases": [
+    {
+      "k": "spud",
+      "n": "Spud"
+    },
+    {
+      "k": "drill",
+      "n": "Drill"
+    },
+    {
+      "k": "complete",
+      "n": "Complete"
+    },
+    {
+      "k": "produce",
+      "n": "Produce"
+    },
+    {
+      "k": "abandon",
+      "n": "Abandon"
+    }
+  ],
+  "current": "produce",
+  "metrics": [
+    {
+      "k": "Drilling",
+      "v": "13",
+      "u": "rig-days"
+    },
+    {
+      "k": "Completion",
+      "v": "168",
+      "u": "rig-days"
+    },
+    {
+      "k": "Max TVD",
+      "v": "21,830",
+      "u": "ft"
+    },
+    {
+      "k": "Mud weight",
+      "v": "14",
+      "u": "ppg"
+    },
+    {
+      "k": "Cum oil",
+      "v": "1.5",
+      "u": "MMbbl"
+    },
+    {
+      "k": "Uptime",
+      "v": "96.3",
+      "u": "%"
+    }
+  ],
+  "cAxis": {
+    "start": 0,
+    "end": 181,
+    "ticks": [
+      {
+        "v": 0,
+        "t": "0"
+      },
+      {
+        "v": 50,
+        "t": "50"
+      },
+      {
+        "v": 100,
+        "t": "100"
+      },
+      {
+        "v": 150,
+        "t": "150"
+      },
+      {
+        "v": 181,
+        "t": "181"
+      }
+    ]
+  },
+  "cGates": [
+    {
+      "x": 0,
+      "lab": "Spud",
+      "dt": "Jul 2024",
+      "kind": ""
+    },
+    {
+      "x": 13,
+      "lab": "TD reached",
+      "dt": "Jul 2024",
+      "kind": ""
+    },
+    {
+      "x": 181,
+      "lab": "Completed",
+      "dt": "Jan 2025",
+      "kind": "now"
+    }
+  ],
+  "cSpans": [
+    {
+      "from": 0,
+      "to": 13,
+      "txt": "Drill · 13 rig-days"
+    },
+    {
+      "from": 13,
+      "to": 181,
+      "txt": "Complete · 168 rig-days"
+    }
+  ],
+  "pAxis": {
+    "start": 2025,
+    "end": 2045,
+    "ticks": [
+      {
+        "v": 2025,
+        "t": "2025"
+      },
+      {
+        "v": 2030,
+        "t": "2030"
+      },
+      {
+        "v": 2035,
+        "t": "2035"
+      },
+      {
+        "v": 2040,
+        "t": "2040"
+      },
+      {
+        "v": 2045,
+        "t": "2045"
+      }
+    ]
+  },
+  "pGates": [
+    {
+      "x": 2025.0416666666667,
+      "lab": "First oil",
+      "dt": "Jan 2025",
+      "kind": "now"
+    },
+    {
+      "x": 2026.5,
+      "lab": "Today",
+      "dt": "2026",
+      "kind": "nowmark"
+    }
+  ],
+  "pSpans": [
+    {
+      "from": 2025.0416666666667,
+      "to": 2043,
+      "txt": "Producing · 1.5 MMbbl · 96.3% uptime"
+    }
+  ],
+  "cards": [
+    {
+      "t": "Drill · done",
+      "big": "13 rig-days",
+      "li": [
+        "TD 21,830 ft",
+        "14 ppg mud",
+        "spud Jul 2024"
+      ]
+    },
+    {
+      "t": "Complete · done",
+      "big": "168 rig-days",
+      "li": [
+        "first oil Jan 2025",
+        "Wilcox / Lower Tertiary"
+      ]
+    },
+    {
+      "t": "Produce · now",
+      "big": "1.5 MMbbl",
+      "li": [
+        "96.3% uptime",
+        "Big Foot · Extended Tension-Leg Platform (eTLP)"
+      ],
+      "cur": true
+    },
+    {
+      "t": "Workover",
+      "big": "0 events",
+      "li": [
+        "none to date"
+      ]
+    },
+    {
+      "t": "Abandon",
+      "big": "—",
+      "li": [
+        "still producing",
+        "no P&A"
+      ]
+    }
+  ]
+};
+const $=id=>document.getElementById(id);
+document.title = WELL.title + " — Well Life-Cycle";
+$("t").textContent = WELL.title;
+$("s").innerHTML = WELL.sub;
+$("st").textContent = WELL.statusLabel;
+$("gen").textContent = WELL.generated + " · original artwork";
+const curIdx=WELL.phases.findIndex(p=>p.k===WELL.current);
+$("m").innerHTML=WELL.metrics.map(m=>`<div class="metric"><div class="k">${m.k}</div><div class="v">${m.v} <small>${m.u}</small></div></div>`).join("");
+$("spine").innerHTML=WELL.phases.map((p,i)=>{
+  let c="future"; if(i<curIdx)c="done"; else if(i===curIdx)c="current";
+  const here=i===curIdx?'<div class="youhere">You are here</div>':"";
+  return `<div class="phase ${c}">${here}<div class="pk">Stage ${i+1}</div><div class="pn">${p.n}</div></div>`;
+}).join("");
+function renderTL(el,axis,gates,spans){
+  const pos=v=>((v-axis.start)/(axis.end-axis.start))*100;
+  let h=`<div class="tl-axis"></div>`;
+  h+=axis.ticks.map(t=>`<div class="tl-tick" style="left:${pos(t.v)}%">${t.t}</div>`).join("");
+  h+=spans.map(s=>{const l=pos(s.from),w=pos(s.to)-pos(s.from);return `<div class="tl-span" style="left:${l}%;width:${w}%"><div class="bar"></div><span class="txt">${s.txt}</span></div>`;}).join("");
+  h+=gates.map(g=>{
+    const cls=g.kind==="sec"?"sec":((g.kind==="now"||g.kind==="nowmark")?"now":"");
+    return `<div class="tl-gate ${cls}" style="left:${pos(g.x)}%"></div><div class="tl-flag" style="left:${pos(g.x)}%"><div class="lab">${g.lab}</div><div class="dt">${g.dt}</div><div class="stem"></div></div>`;
+  }).join("");
+  el.innerHTML=h;
+}
+renderTL($("tlc"),WELL.cAxis,WELL.cGates,WELL.cSpans);
+renderTL($("tlp"),WELL.pAxis,WELL.pGates,WELL.pSpans);
+$("cards").innerHTML=WELL.cards.map(c=>`<div class="card${c.cur?' cur':''}"><h4>${c.t}</h4><div class="big">${c.big}</div><ul>${c.li.map(x=>`<li>${x}</li>`).join("")}</ul></div>`).join("");
+</script>

--- a/reports/lower_tertiary/lifecycle/wells/big_foot_A004_well.html
+++ b/reports/lower_tertiary/lifecycle/wells/big_foot_A004_well.html
@@ -329,7 +329,7 @@ $("spine").innerHTML=WELL.phases.map((p,i)=>{
   return `<div class="phase ${c}">${here}<div class="pk">Stage ${i+1}</div><div class="pn">${p.n}</div></div>`;
 }).join("");
 function renderTL(el,axis,gates,spans){
-  const pos=v=>((v-axis.start)/(axis.end-axis.start))*100;
+  const pos=v=>3+((v-axis.start)/(axis.end-axis.start))*94;  // inset so edge flags aren't clipped
   let h=`<div class="tl-axis"></div>`;
   h+=axis.ticks.map(t=>`<div class="tl-tick" style="left:${pos(t.v)}%">${t.t}</div>`).join("");
   h+=spans.map(s=>{const l=pos(s.from),w=pos(s.to)-pos(s.from);return `<div class="tl-span" style="left:${l}%;width:${w}%"><div class="bar"></div><span class="txt">${s.txt}</span></div>`;}).join("");

--- a/reports/lower_tertiary/lifecycle/wells/big_foot_A004_well.html
+++ b/reports/lower_tertiary/lifecycle/wells/big_foot_A004_well.html
@@ -1,0 +1,345 @@
+<meta charset="utf-8">
+<title>Well Life-Cycle</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root {
+    --bg:#eef2f6; --panel:#fff; --panel-2:#f6f9fc; --ink:#0c1a28; --muted:#5a6b7b; --line:#d6e0ea;
+    --accent:#d9822b; --accent-ink:#7a4410; --done:#1d5fa8; --done-deep:#10365e; --future:#a9bccd;
+    --good:#2e9e6b; --alert:#c0453b; --primary-gate:#1d5fa8;
+    --shadow:0 1px 2px rgba(12,26,40,.06),0 8px 24px rgba(12,26,40,.06);
+    --mono:ui-monospace,"SF Mono","Cascadia Code",Consolas,monospace;
+    --sans:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#0a141f;--panel:#10202f;--panel-2:#0d1b28;--ink:#e8eef4;--muted:#8ca0b3;--line:#24384b;
+    --accent:#f0a24a;--accent-ink:#f7c489;--done:#4d91d6;--done-deep:#2f6ba8;--future:#3a5064;
+    --good:#43b982;--alert:#e0685e;--primary-gate:#5b9de0;--shadow:0 1px 2px rgba(0,0,0,.4),0 10px 30px rgba(0,0,0,.35);}}
+  :root[data-theme="dark"]{--bg:#0a141f;--panel:#10202f;--panel-2:#0d1b28;--ink:#e8eef4;--muted:#8ca0b3;--line:#24384b;
+    --accent:#f0a24a;--accent-ink:#f7c489;--done:#4d91d6;--done-deep:#2f6ba8;--future:#3a5064;--good:#43b982;--alert:#e0685e;--primary-gate:#5b9de0;}
+  :root[data-theme="light"]{--bg:#eef2f6;--panel:#fff;--panel-2:#f6f9fc;--ink:#0c1a28;--muted:#5a6b7b;--line:#d6e0ea;
+    --accent:#d9822b;--accent-ink:#7a4410;--done:#1d5fa8;--done-deep:#10365e;--future:#a9bccd;--good:#2e9e6b;--alert:#c0453b;--primary-gate:#1d5fa8;}
+  *{box-sizing:border-box} body{margin:0}
+  .wrap{background:var(--bg);color:var(--ink);font-family:var(--sans);padding:clamp(16px,3vw,40px);min-height:100%}
+  .sheet{max-width:1180px;margin:0 auto;background:var(--panel);border:1px solid var(--line);border-radius:14px;box-shadow:var(--shadow);overflow:hidden}
+  .head{padding:clamp(18px,2.4vw,30px);border-bottom:1px solid var(--line);display:grid;grid-template-columns:1fr auto;gap:20px;align-items:start}
+  .eyebrow{font-family:var(--mono);font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--muted);margin:0 0 6px}
+  .title{font-size:clamp(26px,4vw,40px);font-weight:800;letter-spacing:-.02em;margin:0;line-height:1.02}
+  .sub{color:var(--muted);margin:8px 0 0;font-size:14.5px;max-width:66ch}
+  .sub a{color:var(--accent-ink)} :root[data-theme="dark"] .sub a,@media(prefers-color-scheme:dark){.sub a{color:var(--accent)}}
+  .status{display:inline-flex;align-items:center;gap:7px;font-family:var(--mono);font-size:12px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;
+    color:var(--good);background:color-mix(in srgb,var(--good) 14%,transparent);border:1px solid color-mix(in srgb,var(--good) 40%,transparent);padding:6px 12px;border-radius:999px;white-space:nowrap}
+  .status .dot{width:8px;height:8px;border-radius:50%;background:var(--good);box-shadow:0 0 0 4px color-mix(in srgb,var(--good) 22%,transparent)}
+  .draft{display:inline-block;font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--alert);
+    border:1px solid color-mix(in srgb,var(--alert) 45%,transparent);padding:3px 8px;border-radius:5px}
+  .metrics{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:1px;background:var(--line);border-top:1px solid var(--line)}
+  .metric{background:var(--panel-2);padding:14px 18px}
+  .metric .k{font-family:var(--mono);font-size:10.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted)}
+  .metric .v{font-family:var(--mono);font-size:20px;font-weight:700;font-variant-numeric:tabular-nums;margin-top:4px}
+  .metric .v small{font-size:12px;color:var(--muted);font-weight:500}
+  .body{padding:clamp(18px,2.4vw,30px);display:grid;gap:30px}
+  .lane-label{font-family:var(--mono);font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:var(--muted);margin:0 0 12px;font-weight:600}
+  .lane-label b{color:var(--accent-ink)} :root[data-theme="dark"] .lane-label b,@media(prefers-color-scheme:dark){.lane-label b{color:var(--accent)}}
+  .scrollx{overflow-x:auto;padding-bottom:4px}
+  .spine{display:flex;min-width:640px;gap:4px}
+  .phase{position:relative;flex:1 1 0;min-width:96px;padding:14px 14px 14px 26px;color:#fff;
+    clip-path:polygon(0 0,calc(100% - 16px) 0,100% 50%,calc(100% - 16px) 100%,0 100%,16px 50%);background:var(--future)}
+  .phase:first-child{padding-left:16px;clip-path:polygon(0 0,calc(100% - 16px) 0,100% 50%,calc(100% - 16px) 100%,0 100%)}
+  .phase.done{background:var(--done)} .phase.done.deep{background:var(--done-deep)}
+  .phase.current{background:var(--accent);color:#1c1206;box-shadow:0 6px 20px color-mix(in srgb,var(--accent) 45%,transparent);z-index:3}
+  .phase.future{background:color-mix(in srgb,var(--future) 55%,var(--panel));color:var(--muted)}
+  .phase .pn{font-weight:800;font-size:15px} .phase .pk{font-family:var(--mono);font-size:9.5px;letter-spacing:.12em;text-transform:uppercase;opacity:.8;margin-bottom:2px}
+  .youhere{position:absolute;top:-30px;left:50%;transform:translateX(-50%);font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--accent-ink);white-space:nowrap}
+  :root[data-theme="dark"] .youhere,@media(prefers-color-scheme:dark){.youhere{color:var(--accent)}}
+  .youhere::after{content:"▼";display:block;text-align:center;margin-top:2px;color:var(--accent)}
+  .tl{position:relative;min-width:640px;height:120px;margin-top:6px}
+  .tl-axis{position:absolute;left:0;right:0;top:82px;height:2px;background:linear-gradient(90deg,var(--future),var(--done) 55%,var(--accent))}
+  .tl-tick{position:absolute;top:90px;transform:translateX(-50%);font-family:var(--mono);font-size:10.5px;color:var(--muted);font-variant-numeric:tabular-nums}
+  .tl-tick::before{content:"";position:absolute;top:-10px;left:50%;width:1px;height:7px;background:var(--line)}
+  .tl-gate{position:absolute;top:82px;transform:translate(-50%,-50%);width:13px;height:13px;border-radius:50%;background:var(--primary-gate);border:2.5px solid var(--panel);box-shadow:0 0 0 1px var(--primary-gate);z-index:2}
+  .tl-gate.sec{background:var(--alert);box-shadow:0 0 0 1px var(--alert)}
+  .tl-gate.now{background:var(--accent);box-shadow:0 0 0 1px var(--accent),0 0 0 6px color-mix(in srgb,var(--accent) 22%,transparent)}
+  .tl-flag{position:absolute;bottom:42px;transform:translateX(-50%);text-align:center;width:120px}
+  .tl-flag .lab{font-size:12px;font-weight:700;line-height:1.15} .tl-flag .dt{font-family:var(--mono);font-size:11px;color:var(--accent-ink);font-variant-numeric:tabular-nums}
+  :root[data-theme="dark"] .tl-flag .dt,@media(prefers-color-scheme:dark){.tl-flag .dt{color:var(--accent)}}
+  .tl-flag .stem{position:absolute;left:50%;bottom:-14px;width:1.5px;height:14px;background:var(--line)}
+  .tl-span{position:absolute;top:68px;height:22px;display:flex;align-items:center;justify-content:center}
+  .tl-span .bar{position:absolute;left:0;right:0;top:9px;height:3px;border-radius:2px;background:color-mix(in srgb,var(--done) 45%,transparent)}
+  .tl-span .txt{position:relative;font-family:var(--mono);font-size:10px;color:var(--muted);background:var(--panel);padding:0 6px;white-space:nowrap}
+  .cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px}
+  .card{background:var(--panel-2);border:1px solid var(--line);border-radius:10px;padding:14px 16px}
+  .card h4{margin:0 0 6px;font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--done)}
+  .card.cur h4{color:var(--accent-ink)} :root[data-theme="dark"] .card.cur h4,@media(prefers-color-scheme:dark){.card.cur h4{color:var(--accent)}}
+  .card .big{font-family:var(--mono);font-size:19px;font-weight:700;font-variant-numeric:tabular-nums}
+  .card ul{margin:6px 0 0;padding-left:15px} .card li{font-size:12.5px;color:var(--muted);margin-bottom:2px}
+  .foot{border-top:1px solid var(--line);padding:16px clamp(18px,2.4vw,30px);display:flex;flex-wrap:wrap;gap:6px 18px;justify-content:space-between;font-size:11px;color:var(--muted);font-family:var(--mono)}
+</style>
+
+<div class="wrap"><div class="sheet">
+  <header class="head">
+    <div>
+      <p class="eyebrow">Well life-cycle · deep-dive</p>
+      <h1 class="title" id="t">—</h1>
+      <p class="sub" id="s">—</p>
+    </div>
+    <div style="display:flex;flex-direction:column;align-items:flex-end;gap:10px">
+      <span class="status"><span class="dot"></span><span id="st">—</span></span>
+      <span class="draft">Draft tracer · #758</span>
+    </div>
+  </header>
+  <div class="metrics" id="m"></div>
+  <div class="body">
+    <section><p class="lane-label">Well stages · <b>you are here</b></p><div class="scrollx"><div class="spine" id="spine"></div></div></section>
+    <section><p class="lane-label">Well construction · rig-day scale</p><div class="scrollx"><div class="tl" id="tlc"></div></div></section>
+    <section><p class="lane-label">Production life · calendar years</p><div class="scrollx"><div class="tl" id="tlp"></div></div></section>
+    <section><p class="lane-label">Stage detail</p><div class="cards" id="cards"></div></section>
+  </div>
+  <footer class="foot">
+    <span>Data: BSEE WAR (spud/complete/workover milestones) + V30 drilling workbook (native rig-days, TD, mud wt) + OGOR-A (first oil, cum, uptime). Draft tracer — refs #758/#754.</span>
+    <span id="gen">original artwork</span>
+  </footer>
+</div></div>
+
+<script>
+const WELL = {
+  "title": "Big Foot · A004",
+  "sub": "API 608124006001 · Walker Ridge 29 · Chevron · Wilcox / Lower Tertiary — nested under the <a href=\"../big_foot_lifecycle.html\">Big Foot field life-cycle</a>",
+  "statusLabel": "Producing",
+  "generated": "Generated 2026-07-04",
+  "phases": [
+    {
+      "k": "spud",
+      "n": "Spud"
+    },
+    {
+      "k": "drill",
+      "n": "Drill"
+    },
+    {
+      "k": "complete",
+      "n": "Complete"
+    },
+    {
+      "k": "produce",
+      "n": "Produce"
+    },
+    {
+      "k": "abandon",
+      "n": "Abandon"
+    }
+  ],
+  "current": "produce",
+  "metrics": [
+    {
+      "k": "Drilling",
+      "v": "15",
+      "u": "rig-days"
+    },
+    {
+      "k": "Completion",
+      "v": "156",
+      "u": "rig-days"
+    },
+    {
+      "k": "Max TVD",
+      "v": "22,253",
+      "u": "ft"
+    },
+    {
+      "k": "Mud weight",
+      "v": "16.4",
+      "u": "ppg"
+    },
+    {
+      "k": "Cum oil",
+      "v": "32.2",
+      "u": "MMbbl"
+    },
+    {
+      "k": "Uptime",
+      "v": "93.7",
+      "u": "%"
+    }
+  ],
+  "cAxis": {
+    "start": 0,
+    "end": 171,
+    "ticks": [
+      {
+        "v": 0,
+        "t": "0"
+      },
+      {
+        "v": 50,
+        "t": "50"
+      },
+      {
+        "v": 100,
+        "t": "100"
+      },
+      {
+        "v": 150,
+        "t": "150"
+      },
+      {
+        "v": 171,
+        "t": "171"
+      }
+    ]
+  },
+  "cGates": [
+    {
+      "x": 0,
+      "lab": "Spud",
+      "dt": "Mar 2019",
+      "kind": ""
+    },
+    {
+      "x": 15,
+      "lab": "TD reached",
+      "dt": "Mar 2019",
+      "kind": ""
+    },
+    {
+      "x": 171,
+      "lab": "Completed",
+      "dt": "Jun 2019",
+      "kind": "now"
+    }
+  ],
+  "cSpans": [
+    {
+      "from": 0,
+      "to": 15,
+      "txt": "Drill · 15 rig-days"
+    },
+    {
+      "from": 15,
+      "to": 171,
+      "txt": "Complete · 156 rig-days"
+    }
+  ],
+  "pAxis": {
+    "start": 2015,
+    "end": 2040,
+    "ticks": [
+      {
+        "v": 2020,
+        "t": "2020"
+      },
+      {
+        "v": 2025,
+        "t": "2025"
+      },
+      {
+        "v": 2030,
+        "t": "2030"
+      },
+      {
+        "v": 2035,
+        "t": "2035"
+      },
+      {
+        "v": 2040,
+        "t": "2040"
+      }
+    ]
+  },
+  "pGates": [
+    {
+      "x": 2019.4583333333333,
+      "lab": "First oil",
+      "dt": "Jun 2019",
+      "kind": "now"
+    },
+    {
+      "x": 2020.625,
+      "lab": "Workover",
+      "dt": "Aug 2020",
+      "kind": "sec"
+    },
+    {
+      "x": 2026.5,
+      "lab": "Today",
+      "dt": "2026",
+      "kind": "nowmark"
+    }
+  ],
+  "pSpans": [
+    {
+      "from": 2019.4583333333333,
+      "to": 2038,
+      "txt": "Producing · 32.2 MMbbl · 93.7% uptime"
+    }
+  ],
+  "cards": [
+    {
+      "t": "Drill · done",
+      "big": "15 rig-days",
+      "li": [
+        "TD 22,253 ft",
+        "16.4 ppg mud",
+        "spud Mar 2019"
+      ]
+    },
+    {
+      "t": "Complete · done",
+      "big": "156 rig-days",
+      "li": [
+        "first oil Jun 2019",
+        "Wilcox / Lower Tertiary"
+      ]
+    },
+    {
+      "t": "Produce · now",
+      "big": "32.2 MMbbl",
+      "li": [
+        "93.7% uptime",
+        "Big Foot · Extended Tension-Leg Platform (eTLP)"
+      ],
+      "cur": true
+    },
+    {
+      "t": "Workover",
+      "big": "1 event",
+      "li": [
+        "Aug 2020 · Workover"
+      ]
+    },
+    {
+      "t": "Abandon",
+      "big": "—",
+      "li": [
+        "still producing",
+        "no P&A"
+      ]
+    }
+  ]
+};
+const $=id=>document.getElementById(id);
+document.title = WELL.title + " — Well Life-Cycle";
+$("t").textContent = WELL.title;
+$("s").innerHTML = WELL.sub;
+$("st").textContent = WELL.statusLabel;
+$("gen").textContent = WELL.generated + " · original artwork";
+const curIdx=WELL.phases.findIndex(p=>p.k===WELL.current);
+$("m").innerHTML=WELL.metrics.map(m=>`<div class="metric"><div class="k">${m.k}</div><div class="v">${m.v} <small>${m.u}</small></div></div>`).join("");
+$("spine").innerHTML=WELL.phases.map((p,i)=>{
+  let c="future"; if(i<curIdx)c="done"; else if(i===curIdx)c="current";
+  const here=i===curIdx?'<div class="youhere">You are here</div>':"";
+  return `<div class="phase ${c}">${here}<div class="pk">Stage ${i+1}</div><div class="pn">${p.n}</div></div>`;
+}).join("");
+function renderTL(el,axis,gates,spans){
+  const pos=v=>((v-axis.start)/(axis.end-axis.start))*100;
+  let h=`<div class="tl-axis"></div>`;
+  h+=axis.ticks.map(t=>`<div class="tl-tick" style="left:${pos(t.v)}%">${t.t}</div>`).join("");
+  h+=spans.map(s=>{const l=pos(s.from),w=pos(s.to)-pos(s.from);return `<div class="tl-span" style="left:${l}%;width:${w}%"><div class="bar"></div><span class="txt">${s.txt}</span></div>`;}).join("");
+  h+=gates.map(g=>{
+    const cls=g.kind==="sec"?"sec":((g.kind==="now"||g.kind==="nowmark")?"now":"");
+    return `<div class="tl-gate ${cls}" style="left:${pos(g.x)}%"></div><div class="tl-flag" style="left:${pos(g.x)}%"><div class="lab">${g.lab}</div><div class="dt">${g.dt}</div><div class="stem"></div></div>`;
+  }).join("");
+  el.innerHTML=h;
+}
+renderTL($("tlc"),WELL.cAxis,WELL.cGates,WELL.cSpans);
+renderTL($("tlp"),WELL.pAxis,WELL.pGates,WELL.pSpans);
+$("cards").innerHTML=WELL.cards.map(c=>`<div class="card${c.cur?' cur':''}"><h4>${c.t}</h4><div class="big">${c.big}</div><ul>${c.li.map(x=>`<li>${x}</li>`).join("")}</ul></div>`).join("");
+</script>

--- a/reports/lower_tertiary/lifecycle/wells/big_foot_A006_well.html
+++ b/reports/lower_tertiary/lifecycle/wells/big_foot_A006_well.html
@@ -333,7 +333,7 @@ $("spine").innerHTML=WELL.phases.map((p,i)=>{
   return `<div class="phase ${c}">${here}<div class="pk">Stage ${i+1}</div><div class="pn">${p.n}</div></div>`;
 }).join("");
 function renderTL(el,axis,gates,spans){
-  const pos=v=>((v-axis.start)/(axis.end-axis.start))*100;
+  const pos=v=>3+((v-axis.start)/(axis.end-axis.start))*94;  // inset so edge flags aren't clipped
   let h=`<div class="tl-axis"></div>`;
   h+=axis.ticks.map(t=>`<div class="tl-tick" style="left:${pos(t.v)}%">${t.t}</div>`).join("");
   h+=spans.map(s=>{const l=pos(s.from),w=pos(s.to)-pos(s.from);return `<div class="tl-span" style="left:${l}%;width:${w}%"><div class="bar"></div><span class="txt">${s.txt}</span></div>`;}).join("");

--- a/reports/lower_tertiary/lifecycle/wells/big_foot_A006_well.html
+++ b/reports/lower_tertiary/lifecycle/wells/big_foot_A006_well.html
@@ -1,0 +1,349 @@
+<meta charset="utf-8">
+<title>Well Life-Cycle</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root {
+    --bg:#eef2f6; --panel:#fff; --panel-2:#f6f9fc; --ink:#0c1a28; --muted:#5a6b7b; --line:#d6e0ea;
+    --accent:#d9822b; --accent-ink:#7a4410; --done:#1d5fa8; --done-deep:#10365e; --future:#a9bccd;
+    --good:#2e9e6b; --alert:#c0453b; --primary-gate:#1d5fa8;
+    --shadow:0 1px 2px rgba(12,26,40,.06),0 8px 24px rgba(12,26,40,.06);
+    --mono:ui-monospace,"SF Mono","Cascadia Code",Consolas,monospace;
+    --sans:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#0a141f;--panel:#10202f;--panel-2:#0d1b28;--ink:#e8eef4;--muted:#8ca0b3;--line:#24384b;
+    --accent:#f0a24a;--accent-ink:#f7c489;--done:#4d91d6;--done-deep:#2f6ba8;--future:#3a5064;
+    --good:#43b982;--alert:#e0685e;--primary-gate:#5b9de0;--shadow:0 1px 2px rgba(0,0,0,.4),0 10px 30px rgba(0,0,0,.35);}}
+  :root[data-theme="dark"]{--bg:#0a141f;--panel:#10202f;--panel-2:#0d1b28;--ink:#e8eef4;--muted:#8ca0b3;--line:#24384b;
+    --accent:#f0a24a;--accent-ink:#f7c489;--done:#4d91d6;--done-deep:#2f6ba8;--future:#3a5064;--good:#43b982;--alert:#e0685e;--primary-gate:#5b9de0;}
+  :root[data-theme="light"]{--bg:#eef2f6;--panel:#fff;--panel-2:#f6f9fc;--ink:#0c1a28;--muted:#5a6b7b;--line:#d6e0ea;
+    --accent:#d9822b;--accent-ink:#7a4410;--done:#1d5fa8;--done-deep:#10365e;--future:#a9bccd;--good:#2e9e6b;--alert:#c0453b;--primary-gate:#1d5fa8;}
+  *{box-sizing:border-box} body{margin:0}
+  .wrap{background:var(--bg);color:var(--ink);font-family:var(--sans);padding:clamp(16px,3vw,40px);min-height:100%}
+  .sheet{max-width:1180px;margin:0 auto;background:var(--panel);border:1px solid var(--line);border-radius:14px;box-shadow:var(--shadow);overflow:hidden}
+  .head{padding:clamp(18px,2.4vw,30px);border-bottom:1px solid var(--line);display:grid;grid-template-columns:1fr auto;gap:20px;align-items:start}
+  .eyebrow{font-family:var(--mono);font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--muted);margin:0 0 6px}
+  .title{font-size:clamp(26px,4vw,40px);font-weight:800;letter-spacing:-.02em;margin:0;line-height:1.02}
+  .sub{color:var(--muted);margin:8px 0 0;font-size:14.5px;max-width:66ch}
+  .sub a{color:var(--accent-ink)} :root[data-theme="dark"] .sub a,@media(prefers-color-scheme:dark){.sub a{color:var(--accent)}}
+  .status{display:inline-flex;align-items:center;gap:7px;font-family:var(--mono);font-size:12px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;
+    color:var(--good);background:color-mix(in srgb,var(--good) 14%,transparent);border:1px solid color-mix(in srgb,var(--good) 40%,transparent);padding:6px 12px;border-radius:999px;white-space:nowrap}
+  .status .dot{width:8px;height:8px;border-radius:50%;background:var(--good);box-shadow:0 0 0 4px color-mix(in srgb,var(--good) 22%,transparent)}
+  .draft{display:inline-block;font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--alert);
+    border:1px solid color-mix(in srgb,var(--alert) 45%,transparent);padding:3px 8px;border-radius:5px}
+  .metrics{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:1px;background:var(--line);border-top:1px solid var(--line)}
+  .metric{background:var(--panel-2);padding:14px 18px}
+  .metric .k{font-family:var(--mono);font-size:10.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted)}
+  .metric .v{font-family:var(--mono);font-size:20px;font-weight:700;font-variant-numeric:tabular-nums;margin-top:4px}
+  .metric .v small{font-size:12px;color:var(--muted);font-weight:500}
+  .body{padding:clamp(18px,2.4vw,30px);display:grid;gap:30px}
+  .lane-label{font-family:var(--mono);font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:var(--muted);margin:0 0 12px;font-weight:600}
+  .lane-label b{color:var(--accent-ink)} :root[data-theme="dark"] .lane-label b,@media(prefers-color-scheme:dark){.lane-label b{color:var(--accent)}}
+  .scrollx{overflow-x:auto;padding-bottom:4px}
+  .spine{display:flex;min-width:640px;gap:4px}
+  .phase{position:relative;flex:1 1 0;min-width:96px;padding:14px 14px 14px 26px;color:#fff;
+    clip-path:polygon(0 0,calc(100% - 16px) 0,100% 50%,calc(100% - 16px) 100%,0 100%,16px 50%);background:var(--future)}
+  .phase:first-child{padding-left:16px;clip-path:polygon(0 0,calc(100% - 16px) 0,100% 50%,calc(100% - 16px) 100%,0 100%)}
+  .phase.done{background:var(--done)} .phase.done.deep{background:var(--done-deep)}
+  .phase.current{background:var(--accent);color:#1c1206;box-shadow:0 6px 20px color-mix(in srgb,var(--accent) 45%,transparent);z-index:3}
+  .phase.future{background:color-mix(in srgb,var(--future) 55%,var(--panel));color:var(--muted)}
+  .phase .pn{font-weight:800;font-size:15px} .phase .pk{font-family:var(--mono);font-size:9.5px;letter-spacing:.12em;text-transform:uppercase;opacity:.8;margin-bottom:2px}
+  .youhere{position:absolute;top:-30px;left:50%;transform:translateX(-50%);font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--accent-ink);white-space:nowrap}
+  :root[data-theme="dark"] .youhere,@media(prefers-color-scheme:dark){.youhere{color:var(--accent)}}
+  .youhere::after{content:"▼";display:block;text-align:center;margin-top:2px;color:var(--accent)}
+  .tl{position:relative;min-width:640px;height:120px;margin-top:6px}
+  .tl-axis{position:absolute;left:0;right:0;top:82px;height:2px;background:linear-gradient(90deg,var(--future),var(--done) 55%,var(--accent))}
+  .tl-tick{position:absolute;top:90px;transform:translateX(-50%);font-family:var(--mono);font-size:10.5px;color:var(--muted);font-variant-numeric:tabular-nums}
+  .tl-tick::before{content:"";position:absolute;top:-10px;left:50%;width:1px;height:7px;background:var(--line)}
+  .tl-gate{position:absolute;top:82px;transform:translate(-50%,-50%);width:13px;height:13px;border-radius:50%;background:var(--primary-gate);border:2.5px solid var(--panel);box-shadow:0 0 0 1px var(--primary-gate);z-index:2}
+  .tl-gate.sec{background:var(--alert);box-shadow:0 0 0 1px var(--alert)}
+  .tl-gate.now{background:var(--accent);box-shadow:0 0 0 1px var(--accent),0 0 0 6px color-mix(in srgb,var(--accent) 22%,transparent)}
+  .tl-flag{position:absolute;bottom:42px;transform:translateX(-50%);text-align:center;width:120px}
+  .tl-flag .lab{font-size:12px;font-weight:700;line-height:1.15} .tl-flag .dt{font-family:var(--mono);font-size:11px;color:var(--accent-ink);font-variant-numeric:tabular-nums}
+  :root[data-theme="dark"] .tl-flag .dt,@media(prefers-color-scheme:dark){.tl-flag .dt{color:var(--accent)}}
+  .tl-flag .stem{position:absolute;left:50%;bottom:-14px;width:1.5px;height:14px;background:var(--line)}
+  .tl-span{position:absolute;top:68px;height:22px;display:flex;align-items:center;justify-content:center}
+  .tl-span .bar{position:absolute;left:0;right:0;top:9px;height:3px;border-radius:2px;background:color-mix(in srgb,var(--done) 45%,transparent)}
+  .tl-span .txt{position:relative;font-family:var(--mono);font-size:10px;color:var(--muted);background:var(--panel);padding:0 6px;white-space:nowrap}
+  .cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px}
+  .card{background:var(--panel-2);border:1px solid var(--line);border-radius:10px;padding:14px 16px}
+  .card h4{margin:0 0 6px;font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--done)}
+  .card.cur h4{color:var(--accent-ink)} :root[data-theme="dark"] .card.cur h4,@media(prefers-color-scheme:dark){.card.cur h4{color:var(--accent)}}
+  .card .big{font-family:var(--mono);font-size:19px;font-weight:700;font-variant-numeric:tabular-nums}
+  .card ul{margin:6px 0 0;padding-left:15px} .card li{font-size:12.5px;color:var(--muted);margin-bottom:2px}
+  .foot{border-top:1px solid var(--line);padding:16px clamp(18px,2.4vw,30px);display:flex;flex-wrap:wrap;gap:6px 18px;justify-content:space-between;font-size:11px;color:var(--muted);font-family:var(--mono)}
+</style>
+
+<div class="wrap"><div class="sheet">
+  <header class="head">
+    <div>
+      <p class="eyebrow">Well life-cycle · deep-dive</p>
+      <h1 class="title" id="t">—</h1>
+      <p class="sub" id="s">—</p>
+    </div>
+    <div style="display:flex;flex-direction:column;align-items:flex-end;gap:10px">
+      <span class="status"><span class="dot"></span><span id="st">—</span></span>
+      <span class="draft">Draft tracer · #758</span>
+    </div>
+  </header>
+  <div class="metrics" id="m"></div>
+  <div class="body">
+    <section><p class="lane-label">Well stages · <b>you are here</b></p><div class="scrollx"><div class="spine" id="spine"></div></div></section>
+    <section><p class="lane-label">Well construction · rig-day scale</p><div class="scrollx"><div class="tl" id="tlc"></div></div></section>
+    <section><p class="lane-label">Production life · calendar years</p><div class="scrollx"><div class="tl" id="tlp"></div></div></section>
+    <section><p class="lane-label">Stage detail</p><div class="cards" id="cards"></div></section>
+  </div>
+  <footer class="foot">
+    <span>Data: BSEE WAR (spud/complete/workover milestones) + V30 drilling workbook (native rig-days, TD, mud wt) + OGOR-A (first oil, cum, uptime). Draft tracer — refs #758/#754.</span>
+    <span id="gen">original artwork</span>
+  </footer>
+</div></div>
+
+<script>
+const WELL = {
+  "title": "Big Foot · A006",
+  "sub": "API 608124006603 · Walker Ridge 29 · Chevron · Wilcox / Lower Tertiary — nested under the <a href=\"../big_foot_lifecycle.html\">Big Foot field life-cycle</a>",
+  "statusLabel": "Producing",
+  "generated": "Generated 2026-07-04",
+  "phases": [
+    {
+      "k": "spud",
+      "n": "Spud"
+    },
+    {
+      "k": "drill",
+      "n": "Drill"
+    },
+    {
+      "k": "complete",
+      "n": "Complete"
+    },
+    {
+      "k": "produce",
+      "n": "Produce"
+    },
+    {
+      "k": "abandon",
+      "n": "Abandon"
+    }
+  ],
+  "current": "produce",
+  "metrics": [
+    {
+      "k": "Drilling",
+      "v": "18",
+      "u": "rig-days"
+    },
+    {
+      "k": "Completion",
+      "v": "224",
+      "u": "rig-days"
+    },
+    {
+      "k": "Max TVD",
+      "v": "21,395",
+      "u": "ft"
+    },
+    {
+      "k": "Mud weight",
+      "v": "16.4",
+      "u": "ppg"
+    },
+    {
+      "k": "Cum oil",
+      "v": "21.3",
+      "u": "MMbbl"
+    },
+    {
+      "k": "Uptime",
+      "v": "92.2",
+      "u": "%"
+    }
+  ],
+  "cAxis": {
+    "start": 0,
+    "end": 242,
+    "ticks": [
+      {
+        "v": 0,
+        "t": "0"
+      },
+      {
+        "v": 50,
+        "t": "50"
+      },
+      {
+        "v": 100,
+        "t": "100"
+      },
+      {
+        "v": 150,
+        "t": "150"
+      },
+      {
+        "v": 200,
+        "t": "200"
+      },
+      {
+        "v": 242,
+        "t": "242"
+      }
+    ]
+  },
+  "cGates": [
+    {
+      "x": 0,
+      "lab": "Spud",
+      "dt": "Feb 2020",
+      "kind": ""
+    },
+    {
+      "x": 18,
+      "lab": "TD reached",
+      "dt": "Mar 2020",
+      "kind": ""
+    },
+    {
+      "x": 242,
+      "lab": "Completed",
+      "dt": "Sep 2020",
+      "kind": "now"
+    }
+  ],
+  "cSpans": [
+    {
+      "from": 0,
+      "to": 18,
+      "txt": "Drill · 18 rig-days"
+    },
+    {
+      "from": 18,
+      "to": 242,
+      "txt": "Complete · 224 rig-days"
+    }
+  ],
+  "pAxis": {
+    "start": 2020,
+    "end": 2040,
+    "ticks": [
+      {
+        "v": 2020,
+        "t": "2020"
+      },
+      {
+        "v": 2025,
+        "t": "2025"
+      },
+      {
+        "v": 2030,
+        "t": "2030"
+      },
+      {
+        "v": 2035,
+        "t": "2035"
+      },
+      {
+        "v": 2040,
+        "t": "2040"
+      }
+    ]
+  },
+  "pGates": [
+    {
+      "x": 2020.7083333333333,
+      "lab": "First oil",
+      "dt": "Sep 2020",
+      "kind": "now"
+    },
+    {
+      "x": 2022.2083333333333,
+      "lab": "Workover",
+      "dt": "Mar 2022",
+      "kind": "sec"
+    },
+    {
+      "x": 2026.5,
+      "lab": "Today",
+      "dt": "2026",
+      "kind": "nowmark"
+    }
+  ],
+  "pSpans": [
+    {
+      "from": 2020.7083333333333,
+      "to": 2038,
+      "txt": "Producing · 21.3 MMbbl · 92.2% uptime"
+    }
+  ],
+  "cards": [
+    {
+      "t": "Drill · done",
+      "big": "18 rig-days",
+      "li": [
+        "TD 21,395 ft",
+        "16.4 ppg mud",
+        "spud Feb 2020"
+      ]
+    },
+    {
+      "t": "Complete · done",
+      "big": "224 rig-days",
+      "li": [
+        "first oil Sep 2020",
+        "Wilcox / Lower Tertiary"
+      ]
+    },
+    {
+      "t": "Produce · now",
+      "big": "21.3 MMbbl",
+      "li": [
+        "92.2% uptime",
+        "Big Foot · Extended Tension-Leg Platform (eTLP)"
+      ],
+      "cur": true
+    },
+    {
+      "t": "Workover",
+      "big": "1 event",
+      "li": [
+        "Mar 2022 · Workover"
+      ]
+    },
+    {
+      "t": "Abandon",
+      "big": "—",
+      "li": [
+        "still producing",
+        "no P&A"
+      ]
+    }
+  ]
+};
+const $=id=>document.getElementById(id);
+document.title = WELL.title + " — Well Life-Cycle";
+$("t").textContent = WELL.title;
+$("s").innerHTML = WELL.sub;
+$("st").textContent = WELL.statusLabel;
+$("gen").textContent = WELL.generated + " · original artwork";
+const curIdx=WELL.phases.findIndex(p=>p.k===WELL.current);
+$("m").innerHTML=WELL.metrics.map(m=>`<div class="metric"><div class="k">${m.k}</div><div class="v">${m.v} <small>${m.u}</small></div></div>`).join("");
+$("spine").innerHTML=WELL.phases.map((p,i)=>{
+  let c="future"; if(i<curIdx)c="done"; else if(i===curIdx)c="current";
+  const here=i===curIdx?'<div class="youhere">You are here</div>':"";
+  return `<div class="phase ${c}">${here}<div class="pk">Stage ${i+1}</div><div class="pn">${p.n}</div></div>`;
+}).join("");
+function renderTL(el,axis,gates,spans){
+  const pos=v=>((v-axis.start)/(axis.end-axis.start))*100;
+  let h=`<div class="tl-axis"></div>`;
+  h+=axis.ticks.map(t=>`<div class="tl-tick" style="left:${pos(t.v)}%">${t.t}</div>`).join("");
+  h+=spans.map(s=>{const l=pos(s.from),w=pos(s.to)-pos(s.from);return `<div class="tl-span" style="left:${l}%;width:${w}%"><div class="bar"></div><span class="txt">${s.txt}</span></div>`;}).join("");
+  h+=gates.map(g=>{
+    const cls=g.kind==="sec"?"sec":((g.kind==="now"||g.kind==="nowmark")?"now":"");
+    return `<div class="tl-gate ${cls}" style="left:${pos(g.x)}%"></div><div class="tl-flag" style="left:${pos(g.x)}%"><div class="lab">${g.lab}</div><div class="dt">${g.dt}</div><div class="stem"></div></div>`;
+  }).join("");
+  el.innerHTML=h;
+}
+renderTL($("tlc"),WELL.cAxis,WELL.cGates,WELL.cSpans);
+renderTL($("tlp"),WELL.pAxis,WELL.pGates,WELL.pSpans);
+$("cards").innerHTML=WELL.cards.map(c=>`<div class="card${c.cur?' cur':''}"><h4>${c.t}</h4><div class="big">${c.big}</div><ul>${c.li.map(x=>`<li>${x}</li>`).join("")}</ul></div>`).join("");
+</script>

--- a/reports/lower_tertiary/lifecycle/wells/big_foot_A008_well.html
+++ b/reports/lower_tertiary/lifecycle/wells/big_foot_A008_well.html
@@ -329,7 +329,7 @@ $("spine").innerHTML=WELL.phases.map((p,i)=>{
   return `<div class="phase ${c}">${here}<div class="pk">Stage ${i+1}</div><div class="pn">${p.n}</div></div>`;
 }).join("");
 function renderTL(el,axis,gates,spans){
-  const pos=v=>((v-axis.start)/(axis.end-axis.start))*100;
+  const pos=v=>3+((v-axis.start)/(axis.end-axis.start))*94;  // inset so edge flags aren't clipped
   let h=`<div class="tl-axis"></div>`;
   h+=axis.ticks.map(t=>`<div class="tl-tick" style="left:${pos(t.v)}%">${t.t}</div>`).join("");
   h+=spans.map(s=>{const l=pos(s.from),w=pos(s.to)-pos(s.from);return `<div class="tl-span" style="left:${l}%;width:${w}%"><div class="bar"></div><span class="txt">${s.txt}</span></div>`;}).join("");

--- a/reports/lower_tertiary/lifecycle/wells/big_foot_A008_well.html
+++ b/reports/lower_tertiary/lifecycle/wells/big_foot_A008_well.html
@@ -1,0 +1,345 @@
+<meta charset="utf-8">
+<title>Well Life-Cycle</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root {
+    --bg:#eef2f6; --panel:#fff; --panel-2:#f6f9fc; --ink:#0c1a28; --muted:#5a6b7b; --line:#d6e0ea;
+    --accent:#d9822b; --accent-ink:#7a4410; --done:#1d5fa8; --done-deep:#10365e; --future:#a9bccd;
+    --good:#2e9e6b; --alert:#c0453b; --primary-gate:#1d5fa8;
+    --shadow:0 1px 2px rgba(12,26,40,.06),0 8px 24px rgba(12,26,40,.06);
+    --mono:ui-monospace,"SF Mono","Cascadia Code",Consolas,monospace;
+    --sans:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#0a141f;--panel:#10202f;--panel-2:#0d1b28;--ink:#e8eef4;--muted:#8ca0b3;--line:#24384b;
+    --accent:#f0a24a;--accent-ink:#f7c489;--done:#4d91d6;--done-deep:#2f6ba8;--future:#3a5064;
+    --good:#43b982;--alert:#e0685e;--primary-gate:#5b9de0;--shadow:0 1px 2px rgba(0,0,0,.4),0 10px 30px rgba(0,0,0,.35);}}
+  :root[data-theme="dark"]{--bg:#0a141f;--panel:#10202f;--panel-2:#0d1b28;--ink:#e8eef4;--muted:#8ca0b3;--line:#24384b;
+    --accent:#f0a24a;--accent-ink:#f7c489;--done:#4d91d6;--done-deep:#2f6ba8;--future:#3a5064;--good:#43b982;--alert:#e0685e;--primary-gate:#5b9de0;}
+  :root[data-theme="light"]{--bg:#eef2f6;--panel:#fff;--panel-2:#f6f9fc;--ink:#0c1a28;--muted:#5a6b7b;--line:#d6e0ea;
+    --accent:#d9822b;--accent-ink:#7a4410;--done:#1d5fa8;--done-deep:#10365e;--future:#a9bccd;--good:#2e9e6b;--alert:#c0453b;--primary-gate:#1d5fa8;}
+  *{box-sizing:border-box} body{margin:0}
+  .wrap{background:var(--bg);color:var(--ink);font-family:var(--sans);padding:clamp(16px,3vw,40px);min-height:100%}
+  .sheet{max-width:1180px;margin:0 auto;background:var(--panel);border:1px solid var(--line);border-radius:14px;box-shadow:var(--shadow);overflow:hidden}
+  .head{padding:clamp(18px,2.4vw,30px);border-bottom:1px solid var(--line);display:grid;grid-template-columns:1fr auto;gap:20px;align-items:start}
+  .eyebrow{font-family:var(--mono);font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--muted);margin:0 0 6px}
+  .title{font-size:clamp(26px,4vw,40px);font-weight:800;letter-spacing:-.02em;margin:0;line-height:1.02}
+  .sub{color:var(--muted);margin:8px 0 0;font-size:14.5px;max-width:66ch}
+  .sub a{color:var(--accent-ink)} :root[data-theme="dark"] .sub a,@media(prefers-color-scheme:dark){.sub a{color:var(--accent)}}
+  .status{display:inline-flex;align-items:center;gap:7px;font-family:var(--mono);font-size:12px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;
+    color:var(--good);background:color-mix(in srgb,var(--good) 14%,transparent);border:1px solid color-mix(in srgb,var(--good) 40%,transparent);padding:6px 12px;border-radius:999px;white-space:nowrap}
+  .status .dot{width:8px;height:8px;border-radius:50%;background:var(--good);box-shadow:0 0 0 4px color-mix(in srgb,var(--good) 22%,transparent)}
+  .draft{display:inline-block;font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--alert);
+    border:1px solid color-mix(in srgb,var(--alert) 45%,transparent);padding:3px 8px;border-radius:5px}
+  .metrics{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:1px;background:var(--line);border-top:1px solid var(--line)}
+  .metric{background:var(--panel-2);padding:14px 18px}
+  .metric .k{font-family:var(--mono);font-size:10.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted)}
+  .metric .v{font-family:var(--mono);font-size:20px;font-weight:700;font-variant-numeric:tabular-nums;margin-top:4px}
+  .metric .v small{font-size:12px;color:var(--muted);font-weight:500}
+  .body{padding:clamp(18px,2.4vw,30px);display:grid;gap:30px}
+  .lane-label{font-family:var(--mono);font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:var(--muted);margin:0 0 12px;font-weight:600}
+  .lane-label b{color:var(--accent-ink)} :root[data-theme="dark"] .lane-label b,@media(prefers-color-scheme:dark){.lane-label b{color:var(--accent)}}
+  .scrollx{overflow-x:auto;padding-bottom:4px}
+  .spine{display:flex;min-width:640px;gap:4px}
+  .phase{position:relative;flex:1 1 0;min-width:96px;padding:14px 14px 14px 26px;color:#fff;
+    clip-path:polygon(0 0,calc(100% - 16px) 0,100% 50%,calc(100% - 16px) 100%,0 100%,16px 50%);background:var(--future)}
+  .phase:first-child{padding-left:16px;clip-path:polygon(0 0,calc(100% - 16px) 0,100% 50%,calc(100% - 16px) 100%,0 100%)}
+  .phase.done{background:var(--done)} .phase.done.deep{background:var(--done-deep)}
+  .phase.current{background:var(--accent);color:#1c1206;box-shadow:0 6px 20px color-mix(in srgb,var(--accent) 45%,transparent);z-index:3}
+  .phase.future{background:color-mix(in srgb,var(--future) 55%,var(--panel));color:var(--muted)}
+  .phase .pn{font-weight:800;font-size:15px} .phase .pk{font-family:var(--mono);font-size:9.5px;letter-spacing:.12em;text-transform:uppercase;opacity:.8;margin-bottom:2px}
+  .youhere{position:absolute;top:-30px;left:50%;transform:translateX(-50%);font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--accent-ink);white-space:nowrap}
+  :root[data-theme="dark"] .youhere,@media(prefers-color-scheme:dark){.youhere{color:var(--accent)}}
+  .youhere::after{content:"▼";display:block;text-align:center;margin-top:2px;color:var(--accent)}
+  .tl{position:relative;min-width:640px;height:120px;margin-top:6px}
+  .tl-axis{position:absolute;left:0;right:0;top:82px;height:2px;background:linear-gradient(90deg,var(--future),var(--done) 55%,var(--accent))}
+  .tl-tick{position:absolute;top:90px;transform:translateX(-50%);font-family:var(--mono);font-size:10.5px;color:var(--muted);font-variant-numeric:tabular-nums}
+  .tl-tick::before{content:"";position:absolute;top:-10px;left:50%;width:1px;height:7px;background:var(--line)}
+  .tl-gate{position:absolute;top:82px;transform:translate(-50%,-50%);width:13px;height:13px;border-radius:50%;background:var(--primary-gate);border:2.5px solid var(--panel);box-shadow:0 0 0 1px var(--primary-gate);z-index:2}
+  .tl-gate.sec{background:var(--alert);box-shadow:0 0 0 1px var(--alert)}
+  .tl-gate.now{background:var(--accent);box-shadow:0 0 0 1px var(--accent),0 0 0 6px color-mix(in srgb,var(--accent) 22%,transparent)}
+  .tl-flag{position:absolute;bottom:42px;transform:translateX(-50%);text-align:center;width:120px}
+  .tl-flag .lab{font-size:12px;font-weight:700;line-height:1.15} .tl-flag .dt{font-family:var(--mono);font-size:11px;color:var(--accent-ink);font-variant-numeric:tabular-nums}
+  :root[data-theme="dark"] .tl-flag .dt,@media(prefers-color-scheme:dark){.tl-flag .dt{color:var(--accent)}}
+  .tl-flag .stem{position:absolute;left:50%;bottom:-14px;width:1.5px;height:14px;background:var(--line)}
+  .tl-span{position:absolute;top:68px;height:22px;display:flex;align-items:center;justify-content:center}
+  .tl-span .bar{position:absolute;left:0;right:0;top:9px;height:3px;border-radius:2px;background:color-mix(in srgb,var(--done) 45%,transparent)}
+  .tl-span .txt{position:relative;font-family:var(--mono);font-size:10px;color:var(--muted);background:var(--panel);padding:0 6px;white-space:nowrap}
+  .cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px}
+  .card{background:var(--panel-2);border:1px solid var(--line);border-radius:10px;padding:14px 16px}
+  .card h4{margin:0 0 6px;font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--done)}
+  .card.cur h4{color:var(--accent-ink)} :root[data-theme="dark"] .card.cur h4,@media(prefers-color-scheme:dark){.card.cur h4{color:var(--accent)}}
+  .card .big{font-family:var(--mono);font-size:19px;font-weight:700;font-variant-numeric:tabular-nums}
+  .card ul{margin:6px 0 0;padding-left:15px} .card li{font-size:12.5px;color:var(--muted);margin-bottom:2px}
+  .foot{border-top:1px solid var(--line);padding:16px clamp(18px,2.4vw,30px);display:flex;flex-wrap:wrap;gap:6px 18px;justify-content:space-between;font-size:11px;color:var(--muted);font-family:var(--mono)}
+</style>
+
+<div class="wrap"><div class="sheet">
+  <header class="head">
+    <div>
+      <p class="eyebrow">Well life-cycle · deep-dive</p>
+      <h1 class="title" id="t">—</h1>
+      <p class="sub" id="s">—</p>
+    </div>
+    <div style="display:flex;flex-direction:column;align-items:flex-end;gap:10px">
+      <span class="status"><span class="dot"></span><span id="st">—</span></span>
+      <span class="draft">Draft tracer · #758</span>
+    </div>
+  </header>
+  <div class="metrics" id="m"></div>
+  <div class="body">
+    <section><p class="lane-label">Well stages · <b>you are here</b></p><div class="scrollx"><div class="spine" id="spine"></div></div></section>
+    <section><p class="lane-label">Well construction · rig-day scale</p><div class="scrollx"><div class="tl" id="tlc"></div></div></section>
+    <section><p class="lane-label">Production life · calendar years</p><div class="scrollx"><div class="tl" id="tlp"></div></div></section>
+    <section><p class="lane-label">Stage detail</p><div class="cards" id="cards"></div></section>
+  </div>
+  <footer class="foot">
+    <span>Data: BSEE WAR (spud/complete/workover milestones) + V30 drilling workbook (native rig-days, TD, mud wt) + OGOR-A (first oil, cum, uptime). Draft tracer — refs #758/#754.</span>
+    <span id="gen">original artwork</span>
+  </footer>
+</div></div>
+
+<script>
+const WELL = {
+  "title": "Big Foot · A008",
+  "sub": "API 608124006800 · Walker Ridge 29 · Chevron · Wilcox / Lower Tertiary — nested under the <a href=\"../big_foot_lifecycle.html\">Big Foot field life-cycle</a>",
+  "statusLabel": "Producing",
+  "generated": "Generated 2026-07-04",
+  "phases": [
+    {
+      "k": "spud",
+      "n": "Spud"
+    },
+    {
+      "k": "drill",
+      "n": "Drill"
+    },
+    {
+      "k": "complete",
+      "n": "Complete"
+    },
+    {
+      "k": "produce",
+      "n": "Produce"
+    },
+    {
+      "k": "abandon",
+      "n": "Abandon"
+    }
+  ],
+  "current": "produce",
+  "metrics": [
+    {
+      "k": "Drilling",
+      "v": "118",
+      "u": "rig-days"
+    },
+    {
+      "k": "Completion",
+      "v": "164",
+      "u": "rig-days"
+    },
+    {
+      "k": "Max TVD",
+      "v": "21,801",
+      "u": "ft"
+    },
+    {
+      "k": "Mud weight",
+      "v": "17",
+      "u": "ppg"
+    },
+    {
+      "k": "Cum oil",
+      "v": "4.7",
+      "u": "MMbbl"
+    },
+    {
+      "k": "Uptime",
+      "v": "92.4",
+      "u": "%"
+    }
+  ],
+  "cAxis": {
+    "start": 0,
+    "end": 282,
+    "ticks": [
+      {
+        "v": 0,
+        "t": "0"
+      },
+      {
+        "v": 100,
+        "t": "100"
+      },
+      {
+        "v": 200,
+        "t": "200"
+      },
+      {
+        "v": 282,
+        "t": "282"
+      }
+    ]
+  },
+  "cGates": [
+    {
+      "x": 0,
+      "lab": "Spud",
+      "dt": "Jan 2013",
+      "kind": ""
+    },
+    {
+      "x": 118,
+      "lab": "TD reached",
+      "dt": "Dec 2021",
+      "kind": ""
+    },
+    {
+      "x": 282,
+      "lab": "Completed",
+      "dt": "Jul 2022",
+      "kind": "now"
+    }
+  ],
+  "cSpans": [
+    {
+      "from": 0,
+      "to": 118,
+      "txt": "Drill · 118 rig-days"
+    },
+    {
+      "from": 118,
+      "to": 282,
+      "txt": "Complete · 164 rig-days"
+    }
+  ],
+  "pAxis": {
+    "start": 2020,
+    "end": 2045,
+    "ticks": [
+      {
+        "v": 2020,
+        "t": "2020"
+      },
+      {
+        "v": 2025,
+        "t": "2025"
+      },
+      {
+        "v": 2030,
+        "t": "2030"
+      },
+      {
+        "v": 2035,
+        "t": "2035"
+      },
+      {
+        "v": 2040,
+        "t": "2040"
+      },
+      {
+        "v": 2045,
+        "t": "2045"
+      }
+    ]
+  },
+  "pGates": [
+    {
+      "x": 2022.5416666666667,
+      "lab": "First oil",
+      "dt": "Jul 2022",
+      "kind": "now"
+    },
+    {
+      "x": 2025.7916666666667,
+      "lab": "Workover",
+      "dt": "Oct 2025",
+      "kind": "sec"
+    },
+    {
+      "x": 2026.5,
+      "lab": "Today",
+      "dt": "2026",
+      "kind": "nowmark"
+    }
+  ],
+  "pSpans": [
+    {
+      "from": 2022.5416666666667,
+      "to": 2043,
+      "txt": "Producing · 4.7 MMbbl · 92.4% uptime"
+    }
+  ],
+  "cards": [
+    {
+      "t": "Drill · done",
+      "big": "118 rig-days",
+      "li": [
+        "TD 21,801 ft",
+        "17 ppg mud",
+        "spud Jan 2013"
+      ]
+    },
+    {
+      "t": "Complete · done",
+      "big": "164 rig-days",
+      "li": [
+        "first oil Jul 2022",
+        "Wilcox / Lower Tertiary"
+      ]
+    },
+    {
+      "t": "Produce · now",
+      "big": "4.7 MMbbl",
+      "li": [
+        "92.4% uptime",
+        "Big Foot · Extended Tension-Leg Platform (eTLP)"
+      ],
+      "cur": true
+    },
+    {
+      "t": "Workover",
+      "big": "1 event",
+      "li": [
+        "Oct 2025 · Workover"
+      ]
+    },
+    {
+      "t": "Abandon",
+      "big": "—",
+      "li": [
+        "still producing",
+        "no P&A"
+      ]
+    }
+  ]
+};
+const $=id=>document.getElementById(id);
+document.title = WELL.title + " — Well Life-Cycle";
+$("t").textContent = WELL.title;
+$("s").innerHTML = WELL.sub;
+$("st").textContent = WELL.statusLabel;
+$("gen").textContent = WELL.generated + " · original artwork";
+const curIdx=WELL.phases.findIndex(p=>p.k===WELL.current);
+$("m").innerHTML=WELL.metrics.map(m=>`<div class="metric"><div class="k">${m.k}</div><div class="v">${m.v} <small>${m.u}</small></div></div>`).join("");
+$("spine").innerHTML=WELL.phases.map((p,i)=>{
+  let c="future"; if(i<curIdx)c="done"; else if(i===curIdx)c="current";
+  const here=i===curIdx?'<div class="youhere">You are here</div>':"";
+  return `<div class="phase ${c}">${here}<div class="pk">Stage ${i+1}</div><div class="pn">${p.n}</div></div>`;
+}).join("");
+function renderTL(el,axis,gates,spans){
+  const pos=v=>((v-axis.start)/(axis.end-axis.start))*100;
+  let h=`<div class="tl-axis"></div>`;
+  h+=axis.ticks.map(t=>`<div class="tl-tick" style="left:${pos(t.v)}%">${t.t}</div>`).join("");
+  h+=spans.map(s=>{const l=pos(s.from),w=pos(s.to)-pos(s.from);return `<div class="tl-span" style="left:${l}%;width:${w}%"><div class="bar"></div><span class="txt">${s.txt}</span></div>`;}).join("");
+  h+=gates.map(g=>{
+    const cls=g.kind==="sec"?"sec":((g.kind==="now"||g.kind==="nowmark")?"now":"");
+    return `<div class="tl-gate ${cls}" style="left:${pos(g.x)}%"></div><div class="tl-flag" style="left:${pos(g.x)}%"><div class="lab">${g.lab}</div><div class="dt">${g.dt}</div><div class="stem"></div></div>`;
+  }).join("");
+  el.innerHTML=h;
+}
+renderTL($("tlc"),WELL.cAxis,WELL.cGates,WELL.cSpans);
+renderTL($("tlp"),WELL.pAxis,WELL.pGates,WELL.pSpans);
+$("cards").innerHTML=WELL.cards.map(c=>`<div class="card${c.cur?' cur':''}"><h4>${c.t}</h4><div class="big">${c.big}</div><ul>${c.li.map(x=>`<li>${x}</li>`).join("")}</ul></div>`).join("");
+</script>

--- a/reports/lower_tertiary/lifecycle/wells/index.html
+++ b/reports/lower_tertiary/lifecycle/wells/index.html
@@ -1,0 +1,21 @@
+<meta charset="utf-8">
+<title>Well Life-Cycle Timelines</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  body{margin:0;font-family:system-ui,-apple-system,"Segoe UI",sans-serif;background:#eef2f6;color:#0c1a28}
+  @media (prefers-color-scheme:dark){body{background:#0a141f;color:#e8eef4}}
+  .w{max-width:640px;margin:0 auto;padding:40px 24px} h1{font-size:26px;letter-spacing:-.02em;margin:0 0 4px}
+  p.sub{color:#5a6b7b;margin:0 0 24px} ul{list-style:none;padding:0;margin:0;display:grid;gap:8px}
+  li{display:grid;grid-template-columns:1fr auto;gap:16px;align-items:center;background:#fff;border:1px solid #d6e0ea;border-radius:10px;padding:14px 18px}
+  @media (prefers-color-scheme:dark){li{background:#10202f;border-color:#24384b}}
+  a{font-weight:700;text-decoration:none;color:inherit;font-size:16px} li span{font-family:ui-monospace,monospace;font-size:12px;color:#5a6b7b}
+</style>
+<div class="w"><h1>Well life-cycle timelines</h1>
+<p class="sub">Per-well granular deep-dives · draft tracers for #758 · sorted by cumulative oil</p>
+<ul>
+      <li><a href="big_foot_A004_well.html">Big Foot · A004</a><span>32.2 MMbbl</span></li>
+      <li><a href="big_foot_A006_well.html">Big Foot · A006</a><span>21.3 MMbbl</span></li>
+      <li><a href="big_foot_A001_well.html">Big Foot · A001</a><span>14.9 MMbbl</span></li>
+      <li><a href="big_foot_A008_well.html">Big Foot · A008</a><span>4.7 MMbbl</span></li>
+      <li><a href="big_foot_A002_well.html">Big Foot · A002</a><span>1.5 MMbbl</span></li>
+</ul></div>

--- a/reports/lower_tertiary/lifecycle/wells/well_lifecycle_template.html
+++ b/reports/lower_tertiary/lifecycle/wells/well_lifecycle_template.html
@@ -115,7 +115,7 @@ $("spine").innerHTML=WELL.phases.map((p,i)=>{
   return `<div class="phase ${c}">${here}<div class="pk">Stage ${i+1}</div><div class="pn">${p.n}</div></div>`;
 }).join("");
 function renderTL(el,axis,gates,spans){
-  const pos=v=>((v-axis.start)/(axis.end-axis.start))*100;
+  const pos=v=>3+((v-axis.start)/(axis.end-axis.start))*94;  // inset so edge flags aren't clipped
   let h=`<div class="tl-axis"></div>`;
   h+=axis.ticks.map(t=>`<div class="tl-tick" style="left:${pos(t.v)}%">${t.t}</div>`).join("");
   h+=spans.map(s=>{const l=pos(s.from),w=pos(s.to)-pos(s.from);return `<div class="tl-span" style="left:${l}%;width:${w}%"><div class="bar"></div><span class="txt">${s.txt}</span></div>`;}).join("");

--- a/reports/lower_tertiary/lifecycle/wells/well_lifecycle_template.html
+++ b/reports/lower_tertiary/lifecycle/wells/well_lifecycle_template.html
@@ -1,0 +1,131 @@
+<meta charset="utf-8">
+<title>Well Life-Cycle</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root {
+    --bg:#eef2f6; --panel:#fff; --panel-2:#f6f9fc; --ink:#0c1a28; --muted:#5a6b7b; --line:#d6e0ea;
+    --accent:#d9822b; --accent-ink:#7a4410; --done:#1d5fa8; --done-deep:#10365e; --future:#a9bccd;
+    --good:#2e9e6b; --alert:#c0453b; --primary-gate:#1d5fa8;
+    --shadow:0 1px 2px rgba(12,26,40,.06),0 8px 24px rgba(12,26,40,.06);
+    --mono:ui-monospace,"SF Mono","Cascadia Code",Consolas,monospace;
+    --sans:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#0a141f;--panel:#10202f;--panel-2:#0d1b28;--ink:#e8eef4;--muted:#8ca0b3;--line:#24384b;
+    --accent:#f0a24a;--accent-ink:#f7c489;--done:#4d91d6;--done-deep:#2f6ba8;--future:#3a5064;
+    --good:#43b982;--alert:#e0685e;--primary-gate:#5b9de0;--shadow:0 1px 2px rgba(0,0,0,.4),0 10px 30px rgba(0,0,0,.35);}}
+  :root[data-theme="dark"]{--bg:#0a141f;--panel:#10202f;--panel-2:#0d1b28;--ink:#e8eef4;--muted:#8ca0b3;--line:#24384b;
+    --accent:#f0a24a;--accent-ink:#f7c489;--done:#4d91d6;--done-deep:#2f6ba8;--future:#3a5064;--good:#43b982;--alert:#e0685e;--primary-gate:#5b9de0;}
+  :root[data-theme="light"]{--bg:#eef2f6;--panel:#fff;--panel-2:#f6f9fc;--ink:#0c1a28;--muted:#5a6b7b;--line:#d6e0ea;
+    --accent:#d9822b;--accent-ink:#7a4410;--done:#1d5fa8;--done-deep:#10365e;--future:#a9bccd;--good:#2e9e6b;--alert:#c0453b;--primary-gate:#1d5fa8;}
+  *{box-sizing:border-box} body{margin:0}
+  .wrap{background:var(--bg);color:var(--ink);font-family:var(--sans);padding:clamp(16px,3vw,40px);min-height:100%}
+  .sheet{max-width:1180px;margin:0 auto;background:var(--panel);border:1px solid var(--line);border-radius:14px;box-shadow:var(--shadow);overflow:hidden}
+  .head{padding:clamp(18px,2.4vw,30px);border-bottom:1px solid var(--line);display:grid;grid-template-columns:1fr auto;gap:20px;align-items:start}
+  .eyebrow{font-family:var(--mono);font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--muted);margin:0 0 6px}
+  .title{font-size:clamp(26px,4vw,40px);font-weight:800;letter-spacing:-.02em;margin:0;line-height:1.02}
+  .sub{color:var(--muted);margin:8px 0 0;font-size:14.5px;max-width:66ch}
+  .sub a{color:var(--accent-ink)} :root[data-theme="dark"] .sub a,@media(prefers-color-scheme:dark){.sub a{color:var(--accent)}}
+  .status{display:inline-flex;align-items:center;gap:7px;font-family:var(--mono);font-size:12px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;
+    color:var(--good);background:color-mix(in srgb,var(--good) 14%,transparent);border:1px solid color-mix(in srgb,var(--good) 40%,transparent);padding:6px 12px;border-radius:999px;white-space:nowrap}
+  .status .dot{width:8px;height:8px;border-radius:50%;background:var(--good);box-shadow:0 0 0 4px color-mix(in srgb,var(--good) 22%,transparent)}
+  .draft{display:inline-block;font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--alert);
+    border:1px solid color-mix(in srgb,var(--alert) 45%,transparent);padding:3px 8px;border-radius:5px}
+  .metrics{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:1px;background:var(--line);border-top:1px solid var(--line)}
+  .metric{background:var(--panel-2);padding:14px 18px}
+  .metric .k{font-family:var(--mono);font-size:10.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted)}
+  .metric .v{font-family:var(--mono);font-size:20px;font-weight:700;font-variant-numeric:tabular-nums;margin-top:4px}
+  .metric .v small{font-size:12px;color:var(--muted);font-weight:500}
+  .body{padding:clamp(18px,2.4vw,30px);display:grid;gap:30px}
+  .lane-label{font-family:var(--mono);font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:var(--muted);margin:0 0 12px;font-weight:600}
+  .lane-label b{color:var(--accent-ink)} :root[data-theme="dark"] .lane-label b,@media(prefers-color-scheme:dark){.lane-label b{color:var(--accent)}}
+  .scrollx{overflow-x:auto;padding-bottom:4px}
+  .spine{display:flex;min-width:640px;gap:4px}
+  .phase{position:relative;flex:1 1 0;min-width:96px;padding:14px 14px 14px 26px;color:#fff;
+    clip-path:polygon(0 0,calc(100% - 16px) 0,100% 50%,calc(100% - 16px) 100%,0 100%,16px 50%);background:var(--future)}
+  .phase:first-child{padding-left:16px;clip-path:polygon(0 0,calc(100% - 16px) 0,100% 50%,calc(100% - 16px) 100%,0 100%)}
+  .phase.done{background:var(--done)} .phase.done.deep{background:var(--done-deep)}
+  .phase.current{background:var(--accent);color:#1c1206;box-shadow:0 6px 20px color-mix(in srgb,var(--accent) 45%,transparent);z-index:3}
+  .phase.future{background:color-mix(in srgb,var(--future) 55%,var(--panel));color:var(--muted)}
+  .phase .pn{font-weight:800;font-size:15px} .phase .pk{font-family:var(--mono);font-size:9.5px;letter-spacing:.12em;text-transform:uppercase;opacity:.8;margin-bottom:2px}
+  .youhere{position:absolute;top:-30px;left:50%;transform:translateX(-50%);font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--accent-ink);white-space:nowrap}
+  :root[data-theme="dark"] .youhere,@media(prefers-color-scheme:dark){.youhere{color:var(--accent)}}
+  .youhere::after{content:"▼";display:block;text-align:center;margin-top:2px;color:var(--accent)}
+  .tl{position:relative;min-width:640px;height:120px;margin-top:6px}
+  .tl-axis{position:absolute;left:0;right:0;top:82px;height:2px;background:linear-gradient(90deg,var(--future),var(--done) 55%,var(--accent))}
+  .tl-tick{position:absolute;top:90px;transform:translateX(-50%);font-family:var(--mono);font-size:10.5px;color:var(--muted);font-variant-numeric:tabular-nums}
+  .tl-tick::before{content:"";position:absolute;top:-10px;left:50%;width:1px;height:7px;background:var(--line)}
+  .tl-gate{position:absolute;top:82px;transform:translate(-50%,-50%);width:13px;height:13px;border-radius:50%;background:var(--primary-gate);border:2.5px solid var(--panel);box-shadow:0 0 0 1px var(--primary-gate);z-index:2}
+  .tl-gate.sec{background:var(--alert);box-shadow:0 0 0 1px var(--alert)}
+  .tl-gate.now{background:var(--accent);box-shadow:0 0 0 1px var(--accent),0 0 0 6px color-mix(in srgb,var(--accent) 22%,transparent)}
+  .tl-flag{position:absolute;bottom:42px;transform:translateX(-50%);text-align:center;width:120px}
+  .tl-flag .lab{font-size:12px;font-weight:700;line-height:1.15} .tl-flag .dt{font-family:var(--mono);font-size:11px;color:var(--accent-ink);font-variant-numeric:tabular-nums}
+  :root[data-theme="dark"] .tl-flag .dt,@media(prefers-color-scheme:dark){.tl-flag .dt{color:var(--accent)}}
+  .tl-flag .stem{position:absolute;left:50%;bottom:-14px;width:1.5px;height:14px;background:var(--line)}
+  .tl-span{position:absolute;top:68px;height:22px;display:flex;align-items:center;justify-content:center}
+  .tl-span .bar{position:absolute;left:0;right:0;top:9px;height:3px;border-radius:2px;background:color-mix(in srgb,var(--done) 45%,transparent)}
+  .tl-span .txt{position:relative;font-family:var(--mono);font-size:10px;color:var(--muted);background:var(--panel);padding:0 6px;white-space:nowrap}
+  .cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px}
+  .card{background:var(--panel-2);border:1px solid var(--line);border-radius:10px;padding:14px 16px}
+  .card h4{margin:0 0 6px;font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--done)}
+  .card.cur h4{color:var(--accent-ink)} :root[data-theme="dark"] .card.cur h4,@media(prefers-color-scheme:dark){.card.cur h4{color:var(--accent)}}
+  .card .big{font-family:var(--mono);font-size:19px;font-weight:700;font-variant-numeric:tabular-nums}
+  .card ul{margin:6px 0 0;padding-left:15px} .card li{font-size:12.5px;color:var(--muted);margin-bottom:2px}
+  .foot{border-top:1px solid var(--line);padding:16px clamp(18px,2.4vw,30px);display:flex;flex-wrap:wrap;gap:6px 18px;justify-content:space-between;font-size:11px;color:var(--muted);font-family:var(--mono)}
+</style>
+
+<div class="wrap"><div class="sheet">
+  <header class="head">
+    <div>
+      <p class="eyebrow">Well life-cycle · deep-dive</p>
+      <h1 class="title" id="t">—</h1>
+      <p class="sub" id="s">—</p>
+    </div>
+    <div style="display:flex;flex-direction:column;align-items:flex-end;gap:10px">
+      <span class="status"><span class="dot"></span><span id="st">—</span></span>
+      <span class="draft">Draft tracer · #758</span>
+    </div>
+  </header>
+  <div class="metrics" id="m"></div>
+  <div class="body">
+    <section><p class="lane-label">Well stages · <b>you are here</b></p><div class="scrollx"><div class="spine" id="spine"></div></div></section>
+    <section><p class="lane-label">Well construction · rig-day scale</p><div class="scrollx"><div class="tl" id="tlc"></div></div></section>
+    <section><p class="lane-label">Production life · calendar years</p><div class="scrollx"><div class="tl" id="tlp"></div></div></section>
+    <section><p class="lane-label">Stage detail</p><div class="cards" id="cards"></div></section>
+  </div>
+  <footer class="foot">
+    <span>Data: BSEE WAR (spud/complete/workover milestones) + V30 drilling workbook (native rig-days, TD, mud wt) + OGOR-A (first oil, cum, uptime). Draft tracer — refs #758/#754.</span>
+    <span id="gen">original artwork</span>
+  </footer>
+</div></div>
+
+<script>
+const WELL = __WELL_JSON__;
+const $=id=>document.getElementById(id);
+document.title = WELL.title + " — Well Life-Cycle";
+$("t").textContent = WELL.title;
+$("s").innerHTML = WELL.sub;
+$("st").textContent = WELL.statusLabel;
+$("gen").textContent = WELL.generated + " · original artwork";
+const curIdx=WELL.phases.findIndex(p=>p.k===WELL.current);
+$("m").innerHTML=WELL.metrics.map(m=>`<div class="metric"><div class="k">${m.k}</div><div class="v">${m.v} <small>${m.u}</small></div></div>`).join("");
+$("spine").innerHTML=WELL.phases.map((p,i)=>{
+  let c="future"; if(i<curIdx)c="done"; else if(i===curIdx)c="current";
+  const here=i===curIdx?'<div class="youhere">You are here</div>':"";
+  return `<div class="phase ${c}">${here}<div class="pk">Stage ${i+1}</div><div class="pn">${p.n}</div></div>`;
+}).join("");
+function renderTL(el,axis,gates,spans){
+  const pos=v=>((v-axis.start)/(axis.end-axis.start))*100;
+  let h=`<div class="tl-axis"></div>`;
+  h+=axis.ticks.map(t=>`<div class="tl-tick" style="left:${pos(t.v)}%">${t.t}</div>`).join("");
+  h+=spans.map(s=>{const l=pos(s.from),w=pos(s.to)-pos(s.from);return `<div class="tl-span" style="left:${l}%;width:${w}%"><div class="bar"></div><span class="txt">${s.txt}</span></div>`;}).join("");
+  h+=gates.map(g=>{
+    const cls=g.kind==="sec"?"sec":((g.kind==="now"||g.kind==="nowmark")?"now":"");
+    return `<div class="tl-gate ${cls}" style="left:${pos(g.x)}%"></div><div class="tl-flag" style="left:${pos(g.x)}%"><div class="lab">${g.lab}</div><div class="dt">${g.dt}</div><div class="stem"></div></div>`;
+  }).join("");
+  el.innerHTML=h;
+}
+renderTL($("tlc"),WELL.cAxis,WELL.cGates,WELL.cSpans);
+renderTL($("tlp"),WELL.pAxis,WELL.pGates,WELL.pSpans);
+$("cards").innerHTML=WELL.cards.map(c=>`<div class="card${c.cur?' cur':''}"><h4>${c.t}</h4><div class="big">${c.big}</div><ul>${c.li.map(x=>`<li>${x}</li>`).join("")}</ul></div>`).join("");
+</script>

--- a/scripts/build_pages.py
+++ b/scripts/build_pages.py
@@ -328,6 +328,14 @@ def build_lower_tertiary(available_viz: dict[str, bool]) -> list[tuple]:
         for html in sorted(lifecycle_src.glob("*_lifecycle.html")):
             shutil.copy2(html, lifecycle_dst / html.name)
         shutil.copy2(lifecycle_src / "index.html", lifecycle_dst / "index.html")
+        # Per-well granular timelines (the fractal well-level deep-dive) nest under wells/.
+        wells_src = lifecycle_src / "wells"
+        if (wells_src / "index.html").exists():
+            wells_dst = lifecycle_dst / "wells"
+            wells_dst.mkdir(parents=True, exist_ok=True)
+            for html in sorted(wells_src.glob("*_well.html")):
+                shutil.copy2(html, wells_dst / html.name)
+            shutil.copy2(wells_src / "index.html", wells_dst / "index.html")
 
     # --- Economics pages (sanctioned V30), one per Lower-Tertiary field ---
     field_names = {

--- a/scripts/lower_tertiary/build_lifecycle_posters.py
+++ b/scripts/lower_tertiary/build_lifecycle_posters.py
@@ -240,8 +240,16 @@ def facts_to_field(f: dict) -> dict:
     if f.get("basin"):
         region = f"{region} · {f['basin']}" if region else f["basin"]
 
+    # Drill-down to well-level timelines, if any were generated for this field.
+    wells_dir = HERE / "wells"
+    well_files = (
+        sorted(wells_dir.glob(f"{f['id']}_*_well.html")) if wells_dir.exists() else []
+    )
+
     return {
         "id": f["id"],
+        "wellsHref": "wells/" if well_files else None,
+        "wellsCount": len(well_files),
         "name": f["name"],
         "operator": f.get("operator", ""),
         "region": region,

--- a/scripts/lower_tertiary/build_well_timelines.py
+++ b/scripts/lower_tertiary/build_well_timelines.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""ABOUTME: Generate per-well GRANULAR life-cycle timelines (the fractal well-level deep-dive).
+ABOUTME: Reads _wells.json facts and stamps them into one shared well template (epic #754, issue #758).
+
+Design mirrors the field life-cycle generator: a small per-well *facts* record →
+a render-shaped ``WELL`` object stamped into ``well_lifecycle_template.html``
+(``__WELL_JSON__`` placeholder). The geometry is computed in code:
+
+  - Well construction band uses a **rig-day scale** (Drill days → Complete days),
+    NOT calendar, because a well can be spudded years before it reaches TD
+    (e.g. Big Foot A008: spud 2013, TD 2021, but only 118 rig-days).
+  - Production life band uses a **calendar-year scale** from first oil, with
+    workover markers and a "today" marker.
+
+Usage
+-----
+    python scripts/lower_tertiary/build_well_timelines.py
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parents[2] / "reports/lower_tertiary/lifecycle/wells"
+TEMPLATE = HERE / "well_lifecycle_template.html"
+FACTS = HERE / "_wells.json"
+GENERATED = "Generated 2026-07-04"
+TODAY_YEAR = 2026.5
+
+MONTHS = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+]
+
+
+def _year(v):
+    """'YYYY-MM-DD' or 'YYYY-MM' → decimal year (mid-month)."""
+    if v is None:
+        return None
+    p = str(v).split("-")
+    y = int(p[0])
+    m = int(p[1]) if len(p) > 1 else 6
+    return y + (m - 0.5) / 12.0
+
+
+def _pretty(v):
+    if v is None:
+        return "—"
+    p = str(v).split("-")
+    if len(p) >= 2:
+        return f"{MONTHS[int(p[1]) - 1]} {p[0]}"
+    return p[0]
+
+
+def facts_to_well(w: dict, field: dict) -> dict:
+    drill = w.get("drilling_rig_days") or 0
+    compl = w.get("completion_rig_days") or 0
+    total = drill + compl
+    fo = _year(w["first_oil"])
+
+    # --- construction band: rig-day scale ---
+    end_c = total if total else 1
+    step = 50 if end_c <= 250 else 100
+    ticks_c = [{"v": t, "t": str(t)} for t in range(0, end_c + 1, step)]
+    if ticks_c[-1]["v"] != end_c:
+        ticks_c.append({"v": end_c, "t": str(end_c)})
+    c_gates = [{"x": 0, "lab": "Spud", "dt": _pretty(w["spud_date"]), "kind": ""}]
+    if drill:
+        c_gates.append(
+            {
+                "x": drill,
+                "lab": "TD reached",
+                "dt": _pretty(w.get("td_date")),
+                "kind": "",
+            }
+        )
+    c_gates.append(
+        {"x": end_c, "lab": "Completed", "dt": _pretty(w["first_oil"]), "kind": "now"}
+    )
+    c_spans = []
+    if drill:
+        c_spans.append({"from": 0, "to": drill, "txt": f"Drill · {drill:g} rig-days"})
+    if compl:
+        c_spans.append(
+            {"from": drill, "to": total, "txt": f"Complete · {compl:g} rig-days"}
+        )
+
+    # --- production band: calendar years ---
+    start_p = int(fo)
+    end_p = start_p + 20
+    end_p += (5 - end_p % 5) % 5
+    start_p -= start_p % 5 if start_p % 5 <= 2 else 0
+    ticks_p = [
+        {"v": t, "t": str(t)} for t in range(((start_p + 4) // 5) * 5, end_p + 1, 5)
+    ]
+    p_gates = [
+        {"x": fo, "lab": "First oil", "dt": _pretty(w["first_oil"]), "kind": "now"}
+    ]
+    for wo in w.get("workovers", []):
+        p_gates.append(
+            {
+                "x": _year(wo["date"]),
+                "lab": wo["type"],
+                "dt": _pretty(wo["date"]),
+                "kind": "sec",
+            }
+        )
+    if fo < TODAY_YEAR < end_p:
+        p_gates.append(
+            {"x": TODAY_YEAR, "lab": "Today", "dt": "2026", "kind": "nowmark"}
+        )
+    cum = w.get("cum_oil_mmbbl")
+    up = w.get("uptime_pct")
+    prod_txt = "Producing"
+    if cum is not None:
+        prod_txt += f" · {cum:g} MMbbl"
+    if up is not None:
+        prod_txt += f" · {up:g}% uptime"
+    p_spans = [{"from": fo, "to": end_p - 2, "txt": prod_txt}]
+
+    metrics = [
+        {"k": "Drilling", "v": f"{drill:g}", "u": "rig-days"},
+        {"k": "Completion", "v": f"{compl:g}", "u": "rig-days"},
+    ]
+    if w.get("max_tvd_ft") is not None:
+        metrics.append({"k": "Max TVD", "v": f"{w['max_tvd_ft']:,}", "u": "ft"})
+    if w.get("mud_weight_ppg") is not None:
+        metrics.append({"k": "Mud weight", "v": f"{w['mud_weight_ppg']:g}", "u": "ppg"})
+    if cum is not None:
+        metrics.append({"k": "Cum oil", "v": f"{cum:g}", "u": "MMbbl"})
+    if up is not None:
+        metrics.append({"k": "Uptime", "v": f"{up:g}", "u": "%"})
+
+    wo_n = len(w.get("workovers", []))
+    cards = [
+        {
+            "t": "Drill · done",
+            "big": f"{drill:g} rig-days",
+            "li": [
+                f"TD {w.get('max_tvd_ft', 0):,} ft",
+                f"{w.get('mud_weight_ppg', '—')} ppg mud",
+                f"spud {_pretty(w['spud_date'])}",
+            ],
+        },
+        {
+            "t": "Complete · done",
+            "big": f"{compl:g} rig-days",
+            "li": [f"first oil {_pretty(w['first_oil'])}", field.get("play", "")],
+        },
+        {
+            "t": "Produce · now",
+            "big": (f"{cum:g} MMbbl" if cum is not None else "producing"),
+            "li": ([f"{up:g}% uptime"] if up is not None else [])
+            + [f"{field['display_name']} · {field.get('host', '')}"],
+            "cur": True,
+        },
+        {
+            "t": "Workover",
+            "big": (f"{wo_n} event" + ("s" if wo_n != 1 else "")),
+            "li": [
+                f"{_pretty(wo['date'])} · {wo['type']}" for wo in w.get("workovers", [])
+            ]
+            or ["none to date"],
+        },
+        {"t": "Abandon", "big": "—", "li": ["still producing", "no P&A"]},
+    ]
+
+    fid = w["field_id"]
+    return {
+        "title": f"{field['display_name']} · {w['slot']}",
+        "sub": (
+            f"API {w['api']} · {field.get('block', '')} · {field.get('operator', '')} · "
+            f"{field.get('play', '')} — nested under the "
+            f"<a href=\"../{fid}_lifecycle.html\">{field['display_name']} field life-cycle</a>"
+        ),
+        "statusLabel": "Producing",
+        "generated": GENERATED,
+        "phases": [
+            {"k": "spud", "n": "Spud"},
+            {"k": "drill", "n": "Drill"},
+            {"k": "complete", "n": "Complete"},
+            {"k": "produce", "n": "Produce"},
+            {"k": "abandon", "n": "Abandon"},
+        ],
+        "current": "produce",
+        "metrics": metrics,
+        "cAxis": {"start": 0, "end": end_c, "ticks": ticks_c},
+        "cGates": c_gates,
+        "cSpans": c_spans,
+        "pAxis": {"start": int(fo) - (int(fo) % 5), "end": end_p, "ticks": ticks_p},
+        "pGates": p_gates,
+        "pSpans": p_spans,
+        "cards": cards,
+    }
+
+
+def render(well: dict) -> str:
+    return TEMPLATE.read_text().replace(
+        "__WELL_JSON__", json.dumps(well, indent=2, ensure_ascii=False)
+    )
+
+
+def build_index(rows: list[dict]) -> str:
+    items = "\n".join(
+        f'      <li><a href="{r["file"]}">{r["title"]}</a><span>{r["cum"]}</span></li>'
+        for r in sorted(rows, key=lambda r: -r["cum_val"])
+    )
+    return f"""<meta charset="utf-8">
+<title>Well Life-Cycle Timelines</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  body{{margin:0;font-family:system-ui,-apple-system,"Segoe UI",sans-serif;background:#eef2f6;color:#0c1a28}}
+  @media (prefers-color-scheme:dark){{body{{background:#0a141f;color:#e8eef4}}}}
+  .w{{max-width:640px;margin:0 auto;padding:40px 24px}} h1{{font-size:26px;letter-spacing:-.02em;margin:0 0 4px}}
+  p.sub{{color:#5a6b7b;margin:0 0 24px}} ul{{list-style:none;padding:0;margin:0;display:grid;gap:8px}}
+  li{{display:grid;grid-template-columns:1fr auto;gap:16px;align-items:center;background:#fff;border:1px solid #d6e0ea;border-radius:10px;padding:14px 18px}}
+  @media (prefers-color-scheme:dark){{li{{background:#10202f;border-color:#24384b}}}}
+  a{{font-weight:700;text-decoration:none;color:inherit;font-size:16px}} li span{{font-family:ui-monospace,monospace;font-size:12px;color:#5a6b7b}}
+</style>
+<div class="w"><h1>Well life-cycle timelines</h1>
+<p class="sub">Per-well granular deep-dives · draft tracers for #758 · sorted by cumulative oil</p>
+<ul>
+{items}
+</ul></div>
+"""
+
+
+def main():
+    data = json.loads(FACTS.read_text())
+    fields = data["fields"]
+    rows = []
+    for w in data["wells"]:
+        field = fields[w["field_id"]]
+        well = facts_to_well(w, field)
+        fname = f"{w['field_id']}_{w['slot']}_well.html"
+        (HERE / fname).write_text(render(well))
+        cum = w.get("cum_oil_mmbbl") or 0
+        rows.append(
+            {
+                "file": fname,
+                "title": well["title"],
+                "cum": f"{cum:g} MMbbl",
+                "cum_val": cum,
+            }
+        )
+        print(
+            f"  wrote {fname}  (drill {w.get('drilling_rig_days')}/compl {w.get('completion_rig_days')} rig-days)"
+        )
+    (HERE / "index.html").write_text(build_index(rows))
+    print(f"  wrote index.html  ({len(rows)} wells)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Well-level granular timelines + canonical field crosswalk

Advances epic #754 with two data-driven, verified pieces (built off `origin/main`).

### 1. Canonical field crosswalk — `config/fields.yml` (#755, the linchpin)
Resolves each field by ONE canonical id (== the lifecycle `_facts.json` id) → BSEE block/lease, FDP portfolio slug, region, play, and which per-field surfaces actually exist (lifecycle poster / economics page / FDP page). Stays honest: only Big Foot carries a lease number in the source data; the 7 FDP portfolio pages that map to **no** canonical field (Miocene/other-play tiebacks) are listed under `unmapped_fdp_pages`.

### 2. Well-level granular timelines (#758, the new fractal component)
The well-level deep-dive that nests under each field poster. Reuses the life-cycle grammar with well phases **Spud → Drill → Complete → Produce → Abandon** and a **dual-scale timeline**:
- **Well construction — rig-day scale.** Drill/Complete as native V30 rig-day bars, deliberately *decoupled from calendar* because a well can be spudded years before it reaches TD (Big Foot A008: spud 2013, TD 2021, but only 118 rig-days).
- **Production life — calendar-year scale.** First oil, workover markers, and a "today" marker.

Data-driven like the field generator: `build_well_timelines.py` turns `_wells.json` facts into the render object; **axis/gate/span geometry is computed in code**. Ships 5 Big Foot wells (A004, A006, A001, A008, A002) sourced from native V30 rig-days (`drilling_and_completion_days.xlsx`) + WAR milestones (`ops_timeline.py`) + OGOR-A. Published under `/lifecycle/wells/` (+ a wells index), each linking up to its parent field poster.

### Files
- `config/fields.yml` — crosswalk registry
- `reports/lower_tertiary/lifecycle/wells/` — `well_lifecycle_template.html`, `_wells.json`, 5 well timelines, `index.html`
- `scripts/lower_tertiary/build_well_timelines.py` — generator
- `scripts/build_pages.py` — publish `wells/` under `public/lifecycle/wells/`

### Verification
- `build_pages.py --domains lower_tertiary` publishes the wells ✓
- `tests/test_build_pages.py` **8/8 pass** ✓ · new generator black + isort clean ✓
- Rendered A001 (391 total rig-days, first oil 2018 after the field delay) confirms the rig-day/calendar split holds.

Draft-tracer dates pending #747 YAML reconciliation. Refs #754, #758, #755.
