### PR TITLE
feat(colorado_ecmc): add Form 5A FacilityDetail ingest

### DIFF
--- a/.planning/plan-approved/751.md
+++ b/.planning/plan-approved/751.md
@@ -1,0 +1,7 @@
+Approved by: user
+Approved at: 2026-07-04
+Issue: https://github.com/vamseeachanta/worldenergydata/issues/751
+Plan: docs/plans/2026-07-04-issue-751-colorado-ecmc-form5a-ingest.md
+Reviewed commit: 47d83e514040e32479356fd02a81679fa28c87f2
+
+Approval source: chat message "approved. continue"

--- a/config/colorado_ecmc_facility_detail_ingest.yml
+++ b/config/colorado_ecmc_facility_detail_ingest.yml
@@ -1,0 +1,30 @@
+# Colorado ECMC FacilityDetail/Form 5A direct-source ingest (#751).
+# Heavy raw/parsed/curated outputs stay under /mnt/ace.
+module: colorado_ecmc_facility_detail_ingest
+
+storage:
+  base_dir: /mnt/ace/worldenergydata/data/modules/colorado_ecmc/facility_detail_ingest
+
+source_list:
+  path: /mnt/ace/worldenergydata/data/modules/colorado_ecmc/raw/wells/WELLS_SHP.ZIP
+  source_type: wells_shapefile
+  refresh: daily
+
+facility_detail:
+  base_url: https://ecmc.state.co.us/cogisdb/Facility/FacilityDetail.aspx
+  refresh: live_cogis_polite
+  timeout_seconds: 60
+  request_delay_seconds: 0.5
+  user_agent: worldenergydata/0.1 (+https://github.com/vamseeachanta/worldenergydata; research ingest)
+  max_retries: 1
+  stop_on_identity_mismatch: true
+
+pressure_observations:
+  atmospheric_psi: 14.7
+
+dry_run_source_list_only: false
+max_requests: 5
+allow_full_source_list: false
+max_failures: 2
+max_parser_drift_fraction: 0.2
+configure_underpressured_screen: false

--- a/docs/data-sources/onshore/state-well-databases/colorado-ecmc-pressure-source-discovery.md
+++ b/docs/data-sources/onshore/state-well-databases/colorado-ecmc-pressure-source-discovery.md
@@ -9,21 +9,23 @@ Survey and live-scout date: 2026-07-04.
 
 ## Decision
 
-The official ECMC FacilityDetail endpoint is a viable candidate for a
-production-grade Form 5A / Initial Test Data pressure ingest, but it is not yet
-a screen-ready Colorado pressure source.
+The official ECMC FacilityDetail endpoint is a viable source for a
+production-grade Form 5A / Initial Test Data pressure ingest, but it remains a
+candidate-only Colorado pressure source for the underpressured screen.
 
 The approved [#749](https://github.com/vamseeachanta/worldenergydata/issues/749)
 scout proved that the public FacilityDetail HTML contains structured initial
 test rows with `CASING_PRESS` and `TUBING_PRESS`. It intentionally used a
 single configured API sample and did not attempt statewide iteration. A
-production ingest now needs a separate reviewed plan under
-[#751](https://github.com/vamseeachanta/worldenergydata/issues/751) covering
-source-list construction, throttling, retry/resume, coverage accounting, parser
-drift checks, and pressure interpretation.
+production ingest lane under
+[#751](https://github.com/vamseeachanta/worldenergydata/issues/751) now covers
+source-list construction, throttling, retry/resume, coverage accounting,
+multi-block parsing, identity checks, and candidate-only pressure
+interpretation.
 
-Colorado therefore remains excluded from underpressured-screen participation
-gates until that follow-up ingest is approved, implemented, and reviewed.
+Colorado Form 5A rows therefore remain excluded from underpressured-screen
+participation gates until a later reviewed rule maps a pressure kind to
+`WHP_shut_in`.
 
 ## Official Source Matrix
 
@@ -93,17 +95,68 @@ The discovery parser classifies pressure-like values before any screen use:
 
 | Lane | Classification | Screen use |
 |---|---|---|
-| FacilityDetail Initial Test Data `CASING_PRESS` | Candidate pressure observation | Not eligible until [#751](https://github.com/vamseeachanta/worldenergydata/issues/751) approves ingest + interpretation |
-| FacilityDetail Initial Test Data `TUBING_PRESS` | Candidate pressure observation | Not eligible until [#751](https://github.com/vamseeachanta/worldenergydata/issues/751) approves ingest + interpretation |
+| FacilityDetail Initial Test Data `CASING_PRESS` | Candidate pressure observation | Candidate-only in [#751](https://github.com/vamseeachanta/worldenergydata/issues/751); not screen-promotable until a later shut-in interpretation rule |
+| FacilityDetail Initial Test Data `TUBING_PRESS` | Candidate pressure observation | Candidate-only in [#751](https://github.com/vamseeachanta/worldenergydata/issues/751); flowing-pressure evidence is not screen-promotable |
 | FacilityDetail treatment pressure | Excluded engineering pressure | Never screen evidence without a later explicit contract change |
 | MIT/Form 21 pressures | Excluded integrity pressure | Never screen evidence without a later explicit contract change |
 | Form 17/bradenhead pressures | Excluded annulus/compliance pressure | Never screen evidence without a later explicit contract change |
 | Form 7 production pressure columns | Implemented spine source | Empty in [#745](https://github.com/vamseeachanta/worldenergydata/issues/745) 2025+monthly live slice |
 
+## Production Ingest Lane (#751)
+
+The production lane is configured by:
+
+```text
+config/colorado_ecmc_facility_detail_ingest.yml
+```
+
+The default configuration is capped (`max_requests: 5`) and writes heavy
+outputs under:
+
+```text
+/mnt/ace/worldenergydata/data/modules/colorado_ecmc/facility_detail_ingest/
+  source_lists/
+  raw/facility_detail/html/
+  raw/facility_detail/status/
+  parsed/
+  curated/pressure/
+  reports/
+```
+
+Refresh cadence:
+
+- WELLS source list spine: daily official GIS ZIP.
+- FacilityDetail/Form 5A pages: live COGIS pages; use a polite, capped,
+  resumable crawl, not a blind daily statewide refresh.
+- Form 7 production pressure columns: monthly/annual bulk lane from
+  [#745](https://github.com/vamseeachanta/worldenergydata/issues/745), not the
+  Form 5A source of record.
+
+The curated Form 5A table preserves reported psig and converted psia, selected
+reference depth, raw HTML lineage, and `era=completion_initial_test`.
+`TUBING_PRESS` is tagged `flowing_tubing_initial_test`; `CASING_PRESS` is
+tagged `initial_test_casing_pressure_unverified`. Both are candidate-only and
+not screen-promotable in [#751](https://github.com/vamseeachanta/worldenergydata/issues/751).
+
+Default capped run evidence from 2026-07-04:
+
+| Metric | Value |
+|---|---:|
+| Source WELLS rows | 124,332 |
+| FacilityDetail request rows | 5 |
+| Fetched pages | 5 |
+| Parsed initial-test rows | 49 |
+| Usable candidate pressure rows | 11 |
+| Screen-promotable rows | 0 |
+| Promotion status | `candidate_only` |
+
+Runtime note: local Miniforge `python3` environments may lack parquet support.
+Use `/usr/bin/python3` or the repo CI environment for commands that write
+parquet outputs.
+
 ## Follow-Up Requirements
 
-[#751](https://github.com/vamseeachanta/worldenergydata/issues/751) should plan
-the production ingest before any statewide run. Required controls:
+Any future statewide run or screen activation should keep these controls:
 
 - use an approved source list from the wells/facilities spine;
 - carry a hard throttle and retry/backoff policy;

--- a/docs/data-sources/onshore/state-well-databases/source-catalog.md
+++ b/docs/data-sources/onshore/state-well-databases/source-catalog.md
@@ -151,7 +151,7 @@ No initial/shut-in BHP, shut-in wellhead pressure, or deliverability-test values
 | Daily Activity Dashboard full export | 9 activity datasets (pending/approved permits Form 2/2A, spuds, completions activity, etc.) | https://ecmc.state.co.us/documents/data/downloads/Dashboard/DAD_Export.zip (26 MB) | Zip of tables | Daily (verified last-mod 2026-07-02) | Free | VERIFIED |
 | Well analytical (chemistry) data | Gas/produced-water analytical sample data (useful for gas composition, not pressure) | https://ecmc.state.co.us/documents/data/downloads/environmental/ProdWellDownLoad.zip | .mdb in zip | Labeled "Updated Monthly" but last-mod 2024-03-01 (stale) | Free | VERIFIED (staleness noted) |
 | Spacing orders | Section/twp/range, cause/order number, well density, unit size, formation code | CauseOrderTabl_Download.zip via spacing-download page | Access .mdb | Post-hearings | Free | Landing page verified; zip path UNVERIFIED |
-| Formation tops / initial completion tests | Tops (with logged/cored/DST flags), casing/cement, completed-interval and **Initial Test Data** — per-well COGIS scout pages only, not bulk | https://ecmc.state.co.us/cogisdb/Facility/FacilityDetail.aspx?api={CCSSSSS} (verified rendering tops + initial test block) | HTML (structured, scrapeable) | Live DB | Free | VERIFIED + SCOUTED ([#749](https://github.com/vamseeachanta/worldenergydata/issues/749)); production ingest deferred to [#751](https://github.com/vamseeachanta/worldenergydata/issues/751) |
+| Formation tops / initial completion tests | Tops (with logged/cored/DST flags), casing/cement, completed-interval and **Initial Test Data** — per-well COGIS scout pages only, not bulk | https://ecmc.state.co.us/cogisdb/Facility/FacilityDetail.aspx?api={CCSSSSS} (verified rendering tops + initial test block) | HTML (structured, scrapeable) | Live DB; use capped polite refresh | Free | VERIFIED + SCOUTED ([#749](https://github.com/vamseeachanta/worldenergydata/issues/749)); candidate-only production ingest added in [#751](https://github.com/vamseeachanta/worldenergydata/issues/751) |
 
 Master index: https://ecmc.colorado.gov/data-maps-reports/downloadable-data-documents (403 to non-browser user agents). Download guide: https://ecmc.state.co.us/documents/data/downloads/ECMC_Download_Guidance_v2_ada.pdf.
 
@@ -176,16 +176,51 @@ candidate pressure observations: `CASING_PRESS=1700` and `TUBING_PRESS=1300`
 for the NIOBRARA (`NBRR`) interval. The sample output lives under
 `/mnt/ace/worldenergydata/data/modules/colorado_ecmc/source_discovery/`.
 
-There is still **no bulk download of the Form 5A test or tops tables**; a
-statewide automated ingest now requires the separate [#751](https://github.com/vamseeachanta/worldenergydata/issues/751)
-plan for source-list construction, throttling, retry/resume, coverage
-accounting, and parser drift checks. Bradenhead (Form 17) annulus-pressure
+There is still **no bulk download of the Form 5A test or tops tables**. The
+[#751](https://github.com/vamseeachanta/worldenergydata/issues/751) production
+lane derives a capped source list from the official WELLS GIS ZIP, fetches live
+FacilityDetail pages with identity checks and status sidecars, parses every
+Initial Test Data block, and emits candidate-only pressure observations under
+`/mnt/ace/worldenergydata/data/modules/colorado_ecmc/facility_detail_ingest/`.
+Bradenhead (Form 17) annulus-pressure
 tests exist as imaged forms only. MIT (Form 21) test data is a genuine
 structured monthly bulk download, but it is engineering integrity pressure, not
 reservoir/wellhead production pressure.
 
 ### Ingestion effort estimate
-**Low** for wells master, production CSVs, MIT, and DAD exports: static HTTPS files with stable URL patterns, no auth — gotchas: ecmc.colorado.gov landing pages 403 without a browser User-Agent, annual summary files are Access .mdb (need mdbtools/UCanAccess), 2023 production file has a nonstandard name (`2023_prod_reports_20240903.csv`). Initial-test/tops data is **medium-high**: FacilityDetail is structured enough for a direct-source parser, but a production run must be throttled, resumable, and coverage-audited before any statewide crawl.
+**Low** for wells master, production CSVs, MIT, and DAD exports: static HTTPS files with stable URL patterns, no auth — gotchas: ecmc.colorado.gov landing pages 403 without a browser User-Agent, annual summary files are Access .mdb (need mdbtools/UCanAccess), 2023 production file has a nonstandard name (`2023_prod_reports_20240903.csv`). Initial-test/tops data is **medium-high**: FacilityDetail is structured enough for a direct-source parser, but production runs must stay throttled, resumable, identity-checked, and coverage-audited before any statewide crawl.
+
+### Implemented [#751](https://github.com/vamseeachanta/worldenergydata/issues/751) Form 5A candidate-ingest lane
+
+The Form 5A lane is configured by:
+
+```text
+config/colorado_ecmc_facility_detail_ingest.yml
+```
+
+Default heavy-output layout:
+
+```text
+/mnt/ace/worldenergydata/data/modules/colorado_ecmc/facility_detail_ingest/
+  source_lists/facility_detail_source_list.parquet
+  raw/facility_detail/status/{fetched,failed,skipped}.jsonl
+  raw/facility_detail/html/{api_fragment}.html
+  parsed/facility_detail_initial_tests.parquet
+  curated/pressure/well_pressure_observations.parquet
+  curated/pressure/colorado_ecmc_form5a_pressure_observation_quality.json
+  reports/colorado_ecmc_form5a_ingest_summary.json
+```
+
+Refresh cadence: WELLS source-list spine is daily; FacilityDetail is live COGIS
+HTML and should be refreshed with explicit caps/throttle rather than a blind
+daily statewide crawl. Curated `CASING_PRESS` and `TUBING_PRESS` rows remain
+candidate-only (`candidate_only` promotion status) and do not enter
+`config/underpressured_screen.yml`.
+
+Default capped run on 2026-07-04 used the official WELLS ZIP
+(124,332 rows), fetched 5 FacilityDetail pages, parsed 49 Initial Test Data
+rows, and produced 11 usable candidate pressure observations with 0
+screen-promotable rows.
 
 ### Implemented [#749](https://github.com/vamseeachanta/worldenergydata/issues/749) source-discovery snapshot
 

--- a/docs/plans/2026-07-04-issue-751-colorado-ecmc-form5a-ingest.md
+++ b/docs/plans/2026-07-04-issue-751-colorado-ecmc-form5a-ingest.md
@@ -1,7 +1,7 @@
 # Plan: Issue #751 - Colorado ECMC Form 5A initial-test pressure ingest
 
 **Issue:** https://github.com/vamseeachanta/worldenergydata/issues/751
-**Status:** plan-review
+**Status:** plan-approved
 **Tier:** T3 (production-grade direct-source HTML ingest, resumable `/mnt/ace` writes, pressure-screen contract risk)
 **Client:** N/A
 **Project:** worldenergydata onshore pressure screen
@@ -28,7 +28,7 @@ Planning-time probes on 2026-07-04 show:
 |---|---|---|
 | [#745](https://github.com/vamseeachanta/worldenergydata/issues/745) | closed, `status:done` | Colorado bulk Form 7 production + WELLS GIS spine |
 | [#749](https://github.com/vamseeachanta/worldenergydata/issues/749) | closed, `status:done` | FacilityDetail/Form 5A source-discovery scout |
-| [#751](https://github.com/vamseeachanta/worldenergydata/issues/751) | open, `status:needs-plan` | This production-grade FacilityDetail/Form 5A ingest |
+| [#751](https://github.com/vamseeachanta/worldenergydata/issues/751) | open, `status:plan-approved` | This production-grade FacilityDetail/Form 5A ingest |
 | [#708](https://github.com/vamseeachanta/worldenergydata/issues/708) | open parent epic | Multi-state underpressured-screen lifecycle |
 
 [#751](https://github.com/vamseeachanta/worldenergydata/issues/751) will build

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -87,7 +87,7 @@ This directory contains issue-plan artifacts created during the issue-planning-m
 | [#740](https://github.com/vamseeachanta/worldenergydata/issues/740) | [oklahoma-occ-pressure-observations](2026-07-03-issue-740-oklahoma-occ-pressure-observations.md) | implemented | 2026-07-03 |
 | [#745](https://github.com/vamseeachanta/worldenergydata/issues/745) | [colorado-ecmc-wellhead-pressure-observations](2026-07-03-issue-745-colorado-ecmc-wellhead-pressure-observations.md) | implemented | 2026-07-03 |
 | [#749](https://github.com/vamseeachanta/worldenergydata/issues/749) | [colorado-ecmc-pressure-source-discovery](2026-07-04-issue-749-colorado-ecmc-pressure-source-discovery.md) | implemented | 2026-07-04 |
-| [#751](https://github.com/vamseeachanta/worldenergydata/issues/751) | [colorado-ecmc-form5a-ingest](2026-07-04-issue-751-colorado-ecmc-form5a-ingest.md) | plan-review | 2026-07-04 |
+| [#751](https://github.com/vamseeachanta/worldenergydata/issues/751) | [colorado-ecmc-form5a-ingest](2026-07-04-issue-751-colorado-ecmc-form5a-ingest.md) | plan-approved | 2026-07-04 |
 
 ## Closed / superseded plans
 

--- a/scripts/review/results/2026-07-04-code-751-codex-inline.md
+++ b/scripts/review/results/2026-07-04-code-751-codex-inline.md
@@ -1,0 +1,51 @@
+# Code Review: Issue #751 Colorado ECMC Form 5A Ingest
+
+Issue: https://github.com/vamseeachanta/worldenergydata/issues/751
+Reviewer: Codex inline
+Date: 2026-07-04
+Scope: implementation branch `feature/colorado-ecmc-form5a-ingest-751`
+
+## Verdict
+
+APPROVE after inline fix.
+
+## Review Notes
+
+Multi-agent dispatch was not used because the available subagent tool requires
+explicit user authorization for subagents/delegation. This review was performed
+inline against the code diff, tests, tracked config, docs, and live `/mnt/ace`
+run evidence.
+
+## Findings
+
+### Important - Default Config Was Capped But Not Runnable
+
+The first implementation of `build_facility_detail_source_list` raised whenever
+the full raw WELLS source-list length exceeded `max_requests` unless
+`allow_full_source_list` was true. That made the tracked conservative config
+(`max_requests: 5`, `allow_full_source_list: false`) unable to run any capped
+live fetch.
+
+Resolution:
+
+- Changed the guard to block only full-population runs unless
+  `allow_full_source_list` is true.
+- Updated tests to assert capped runs are allowed and full-list runs fail
+  closed.
+- Verified the tracked config now runs as a 5-page live direct-source crawl.
+
+## Verification
+
+- Focused suite: `59 passed`
+- Ruff check: pass
+- Ruff format check: pass
+- `git diff --check`: pass
+- `scripts/legal/legal-sanity-scan.sh`: pass
+- Live direct-source run with tracked config:
+  - WELLS rows: 124,332
+  - FacilityDetail request rows: 5
+  - fetched pages: 5
+  - parsed Initial Test Data rows: 49
+  - usable candidate pressure rows: 11
+  - screen-promotable rows: 0
+  - promotion: `candidate_only`

--- a/src/worldenergydata/analysis/underpressured_screen/screen.py
+++ b/src/worldenergydata/analysis/underpressured_screen/screen.py
@@ -40,8 +40,8 @@ def load_config(config_path: str | Path) -> dict:
 def estimate_bhp(observations: pd.DataFrame, settings: dict) -> pd.DataFrame:
     """Add ``bhp_psia_est`` and ``bhp_gradient_psi_ft``.
 
-    Wellhead readings get the average-temperature-and-z static gas-column
-    correction; measured BHP values pass through unchanged.
+    Shut-in wellhead readings get the average-temperature-and-z static gas-column
+    correction; measured BHP and non-shut-in WHP values pass through unchanged.
     """
     frame = observations.copy()
     exponent = (
@@ -51,11 +51,13 @@ def estimate_bhp(observations: pd.DataFrame, settings: dict) -> pd.DataFrame:
         / (settings["z_avg"] * settings["t_avg_rankine"])
     )
     multiplier = np.exp(exponent)
-    is_whp = frame["pressure_kind"].fillna("").astype(str).str.startswith("WHP_")
+    is_shut_in_whp = frame["pressure_kind"].fillna("").astype(str).eq("WHP_shut_in")
     frame["bhp_psia_est"] = frame["pressure_psia"].where(
-        ~is_whp, frame["pressure_psia"] * multiplier
+        ~is_shut_in_whp, frame["pressure_psia"] * multiplier
     )
-    frame["bhp_method"] = np.where(is_whp, "static_gas_column_avg_zt", "as_reported")
+    frame["bhp_method"] = np.where(
+        is_shut_in_whp, "static_gas_column_avg_zt", "as_reported"
+    )
     has_depth = frame["reference_depth_ft"] > 0
     frame["bhp_gradient_psi_ft"] = np.where(
         has_depth, frame["bhp_psia_est"] / frame["reference_depth_ft"], np.nan

--- a/src/worldenergydata/modules/state_regulators/colorado_ecmc/facility_detail.py
+++ b/src/worldenergydata/modules/state_regulators/colorado_ecmc/facility_detail.py
@@ -20,23 +20,25 @@ def parse_facility_detail_html(
     soup = BeautifulSoup(html, "html.parser")
     page_text = _normalize_space(soup.get_text(" ", strip=True))
     context = _page_context(page_text)
-    initial_table = _find_initial_test_table(soup)
-    if initial_table is None:
+    initial_tables = _find_initial_test_tables(soup)
+    if not initial_tables:
         return pd.DataFrame(columns=_columns())
 
-    fields = {**context, **_initial_test_fields(initial_table)}
     rows = []
-    for test_type, measure in _initial_test_measures(initial_table):
-        rows.append(
-            {
-                **fields,
-                "source_url": source_url,
-                "source_section": "initial_test_data",
-                "test_type": test_type,
-                "measure_value": _number(measure),
-                "measure_raw": measure,
-            }
-        )
+    for initial_table in initial_tables:
+        block_context = _present_values(_initial_test_block_context(initial_table))
+        fields = {**context, **block_context, **_initial_test_fields(initial_table)}
+        for test_type, measure in _initial_test_measures(initial_table):
+            rows.append(
+                {
+                    **fields,
+                    "source_url": source_url,
+                    "source_section": "initial_test_data",
+                    "test_type": test_type,
+                    "measure_value": _number(measure),
+                    "measure_raw": measure,
+                }
+            )
     return pd.DataFrame(rows, columns=_columns())
 
 
@@ -103,11 +105,40 @@ def _page_context(page_text: str) -> dict:
     }
 
 
-def _find_initial_test_table(soup: BeautifulSoup):
-    marker = soup.find(string=lambda text: text and "Initial Test Data" in text)
-    if marker is None:
-        return None
-    return marker.find_parent("table")
+def _find_initial_test_tables(soup: BeautifulSoup) -> list:
+    tables = []
+    seen = set()
+    markers = soup.find_all(string=lambda text: text and "Initial Test Data" in text)
+    for marker in markers:
+        table = marker.find_parent("table")
+        if table is not None and id(table) not in seen:
+            tables.append(table)
+            seen.add(id(table))
+    return tables
+
+
+def _initial_test_block_context(table) -> dict:
+    container = table.find_parent("div", class_="accordion2") or table
+    block_text = _normalize_space(container.get_text(" ", strip=True))
+    return {
+        "formation_code": _first_group(
+            r"Formation\s+([A-Z0-9]+)\s+Formation Classification", block_text
+        ),
+        "formation": _first_group(
+            r"Completed Information for Formation\s+([A-Z0-9 ]+?)"
+            r"(?:\s+1st Production Date|\s+Formation Name|$)",
+            block_text,
+        ),
+        "interval_top_ft": _number(
+            _first_group(r"Interval Top:\s*([\d,]+)\s*ft", block_text)
+        ),
+        "interval_bottom_ft": _number(
+            _first_group(r"Interval Bottom:\s*([\d,]+)\s*ft", block_text)
+        ),
+        "first_production_date": _date(
+            _first_group(r"1st Production Date:\s*([0-9/]+)", block_text)
+        ),
+    }
 
 
 def _initial_test_fields(table) -> dict:
@@ -183,6 +214,10 @@ def _clean_field(value):
     if pd.isna(value):
         return pd.NA
     return str(value).split("-", 1)[0].strip()
+
+
+def _present_values(values: dict) -> dict:
+    return {key: value for key, value in values.items() if not pd.isna(value)}
 
 
 def _number(value):

--- a/src/worldenergydata/modules/state_regulators/colorado_ecmc/facility_detail_candidates.py
+++ b/src/worldenergydata/modules/state_regulators/colorado_ecmc/facility_detail_candidates.py
@@ -1,0 +1,190 @@
+"""Candidate Form 5A pressure observations for Colorado ECMC (#751)."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+CANDIDATE_PRESSURE_KINDS = {
+    "CASING_PRESS": "initial_test_casing_pressure_unverified",
+    "TUBING_PRESS": "flowing_tubing_initial_test",
+}
+DEPTH_PRIORITY = (
+    "interval_bottom_ft",
+    "vertical_td_ft",
+    "max_tvd_ft",
+    "max_md_ft",
+)
+PRESSURE_PRIORITY = {"CASING_PRESS": 0, "TUBING_PRESS": 1}
+CANDIDATE_COLUMNS = (
+    "well_key",
+    "state",
+    "api10",
+    "facility_id",
+    "field",
+    "test_date",
+    "test_year",
+    "test_type",
+    "pressure_kind",
+    "pressure_psig",
+    "pressure_psia",
+    "reference_depth_ft",
+    "reference_depth_source",
+    "source_name",
+    "source_url",
+    "raw_path",
+    "source_discovery_sha256",
+    "era",
+    "screen_promotable",
+    "underpressured_screen_eligible",
+    "screen_observation_priority",
+    "is_earliest_observation",
+)
+
+
+def build_form5a_pressure_candidates(
+    classified: pd.DataFrame, config: dict
+) -> tuple[pd.DataFrame, dict]:
+    """Convert parsed Form 5A Initial Test Data rows into candidate observations."""
+    atmospheric_psi = float(
+        config.get("pressure_observations", {}).get("atmospheric_psi", 14.7)
+    )
+    candidates = classified[_candidate_pressure_mask(classified)].copy()
+    rows, quality = [], _candidate_quality_template(candidates)
+    for _, row in candidates.iterrows():
+        field = _text(row.get("field"))
+        depth, depth_source = _select_reference_depth(row)
+        pressure_psig = _positive_number(row.get("measure_value"))
+        if not field:
+            quality["excluded_missing_field"] += 1
+            continue
+        if depth is None:
+            quality["excluded_missing_depth"] += 1
+            continue
+        if pressure_psig is None:
+            quality["excluded_missing_pressure"] += 1
+            continue
+        rows.append(
+            _candidate_record(
+                row, field, depth, depth_source, pressure_psig, atmospheric_psi
+            )
+        )
+    result = pd.DataFrame(rows, columns=list(CANDIDATE_COLUMNS))
+    if not result.empty:
+        result = _add_candidate_priority(result)
+    quality["usable_candidate_rows"] = int(len(result))
+    quality["screen_promotable_rows"] = int(
+        result.get("screen_promotable", pd.Series(dtype=bool)).sum()
+    )
+    return result, quality
+
+
+def evaluate_screen_promotion(
+    candidates: pd.DataFrame, quality: dict, config: dict
+) -> dict:
+    """Report whether Form 5A candidates are allowed into the screen."""
+    promotable = int(quality.get("screen_promotable_rows", 0))
+    configured = bool(config.get("configure_underpressured_screen")) and promotable > 0
+    status = "configured_for_screen" if configured else "candidate_only"
+    if promotable and not configured:
+        status = "screen_ready_but_not_configured"
+    return {
+        "status": status,
+        "candidate_rows": int(len(candidates)),
+        "screen_promotable_rows": promotable,
+        "configured_for_screen": configured,
+    }
+
+
+def _candidate_pressure_mask(frame: pd.DataFrame) -> pd.Series:
+    pressure_role = frame.get("pressure_role", pd.Series("", index=frame.index))
+    return (
+        frame["source_section"].eq("initial_test_data")
+        & frame["test_type"].isin(CANDIDATE_PRESSURE_KINDS)
+        & pressure_role.eq("candidate_pressure_observation")
+    )
+
+
+def _candidate_quality_template(candidates: pd.DataFrame) -> dict:
+    return {
+        "candidate_pressure_rows": int(len(candidates)),
+        "usable_candidate_rows": 0,
+        "screen_promotable_rows": 0,
+        "excluded_missing_field": 0,
+        "excluded_missing_depth": 0,
+        "excluded_missing_pressure": 0,
+    }
+
+
+def _candidate_record(
+    row: pd.Series,
+    field: str,
+    depth: float,
+    depth_source: str,
+    pressure_psig: float,
+    atmospheric_psi: float,
+) -> dict:
+    test_date = pd.to_datetime(row.get("test_date"), errors="coerce")
+    facility_id = _text(row.get("facility_id"))
+    api10 = _text(row.get("api10"))
+    test_type = _text(row.get("test_type"))
+    return {
+        "well_key": _candidate_well_key(facility_id, api10),
+        "state": "CO",
+        "api10": api10,
+        "facility_id": facility_id,
+        "field": field,
+        "test_date": test_date,
+        "test_year": int(test_date.year) if not pd.isna(test_date) else pd.NA,
+        "test_type": test_type,
+        "pressure_kind": CANDIDATE_PRESSURE_KINDS[test_type],
+        "pressure_psig": pressure_psig,
+        "pressure_psia": pressure_psig + atmospheric_psi,
+        "reference_depth_ft": depth,
+        "reference_depth_source": depth_source,
+        "source_name": "colorado_ecmc_form5a_facility_detail",
+        "source_url": _text(row.get("source_url")),
+        "raw_path": _text(row.get("raw_path")),
+        "source_discovery_sha256": _text(row.get("sha256")),
+        "era": "completion_initial_test",
+        "screen_promotable": False,
+        "underpressured_screen_eligible": False,
+    }
+
+
+def _candidate_well_key(facility_id: str, api10: str) -> str:
+    if facility_id:
+        return f"CO_ECMC_FACILITY:{facility_id}"
+    return f"CO_ECMC_API10:{api10}"
+
+
+def _select_reference_depth(row: pd.Series) -> tuple[float | None, str]:
+    for column in DEPTH_PRIORITY:
+        value = _positive_number(row.get(column))
+        if value is not None:
+            return value, column
+    return None, ""
+
+
+def _positive_number(value: object) -> float | None:
+    number = pd.to_numeric(value, errors="coerce")
+    if pd.isna(number) or float(number) <= 0:
+        return None
+    return float(number)
+
+
+def _add_candidate_priority(candidates: pd.DataFrame) -> pd.DataFrame:
+    result = candidates.copy()
+    result["_pressure_priority"] = result["test_type"].map(PRESSURE_PRIORITY).fillna(99)
+    result = result.sort_values(["well_key", "test_date", "_pressure_priority"])
+    result["screen_observation_priority"] = result.groupby("well_key").cumcount()
+    result["is_earliest_observation"] = result["screen_observation_priority"].eq(0)
+    result = result.drop(columns=["_pressure_priority"]).reset_index(drop=True)
+    for column in ["screen_promotable", "underpressured_screen_eligible"]:
+        result[column] = result[column].astype(object)
+    return result
+
+
+def _text(value: object) -> str:
+    if pd.isna(value):
+        return ""
+    return str(value).strip()

--- a/src/worldenergydata/modules/state_regulators/colorado_ecmc/facility_detail_ingest.py
+++ b/src/worldenergydata/modules/state_regulators/colorado_ecmc/facility_detail_ingest.py
@@ -1,0 +1,239 @@
+"""Production FacilityDetail/Form 5A ingest for Colorado ECMC (#751)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from time import sleep
+from urllib.error import HTTPError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+import pandas as pd
+
+from worldenergydata.modules.state_regulators.colorado_ecmc.facility_detail_candidates import (
+    build_form5a_pressure_candidates,
+    evaluate_screen_promotion,
+)
+
+__all__ = [
+    "build_facility_detail_source_list",
+    "fetch_facility_detail_pages",
+    "build_form5a_pressure_candidates",
+    "evaluate_screen_promotion",
+]
+
+REQUIRED_WELL_COLUMNS = {
+    "API",
+    "API_County",
+    "API_Seq",
+    "API_Label",
+    "Facil_Id",
+    "Field_Name",
+    "Max_MD",
+    "Max_TVD",
+}
+
+
+def build_facility_detail_source_list(
+    wells: pd.DataFrame, config: dict
+) -> tuple[pd.DataFrame, dict]:
+    """Build FacilityDetail request rows from raw ECMC WELLS data."""
+    _validate_columns(wells, REQUIRED_WELL_COLUMNS, "raw ECMC WELLS")
+    rows = []
+    for _, row in wells.iterrows():
+        api_fragment = _api_fragment(row)
+        _validate_api_label(api_fragment, row["API_Label"])
+        rows.append(
+            {
+                "api_fragment": api_fragment,
+                "api10": f"05{api_fragment}",
+                "api12": pd.NA,
+                "facility_id": _text(row["Facil_Id"]),
+                "field": _text(row["Field_Name"]),
+                "max_md_ft": pd.to_numeric(row["Max_MD"], errors="coerce"),
+                "max_tvd_ft": pd.to_numeric(row["Max_TVD"], errors="coerce"),
+                "latitude": pd.to_numeric(row.get("Latitude"), errors="coerce"),
+                "longitude": pd.to_numeric(row.get("Longitude"), errors="coerce"),
+            }
+        )
+    source_list = pd.DataFrame(rows).drop_duplicates("api_fragment")
+    max_requests = int(config.get("max_requests", len(source_list)))
+    if max_requests >= len(source_list) and not config.get("allow_full_source_list"):
+        raise ValueError(
+            "full source list run requires allow_full_source_list approval"
+        )
+    source_list = source_list.head(max_requests)
+    quality = {
+        "source_rows": int(len(wells)),
+        "request_rows": int(len(source_list)),
+        "max_requests": max_requests,
+        "allow_full_source_list": bool(config.get("allow_full_source_list")),
+    }
+    return source_list.reset_index(drop=True), quality
+
+
+def fetch_facility_detail_pages(source_list: pd.DataFrame, config: dict) -> dict:
+    """Fetch approved FacilityDetail pages with resumable provenance."""
+    base = Path(config["storage"]["base_dir"])
+    raw_dir = base / "raw" / "facility_detail" / "html"
+    status_dir = base / "raw" / "facility_detail" / "status"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    status_dir.mkdir(parents=True, exist_ok=True)
+    fetched, failed = [], []
+    settings = config["facility_detail"]
+    for index, row in source_list.reset_index(drop=True).iterrows():
+        try:
+            metadata = _fetch_one_page(row, raw_dir, settings)
+        except HTTPError as error:
+            metadata = _failed_metadata(row, settings, error)
+            failed.append(metadata)
+            _append_jsonl(status_dir / "failed.jsonl", metadata)
+        else:
+            if _should_exclude_identity_mismatch(metadata, settings):
+                metadata = _identity_mismatch_metadata(metadata)
+                failed.append(metadata)
+                _append_jsonl(status_dir / "failed.jsonl", metadata)
+            else:
+                fetched.append(metadata)
+                _append_jsonl(status_dir / "fetched.jsonl", metadata)
+        if index < len(source_list) - 1:
+            sleep(float(settings.get("request_delay_seconds", 0)))
+    return {"fetched": fetched, "failed": failed, "skipped": []}
+
+
+def _fetch_one_page(row: pd.Series, raw_dir: Path, settings: dict) -> dict:
+    api_fragment = str(row["api_fragment"])
+    url = _facility_detail_url(api_fragment, settings["base_url"])
+    request = Request(url, headers={"User-Agent": settings["user_agent"]})
+    with urlopen(request, timeout=int(settings.get("timeout_seconds", 60))) as response:
+        payload = response.read()
+        status_code = response.getcode()
+        headers = response.headers
+    raw_path = raw_dir / f"{api_fragment}.html"
+    raw_path.write_bytes(payload)
+    text = payload.decode("utf-8", errors="ignore")
+    return {
+        "api_fragment": api_fragment,
+        "facility_id": _text(row.get("facility_id")),
+        "rendered_api_fragment": _rendered_api_fragment(text),
+        "rendered_facility_id": _rendered_facility_id(text),
+        "source_url": url,
+        "raw_path": str(raw_path),
+        "status_code": int(status_code),
+        "size_bytes": len(payload),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "etag": headers.get("ETag"),
+        "downloaded_at": datetime.now(timezone.utc).isoformat(),
+        "retry_count": 0,
+    }
+
+
+def _facility_detail_url(api_fragment: str, base_url: str) -> str:
+    return f"{base_url}?{urlencode({'api': api_fragment})}"
+
+
+def _failed_metadata(row: pd.Series, settings: dict, error: HTTPError) -> dict:
+    api_fragment = str(row["api_fragment"])
+    status_code = int(error.code)
+    return {
+        "api_fragment": api_fragment,
+        "facility_id": _text(row.get("facility_id")),
+        "source_url": _facility_detail_url(api_fragment, settings["base_url"]),
+        "status_code": status_code,
+        "error_class": error.__class__.__name__,
+        "error_text": str(error),
+        "retryable": status_code not in {403, 404},
+        "retry_count": 0,
+        "failed_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _should_exclude_identity_mismatch(metadata: dict, settings: dict) -> bool:
+    return bool(settings.get("stop_on_identity_mismatch")) and _has_identity_mismatch(
+        metadata
+    )
+
+
+def _has_identity_mismatch(metadata: dict) -> bool:
+    rendered_api = metadata.get("rendered_api_fragment")
+    if rendered_api and rendered_api != metadata["api_fragment"]:
+        return True
+    rendered_facility = metadata.get("rendered_facility_id")
+    facility_id = metadata.get("facility_id")
+    return bool(rendered_facility and facility_id and rendered_facility != facility_id)
+
+
+def _identity_mismatch_metadata(metadata: dict) -> dict:
+    failed = dict(metadata)
+    failed.update(
+        {
+            "status": "identity_mismatch",
+            "error_class": "IdentityMismatch",
+            "error_text": (
+                "rendered FacilityDetail identity does not match requested API/facility"
+            ),
+            "retryable": False,
+            "failed_at": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+    return failed
+
+
+def _append_jsonl(path: Path, row: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def _validate_columns(frame: pd.DataFrame, required: set[str], label: str) -> None:
+    missing = sorted(required - set(frame.columns))
+    if missing:
+        raise ValueError(f"{label} missing required columns: {', '.join(missing)}")
+
+
+def _api_fragment(row: pd.Series) -> str:
+    api = _digits(row.get("API"))
+    if len(api) == 8:
+        return api
+    county = _digits(row.get("API_County")).zfill(3)
+    sequence = _digits(row.get("API_Seq")).zfill(5)
+    fragment = f"{county}{sequence}"
+    if not re.fullmatch(r"\d{8}", fragment):
+        raise ValueError("raw ECMC WELLS row has invalid API fragment")
+    return fragment
+
+
+def _validate_api_label(api_fragment: str, label: object) -> None:
+    digits = _digits(label)
+    expected = f"05{api_fragment}"
+    if digits != expected:
+        raise ValueError(f"API_Label {label!r} does not match {expected}")
+
+
+def _digits(value: object) -> str:
+    if pd.isna(value):
+        return ""
+    return "".join(char for char in str(value) if char.isdigit())
+
+
+def _rendered_api_fragment(text: str) -> str:
+    match = re.search(r"API\s*#?\s*[:#]?\s*(05[-\s]?\d{3}[-\s]?\d{5})", text, re.I)
+    if not match:
+        return ""
+    digits = _digits(match.group(1))
+    return digits[2:] if len(digits) == 10 and digits.startswith("05") else ""
+
+
+def _rendered_facility_id(text: str) -> str:
+    match = re.search(r"Facility\s*ID\s*[:#]?\s*(\d+)", text, re.I)
+    return match.group(1) if match else ""
+
+
+def _text(value: object) -> str:
+    if pd.isna(value):
+        return ""
+    return str(value).strip()

--- a/src/worldenergydata/modules/state_regulators/colorado_ecmc/facility_detail_pipeline.py
+++ b/src/worldenergydata/modules/state_regulators/colorado_ecmc/facility_detail_pipeline.py
@@ -1,0 +1,216 @@
+"""End-to-end Colorado ECMC FacilityDetail/Form 5A ingest runner (#751)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from zipfile import ZipFile
+
+import pandas as pd
+import shapefile
+import yaml
+
+from worldenergydata.modules.state_regulators.colorado_ecmc.facility_detail import (
+    classify_facility_detail_pressures,
+    parse_facility_detail_html,
+)
+from worldenergydata.modules.state_regulators.colorado_ecmc.facility_detail_candidates import (
+    build_form5a_pressure_candidates,
+    evaluate_screen_promotion,
+)
+from worldenergydata.modules.state_regulators.colorado_ecmc.facility_detail_ingest import (
+    build_facility_detail_source_list,
+    fetch_facility_detail_pages,
+)
+
+
+def load_config(config_path: str | Path) -> dict:
+    with Path(config_path).open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def read_raw_wells_source(source_config: dict) -> pd.DataFrame:
+    """Read the configured WELLS source with raw ECMC DBF field names intact."""
+    path = Path(source_config["path"])
+    suffix = path.suffix.lower()
+    if suffix == ".parquet":
+        return pd.read_parquet(path)
+    if suffix == ".csv":
+        return pd.read_csv(path)
+    with _shapefile_reader(path) as reader:
+        field_names = [field[0] for field in reader.fields[1:]]
+        records = [
+            dict(zip(field_names, record, strict=False)) for record in reader.records()
+        ]
+    return pd.DataFrame.from_records(records)
+
+
+def parse_facility_detail_pages(fetch_manifest: dict) -> tuple[pd.DataFrame, dict]:
+    frames = []
+    quality = {
+        "fetched_pages": int(len(fetch_manifest.get("fetched", []))),
+        "parsed_pages": 0,
+        "no_initial_test_pages": 0,
+        "parsed_initial_test_rows": 0,
+    }
+    for metadata in fetch_manifest.get("fetched", []):
+        html = Path(metadata["raw_path"]).read_text(encoding="utf-8", errors="ignore")
+        parsed = parse_facility_detail_html(html, metadata.get("source_url"))
+        if parsed.empty:
+            quality["no_initial_test_pages"] += 1
+            continue
+        parsed = parsed.assign(
+            raw_path=metadata.get("raw_path"),
+            sha256=metadata.get("sha256"),
+            downloaded_at=metadata.get("downloaded_at"),
+        )
+        frames.append(parsed)
+        quality["parsed_pages"] += 1
+        quality["parsed_initial_test_rows"] += int(len(parsed))
+    if not frames:
+        empty = parse_facility_detail_html("", None)
+        return empty.assign(raw_path=pd.NA, sha256=pd.NA, downloaded_at=pd.NA), quality
+    return pd.concat(frames, ignore_index=True), quality
+
+
+def run_facility_detail_ingest(config_path: str | Path) -> dict:
+    config = load_config(config_path)
+    base_dir = Path(config["storage"]["base_dir"])
+    wells = read_raw_wells_source(config["source_list"])
+    source_list, source_quality = build_facility_detail_source_list(wells, config)
+    _write_source_list_outputs(base_dir, source_list, source_quality)
+    if config.get("dry_run_source_list_only"):
+        summary = _summary(source_quality, {}, {}, {}, {})
+        _write_report(base_dir, summary)
+        return summary
+
+    fetch_manifest = fetch_facility_detail_pages(source_list, config)
+    parsed, parser_quality = parse_facility_detail_pages(fetch_manifest)
+    classified = classify_facility_detail_pressures(parsed)
+    candidates, candidate_quality = build_form5a_pressure_candidates(classified, config)
+    promotion = evaluate_screen_promotion(candidates, candidate_quality, config)
+    summary = _summary(
+        source_quality, fetch_manifest, parser_quality, candidate_quality, promotion
+    )
+    _write_outputs(
+        base_dir, parsed, parser_quality, candidates, candidate_quality, summary
+    )
+    return summary
+
+
+def _write_source_list_outputs(
+    base_dir: Path, source_list: pd.DataFrame, source_quality: dict
+) -> None:
+    out_dir = base_dir / "source_lists"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    source_list.to_parquet(out_dir / "facility_detail_source_list.parquet")
+    (out_dir / "facility_detail_source_list_quality.json").write_text(
+        json.dumps(source_quality, indent=2), encoding="utf-8"
+    )
+
+
+def _write_outputs(
+    base_dir: Path,
+    parsed: pd.DataFrame,
+    parser_quality: dict,
+    candidates: pd.DataFrame,
+    candidate_quality: dict,
+    summary: dict,
+) -> None:
+    parsed_dir = base_dir / "parsed"
+    parsed_dir.mkdir(parents=True, exist_ok=True)
+    _parquet_safe_frame(parsed).to_parquet(
+        parsed_dir / "facility_detail_initial_tests.parquet"
+    )
+    parsed.to_json(
+        parsed_dir / "facility_detail_initial_tests.json",
+        orient="records",
+        date_format="iso",
+        indent=2,
+    )
+    (parsed_dir / "parser_quality.json").write_text(
+        json.dumps(parser_quality, indent=2), encoding="utf-8"
+    )
+    pressure_dir = base_dir / "curated" / "pressure"
+    pressure_dir.mkdir(parents=True, exist_ok=True)
+    _parquet_safe_frame(candidates).to_parquet(
+        pressure_dir / "well_pressure_observations.parquet"
+    )
+    (
+        pressure_dir / "colorado_ecmc_form5a_pressure_observation_quality.json"
+    ).write_text(json.dumps(candidate_quality, indent=2), encoding="utf-8")
+    _write_report(base_dir, summary)
+
+
+def _summary(
+    source_quality: dict,
+    fetch_manifest: dict,
+    parser_quality: dict,
+    candidate_quality: dict,
+    promotion: dict,
+) -> dict:
+    return {
+        "source_quality": source_quality,
+        "fetch_counts": {
+            key: len(fetch_manifest.get(key, []))
+            for key in ["fetched", "failed", "skipped"]
+        },
+        "parser_quality": parser_quality,
+        "candidate_quality": candidate_quality,
+        "promotion": promotion,
+        "written_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _write_report(base_dir: Path, summary: dict) -> None:
+    report_dir = base_dir / "reports"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "colorado_ecmc_form5a_ingest_summary.json").write_text(
+        json.dumps(summary, indent=2), encoding="utf-8"
+    )
+
+
+def _parquet_safe_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    result = frame.copy()
+    for column in result.select_dtypes(include=["object"]).columns:
+        result[column] = result[column].map(_nullable_text).astype("string")
+    return result
+
+
+def _nullable_text(value: object) -> str | None:
+    if pd.isna(value):
+        return None
+    return str(value)
+
+
+def _shapefile_reader(path: Path):
+    if path.suffix.lower() != ".zip":
+        return shapefile.Reader(str(path))
+    with ZipFile(path) as archive:
+        return shapefile.Reader(
+            shp=archive.open(_zip_member(archive, ".shp")),
+            shx=archive.open(_zip_member(archive, ".shx")),
+            dbf=archive.open(_zip_member(archive, ".dbf")),
+        )
+
+
+def _zip_member(archive: ZipFile, suffix: str) -> str:
+    for name in archive.namelist():
+        if name.lower().endswith(suffix):
+            return name
+    raise ValueError(f"ECMC wells shapefile ZIP missing {suffix} member")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Colorado ECMC Form 5A ingest (#751)")
+    parser.add_argument(
+        "--config", default="config/colorado_ecmc_facility_detail_ingest.yml"
+    )
+    args = parser.parse_args()
+    print(json.dumps(run_facility_detail_ingest(args.config), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/analysis/test_underpressured_screen.py
+++ b/tests/unit/analysis/test_underpressured_screen.py
@@ -57,7 +57,7 @@ class TestEstimateBhp:
         assert result["bhp_psia_est"].iloc[0] == pytest.approx(expected)
         assert result["bhp_method"].iloc[0] == "static_gas_column_avg_zt"
 
-    def test_flowing_tubing_whp_gets_static_column_screening_correction(self):
+    def test_non_shut_in_whp_kind_passes_through_without_static_column_correction(self):
         obs = make_observations(
             [
                 {
@@ -65,14 +65,13 @@ class TestEstimateBhp:
                     "test_year": 2024,
                     "pressure_psia": 100.0,
                     "reference_depth_ft": 2800.0,
-                    "pressure_kind": "WHP_flowing_tubing",
+                    "pressure_kind": "WHP_flowing_tubing_initial_test",
                 }
             ]
         )
         result = estimate_bhp(obs, BHP_SETTINGS)
-        expected = 100.0 * math.exp(0.01875 * 0.65 * 2800.0 / (0.95 * 520.0))
-        assert result["bhp_psia_est"].iloc[0] == pytest.approx(expected)
-        assert result["bhp_method"].iloc[0] == "static_gas_column_avg_zt"
+        assert result["bhp_psia_est"].iloc[0] == pytest.approx(100.0)
+        assert result["bhp_method"].iloc[0] == "as_reported"
 
     def test_measured_bhp_passes_through(self):
         obs = make_observations(

--- a/tests/unit/modules/state_regulators/test_colorado_ecmc_facility_detail.py
+++ b/tests/unit/modules/state_regulators/test_colorado_ecmc_facility_detail.py
@@ -58,6 +58,53 @@ def test_parse_facility_detail_html_extracts_initial_test_rows():
     assert tubing["measure_value"] == 1300
 
 
+def test_parse_facility_detail_html_extracts_multiple_initial_test_blocks():
+    html = """
+    <html><body>
+      <table>
+        <tr><td>API# 05-123-32498</td></tr>
+        <tr><td>FacilityID:</td><td>420193</td><td>Field:</td><td>WATTENBERG</td></tr>
+      </table>
+      <div class="accordion2">
+        <h4>Formation NBRR Formation Classification: OW
+            Interval Top: 7397 ft. Interval Bottom: 14700 ft.</h4>
+        <table>
+          <tr><td>Completed Information for Formation NIOBRARA</td></tr>
+          <tr><td>1st Production Date:</td><td>5/19/2017</td></tr>
+          <tr><td>Initial Test Data:</td></tr>
+          <tr><td>Test Date:</td><td>5/19/2017</td><td>Test Method:</td><td>Flowing</td></tr>
+          <tr><th>Test Type</th><th>Measure</th></tr>
+          <tr><td>CASING_PRESS</td><td>1700</td></tr>
+          <tr><td>TUBING_PRESS</td><td>1300</td></tr>
+        </table>
+      </div>
+      <div class="accordion2">
+        <h4>Formation CODE Formation Classification: OW
+            Interval Top: 7020 ft. Interval Bottom: 7300 ft.</h4>
+        <table>
+          <tr><td>Completed Information for Formation CODELL</td></tr>
+          <tr><td>1st Production Date:</td><td>6/1/2017</td></tr>
+          <tr><td>Initial Test Data:</td></tr>
+          <tr><td>Test Date:</td><td>6/2/2017</td><td>Test Method:</td><td>Flowing</td></tr>
+          <tr><th>Test Type</th><th>Measure</th></tr>
+          <tr><td>CASING_PRESS</td><td>1800</td></tr>
+          <tr><td>TUBING_PRESS</td><td>1400</td></tr>
+        </table>
+      </div>
+    </body></html>
+    """
+
+    rows = parse_facility_detail_html(html, source_url=SOURCE_URL)
+    casing = rows[rows["test_type"] == "CASING_PRESS"].sort_values("formation_code")
+
+    assert len(rows) == 4
+    assert list(casing["formation_code"]) == ["CODE", "NBRR"]
+    assert list(casing["formation"]) == ["CODELL", "NIOBRARA"]
+    assert list(casing["interval_top_ft"]) == [7020, 7397]
+    assert list(casing["interval_bottom_ft"]) == [7300, 14700]
+    assert list(casing["measure_value"]) == [1800, 1700]
+
+
 def test_classify_facility_detail_pressures_keeps_only_initial_test_candidates():
     raw = pd.DataFrame(
         [

--- a/tests/unit/modules/state_regulators/test_colorado_ecmc_facility_detail_ingest.py
+++ b/tests/unit/modules/state_regulators/test_colorado_ecmc_facility_detail_ingest.py
@@ -1,8 +1,9 @@
 """Tests for production Colorado ECMC FacilityDetail/Form 5A ingest (#751)."""
 
+from urllib.error import HTTPError
+
 import pandas as pd
 import pytest
-from urllib.error import HTTPError
 
 from worldenergydata.modules.state_regulators.colorado_ecmc import (
     facility_detail_ingest,

--- a/tests/unit/modules/state_regulators/test_colorado_ecmc_facility_detail_ingest.py
+++ b/tests/unit/modules/state_regulators/test_colorado_ecmc_facility_detail_ingest.py
@@ -1,0 +1,343 @@
+"""Tests for production Colorado ECMC FacilityDetail/Form 5A ingest (#751)."""
+
+import pandas as pd
+import pytest
+from urllib.error import HTTPError
+
+from worldenergydata.modules.state_regulators.colorado_ecmc import (
+    facility_detail_ingest,
+)
+from worldenergydata.modules.state_regulators.colorado_ecmc.facility_detail_ingest import (
+    build_facility_detail_source_list,
+)
+
+
+def test_build_source_list_derives_facility_detail_keys_from_raw_wells():
+    wells = pd.DataFrame(
+        [
+            {
+                "API": "12332498",
+                "API_County": "123",
+                "API_Seq": "32498",
+                "API_Label": "05-123-32498",
+                "Facil_Id": 420193,
+                "Field_Name": "WATTENBERG",
+                "Max_MD": 14829,
+                "Max_TVD": 7041,
+                "Latitude": 40.1,
+                "Longitude": -104.8,
+            }
+        ]
+    )
+
+    source_list, quality = build_facility_detail_source_list(
+        wells, {"allow_full_source_list": True, "max_requests": 1}
+    )
+
+    row = source_list.iloc[0]
+    assert row["api_fragment"] == "12332498"
+    assert row["api10"] == "0512332498"
+    assert pd.isna(row["api12"])
+    assert row["facility_id"] == "420193"
+    assert row["field"] == "WATTENBERG"
+    assert row["max_md_ft"] == 14829
+    assert row["max_tvd_ft"] == 7041
+    assert quality["source_rows"] == 1
+    assert quality["request_rows"] == 1
+
+
+def test_build_source_list_fails_closed_without_full_list_approval():
+    wells = pd.DataFrame(
+        [
+            {
+                "API": "12332498",
+                "API_County": "123",
+                "API_Seq": "32498",
+                "API_Label": "05-123-32498",
+                "Facil_Id": 420193,
+                "Field_Name": "WATTENBERG",
+                "Max_MD": 14829,
+                "Max_TVD": 7041,
+            },
+            {
+                "API": "12324638",
+                "API_County": "123",
+                "API_Seq": "24638",
+                "API_Label": "05-123-24638",
+                "Facil_Id": 288652,
+                "Field_Name": "WATTENBERG",
+                "Max_MD": 10201,
+                "Max_TVD": 7300,
+            },
+        ]
+    )
+
+    capped, quality = build_facility_detail_source_list(wells, {"max_requests": 1})
+    assert list(capped["api_fragment"]) == ["12332498"]
+    assert quality["request_rows"] == 1
+    assert quality["allow_full_source_list"] is False
+
+    with pytest.raises(ValueError, match="allow_full_source_list"):
+        build_facility_detail_source_list(wells, {"max_requests": 2})
+
+
+def test_fetch_facility_detail_pages_uses_user_agent_and_writes_status(
+    tmp_path, monkeypatch
+):
+    source_list = pd.DataFrame([{"api_fragment": "12332498", "facility_id": "420193"}])
+    payload = b"<html>API# 05-123-32498 FacilityID: 420193 Initial Test Data</html>"
+    seen = {}
+
+    class FakeResponse:
+        headers = {"ETag": "abc"}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self, size=-1):
+            return payload if size != 0 else b""
+
+        def getcode(self):
+            return 200
+
+    def fake_urlopen(request, timeout):
+        seen["url"] = request.full_url
+        seen["user_agent"] = request.headers["User-agent"]
+        seen["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(facility_detail_ingest, "urlopen", fake_urlopen)
+    monkeypatch.setattr(facility_detail_ingest, "sleep", lambda _: None)
+
+    result = facility_detail_ingest.fetch_facility_detail_pages(
+        source_list,
+        {
+            "storage": {"base_dir": str(tmp_path)},
+            "facility_detail": {
+                "base_url": "https://ecmc.state.co.us/cogisdb/Facility/FacilityDetail.aspx",
+                "timeout_seconds": 30,
+                "request_delay_seconds": 0,
+                "user_agent": "worldenergydata-test/1.0",
+                "max_retries": 0,
+            },
+        },
+    )
+
+    raw_path = tmp_path / "raw" / "facility_detail" / "html" / "12332498.html"
+    fetched_path = tmp_path / "raw" / "facility_detail" / "status" / "fetched.jsonl"
+    assert seen == {
+        "url": "https://ecmc.state.co.us/cogisdb/Facility/FacilityDetail.aspx?api=12332498",
+        "user_agent": "worldenergydata-test/1.0",
+        "timeout": 30,
+    }
+    assert raw_path.read_bytes() == payload
+    assert fetched_path.read_text(encoding="utf-8").count("\n") == 1
+    assert result["fetched"][0]["api_fragment"] == "12332498"
+    assert result["fetched"][0]["status_code"] == 200
+    assert result["fetched"][0]["raw_path"] == str(raw_path)
+
+
+def test_fetch_facility_detail_pages_treats_403_as_terminal_failure(
+    tmp_path, monkeypatch
+):
+    source_list = pd.DataFrame([{"api_fragment": "12332498", "facility_id": "420193"}])
+    calls = {"count": 0}
+
+    def fake_urlopen(request, timeout):
+        calls["count"] += 1
+        raise HTTPError(request.full_url, 403, "Forbidden", hdrs={}, fp=None)
+
+    monkeypatch.setattr(facility_detail_ingest, "urlopen", fake_urlopen)
+
+    result = facility_detail_ingest.fetch_facility_detail_pages(
+        source_list,
+        {
+            "storage": {"base_dir": str(tmp_path)},
+            "facility_detail": {
+                "base_url": "https://ecmc.state.co.us/cogisdb/Facility/FacilityDetail.aspx",
+                "timeout_seconds": 30,
+                "request_delay_seconds": 0,
+                "user_agent": "worldenergydata-test/1.0",
+                "max_retries": 3,
+            },
+        },
+    )
+
+    failed_path = tmp_path / "raw" / "facility_detail" / "status" / "failed.jsonl"
+    assert calls["count"] == 1
+    assert result["failed"][0]["status_code"] == 403
+    assert result["failed"][0]["error_class"] == "HTTPError"
+    assert result["failed"][0]["retryable"] is False
+    assert failed_path.read_text(encoding="utf-8").count("\n") == 1
+
+
+def test_fetch_facility_detail_pages_excludes_identity_mismatch(tmp_path, monkeypatch):
+    source_list = pd.DataFrame([{"api_fragment": "12332498", "facility_id": "420193"}])
+    payload = b"<html>API# 05-123-00001 FacilityID: 999999 Initial Test Data</html>"
+
+    class FakeResponse:
+        headers = {}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self, size=-1):
+            return payload
+
+        def getcode(self):
+            return 200
+
+    monkeypatch.setattr(
+        facility_detail_ingest,
+        "urlopen",
+        lambda request, timeout: FakeResponse(),
+    )
+
+    result = facility_detail_ingest.fetch_facility_detail_pages(
+        source_list,
+        {
+            "storage": {"base_dir": str(tmp_path)},
+            "facility_detail": {
+                "base_url": "https://ecmc.state.co.us/cogisdb/Facility/FacilityDetail.aspx",
+                "timeout_seconds": 30,
+                "request_delay_seconds": 0,
+                "user_agent": "worldenergydata-test/1.0",
+                "max_retries": 0,
+                "stop_on_identity_mismatch": True,
+            },
+        },
+    )
+
+    assert result["fetched"] == []
+    assert result["failed"][0]["status"] == "identity_mismatch"
+    assert result["failed"][0]["retryable"] is False
+
+
+def test_build_form5a_pressure_candidates_converts_initial_test_pressures():
+    classified = pd.DataFrame(
+        [
+            {
+                "api10": "0512332498",
+                "facility_id": "420193",
+                "field": "WATTENBERG",
+                "test_date": pd.Timestamp("2017-05-19"),
+                "test_type": "CASING_PRESS",
+                "measure_value": 1700,
+                "source_section": "initial_test_data",
+                "pressure_role": "candidate_pressure_observation",
+                "interval_bottom_ft": 14700,
+                "vertical_td_ft": 7041,
+                "max_tvd_ft": 7041,
+                "max_md_ft": 14829,
+                "source_url": "https://ecmc.example/facility?api=12332498",
+                "raw_path": "/mnt/ace/raw/12332498.html",
+                "sha256": "abc123",
+            },
+            {
+                "api10": "0512332498",
+                "facility_id": "420193",
+                "field": "WATTENBERG",
+                "test_date": pd.Timestamp("2017-05-19"),
+                "test_type": "TUBING_PRESS",
+                "measure_value": 1300,
+                "source_section": "initial_test_data",
+                "pressure_role": "candidate_pressure_observation",
+                "interval_bottom_ft": 14700,
+                "vertical_td_ft": 7041,
+                "max_tvd_ft": 7041,
+                "max_md_ft": 14829,
+                "source_url": "https://ecmc.example/facility?api=12332498",
+                "raw_path": "/mnt/ace/raw/12332498.html",
+                "sha256": "abc123",
+            },
+        ]
+    )
+
+    candidates, quality = facility_detail_ingest.build_form5a_pressure_candidates(
+        classified, {"pressure_observations": {"atmospheric_psi": 14.7}}
+    )
+    by_type = candidates.set_index("test_type")
+
+    casing = by_type.loc["CASING_PRESS"]
+    tubing = by_type.loc["TUBING_PRESS"]
+    assert casing["well_key"] == "CO_ECMC_FACILITY:420193"
+    assert casing["state"] == "CO"
+    assert casing["pressure_kind"] == "initial_test_casing_pressure_unverified"
+    assert casing["pressure_psig"] == 1700
+    assert casing["pressure_psia"] == pytest.approx(1714.7)
+    assert casing["reference_depth_ft"] == 14700
+    assert casing["reference_depth_source"] == "interval_bottom_ft"
+    assert casing["era"] == "completion_initial_test"
+    assert casing["source_name"] == "colorado_ecmc_form5a_facility_detail"
+    assert casing["screen_promotable"] is False
+    assert tubing["pressure_kind"] == "flowing_tubing_initial_test"
+    assert tubing["screen_promotable"] is False
+    assert quality["candidate_pressure_rows"] == 2
+    assert quality["screen_promotable_rows"] == 0
+
+
+def test_build_form5a_pressure_candidates_excludes_missing_field_or_depth():
+    classified = pd.DataFrame(
+        [
+            {
+                "api10": "0512332498",
+                "facility_id": "420193",
+                "field": None,
+                "test_date": pd.Timestamp("2017-05-19"),
+                "test_type": "CASING_PRESS",
+                "measure_value": 1700,
+                "source_section": "initial_test_data",
+                "pressure_role": "candidate_pressure_observation",
+                "interval_bottom_ft": 14700,
+            },
+            {
+                "api10": "0512332499",
+                "facility_id": "420194",
+                "field": "WATTENBERG",
+                "test_date": pd.Timestamp("2017-05-20"),
+                "test_type": "TUBING_PRESS",
+                "measure_value": 1300,
+                "source_section": "initial_test_data",
+                "pressure_role": "candidate_pressure_observation",
+                "interval_bottom_ft": 0,
+                "vertical_td_ft": None,
+                "max_tvd_ft": None,
+                "max_md_ft": None,
+            },
+        ]
+    )
+
+    candidates, quality = facility_detail_ingest.build_form5a_pressure_candidates(
+        classified, {"pressure_observations": {"atmospheric_psi": 14.7}}
+    )
+
+    assert candidates.empty
+    assert quality["candidate_pressure_rows"] == 2
+    assert quality["excluded_missing_field"] == 1
+    assert quality["excluded_missing_depth"] == 1
+    assert quality["usable_candidate_rows"] == 0
+
+
+def test_evaluate_screen_promotion_keeps_form5a_candidate_only():
+    candidates = pd.DataFrame(
+        [
+            {
+                "well_key": "CO_ECMC_FACILITY:420193",
+                "pressure_kind": "flowing_tubing_initial_test",
+                "screen_promotable": False,
+            }
+        ]
+    )
+
+    promotion = facility_detail_ingest.evaluate_screen_promotion(
+        candidates, {"screen_promotable_rows": 0}, {}
+    )
+
+    assert promotion["status"] == "candidate_only"
+    assert promotion["screen_promotable_rows"] == 0

--- a/tests/unit/modules/state_regulators/test_colorado_ecmc_facility_detail_pipeline.py
+++ b/tests/unit/modules/state_regulators/test_colorado_ecmc_facility_detail_pipeline.py
@@ -1,0 +1,150 @@
+"""Tests for Colorado ECMC FacilityDetail/Form 5A ingest runner (#751)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+from worldenergydata.modules.state_regulators.colorado_ecmc import (
+    facility_detail_pipeline,
+)
+
+FIXTURE = (
+    Path(__file__).parents[3]
+    / "fixtures"
+    / "colorado_ecmc"
+    / "facility_detail_12339345_excerpt.html"
+)
+SOURCE_URL = (
+    "https://ecmc.state.co.us/cogisdb/Facility/FacilityDetail.aspx?api=12339345"
+)
+
+
+def test_facility_detail_ingest_config_is_capped_and_direct_source():
+    config = facility_detail_pipeline.load_config(
+        "config/colorado_ecmc_facility_detail_ingest.yml"
+    )
+
+    assert config["storage"]["base_dir"].startswith("/mnt/ace/")
+    assert config["source_list"]["path"].endswith("raw/wells/WELLS_SHP.ZIP")
+    assert config["source_list"]["refresh"] == "daily"
+    assert config["facility_detail"]["base_url"].endswith(
+        "/cogisdb/Facility/FacilityDetail.aspx"
+    )
+    assert config["facility_detail"]["request_delay_seconds"] >= 0.25
+    assert config["facility_detail"]["stop_on_identity_mismatch"] is True
+    assert config["max_requests"] <= 10
+    assert config["allow_full_source_list"] is False
+    assert config["pressure_observations"]["atmospheric_psi"] == 14.7
+
+
+def test_parse_facility_detail_pages_preserves_raw_lineage(tmp_path):
+    raw_path = tmp_path / "12339345.html"
+    raw_path.write_text(FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    fetch_manifest = {
+        "fetched": [
+            {
+                "api_fragment": "12339345",
+                "raw_path": str(raw_path),
+                "source_url": SOURCE_URL,
+                "sha256": "fixture-sha",
+            }
+        ],
+        "failed": [],
+        "skipped": [],
+    }
+
+    parsed, quality = facility_detail_pipeline.parse_facility_detail_pages(
+        fetch_manifest
+    )
+
+    assert len(parsed) == 7
+    assert parsed["raw_path"].nunique() == 1
+    assert parsed["sha256"].unique().tolist() == ["fixture-sha"]
+    assert quality["fetched_pages"] == 1
+    assert quality["parsed_pages"] == 1
+    assert quality["parsed_initial_test_rows"] == 7
+
+
+def test_run_facility_detail_ingest_writes_source_parsed_curated_report(
+    tmp_path, monkeypatch
+):
+    raw_path = tmp_path / "12339345.html"
+    raw_path.write_text(FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    config_path = _write_runner_config(tmp_path)
+    wells = pd.DataFrame(
+        [
+            {
+                "API": "12339345",
+                "API_County": "123",
+                "API_Seq": "39345",
+                "API_Label": "05-123-39345",
+                "Facil_Id": "436953",
+                "Field_Name": "WATTENBERG",
+                "Max_MD": 14829,
+                "Max_TVD": 7041,
+            }
+        ]
+    )
+
+    monkeypatch.setattr(
+        facility_detail_pipeline, "read_raw_wells_source", lambda _: wells
+    )
+    monkeypatch.setattr(
+        facility_detail_pipeline,
+        "fetch_facility_detail_pages",
+        lambda source_list, config: {
+            "fetched": [
+                {
+                    "api_fragment": "12339345",
+                    "raw_path": str(raw_path),
+                    "source_url": SOURCE_URL,
+                    "sha256": "fixture-sha",
+                }
+            ],
+            "failed": [],
+            "skipped": [],
+        },
+    )
+
+    summary = facility_detail_pipeline.run_facility_detail_ingest(config_path)
+
+    base_dir = tmp_path / "facility_detail_ingest"
+    candidates_path = (
+        base_dir / "curated" / "pressure" / "well_pressure_observations.parquet"
+    )
+    report_path = base_dir / "reports" / "colorado_ecmc_form5a_ingest_summary.json"
+    assert summary["promotion"]["status"] == "candidate_only"
+    assert summary["candidate_quality"]["usable_candidate_rows"] == 2
+    assert candidates_path.exists()
+    assert (
+        json.loads(report_path.read_text(encoding="utf-8"))["promotion"]["status"]
+        == "candidate_only"
+    )
+
+
+def _write_runner_config(tmp_path: Path) -> Path:
+    config_path = tmp_path / "facility_detail.yml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "storage": {"base_dir": str(tmp_path / "facility_detail_ingest")},
+                "source_list": {"path": str(tmp_path / "WELLS_SHP.ZIP")},
+                "facility_detail": {
+                    "base_url": "https://ecmc.state.co.us/cogisdb/Facility/FacilityDetail.aspx",
+                    "timeout_seconds": 30,
+                    "request_delay_seconds": 0,
+                    "user_agent": "worldenergydata-test/1.0",
+                    "stop_on_identity_mismatch": True,
+                },
+                "max_requests": 1,
+                "allow_full_source_list": True,
+                "pressure_observations": {"atmospheric_psi": 14.7},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return config_path


### PR DESCRIPTION
## Summary
- Add a production Colorado ECMC FacilityDetail/Form 5A ingest lane using the official WELLS ZIP source list and live FacilityDetail pages.
- Keep Form 5A casing/tubing pressure evidence candidate-only with explicit psig/psia conversion, depth selection, lineage, and promotion reporting.
- Harden parsing for multiple Initial Test Data blocks and restrict underpressured-screen static correction to WHP_shut_in only.

## Direct-source /mnt/ace evidence
Tracked config run on 2026-07-04:
- WELLS rows: 124,332
- FacilityDetail request rows: 5
- fetched pages: 5
- parsed Initial Test Data rows: 49
- usable candidate pressure rows: 11
- screen-promotable rows: 0
- promotion: candidate_only
- output root: /mnt/ace/worldenergydata/data/modules/colorado_ecmc/facility_detail_ingest/

## Verification
- PYTHONPATH=src:packages/worldenergydata-core/src /usr/bin/python3 -m pytest tests/unit/modules/state_regulators/test_colorado_ecmc_facility_detail_ingest.py tests/unit/modules/state_regulators/test_colorado_ecmc_facility_detail_pipeline.py tests/unit/modules/state_regulators/test_colorado_ecmc_facility_detail.py tests/unit/modules/state_regulators/test_colorado_ecmc_pipeline.py tests/unit/modules/state_regulators/test_colorado_ecmc_parsers.py tests/unit/modules/state_regulators/test_colorado_ecmc_observations.py tests/unit/analysis/test_underpressured_observations.py tests/unit/analysis/test_underpressured_screen.py -q
- ruff check touched Python files
- ruff format --check touched Python files
- git diff --check
- scripts/legal/legal-sanity-scan.sh

## Review
- Inline adversarial code review artifact: scripts/review/results/2026-07-04-code-751-codex-inline.md

Closes #751