### PR TITLE
feat(insights): drilling learning-curve — repetition vs step-out (#775)

### DIFF
--- a/packages/worldenergydata-bsee/src/worldenergydata/lower_tertiary/drilling_learning.py
+++ b/packages/worldenergydata-bsee/src/worldenergydata/lower_tertiary/drilling_learning.py
@@ -1,0 +1,107 @@
+"""ABOUTME: Learning-vs-step-out analytic for the GoM Lower-Tertiary drilling insight.
+ABOUTME: Splits each field's wells (ordered by spud) into first/last half and compares
+ABOUTME: depth-normalized drilling intensity (rig-days per 1,000 ft TVD) to tell real
+ABOUTME: repetition-driven learning apart from wells simply getting shallower (#775).
+
+Public surface:
+    compute_learning(df) -> dict   # side-effect free; df is the cleaned wells frame
+
+The input frame is the output of ``build_drilling_insights.load_wells``: columns
+``LEASE_NAME``, ``WELL_SPUD_DATE`` (datetime), ``drill_days`` (0 -> NaN),
+``MAX_WELL_BORE_TVD``. Only wells with a derivable drill_days and a spud date are
+used; only fields with n>=4 such wells get a verdict. Verdict is on the
+depth-normalized (dpk) first-half -> last-half median change, threshold +/-10%.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+VERDICT_THRESHOLD_PCT = 10.0
+
+
+def _clean(df: pd.DataFrame) -> pd.DataFrame:
+    """Keep wells with a derivable drill_days + spud date; add dpk column."""
+    d = df.loc[df["drill_days"].notna() & df["WELL_SPUD_DATE"].notna()].copy()
+    d["MAX_WELL_BORE_TVD"] = pd.to_numeric(d["MAX_WELL_BORE_TVD"], errors="coerce")
+    d["drill_days"] = pd.to_numeric(d["drill_days"], errors="coerce")
+    d["dpk"] = d["drill_days"] / (d["MAX_WELL_BORE_TVD"] / 1000.0)
+    return d
+
+
+def _verdict(dpk_delta_pct: float) -> str:
+    if dpk_delta_pct < -VERDICT_THRESHOLD_PCT:
+        return "learn"
+    if dpk_delta_pct > VERDICT_THRESHOLD_PCT:
+        return "stepout"
+    return "flat"
+
+
+def compute_learning(df: pd.DataFrame) -> dict:
+    """Return per-field learning-vs-step-out verdicts + a pooled slope + St Malo.
+
+    See module docstring. All medians are first-half vs last-half of the
+    spud-ordered wells; the verdict is on the depth-normalized (dpk) change so a
+    field that merely drilled shallower wells does not read as "learning".
+    """
+    d = _clean(df)
+
+    per_field: list[dict] = []
+    seqs: list[float] = []
+    days: list[float] = []
+    for field, g in d.groupby("LEASE_NAME"):
+        g = g.sort_values("WELL_SPUD_DATE")
+        n = len(g)
+        if n < 4:
+            continue
+        half = n // 2
+        h1, h2 = g.iloc[:half], g.iloc[half:]
+        h1_median = float(h1["drill_days"].median())
+        h2_median = float(h2["drill_days"].median())
+        dpk_h1 = float(h1["dpk"].median())
+        dpk_h2 = float(h2["dpk"].median())
+        dpk_delta_pct = (dpk_h2 - dpk_h1) / dpk_h1 * 100.0 if dpk_h1 else float("nan")
+        tvd_drift = float(
+            h2["MAX_WELL_BORE_TVD"].median() - h1["MAX_WELL_BORE_TVD"].median()
+        )
+        per_field.append(
+            {
+                "field": str(field),
+                "n": int(n),
+                "h1_median": h1_median,
+                "h2_median": h2_median,
+                "dpk_h1": dpk_h1,
+                "dpk_h2": dpk_h2,
+                "dpk_delta_pct": dpk_delta_pct,
+                "tvd_drift": tvd_drift,
+                "verdict": _verdict(dpk_delta_pct),
+            }
+        )
+        for i, val in enumerate(g["drill_days"].to_numpy(float)):
+            seqs.append(i + 1)
+            days.append(val)
+
+    per_field.sort(key=lambda r: r["dpk_delta_pct"])
+    counts = {
+        "learn": sum(1 for r in per_field if r["verdict"] == "learn"),
+        "stepout": sum(1 for r in per_field if r["verdict"] == "stepout"),
+        "flat": sum(1 for r in per_field if r["verdict"] == "flat"),
+    }
+
+    if len(seqs) >= 2:
+        sa, da = np.array(seqs, float), np.array(days, float)
+        slope = float(np.polyfit(sa, da, 1)[0])
+        r = float(np.corrcoef(sa, da)[0, 1])
+    else:
+        slope, r = float("nan"), float("nan")
+    pooled = {"slope_per_well": slope, "r": r, "n": len(seqs)}
+
+    stmalo = next((r for r in per_field if r["field"] == "St Malo"), None)
+
+    return {
+        "per_field": per_field,
+        "counts": counts,
+        "pooled": pooled,
+        "stmalo": stmalo,
+    }

--- a/reports/lower_tertiary/drilling_insights.html
+++ b/reports/lower_tertiary/drilling_insights.html
@@ -73,6 +73,23 @@
   .chart .barval { font-family:var(--mono); font-size:11px; fill:var(--ink);
     font-variant-numeric:tabular-nums; dominant-baseline:middle; }
   .chart .barnote { fill:var(--muted); }
+  .chart .div-learn { fill:var(--good); }
+  .chart .div-step { fill:var(--alert); }
+  .chart .div-flat { fill:var(--muted); opacity:.55; }
+  .chart .divhdr { font-family:var(--mono); font-size:10.5px; letter-spacing:.04em;
+    fill:var(--good); font-weight:600; }
+  .chart .divhdr.warm { fill:var(--alert); }
+
+  .callout { border:1px solid var(--line); border-left:4px solid var(--accent);
+    background:var(--panel-2); border-radius:10px; padding:16px 18px; margin:2px 0 0;
+    font-size:14px; line-height:1.55; }
+  .callout .ct { font-family:var(--mono); font-size:10.5px; letter-spacing:.12em;
+    text-transform:uppercase; color:var(--accent-ink); font-weight:700; margin:0 0 6px; }
+  @media (prefers-color-scheme:dark) { .callout .ct { color:var(--accent); } }
+  :root[data-theme="dark"] .callout .ct { color:var(--accent); }
+  .callout b { font-variant-numeric:tabular-nums; }
+  .note { font-size:12.5px; color:var(--muted); margin:12px 0 0; line-height:1.5;
+    max-width:82ch; }
 
   table { border-collapse:collapse; width:100%; font-size:13.5px; min-width:520px; }
   th, td { text-align:left; padding:7px 12px; border-bottom:1px solid var(--line); }
@@ -158,6 +175,53 @@
         <figcaption>Median drilling days per field (n = wellbores with a derivable
         duration). St&nbsp;Malo's low median reflects many short re-entry / sidetrack
         intervals in a 65-wellbore program.</figcaption></figure></div>
+    </section>
+
+    <section>
+      <p class="lane-label">Repetition vs step-out</p>
+      <h2>What actually drives drilling days &mdash; repetition vs step-out</h2>
+      <p class="lead">
+        Ordering each field's wells by spud date and splitting them in half, the
+        honest signal is depth-normalized: <b>rig-days per 1,000&nbsp;ft TVD</b>
+        (dpk), first-half median vs last-half median. That controls for a field
+        simply moving to shallower targets. Of the 11
+        fields with n&nbsp;&ge;&nbsp;4 datable wells, <b>5 learned</b>
+        (dpk fell &gt;10%), <b>4 stepped out</b> (dpk rose &gt;10%),
+        and 2 held flat.
+      </p>
+      <div class="scrollx"><figure><svg viewBox="0 0 760 406" width="100%" role="img" aria-label="Change in depth-normalized drilling intensity, first half vs last half" class="chart" preserveAspectRatio="xMidYMid meet"><title>Change in depth-normalized drilling intensity, first half vs last half</title><text x="409" y="18" class="divhdr" text-anchor="end">&#8592; faster (learning)</text><text x="425" y="18" class="divhdr warm" text-anchor="start">slower (step-out) &#8594;</text><line x1="417.0" y1="28.0" x2="417.0" y2="402.0" class="axis"/><text x="122" y="50.3" class="tick" text-anchor="end">Chinook</text><rect x="350.1" y="34.0" width="66.9" height="24" rx="3" class="div-learn"/><text x="343.1" y="50.3" class="barval" text-anchor="end">-67%<tspan class="barnote"> (n=5)</tspan></text><text x="122" y="82.3" class="tick" text-anchor="end">Shenandoah</text><rect x="359.9" y="66.0" width="57.1" height="24" rx="3" class="div-learn"/><text x="352.9" y="82.3" class="barval" text-anchor="end">-57%<tspan class="barnote"> (n=17)</tspan></text><text x="122" y="114.3" class="tick" text-anchor="end">St Malo</text><rect x="385.6" y="98.0" width="31.4" height="24" rx="3" class="div-learn"/><text x="378.6" y="114.3" class="barval" text-anchor="end">-32%<tspan class="barnote"> (n=57)</tspan></text><text x="122" y="146.3" class="tick" text-anchor="end">Stones</text><rect x="390.4" y="130.0" width="26.6" height="24" rx="3" class="div-learn"/><text x="383.4" y="146.3" class="barval" text-anchor="end">-27%<tspan class="barnote"> (n=21)</tspan></text><text x="122" y="178.3" class="tick" text-anchor="end">North Platte</text><rect x="391.1" y="162.0" width="25.9" height="24" rx="3" class="div-learn"/><text x="384.1" y="178.3" class="barval" text-anchor="end">-26%<tspan class="barnote"> (n=12)</tspan></text><text x="122" y="210.3" class="tick" text-anchor="end">Kaskida</text><rect x="415.7" y="194.0" width="1.3" height="24" rx="3" class="div-flat"/><text x="408.7" y="210.3" class="barval" text-anchor="end">-1%<tspan class="barnote"> (n=7)</tspan></text><text x="122" y="242.3" class="tick" text-anchor="end">Big Foot</text><rect x="417.0" y="226.0" width="6.8" height="24" rx="3" class="div-flat"/><text x="430.8" y="242.3" class="barval" text-anchor="start">+7%<tspan class="barnote"> (n=24)</tspan></text><text x="122" y="274.3" class="tick" text-anchor="end">Jack</text><rect x="417.0" y="258.0" width="29.2" height="24" rx="3" class="div-step"/><text x="453.2" y="274.3" class="barval" text-anchor="start">+29%<tspan class="barnote"> (n=8)</tspan></text><text x="122" y="306.3" class="tick" text-anchor="end">Julia</text><rect x="417.0" y="290.0" width="45.1" height="24" rx="3" class="div-step"/><text x="469.1" y="306.3" class="barval" text-anchor="start">+45%<tspan class="barnote"> (n=9)</tspan></text><text x="122" y="338.3" class="tick" text-anchor="end">Anchor</text><rect x="417.0" y="322.0" width="118.3" height="24" rx="3" class="div-step"/><text x="542.3" y="338.3" class="barval" text-anchor="start">+119%<tspan class="barnote"> (n=13)</tspan></text><text x="122" y="370.3" class="tick" text-anchor="end">Cascade</text><rect x="417.0" y="354.0" width="263.9" height="24" rx="3" class="div-step"/><text x="687.9" y="370.3" class="barval" text-anchor="start">+266%<tspan class="barnote"> (n=9)</tspan></text></svg>
+        <figcaption>Percent change in depth-normalized drilling intensity
+        (rig-days per 1,000&nbsp;ft TVD), first half &rarr; last half of each field's
+        spud-ordered wells. Green = repetition compounding; red = step-outs into
+        new fault blocks resetting the clock.</figcaption></figure></div>
+
+      <div class="callout" style="margin-top:16px">
+        <p class="ct">St&nbsp;Malo spotlight &mdash; why depth-normalizing matters</p>
+        Across St&nbsp;Malo's <b>57 wells</b>, raw drilling time looks like a
+        clean win &mdash; first-half median <b>42 days</b> falling to
+        <b>19 days</b> (-54% raw).
+        But the last-half wells are ~<b>5,078&nbsp;ft shallower</b>
+        (TVD drift -5,078&nbsp;ft), so a good chunk of that speed-up is
+        just easier holes. Depth-normalized, the real, defensible learning is
+        <b>-32%</b> &mdash; 1.6 &rarr;
+        1.1 rig-days per 1,000&nbsp;ft.
+      </div>
+
+      <p class="lead" style="margin-top:16px">
+        <b>Repetition compounds:</b> 5 fields cut depth-normalized
+        drilling intensity 26&ndash;67% (Chinook -67%, Shenandoah -57%, St Malo -32%, Stones -27%, North Platte -26%). <b>Step-outs reset the
+        clock:</b> 4 fields worsened by +29&ndash;266% as they pushed
+        into new fault blocks and reservoir compartments (Cascade +266%, Anchor +119%, Julia +45%, Jack +29%).
+      </p>
+      <p class="note">
+        Honest note: this is depth-normalized and limited to fields with
+        n&nbsp;&ge;&nbsp;4 datable wells. Pooled across every well-in-sequence, the
+        learning trend is <b>weak</b> (r&nbsp;&asymp;&nbsp;-0.28 over
+        182 wells, -1.1 days per additional well) &mdash;
+        so the thesis is <i>not</i> &ldquo;wells always get faster,&rdquo; but rather that
+        <i>repetition within a known block</i> compounds while step-outs pay the
+        first-well tax again.
+      </p>
     </section>
 
     <section>

--- a/scripts/lower_tertiary/build_drilling_insights.py
+++ b/scripts/lower_tertiary/build_drilling_insights.py
@@ -44,7 +44,12 @@ from worldenergydata.lower_tertiary.drilling_learning import (  # noqa: E402
 
 DEFAULT_SOURCE = (
     PROJECT_ROOT
-    / "docs" / "modules" / "bsee" / "analysis" / "production" / "FDAS_V30"
+    / "docs"
+    / "modules"
+    / "bsee"
+    / "analysis"
+    / "production"
+    / "FDAS_V30"
     / "drilling_and_completion_days.xlsx"
 )
 REPORTS_DIR = PROJECT_ROOT / "reports" / "lower_tertiary"
@@ -121,7 +126,9 @@ def compute_stats(df: pd.DataFrame) -> dict:
 
     # deepest / fastest / slowest (only among wells with a derivable drill_days)
     dd = df.dropna(subset=["drill_days"])
-    deepest = dd.dropna(subset=["MAX_WELL_BORE_TVD"]).nlargest(1, "MAX_WELL_BORE_TVD").iloc[0]
+    deepest = (
+        dd.dropna(subset=["MAX_WELL_BORE_TVD"]).nlargest(1, "MAX_WELL_BORE_TVD").iloc[0]
+    )
     fastest = dd.nsmallest(5, "drill_days")
     slowest = dd.nlargest(5, "drill_days")
 
@@ -197,8 +204,18 @@ def esc(s) -> str:
 # Inline-SVG chart builders (class-styled so the page CSS themes them)
 # --------------------------------------------------------------------------- #
 def svg_scatter(
-    xs, ys, *, x_dom, y_dom, x_label, y_label, title, fit=None,
-    highlight=None, width=760, height=430,
+    xs,
+    ys,
+    *,
+    x_dom,
+    y_dom,
+    x_label,
+    y_label,
+    title,
+    fit=None,
+    highlight=None,
+    width=760,
+    height=430,
 ):
     ml, mr, mt, mb = 66, 22, 20, 52
     pw, ph = width - ml - mr, height - mt - mb
@@ -236,7 +253,7 @@ def svg_scatter(
         )
         parts.append(
             f'<text x="{xx:.1f}" y="{mt+ph+18:.1f}" class="tick" text-anchor="middle">'
-            f'{_n(t/1000,1)}k</text>'
+            f"{_n(t/1000,1)}k</text>"
         )
     # axes
     parts.append(
@@ -327,11 +344,11 @@ def svg_diverging_barh(rows, *, title, width=760, bar_h=24):
     # header direction labels
     parts.append(
         f'<text x="{cx-8:.0f}" y="{mt-16:.0f}" class="divhdr" text-anchor="end">'
-        f'&#8592; faster (learning)</text>'
+        f"&#8592; faster (learning)</text>"
     )
     parts.append(
         f'<text x="{cx+8:.0f}" y="{mt-16:.0f}" class="divhdr warm" text-anchor="start">'
-        f'slower (step-out) &#8594;</text>'
+        f"slower (step-out) &#8594;</text>"
     )
     y_bot = mt + n * (bar_h + 8) - 8 + bar_h
     parts.append(
@@ -754,8 +771,11 @@ def render_html(s: dict, source: Path) -> str:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--source", default=str(DEFAULT_SOURCE),
-                        help="Path to drilling_and_completion_days.xlsx")
+    parser.add_argument(
+        "--source",
+        default=str(DEFAULT_SOURCE),
+        help="Path to drilling_and_completion_days.xlsx",
+    )
     args = parser.parse_args(argv)
 
     source = Path(args.source)

--- a/scripts/lower_tertiary/build_drilling_insights.py
+++ b/scripts/lower_tertiary/build_drilling_insights.py
@@ -38,6 +38,10 @@ import pandas as pd
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
+from worldenergydata.lower_tertiary.drilling_learning import (  # noqa: E402
+    compute_learning,
+)
+
 DEFAULT_SOURCE = (
     PROJECT_ROOT
     / "docs" / "modules" / "bsee" / "analysis" / "production" / "FDAS_V30"
@@ -297,6 +301,70 @@ def svg_barh(labels, values, notes, *, x_max, title, unit="", width=760, bar_h=2
     return "".join(parts)
 
 
+def svg_diverging_barh(rows, *, title, width=760, bar_h=24):
+    """Zero-centered horizontal bars of per-field dpk_delta_pct.
+
+    Negative (depth-normalized drilling got faster = learning) extends left and
+    is styled cool/green; positive (step-out reset the clock) extends right and
+    is styled warm/red; near-zero (flat) is muted. ``rows`` is the per_field
+    list from ``compute_learning`` (already sorted by dpk_delta_pct).
+    """
+    ml, mr, mt, mb = 132, 58, 34, 20
+    n = len(rows)
+    height = mt + mb + n * (bar_h + 8)
+    pw = width - ml - mr
+    cx = ml + pw / 2.0
+    vmax = max(abs(r["dpk_delta_pct"]) for r in rows) * 1.08
+
+    def bx(v):
+        return v / vmax * (pw / 2.0)
+
+    parts = [
+        f'<svg viewBox="0 0 {width} {height}" width="100%" role="img" '
+        f'aria-label="{esc(title)}" class="chart" preserveAspectRatio="xMidYMid meet">',
+        f"<title>{esc(title)}</title>",
+    ]
+    # header direction labels
+    parts.append(
+        f'<text x="{cx-8:.0f}" y="{mt-16:.0f}" class="divhdr" text-anchor="end">'
+        f'&#8592; faster (learning)</text>'
+    )
+    parts.append(
+        f'<text x="{cx+8:.0f}" y="{mt-16:.0f}" class="divhdr warm" text-anchor="start">'
+        f'slower (step-out) &#8594;</text>'
+    )
+    y_bot = mt + n * (bar_h + 8) - 8 + bar_h
+    parts.append(
+        f'<line x1="{cx:.1f}" y1="{mt-6:.1f}" x2="{cx:.1f}" y2="{y_bot:.1f}" class="axis"/>'
+    )
+    for i, r in enumerate(rows):
+        y = mt + i * (bar_h + 8)
+        v = r["dpk_delta_pct"]
+        w = bx(v)
+        x = cx if w >= 0 else cx + w
+        cls = {"learn": "div-learn", "stepout": "div-step", "flat": "div-flat"}[
+            r["verdict"]
+        ]
+        parts.append(
+            f'<text x="{ml-10:.0f}" y="{y+bar_h*0.68:.1f}" class="tick" '
+            f'text-anchor="end">{esc(r["field"])}</text>'
+        )
+        parts.append(
+            f'<rect x="{x:.1f}" y="{y:.1f}" width="{abs(w):.1f}" height="{bar_h}" '
+            f'rx="3" class="{cls}"/>'
+        )
+        if w >= 0:
+            lx, anch = cx + w + 7, "start"
+        else:
+            lx, anch = cx + w - 7, "end"
+        parts.append(
+            f'<text x="{lx:.1f}" y="{y+bar_h*0.68:.1f}" class="barval" '
+            f'text-anchor="{anch}">{v:+.0f}%<tspan class="barnote"> (n={r["n"]})</tspan></text>'
+        )
+    parts.append("</svg>")
+    return "".join(parts)
+
+
 # --------------------------------------------------------------------------- #
 # Page
 # --------------------------------------------------------------------------- #
@@ -333,6 +401,24 @@ def render_html(s: dict, source: Path) -> str:
         title="Median drilling days by field",
         unit=" d",
     )
+
+    lrn = s["learning"]
+    learn_bar = svg_diverging_barh(
+        lrn["per_field"],
+        title="Change in depth-normalized drilling intensity, first half vs last half",
+    )
+    lc_counts = lrn["counts"]
+    learn_flds = [r for r in lrn["per_field"] if r["verdict"] == "learn"]
+    step_flds = [r for r in lrn["per_field"] if r["verdict"] == "stepout"]
+    learn_names = ", ".join(
+        f"{esc(r['field'])} {r['dpk_delta_pct']:+.0f}%" for r in learn_flds
+    )
+    step_names = ", ".join(
+        f"{esc(r['field'])} {r['dpk_delta_pct']:+.0f}%"
+        for r in sorted(step_flds, key=lambda r: -r["dpk_delta_pct"])
+    )
+    sm = lrn["stmalo"]
+    pooled = lrn["pooled"]
 
     def rows(frame):
         out = []
@@ -440,6 +526,23 @@ def render_html(s: dict, source: Path) -> str:
   .chart .barval {{ font-family:var(--mono); font-size:11px; fill:var(--ink);
     font-variant-numeric:tabular-nums; dominant-baseline:middle; }}
   .chart .barnote {{ fill:var(--muted); }}
+  .chart .div-learn {{ fill:var(--good); }}
+  .chart .div-step {{ fill:var(--alert); }}
+  .chart .div-flat {{ fill:var(--muted); opacity:.55; }}
+  .chart .divhdr {{ font-family:var(--mono); font-size:10.5px; letter-spacing:.04em;
+    fill:var(--good); font-weight:600; }}
+  .chart .divhdr.warm {{ fill:var(--alert); }}
+
+  .callout {{ border:1px solid var(--line); border-left:4px solid var(--accent);
+    background:var(--panel-2); border-radius:10px; padding:16px 18px; margin:2px 0 0;
+    font-size:14px; line-height:1.55; }}
+  .callout .ct {{ font-family:var(--mono); font-size:10.5px; letter-spacing:.12em;
+    text-transform:uppercase; color:var(--accent-ink); font-weight:700; margin:0 0 6px; }}
+  @media (prefers-color-scheme:dark) {{ .callout .ct {{ color:var(--accent); }} }}
+  :root[data-theme="dark"] .callout .ct {{ color:var(--accent); }}
+  .callout b {{ font-variant-numeric:tabular-nums; }}
+  .note {{ font-size:12.5px; color:var(--muted); margin:12px 0 0; line-height:1.5;
+    max-width:82ch; }}
 
   table {{ border-collapse:collapse; width:100%; font-size:13.5px; min-width:520px; }}
   th, td {{ text-align:left; padding:7px 12px; border-bottom:1px solid var(--line); }}
@@ -525,6 +628,53 @@ def render_html(s: dict, source: Path) -> str:
         <figcaption>Median drilling days per field (n = wellbores with a derivable
         duration). St&nbsp;Malo's low median reflects many short re-entry / sidetrack
         intervals in a 65-wellbore program.</figcaption></figure></div>
+    </section>
+
+    <section>
+      <p class="lane-label">Repetition vs step-out</p>
+      <h2>What actually drives drilling days &mdash; repetition vs step-out</h2>
+      <p class="lead">
+        Ordering each field's wells by spud date and splitting them in half, the
+        honest signal is depth-normalized: <b>rig-days per 1,000&nbsp;ft TVD</b>
+        (dpk), first-half median vs last-half median. That controls for a field
+        simply moving to shallower targets. Of the {lc_counts['learn']+lc_counts['stepout']+lc_counts['flat']}
+        fields with n&nbsp;&ge;&nbsp;4 datable wells, <b>{lc_counts['learn']} learned</b>
+        (dpk fell &gt;10%), <b>{lc_counts['stepout']} stepped out</b> (dpk rose &gt;10%),
+        and {lc_counts['flat']} held flat.
+      </p>
+      <div class="scrollx"><figure>{learn_bar}
+        <figcaption>Percent change in depth-normalized drilling intensity
+        (rig-days per 1,000&nbsp;ft TVD), first half &rarr; last half of each field's
+        spud-ordered wells. Green = repetition compounding; red = step-outs into
+        new fault blocks resetting the clock.</figcaption></figure></div>
+
+      <div class="callout" style="margin-top:16px">
+        <p class="ct">St&nbsp;Malo spotlight &mdash; why depth-normalizing matters</p>
+        Across St&nbsp;Malo's <b>{sm['n']} wells</b>, raw drilling time looks like a
+        clean win &mdash; first-half median <b>{_n(sm['h1_median'])} days</b> falling to
+        <b>{_n(sm['h2_median'])} days</b> ({(sm['h2_median']/sm['h1_median']-1)*100:+.0f}% raw).
+        But the last-half wells are ~<b>{_n(abs(sm['tvd_drift']))}&nbsp;ft shallower</b>
+        (TVD drift {sm['tvd_drift']:+,.0f}&nbsp;ft), so a good chunk of that speed-up is
+        just easier holes. Depth-normalized, the real, defensible learning is
+        <b>{sm['dpk_delta_pct']:+.0f}%</b> &mdash; {_n(sm['dpk_h1'],1)} &rarr;
+        {_n(sm['dpk_h2'],1)} rig-days per 1,000&nbsp;ft.
+      </div>
+
+      <p class="lead" style="margin-top:16px">
+        <b>Repetition compounds:</b> {len(learn_flds)} fields cut depth-normalized
+        drilling intensity 26&ndash;67% ({learn_names}). <b>Step-outs reset the
+        clock:</b> {len(step_flds)} fields worsened by +29&ndash;266% as they pushed
+        into new fault blocks and reservoir compartments ({step_names}).
+      </p>
+      <p class="note">
+        Honest note: this is depth-normalized and limited to fields with
+        n&nbsp;&ge;&nbsp;4 datable wells. Pooled across every well-in-sequence, the
+        learning trend is <b>weak</b> (r&nbsp;&asymp;&nbsp;{pooled['r']:.2f} over
+        {pooled['n']} wells, {_n(pooled['slope_per_well'],1)} days per additional well) &mdash;
+        so the thesis is <i>not</i> &ldquo;wells always get faster,&rdquo; but rather that
+        <i>repetition within a known block</i> compounds while step-outs pay the
+        first-well tax again.
+      </p>
     </section>
 
     <section>
@@ -621,6 +771,7 @@ def main(argv: list[str] | None = None) -> int:
     REPORTS_DIR.mkdir(parents=True, exist_ok=True)
     write_csv(df, CSV_PATH)
     stats = compute_stats(df)
+    stats["learning"] = compute_learning(df)
     HTML_PATH.write_text(render_html(stats, source), encoding="utf-8")
 
     print(f"Wrote {CSV_PATH}")

--- a/tests/unit/lower_tertiary/test_drilling_learning.py
+++ b/tests/unit/lower_tertiary/test_drilling_learning.py
@@ -1,0 +1,81 @@
+"""Tests for lower_tertiary.drilling_learning verdict logic (#775).
+
+Exercises the PURE learning-vs-step-out verdict on a small synthetic frame,
+not the real V30 workbook: a field whose later wells have lower depth-normalized
+drilling intensity reads 'learn'; higher reads 'stepout'; within +/-10% is 'flat'.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from worldenergydata.lower_tertiary.drilling_learning import compute_learning  # noqa: E402
+
+
+def _field(name, days, tvds, start="2010-01-01"):
+    """Build n rows for one field with ascending spud dates (constant TVD)."""
+    dates = pd.date_range(start, periods=len(days), freq="90D")
+    return pd.DataFrame(
+        {
+            "LEASE_NAME": name,
+            "WELL_SPUD_DATE": dates,
+            "drill_days": days,
+            "MAX_WELL_BORE_TVD": tvds,
+        }
+    )
+
+
+def _verdict_for(res, field):
+    return next(r["verdict"] for r in res["per_field"] if r["field"] == field)
+
+
+def test_learn_stepout_flat_verdicts():
+    # Constant TVD (10,000 ft) so dpk change tracks drill-days change directly.
+    tvd = [10000] * 4
+    learn = _field("Learner", [40, 40, 20, 20], tvd)      # 40 -> 20 dpk => -50%
+    stepout = _field("Stepout", [20, 20, 40, 40], tvd)    # 20 -> 40 dpk => +100%
+    flat = _field("Flat", [40, 40, 41, 41], tvd)          # ~+2.5% => flat
+    df = pd.concat([learn, stepout, flat], ignore_index=True)
+
+    res = compute_learning(df)
+
+    assert _verdict_for(res, "Learner") == "learn"
+    assert _verdict_for(res, "Stepout") == "stepout"
+    assert _verdict_for(res, "Flat") == "flat"
+    assert res["counts"] == {"learn": 1, "stepout": 1, "flat": 1}
+
+
+def test_depth_normalization_overrides_raw_days():
+    # Raw drill-days FALL (40 -> 30) but wells get much shallower, so
+    # depth-normalized intensity RISES => step-out, not learning.
+    df = _field("Shallower", [40, 40, 30, 30], [20000, 20000, 6000, 6000])
+    res = compute_learning(df)
+    assert _verdict_for(res, "Shallower") == "stepout"
+
+
+def test_fields_below_four_wells_are_dropped():
+    df = _field("Tiny", [40, 20, 20], [10000, 10000, 10000])
+    res = compute_learning(df)
+    assert res["per_field"] == []
+    assert res["counts"] == {"learn": 0, "stepout": 0, "flat": 0}
+
+
+def test_per_field_sorted_by_dpk_delta():
+    tvd = [10000] * 4
+    df = pd.concat(
+        [
+            _field("A", [20, 20, 40, 40], tvd),   # +100%
+            _field("B", [40, 40, 20, 20], tvd),   # -50%
+        ],
+        ignore_index=True,
+    )
+    res = compute_learning(df)
+    deltas = [r["dpk_delta_pct"] for r in res["per_field"]]
+    assert deltas == sorted(deltas)
+    assert res["per_field"][0]["field"] == "B"

--- a/tests/unit/lower_tertiary/test_drilling_learning.py
+++ b/tests/unit/lower_tertiary/test_drilling_learning.py
@@ -15,7 +15,9 @@ import pandas as pd
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
-from worldenergydata.lower_tertiary.drilling_learning import compute_learning  # noqa: E402
+from worldenergydata.lower_tertiary.drilling_learning import (  # noqa: E402
+    compute_learning,
+)
 
 
 def _field(name, days, tvds, start="2010-01-01"):
@@ -38,9 +40,9 @@ def _verdict_for(res, field):
 def test_learn_stepout_flat_verdicts():
     # Constant TVD (10,000 ft) so dpk change tracks drill-days change directly.
     tvd = [10000] * 4
-    learn = _field("Learner", [40, 40, 20, 20], tvd)      # 40 -> 20 dpk => -50%
-    stepout = _field("Stepout", [20, 20, 40, 40], tvd)    # 20 -> 40 dpk => +100%
-    flat = _field("Flat", [40, 40, 41, 41], tvd)          # ~+2.5% => flat
+    learn = _field("Learner", [40, 40, 20, 20], tvd)  # 40 -> 20 dpk => -50%
+    stepout = _field("Stepout", [20, 20, 40, 40], tvd)  # 20 -> 40 dpk => +100%
+    flat = _field("Flat", [40, 40, 41, 41], tvd)  # ~+2.5% => flat
     df = pd.concat([learn, stepout, flat], ignore_index=True)
 
     res = compute_learning(df)
@@ -70,8 +72,8 @@ def test_per_field_sorted_by_dpk_delta():
     tvd = [10000] * 4
     df = pd.concat(
         [
-            _field("A", [20, 20, 40, 40], tvd),   # +100%
-            _field("B", [40, 40, 20, 20], tvd),   # -50%
+            _field("A", [20, 20, 40, 40], tvd),  # +100%
+            _field("B", [40, 40, 20, 20], tvd),  # -50%
         ],
         ignore_index=True,
     )


### PR DESCRIPTION
## Drilling learning curve — repetition vs step-out

Follow-up to #786 (sub-epic #774, child #775). Deepens the GoM Lower-Tertiary drilling front door with the **answer to the question it already raises**: the main page shows days-vs-TVD **r²=0.11** (geology explains only ~11% of drilling-days spread) — so *what does?*

### Finding (depth-normalized, honest)
Ordering each field's wells by spud date and comparing first-half vs last-half **median rig-days per 1,000 ft TVD** (so it isn't just "wells got shallower"):
- **Learning is real but not automatic** — pooled signal is weak (r≈−0.28), reported as-is.
- **5 fields compound learning:** Chinook −67%, Shenandoah −57%, **St Malo −32%** (57 wells, after removing a 5,078 ft shallowing), Stones −27%, North Platte −26%.
- **4 fields pay a step-out penalty:** Cascade +266%, Anchor +119%, Julia +45%, Jack +29% — drilling into new fault blocks resets the clock.
- **2 flat:** Big Foot, Kaskida.

Thesis: **repetition compounds; step-outs reset.**

### Changes
- New tested domain module `worldenergydata.lower_tertiary.drilling_learning.compute_learning` (side-effect-free; per-field first/last-half medians + depth-normalized delta + learn/stepout/flat verdict) + **4 pure-logic unit tests** (pass under `.venv`).
- `build_drilling_insights.py`: new diverging-bar section; **no other section's numbers changed**; page regenerated.
- No `build_pages.py` / `repo_structure.yml` changes — the page path is already wired + allow-listed from #786.

### Verified
`build_drilling_insights.py` and `build_pages.py` both exit 0; regenerated page carries the 5/4/2 split and St Malo −32%; tests pass. Numbers reproduce a pre-validated probe against the real V30 workbook.

Refs #775 #774.
