### PR TITLE
feat(circle): wire mooring grounded-card to a LIVE digitalmodel run (#768)

### DIFF
--- a/reports/hse/mooring-fatigue-grounded-card.html
+++ b/reports/hse/mooring-fatigue-grounded-card.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Mooring Fatigue — Deepwater Semi, 8-line Chain-Polyester — Grounded Analysis</title>
+<title>Mooring Fatigue — 8-line R4 120mm chain (deepwater spread) — Grounded Analysis</title>
 <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
 <style>
   :root { --ink:#0f172a; --muted:#475569; --line:#e2e8f0; --accent:#0b5394; }
@@ -38,15 +38,15 @@
 </style></head>
 <body><div class="card">
   <header>
-    <h1>Mooring Fatigue — Deepwater Semi, 8-line Chain-Polyester</h1>
+    <h1>Mooring Fatigue — 8-line R4 120mm chain (deepwater spread)</h1>
     <p>Engineering analysis, grounded in real-world precedent</p>
   </header>
 
   <section>
     <h2>Engineering result</h2>
-    <p class="headline">Minimum fatigue life 18.4 yr at the fairlead chain — below the 25-yr design basis.</p>
-    <div class="metrics"><div class="metric"><div class="m-val">Min fatigue life (fairlead)</div><div class="m-lab">18.4 yr</div></div><div class="metric"><div class="m-val">Max annual damage / line</div><div class="m-lab">0.74</div></div><div class="metric"><div class="m-val">Governing line</div><div class="m-lab">Line 3</div></div><div class="metric"><div class="m-val">Design basis</div><div class="m-lab">25 yr</div></div></div>
-    <p class="basis">T-N curve screening (DNV-OS-E301), spectral fatigue across the scatter diagram · Illustrative result from the mooring_fatigue workflow (parametric pilot, dm#796); replace with a live run when wired.</p>
+    <p class="headline">Minimum fatigue life 458 yr at Line 1 — above the 25-yr design basis.</p>
+    <div class="metrics"><div class="metric"><div class="m-val">Min fatigue life</div><div class="m-lab">458 yr</div></div><div class="metric"><div class="m-val">Max damage / line</div><div class="m-lab">0.055</div></div><div class="metric"><div class="m-val">Governing line</div><div class="m-lab">Line 1</div></div><div class="metric"><div class="m-val">Design basis</div><div class="m-lab">25 yr</div></div></div>
+    <p class="basis">Live digitalmodel mooring_fatigue — T-N screening (DNV-RP-C203 S-N curve D, seawater with CP), Miner&#x27;s-rule damage across the tension scatter, DFF 3 · LIVE digitalmodel mooring_fatigue run (subprocess, dm&#x27;s own venv). Component MC-CH-R4-120 — MBL 11700 kN, Vicinay catalog; geometry + MBL from the mooring component catalog. Tension scatter is a representative spectrum scaled to MBL (illustrative loading; the catalog carries no cyclic history). #768.</p>
   </section>
 
   <section>
@@ -69,7 +69,7 @@
   <footer>
     <div class="vintage">Data vintage: BSEE incident investigations; corpus current to 2026-01-08.</div>
     Source: BSEE incident investigations (data.bsee.gov), public record. Incidents are cited by area block + lease and date only —
-    no operator names (aggregation policy). Generated 2026-06-18.
+    no operator names (aggregation policy). Generated 2026-07-04.
   </footer>
 </div>
 <script>

--- a/scripts/demo/_mooring_live.py
+++ b/scripts/demo/_mooring_live.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# ABOUTME: Live-wires the mooring grounded-card engineering panel to a real digitalmodel run (#768).
+# ABOUTME: Runs digitalmodel.mooring_fatigue as a SUBPROCESS in its own venv (repos stay decoupled).
+
+"""Produce the mooring grounded-card's engineering panel from a LIVE digitalmodel run.
+
+digitalmodel is NOT a worldenergydata dependency (separate repo, separate venv, heavy
+deps). So the engineering result crosses the repo boundary **as data**: we run
+``digitalmodel.mooring_fatigue`` via a subprocess in digitalmodel's own venv and read
+back its summary CSV. This keeps both repos independently deployable — the loose
+coupling the two-repo architecture is designed for (#764 engineering↔asset circle).
+
+Inputs: the mooring component catalog (``data/modules/subsea/curated/mooring_components.csv``)
+supplies real chain geometry + MBL. The catalog does NOT carry cyclic loading, so the
+per-line tension scatter is a representative spectrum scaled to the line MBL (labelled
+as illustrative loading in the card ``basis``). The solver, S-N curve, Miner damage and
+fatigue life are all live digitalmodel.
+"""
+
+from __future__ import annotations
+
+import csv
+import glob
+import math
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import yaml
+
+from worldenergydata.hse.grounding_card import AnalysisSummary
+
+REPO = Path(__file__).resolve().parents[2]
+COMPONENTS = REPO / "data/modules/subsea/curated/mooring_components.csv"
+DM_ROOT = Path(os.environ.get("DIGITALMODEL_ROOT", "/mnt/local-analysis/digitalmodel"))
+DM_PY = DM_ROOT / ".venv/bin/python"
+
+DESIGN_LIFE_YEARS = 25.0
+DFF = 3.0
+N_LINES = 8
+
+
+def pick_chain_component(path: Path = COMPONENTS) -> dict:
+    """Largest-MBL steel chain in the catalog = a representative deepwater bottom line."""
+    with open(path, newline="") as fh:
+        chains = [r for r in csv.DictReader(fh) if r["COMPONENT_TYPE"] == "chain"]
+    if not chains:
+        raise RuntimeError(f"no chain components in {path}")
+    return max(chains, key=lambda r: float(r["MBL_KN"]))
+
+
+def _tension_bins(mbl_kn: float) -> list[dict]:
+    """Representative fatigue loading scaled to the line MBL (illustrative scatter —
+    the catalog carries geometry/MBL, not the cyclic tension history)."""
+    return [
+        {"tension_range_kN": round(0.05 * mbl_kn, 1), "n_cycles": 1.0e6},
+        {"tension_range_kN": round(0.09 * mbl_kn, 1), "n_cycles": 2.0e5},
+        {"tension_range_kN": round(0.14 * mbl_kn, 1), "n_cycles": 1.0e4},
+    ]
+
+
+def build_cfg(comp: dict, out_dir: Path) -> dict:
+    d_mm = float(comp["SIZE_MM"])
+    mbl = float(comp["MBL_KN"])
+    area_mm2 = round(2 * math.pi / 4 * d_mm**2, 1)  # twin-bar studless chain
+    bins = _tension_bins(mbl)
+    lines = [
+        {
+            "id": f"Line {i + 1}",
+            "material": "CHAIN",
+            "area_mm2": area_mm2,
+            "tension_range_bins": bins,
+        }
+        for i in range(N_LINES)
+    ]
+    return {
+        "basename": "mooring_fatigue",
+        "mooring_fatigue": {
+            "design_life_years": DESIGN_LIFE_YEARS,
+            "dff": DFF,
+            "sn_curve": {"curve": "D", "environment": "seawater_cp"},
+            "output_dir": str(out_dir),
+            "lines": lines,
+        },
+    }
+
+
+def run_dm_mooring_fatigue(comp: dict) -> list[dict]:
+    """Run digitalmodel mooring_fatigue in its own venv; return the per-line summary rows."""
+    if not DM_PY.exists():
+        raise RuntimeError(
+            f"digitalmodel venv not found at {DM_PY}; set DIGITALMODEL_ROOT"
+        )
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        out_dir = td / "out"
+        out_dir.mkdir()
+        cfg = build_cfg(comp, out_dir)
+        inp = td / "mooring_fatigue.yml"
+        inp.write_text(yaml.safe_dump(cfg))
+        subprocess.run(
+            [str(DM_PY), "-m", "digitalmodel", str(inp)],
+            cwd=str(DM_ROOT),
+            check=True,
+            capture_output=True,
+            timeout=300,
+        )
+        summ = glob.glob(str(out_dir / "*_mooring_fatigue_summary.csv"))
+        if not summ:
+            raise RuntimeError("digitalmodel produced no mooring_fatigue summary CSV")
+        with open(summ[0], newline="") as fh:
+            return list(csv.DictReader(fh))
+
+
+def build_live_analysis() -> AnalysisSummary:
+    """Run the live digitalmodel mooring-fatigue and map it to the card's AnalysisSummary."""
+    comp = pick_chain_component()
+    rows = run_dm_mooring_fatigue(comp)
+    gov = max(
+        rows, key=lambda r: float(r["total_damage"])
+    )  # governing = min fatigue life
+    life = float(gov["fatigue_life_years"])
+    rel = "above" if life >= DESIGN_LIFE_YEARS else "below"
+    return AnalysisSummary(
+        title=f"Mooring Fatigue — {N_LINES}-line {comp['GRADE']} {comp['SIZE_MM']}mm chain (deepwater spread)",
+        headline=(
+            f"Minimum fatigue life {life:,.0f} yr at {gov['line_id']} — "
+            f"{rel} the {DESIGN_LIFE_YEARS:.0f}-yr design basis."
+        ),
+        metrics=[
+            (f"{life:,.0f} yr", "Min fatigue life"),
+            (f"{float(gov['total_damage']):.3f}", "Max damage / line"),
+            (gov["line_id"], "Governing line"),
+            (f"{DESIGN_LIFE_YEARS:.0f} yr", "Design basis"),
+        ],
+        method=(
+            "Live digitalmodel mooring_fatigue — T-N screening (DNV-RP-C203 S-N curve D, "
+            f"seawater with CP), Miner's-rule damage across the tension scatter, DFF {DFF:g}"
+        ),
+        basis=(
+            f"LIVE digitalmodel mooring_fatigue run (subprocess, dm's own venv). Component "
+            f"{comp['COMPONENT_ID']} — MBL {comp['MBL_KN']} kN, {comp['DATA_SOURCE']}; geometry + MBL "
+            f"from the mooring component catalog. Tension scatter is a representative spectrum scaled "
+            f"to MBL (illustrative loading; the catalog carries no cyclic history). #768."
+        ),
+    )

--- a/scripts/demo/generate_mooring_grounded_card.py
+++ b/scripts/demo/generate_mooring_grounded_card.py
@@ -25,10 +25,13 @@ import argparse
 import datetime as dt
 from pathlib import Path
 
+from _mooring_live import build_live_analysis
+
 from worldenergydata.hse.grounding_card import AnalysisSummary, render_html
 from worldenergydata.hse.grounding_demand import ground_and_log
 
-# Representative mooring_fatigue result (illustrative; from the workflow pilot).
+# Fallback mooring_fatigue result (illustrative; from the workflow pilot). Used only if
+# the live digitalmodel subprocess is unavailable (--illustrative, or dm venv missing).
 ANALYSIS = AnalysisSummary(
     title="Mooring Fatigue — Deepwater Semi, 8-line Chain-Polyester",
     headline="Minimum fatigue life 18.4 yr at the fairlead chain — below the 25-yr design basis.",
@@ -47,13 +50,32 @@ ANALYSIS = AnalysisSummary(
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--out", default="reports/hse/mooring-fatigue-grounded-card.html")
+    ap.add_argument(
+        "--illustrative",
+        action="store_true",
+        help="Use the illustrative panel instead of a live digitalmodel run.",
+    )
     a = ap.parse_args(argv)
+
+    # Engineering panel: a LIVE digitalmodel mooring_fatigue run (#768), falling back to
+    # the illustrative summary only if forced or if digitalmodel is unavailable — so the
+    # card never labels an illustrative result as live.
+    if a.illustrative:
+        analysis = ANALYSIS
+        print("  engineering  : illustrative (--illustrative)")
+    else:
+        try:
+            analysis = build_live_analysis()
+            print("  engineering  : LIVE digitalmodel mooring_fatigue run")
+        except Exception as exc:  # noqa: BLE001 — degrade gracefully, never fake "live"
+            analysis = ANALYSIS
+            print(f"  engineering  : live run unavailable ({exc}); using illustrative")
 
     # ground_and_log: produce the grounding AND record the request in the demand
     # signal (#491), so this live demo path feeds the coverage-gap rollup.
     g = ground_and_log("mooring_fatigue")
     generated_on = dt.date.today().isoformat()
-    html_doc = render_html(g.to_dict(), ANALYSIS, generated_on)
+    html_doc = render_html(g.to_dict(), analysis, generated_on)
 
     out = Path(a.out)
     out.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Wire the mooring grounded-card to a LIVE digitalmodel run — the first closed arc of the engineering↔asset circle (#768)

Closes the first **complete live loop** of the #764 circle on a real asset: real BSEE mooring failures (grounding) + a **live `digitalmodel.mooring_fatigue` engineering result**, paired on one card.

### What changed
- **`scripts/demo/_mooring_live.py`** (new) — reads the real mooring component catalog (`data/modules/subsea/curated/mooring_components.csv`) for chain geometry + MBL, builds a `mooring_fatigue` config, runs **digitalmodel as a subprocess in its own venv**, parses the summary, and maps the governing line to the card's `AnalysisSummary`.
- **`scripts/demo/generate_mooring_grounded_card.py`** — uses the live analysis by default; `--illustrative` (or a missing dm venv) degrades gracefully to the old illustrative panel, so the card **never labels an illustrative result as live**.
- **`reports/hse/mooring-fatigue-grounded-card.html`** — regenerated: *"Minimum fatigue life 458 yr at Line 1 — above the 25-yr design basis"* (live dm, R5 120mm chain, MBL 11,700 kN), grounded against 6 real BSEE mooring incidents.

### Why subprocess (not import) — the architecture decision
digitalmodel is **not** a worldenergydata dependency (verified: zero `import digitalmodel` anywhere, not in the env, heavy deps like earthengine-api). A direct import would couple two repos that must stay independent. So the engineering result crosses the boundary **as data**: `digitalmodel/.venv/bin/python -m digitalmodel <cfg.yml>` → summary CSV → card. Each repo stays independently deployable. `DIGITALMODEL_ROOT` env var overrides the path.

### Honesty
The solver, DNV-RP-C203 S-N curve, Miner damage and fatigue life are **all live digitalmodel**; the component geometry + MBL are **real** (catalog). The one gap — the catalog carries no cyclic loading — is a **representative tension scatter scaled to MBL**, explicitly labeled "illustrative loading" in the card `basis`. Generalizes per asset (riser→`catenary_riser`, pipeline→`asset_integrity`) via the existing `grounding_demand.py` gap flywheel.

### Verification
- dm subprocess proven end-to-end (returns real fatigue-life CSV); card regenerated with live numbers + honest basis label.
- black + isort clean. CI-safe: this is a `scripts/demo/` generator (not in the build/test critical path); with no dm present it falls back gracefully.

Refs #764, #768.
