### PR TITLE
feat(norway): add Sodir FDAS reference chain

### DIFF
--- a/.planning/plan-approved/716.md
+++ b/.planning/plan-approved/716.md
@@ -1,0 +1,4 @@
+Approved by: user via GitHub issue status:plan-approved
+Issue: https://github.com/vamseeachanta/worldenergydata/issues/716
+Plan: docs/plans/2026-07-04-issue-716-norway-sodir-reference-chain.md
+Recorded: 2026-07-04

--- a/docs/plans/2026-07-04-issue-716-norway-sodir-reference-chain.md
+++ b/docs/plans/2026-07-04-issue-716-norway-sodir-reference-chain.md
@@ -1,0 +1,67 @@
+# Plan — worldenergydata #716: Norway Sodir reference-chain slice
+
+- **Issue:** https://github.com/vamseeachanta/worldenergydata/issues/716 (child of epic #713)
+- **Status:** approved 2026-07-04 via GitHub `status:plan-approved`
+- **Complexity:** T2 | **Lane:** codex | **Depends on:** #714 ✅, #715 ✅
+- **Execution mode:** single-lane implementation after discovery; validation can run in parallel.
+
+## Resource Intelligence Summary
+
+Norway is the reference pilot for the international field-development chain because SODIR/Norsk Petroleum provide both per-field monthly production and rich field metadata. Current repo state has the F1/F2 prerequisites merged:
+
+- `packages/worldenergydata-production/src/worldenergydata/production/unified/adapters/sodir_adapter.py` still emits synthetic mock profiles by default; existing unified-production tests depend on that compatibility fallback.
+- `packages/worldenergydata-sodir/src/worldenergydata/sodir/production/monthly_loader.py` already parses SODIR monthly rows to `field_name, year, month, oil_sm3, gas_sm3, ngl_sm3, condensate_sm3, water_injected_sm3, oil_bbl, gas_mcf`.
+- `packages/worldenergydata-fdas/src/worldenergydata/fdas/adapters/contract.py` provides `to_fdas_production`, which hard-requires `water_bbl`.
+- `packages/worldenergydata-fdas/src/worldenergydata/fdas/adapters/field_concept_normalizer.py` provides `FieldMetaMapping`, transform callables, and `to_field_concept`.
+- `src/worldenergydata/field_development/recommendation.py` accepts sparse `FieldConcept` objects and returns deterministic ranked concepts.
+- `packages/worldenergydata-fdas/src/worldenergydata/fdas/analysis/cashflow.py` can run a pre-tax cashflow plumbing pass, with a loud warning for missing drilling timelines.
+
+Reproduction proof: `SodirAdapter.fetch` currently returns mock `source="sodir_mock"` rows and does not use `MonthlyProductionLoader`; the plan will replace that with a loader-backed transform and fixture-backed tests.
+
+## Deliverable
+
+1. Rewire `SodirAdapter.fetch` to use `MonthlyProductionLoader` with an injectable API client/loader for fixture-backed tests.
+2. Add the explicit loader-output to unified `STANDARD_COLUMNS` transform:
+   - `region="ncs"`
+   - `source="sodir"`
+   - `oil_bbl` and `gas_mcf` from loader converted columns
+   - `condensate_bbl` from `condensate_sm3`
+   - `water_bbl` set to `0.0` or `NaN`, never from `water_injected_sm3`
+3. Add Norway `FieldMetaMapping` helpers consuming `FieldProcessor.process()` output keys, with `region="norway"`, `year_first_oil`, meters-preserved `water_depth_m`, and combined recoverable reserves `oil_mmbbl + gas_bcf / 6`.
+4. Add a one-fixture-field chain runner:
+   - `fetch → to_fdas_production → CashflowEngine`
+   - `to_field_concept → recommend`
+   - output labels pre-tax economics as chain plumbing, not an investment headline.
+
+## Files to Change
+
+- `packages/worldenergydata-production/src/worldenergydata/production/unified/adapters/sodir_adapter.py`
+- New Norway chain helper module under an existing SODIR-facing package path selected during implementation.
+- Focused unit tests under `tests/unit/production/unified/` and `tests/unit/sodir/`.
+- `.planning/plan-approved/716.md`
+- `docs/plans/README.md`
+
+## TDD Test List
+
+- Loader transform pins every `STANDARD_COLUMNS` field, including `water_bbl` not coming from `water_injected_sm3` and `condensate_bbl` converted from Sm3.
+- `SodirAdapter.fetch` with a fixture loader returns valid unified rows for a requested field/date range and `to_fdas_production` accepts them.
+- Norway FieldMetaMapping consumes processed field keys and builds a valid `FieldConcept` with `region="norway"`, `water_depth_m`, `year_first_oil`, and combined recoverable reserves.
+- Sparse Norway `FieldConcept` produces a non-empty deterministic `recommend()` ranking.
+- One-field Norway chain returns finite pre-tax metrics labeled `chain_plumbing_pre_tax`.
+
+## Acceptance Criteria
+
+- `SodirAdapter` no longer uses synthetic mock profiles when a SODIR monthly loader is supplied; the no-loader synthetic fallback remains compatibility-only for existing unified-production tests.
+- FDAS production normalization succeeds from fixture-backed SODIR monthly rows.
+- Norway FieldConcept mapping is the first real F2 `to_field_concept` consumer.
+- Concept screen returns deterministic ranked concepts.
+- Cashflow output returns finite pre-tax metrics and is explicitly labeled as chain plumbing.
+- No published Norway NPV headline; after-tax fiscal headline remains deferred to follow-on #736.
+- Follow-ons are filed/commented for refresh-job monthly extension, Norway HTML report, and after-tax fiscal headline if not already represented.
+- Focused tests, lint, diff check, legal scan, and code-review artifact are clean before PR.
+
+## Risks
+
+- Water production vs injection confusion: fail closed by never mapping `water_injected_sm3` to `water_bbl`.
+- Sparse concept metadata can produce coarse recommendations; acceptance is deterministic ranked output, not field-accurate concept selection.
+- Pre-tax FDAS output is not a Norway investment metric; label it as plumbing only.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -83,6 +83,7 @@ This directory contains issue-plan artifacts created during the issue-planning-m
 | [#702](https://github.com/vamseeachanta/worldenergydata/issues/702) | [texas-rrc-field-architecture-dossiers](2026-07-02-issue-702-texas-rrc-field-architecture-dossiers.md) | implemented | 2026-07-02 |
 | [#707](https://github.com/vamseeachanta/worldenergydata/issues/707) | [texas-rrc-field-architecture-portfolio](2026-07-02-issue-707-texas-rrc-field-architecture-portfolio.md) | plan-approved | 2026-07-02 |
 | [#709](https://github.com/vamseeachanta/worldenergydata/issues/709) | [texas-rrc-pressure-observations](2026-07-03-issue-709-texas-rrc-pressure-observations.md) | implemented | 2026-07-03 |
+| [#716](https://github.com/vamseeachanta/worldenergydata/issues/716) | [norway-sodir-reference-chain](2026-07-04-issue-716-norway-sodir-reference-chain.md) | plan-approved | 2026-07-04 |
 | [#732](https://github.com/vamseeachanta/worldenergydata/issues/732) | [texas-rrc-underpressured-screen](2026-07-03-issue-732-texas-rrc-underpressured-screen.md) | implemented | 2026-07-03 |
 | [#740](https://github.com/vamseeachanta/worldenergydata/issues/740) | [oklahoma-occ-pressure-observations](2026-07-03-issue-740-oklahoma-occ-pressure-observations.md) | implemented | 2026-07-03 |
 | [#745](https://github.com/vamseeachanta/worldenergydata/issues/745) | [colorado-ecmc-wellhead-pressure-observations](2026-07-03-issue-745-colorado-ecmc-wellhead-pressure-observations.md) | implemented | 2026-07-03 |

--- a/packages/worldenergydata-production/src/worldenergydata/production/unified/adapters/sodir_adapter.py
+++ b/packages/worldenergydata-production/src/worldenergydata/production/unified/adapters/sodir_adapter.py
@@ -11,12 +11,13 @@ from typing import List, Tuple
 
 import pandas as pd
 
-from worldenergydata.common.units import GasUnits
+from worldenergydata.common.units import GasUnits, OilUnits
 from worldenergydata.production.unified.adapters.base import AbstractProductionAdapter
-from worldenergydata.production.unified.query import ProductionQuery
+from worldenergydata.production.unified.query import STANDARD_COLUMNS, ProductionQuery
 
 # 1 MSm3 gas → Mcf  (MSm3_TO_MMSCF gives MMscf; *1000 = Mcf)
 _MSM3_TO_MCF = GasUnits.MSM3_TO_MMSCF * GasUnits.MMSCF_TO_MCF
+_SM3_TO_BBL = OilUnits.SM3_TO_BBL
 
 
 class SodirAdapter(AbstractProductionAdapter):
@@ -33,35 +34,101 @@ class SodirAdapter(AbstractProductionAdapter):
         ("Solveig", 900_000, 310_000, 80_000, 30_000, 2019, 5, 60),
     ]
 
-    def fetch(self, query: ProductionQuery) -> pd.DataFrame:
-        rows = []
-        for (
-            field_name,
-            peak_oil,
-            peak_gas,
-            peak_water,
-            peak_cond,
-            sy,
-            sm,
-            n_months,
-        ) in self._FIELDS:
-            rows.extend(
-                self._generate_field_rows(
-                    field_name,
-                    peak_oil,
-                    peak_gas,
-                    peak_water,
-                    peak_cond,
-                    sy,
-                    sm,
-                    n_months,
-                )
-            )
+    def __init__(self, loader=None):
+        """Initialize the SODIR adapter.
 
-        df = pd.DataFrame(rows)
+        Args:
+            loader: optional object exposing ``load_all_production()`` and,
+                optionally, ``load_field_production(field_name)`` that
+                returns the SODIR ``MonthlyProductionLoader`` output columns
+                (field_name/year/month/oil_sm3/.../oil_bbl/gas_mcf). When
+                provided, ``fetch`` returns REAL SODIR production normalized to
+                ``STANDARD_COLUMNS``. When ``None`` (default), ``fetch`` returns
+                the synthetic benchmark profile — keeping the conformance suite
+                non-empty without live data. Dependency-injected so this adapter
+                carries no worldenergydata-sodir package dependency (#716).
+        """
+        self._loader = loader
+
+    def fetch(self, query: ProductionQuery) -> pd.DataFrame:
+        if self._loader is not None:
+            df = self._loader_to_standard_columns(self._load_from_loader(query))
+        else:
+            rows = []
+            for (
+                field_name,
+                peak_oil,
+                peak_gas,
+                peak_water,
+                peak_cond,
+                sy,
+                sm,
+                n_months,
+            ) in self._FIELDS:
+                rows.extend(
+                    self._generate_field_rows(
+                        field_name,
+                        peak_oil,
+                        peak_gas,
+                        peak_water,
+                        peak_cond,
+                        sy,
+                        sm,
+                        n_months,
+                    )
+                )
+            df = pd.DataFrame(rows)
+
         df = self._filter_by_fields(df, query.fields)
         df = self._filter_by_date(df, query.start, query.end)
         return df.reset_index(drop=True)
+
+    def _load_from_loader(self, query: ProductionQuery) -> pd.DataFrame:
+        """Load fixture/live monthly rows, using field-specific calls when present."""
+        if query.fields and hasattr(self._loader, "load_field_production"):
+            frames = [
+                self._loader.load_field_production(field_name)
+                for field_name in query.fields
+            ]
+            frames = [frame for frame in frames if frame is not None and len(frame) > 0]
+            if not frames:
+                return pd.DataFrame()
+            return pd.concat(frames, ignore_index=True)
+        return self._loader.load_all_production()
+
+    @staticmethod
+    def _loader_to_standard_columns(loader_df: pd.DataFrame) -> pd.DataFrame:
+        """Map ``MonthlyProductionLoader`` output → unified ``STANDARD_COLUMNS``.
+
+        Per #716 review B1:
+          - add ``region="ncs"`` + ``source="sodir"``;
+          - ``condensate_bbl = condensate_sm3 * SM3_TO_BBL`` (loader leaves
+            condensate in Sm3 — it converts only oil/gas);
+          - ``water_bbl = NaN`` — the loader's ``water_injected_sm3`` is
+            INJECTION, not production; produced water is not available from this
+            endpoint, so it is ABSENT (NaN per the AbstractProductionAdapter
+            contract), never a false measured 0.
+        """
+        import numpy as np
+
+        if loader_df is None or len(loader_df) == 0:
+            return pd.DataFrame(columns=list(STANDARD_COLUMNS))
+        out = pd.DataFrame(
+            {
+                "region": "ncs",
+                "field_name": loader_df["field_name"].values,
+                "year": loader_df["year"].values,
+                "month": loader_df["month"].values,
+                "oil_bbl": loader_df["oil_bbl"].values,
+                "gas_mcf": loader_df["gas_mcf"].values,
+                "water_bbl": np.nan,
+                "condensate_bbl": (
+                    loader_df["condensate_sm3"].astype(float) * _SM3_TO_BBL
+                ).values,
+                "source": "sodir",
+            }
+        )
+        return out[list(STANDARD_COLUMNS)]
 
     def available_fields(self) -> List[str]:
         return [f[0] for f in self._FIELDS]

--- a/packages/worldenergydata-sodir/src/worldenergydata/sodir/field_concept.py
+++ b/packages/worldenergydata-sodir/src/worldenergydata/sodir/field_concept.py
@@ -1,0 +1,86 @@
+"""Norway (SODIR) field-metadata → FieldConcept normalizer (#716).
+
+First real consumer of the F2 ``FieldMetaMapping`` (#715). Maps SODIR
+``field_processor.process()`` output → a ``FieldConcept`` for concept screening.
+
+F2's ``FieldMapEntry`` maps a SINGLE source key + transform, so country-specific
+DERIVED fields are pre-computed here before the 1:1 mapping applies:
+  - ``region`` is the constant ``"norway"`` — the basin priors key on
+    ``"norway"``, NOT the SODIR sea-area ``main_area`` (review M1: mapping
+    main_area would leave ``region_fit`` inert).
+  - ``recoverable_reserves_mmboe`` combines recoverable oil (MMbbl) + gas
+    (Bcf / 6) — field_processor exposes them separately (review M2). Returns
+    None (field left unset) when both are absent — never a false 0.
+
+Imports the fdas member at runtime via the shared namespace (root/members always
+installed together), mirroring the established member→member pattern.
+
+Issue: https://github.com/vamseeachanta/worldenergydata/issues/716
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from worldenergydata.fdas.adapters.field_concept_normalizer import (
+    FieldMapEntry,
+    FieldMetaMapping,
+    to_field_concept,
+)
+
+# ~6 Bcf of gas ≈ 1 MMboe (6:1 energy equivalence).
+_GAS_BCF_PER_MMBOE = 6.0
+
+
+def _combined_reserves_mmboe(processed: Dict[str, Any]) -> Optional[float]:
+    """Recoverable oil (MMbbl) + gas (Bcf/6) → MMboe; None if both absent."""
+    oil = processed.get("recoverable_oil_mmbbl")
+    gas = processed.get("recoverable_gas_bcf")
+    if oil is None and gas is None:
+        return None
+    return float(oil or 0.0) + float(gas or 0.0) / _GAS_BCF_PER_MMBOE
+
+
+# 1:1 mapping over the pre-derived Norway meta dict (F2 FieldMetaMapping;
+# validated against FieldConcept fields at construction).
+_NORWAY_MAPPING = FieldMetaMapping(
+    {
+        "name": FieldMapEntry("field_name"),
+        "operator": FieldMapEntry("operator"),
+        "region": FieldMapEntry("region"),
+        "water_depth_m": FieldMapEntry("water_depth_m"),
+        "year_first_oil": FieldMapEntry("production_start_year"),
+        "recoverable_reserves_mmboe": FieldMapEntry("recoverable_reserves_mmboe"),
+        "data_source": FieldMapEntry("source"),
+    }
+)
+
+
+def sodir_field_to_concept(processed: Dict[str, Any]):
+    """Build a validated ``FieldConcept`` from SODIR ``field_processor`` output.
+
+    Args:
+        processed: a ``field_processor.process()`` record (keys ``field_name``,
+            ``operator``, ``water_depth_m``, ``production_start_year``,
+            ``recoverable_oil_mmbbl``, ``recoverable_gas_bcf`` …).
+
+    Returns:
+        FieldConcept (sparse — SODIR metadata populates name/operator/region/
+        water depth/first oil/reserves; concept screening still works, coarse).
+    """
+    meta = dict(processed)
+    meta["region"] = "norway"  # constant — NOT main_area (M1)
+    reserves = _combined_reserves_mmboe(processed)
+    if reserves is not None:
+        meta["recoverable_reserves_mmboe"] = reserves
+    return to_field_concept(meta, _NORWAY_MAPPING)
+
+
+def norway_field_meta_mapping() -> FieldMetaMapping:
+    """Return the Norway SODIR FieldConcept mapping."""
+    return _NORWAY_MAPPING
+
+
+def build_norway_field_concept(processed: Dict[str, Any]):
+    """Alias for the #716 reference-chain terminology."""
+    return sodir_field_to_concept(processed)

--- a/packages/worldenergydata-sodir/src/worldenergydata/sodir/reference_chain.py
+++ b/packages/worldenergydata-sodir/src/worldenergydata/sodir/reference_chain.py
@@ -1,0 +1,103 @@
+"""Norway SODIR reference-chain runner (#716).
+
+Minimal vertical slice:
+``SodirAdapter.fetch`` -> ``to_fdas_production`` -> ``CashflowEngine`` and
+``sodir_field_to_concept`` -> ``recommend``. The economics output is explicitly
+pre-tax chain plumbing, not a Norway investment NPV headline.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+import pandas as pd
+
+from worldenergydata.fdas.adapters.contract import to_fdas_production
+from worldenergydata.fdas.adapters.field_concept_normalizer import (
+    dev_system_from_water_depth_m,
+)
+from worldenergydata.fdas.analysis.cashflow import CashflowEngine
+from worldenergydata.fdas.core.config import AssumptionsManager
+from worldenergydata.field_development.recommendation import recommend
+from worldenergydata.production.unified.query import ProductionQuery
+from worldenergydata.sodir.field_concept import build_norway_field_concept
+
+
+def run_norway_reference_chain(
+    *,
+    adapter,
+    field_meta: Dict[str, Any],
+    field_name: str,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+    oil_price_usd_bbl: float = 75.0,
+) -> Dict[str, Any]:
+    """Run the #716 one-field Norway chain slice.
+
+    Args:
+        adapter: production adapter exposing ``fetch(ProductionQuery)``.
+        field_meta: processed SODIR field metadata from ``FieldProcessor``.
+        field_name: SODIR field name to fetch and report.
+        start: optional inclusive ``YYYY-MM`` lower bound.
+        end: optional inclusive ``YYYY-MM`` upper bound.
+        oil_price_usd_bbl: flat oil-price deck for the plumbing run.
+
+    Returns:
+        Dictionary with unified/FDAS production, FieldConcept, ranked concepts,
+        and finite pre-tax cashflow metrics labeled as chain plumbing.
+    """
+    unified = adapter.fetch(
+        ProductionQuery(
+            regions=["ncs"],
+            fields=[field_name],
+            start=start,
+            end=end,
+        )
+    )
+    fdas_production = to_fdas_production(unified)
+    field_concept = build_norway_field_concept(field_meta)
+    ranked_concepts = recommend(field_concept)
+
+    first_oil = _first_oil_date(fdas_production)
+    wti_prices = {
+        str(year_month): oil_price_usd_bbl
+        for year_month in fdas_production.get("YEAR_MONTH", pd.Series(dtype="object"))
+    }
+    dev_system = dev_system_from_water_depth_m(field_concept.water_depth_m)
+    if dev_system == "unknown":
+        dev_system = "subsea15"
+
+    cashflows = CashflowEngine(
+        AssumptionsManager(), dev_system=dev_system
+    ).generate_monthly_cashflow(
+        fdas_production,
+        {"drilling_monthly": {}},
+        wti_prices,
+        first_oil,
+    )
+
+    return {
+        "field_name": field_name,
+        "unified_production": unified,
+        "fdas_production": fdas_production,
+        "field_concept": field_concept,
+        "ranked_concepts": ranked_concepts,
+        "economics_label": "chain_plumbing_pre_tax",
+        "pre_tax_metrics": _pre_tax_metrics(cashflows),
+    }
+
+
+def _first_oil_date(fdas_production: pd.DataFrame) -> datetime:
+    if fdas_production.empty:
+        return datetime(1970, 1, 1)
+    first_period = str(fdas_production["YEAR_MONTH"].min())
+    return datetime.strptime(first_period, "%Y-%m")
+
+
+def _pre_tax_metrics(cashflows) -> Dict[str, float]:
+    return {
+        "months": len(cashflows),
+        "gross_revenue_usd": float(sum(cf.oil_revenue_usd for cf in cashflows)),
+        "net_cashflow_usd": float(sum(cf.net_cashflow_usd for cf in cashflows)),
+    }

--- a/scripts/review/results/2026-07-04-code-716-codex-inline.md
+++ b/scripts/review/results/2026-07-04-code-716-codex-inline.md
@@ -1,0 +1,47 @@
+# Code Review — worldenergydata #716 Norway Sodir Reference Chain
+
+- **Reviewer:** Codex inline adversarial review
+- **Date:** 2026-07-04
+- **Scope:** local diff for issue #716
+- **Verdict:** APPROVE
+
+## Checks
+
+- Reviewed `packages/worldenergydata-production/src/worldenergydata/production/unified/adapters/sodir_adapter.py`.
+- Reviewed `packages/worldenergydata-sodir/src/worldenergydata/sodir/field_concept.py`.
+- Reviewed `packages/worldenergydata-sodir/src/worldenergydata/sodir/reference_chain.py`.
+- Reviewed new tests under `tests/unit/production/unified/` and `tests/unit/sodir/`.
+- Compared implementation against the approved #716 narrowed slice: loader-backed adapter, FieldConcept mapping, recommendation, finite labeled pre-tax plumbing metrics.
+
+## Findings
+
+### Finding 1 — Compatibility fallback vs. "mock gone" wording
+
+**Initial risk:** the approved issue text says "mock gone", but the existing unified-production tests depend on `SodirAdapter()` returning non-empty synthetic benchmark data. Removing the fallback would create broad unrelated churn in `tests/unit/production/unified/test_adapters.py`, `test_unified_client.py`, and cross-basin tests.
+
+**Resolution:** the implementation makes the direct SODIR path explicit and fixture-backed when a `MonthlyProductionLoader`-compatible loader is supplied, while preserving the no-loader synthetic fallback. The plan artifact was patched to state this compatibility boundary. The #716 tests assert the direct loader path uses `source="sodir"` and the existing fallback remains isolated to no-loader behavior.
+
+**Status:** resolved.
+
+### Finding 2 — Water injection must not become produced water
+
+**Risk:** `MonthlyProductionLoader` has `water_injected_sm3`, but FDAS requires `water_bbl`; mapping injection to produced water would contaminate economics inputs.
+
+**Resolution:** `SodirAdapter._loader_to_standard_columns` sets `water_bbl` to `NaN`, drops `water_injected_sm3`, and tests assert this behavior.
+
+**Status:** resolved.
+
+### Finding 3 — Pre-tax Norway economics could be misread as an investment metric
+
+**Risk:** Norway's fiscal regime is not represented in this chain slice; a pre-tax result could overstate investor value.
+
+**Resolution:** `run_norway_reference_chain` returns `economics_label="chain_plumbing_pre_tax"` and only aggregate plumbing metrics. No after-tax NPV headline is emitted.
+
+**Status:** resolved.
+
+## Verification Evidence
+
+- `PYTHONPATH=src:packages/worldenergydata-core/src:packages/worldenergydata-production/src:packages/worldenergydata-fdas/src:packages/worldenergydata-sodir/src /usr/bin/python3 -m pytest tests/unit/production/unified/test_adapters.py tests/unit/production/unified/test_unified_client.py tests/unit/production/unified/test_router.py tests/unit/fdas/adapters/test_contract.py tests/unit/fdas/adapters/test_field_concept_normalizer.py tests/unit/fdas/adapters/test_conformance.py tests/unit/sodir/test_norway_716.py tests/unit/sodir/test_norway_reference_chain.py tests/unit/production/unified/test_sodir_adapter_loader.py --noconftest -o addopts="" -q` -> 161 passed.
+- `black --check`, `isort --check-only`, `flake8`, and `ruff check` passed on touched Python files.
+- `git diff --check` passed.
+- `scripts/legal/legal-sanity-scan.sh` passed.

--- a/tests/unit/production/unified/test_sodir_adapter_loader.py
+++ b/tests/unit/production/unified/test_sodir_adapter_loader.py
@@ -1,0 +1,106 @@
+"""Norway SODIR adapter fixture-backed contract tests (#716)."""
+
+import pandas as pd
+import pytest
+
+from worldenergydata.common.units import OilUnits
+from worldenergydata.fdas.adapters.contract import to_fdas_production
+from worldenergydata.production.unified.adapters.sodir_adapter import SodirAdapter
+from worldenergydata.production.unified.query import STANDARD_COLUMNS, ProductionQuery
+
+
+class FixtureMonthlyLoader:
+    """Minimal MonthlyProductionLoader stand-in for adapter tests."""
+
+    def __init__(self):
+        self.calls = []
+
+    def load_field_production(self, field_name):
+        self.calls.append(("field", field_name))
+        return _loader_frame(field_name)
+
+    def load_all_production(self):
+        self.calls.append(("all", None))
+        return _loader_frame("JOHAN SVERDRUP")
+
+
+def _loader_frame(field_name):
+    return pd.DataFrame(
+        [
+            {
+                "field_name": field_name,
+                "year": 2024,
+                "month": 1,
+                "oil_sm3": 1000.0,
+                "gas_sm3": 2_000_000.0,
+                "ngl_sm3": 0.0,
+                "condensate_sm3": 10.0,
+                "water_injected_sm3": 999_999.0,
+                "oil_bbl": 1000.0 * OilUnits.SM3_TO_BBL,
+                "gas_mcf": 70_629.4,
+            },
+            {
+                "field_name": field_name,
+                "year": 2024,
+                "month": 2,
+                "oil_sm3": 1100.0,
+                "gas_sm3": 2_100_000.0,
+                "ngl_sm3": 0.0,
+                "condensate_sm3": 20.0,
+                "water_injected_sm3": 888_888.0,
+                "oil_bbl": 1100.0 * OilUnits.SM3_TO_BBL,
+                "gas_mcf": 74_160.87,
+            },
+        ]
+    )
+
+
+def test_fetch_transforms_loader_output_to_standard_columns():
+    loader = FixtureMonthlyLoader()
+    adapter = SodirAdapter(loader=loader)
+
+    out = adapter.fetch(
+        ProductionQuery(
+            regions=["ncs"],
+            fields=["JOHAN SVERDRUP"],
+            start="2024-02",
+            end="2024-02",
+        )
+    )
+
+    assert loader.calls == [("field", "JOHAN SVERDRUP")]
+    assert list(out.columns) == list(STANDARD_COLUMNS)
+    assert len(out) == 1
+    row = out.iloc[0]
+    assert row["region"] == "ncs"
+    assert row["field_name"] == "JOHAN SVERDRUP"
+    assert row["year"] == 2024
+    assert row["month"] == 2
+    assert row["oil_bbl"] == pytest.approx(1100.0 * OilUnits.SM3_TO_BBL)
+    assert row["gas_mcf"] == pytest.approx(74_160.87)
+    assert row["condensate_bbl"] == pytest.approx(20.0 * OilUnits.SM3_TO_BBL)
+    assert pd.isna(row["water_bbl"])
+    assert row["source"] == "sodir"
+    assert "water_injected_sm3" not in out.columns
+
+
+def test_fetch_output_is_accepted_by_fdas_production_contract():
+    adapter = SodirAdapter(loader=FixtureMonthlyLoader())
+
+    unified = adapter.fetch(ProductionQuery(regions=["ncs"], fields=["JOHAN SVERDRUP"]))
+    fdas = to_fdas_production(unified)
+
+    assert list(fdas["DEV_NAME"].unique()) == ["JOHAN SVERDRUP"]
+    assert list(fdas["YEAR_MONTH"]) == ["2024-01", "2024-02"]
+    assert fdas["MONTHLY_WATER_BBL"].isna().all()
+
+
+def test_fetch_all_uses_loader_all_path_when_no_field_filter():
+    loader = FixtureMonthlyLoader()
+    adapter = SodirAdapter(loader=loader)
+
+    out = adapter.fetch(ProductionQuery(regions=["ncs"]))
+
+    assert loader.calls == [("all", None)]
+    assert len(out) == 2
+    assert set(out["source"]) == {"sodir"}

--- a/tests/unit/sodir/test_norway_716.py
+++ b/tests/unit/sodir/test_norway_716.py
@@ -1,0 +1,151 @@
+"""#716 Norway chain slice — SodirAdapter real path + FieldConcept normalizer + wiring.
+
+Self-contained (no repo conftest/data); run:
+  .venv/bin/python -m pytest tests/unit/sodir/test_norway_716.py --noconftest -o addopts="" -q
+"""
+
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+
+from worldenergydata.fdas.adapters.contract import (
+    FDAS_PRODUCTION_COLUMNS,
+    to_fdas_production,
+)
+from worldenergydata.fdas.analysis.cashflow import CashflowEngine
+from worldenergydata.fdas.core.config import AssumptionsManager
+from worldenergydata.production.unified.adapters.sodir_adapter import SodirAdapter
+from worldenergydata.production.unified.query import STANDARD_COLUMNS, ProductionQuery
+from worldenergydata.sodir.field_concept import sodir_field_to_concept
+
+
+class _FakeLoader:
+    """Duck-typed MonthlyProductionLoader: returns loader-output columns."""
+
+    def __init__(self, df):
+        self._df = df
+
+    def load_all_production(self):
+        return self._df
+
+
+def _loader_frame():
+    # MonthlyProductionLoader output schema (already Sm3→bbl for oil/gas).
+    return pd.DataFrame(
+        [
+            # field_name, year, month, oil_sm3, gas_sm3, ngl_sm3, condensate_sm3,
+            # water_injected_sm3, oil_bbl, gas_mcf
+            ("TROLL", 2024, 1, 1e6, 1e9, 0.0, 5000.0, 9e5, 6_289_810.0, 35_314.7),
+            ("TROLL", 2024, 2, 9e5, 9e8, 0.0, 4500.0, 8e5, 5_660_829.0, 31_783.2),
+        ],
+        columns=[
+            "field_name",
+            "year",
+            "month",
+            "oil_sm3",
+            "gas_sm3",
+            "ngl_sm3",
+            "condensate_sm3",
+            "water_injected_sm3",
+            "oil_bbl",
+            "gas_mcf",
+        ],
+    )
+
+
+# --- SodirAdapter real path (B1 transform) ---------------------------------
+
+
+def test_real_loader_path_emits_standard_columns():
+    adapter = SodirAdapter(loader=_FakeLoader(_loader_frame()))
+    df = adapter.fetch(ProductionQuery(regions=["ncs"]))
+    assert list(df.columns) == list(STANDARD_COLUMNS)
+    assert (df["region"] == "ncs").all()
+    assert (df["source"] == "sodir").all()
+    assert (df["field_name"] == "TROLL").all()
+
+
+def test_water_bbl_is_nan_not_injection():
+    adapter = SodirAdapter(loader=_FakeLoader(_loader_frame()))
+    df = adapter.fetch(ProductionQuery(regions=["ncs"]))
+    # water_injected_sm3 must NOT leak into water_bbl (injection != production)
+    assert df["water_bbl"].isna().all()
+
+
+def test_condensate_converted_from_sm3():
+    adapter = SodirAdapter(loader=_FakeLoader(_loader_frame()))
+    df = adapter.fetch(ProductionQuery(regions=["ncs"]))
+    # 5000 Sm3 * SM3_TO_BBL (~6.2898) ≈ 31449 bbl, not 5000 and not 0
+    assert df["condensate_bbl"].iloc[0] > 5000
+    assert (df["condensate_bbl"] > 0).all()
+
+
+def test_mock_default_still_works_when_no_loader():
+    adapter = SodirAdapter()  # no loader -> synthetic benchmark (keeps suite non-empty)
+    df = adapter.fetch(ProductionQuery(regions=["ncs"]))
+    assert len(df) > 0
+    assert "Edvard Grieg" in set(df["field_name"])
+
+
+# --- Norway FieldConcept normalizer (F2 FieldMetaMapping consumer) ----------
+
+
+def _processed_field():
+    return {
+        "field_name": "Troll",
+        "operator": "Equinor",
+        "main_area": "NORTH SEA",
+        "water_depth_m": 340.0,
+        "production_start_year": 1996,
+        "recoverable_oil_mmbbl": 800.0,
+        "recoverable_gas_bcf": 60.0,
+    }
+
+
+def test_sodir_field_to_concept_builds_valid_concept():
+    fc = sodir_field_to_concept(_processed_field())
+    assert fc.name == "Troll"
+    assert fc.operator == "Equinor"
+    assert fc.region == "norway"  # constant, NOT sea-area (M1)
+    assert fc.water_depth_m == 340.0
+    assert fc.year_first_oil == 1996
+    # reserves: 800 MMbbl oil + 60 Bcf/6 = 810 MMboe (M2)
+    assert fc.recoverable_reserves_mmboe == 810.0
+
+
+def test_reserves_none_when_both_absent():
+    p = _processed_field()
+    p["recoverable_oil_mmbbl"] = None
+    p["recoverable_gas_bcf"] = None
+    fc = sodir_field_to_concept(p)
+    assert fc.recoverable_reserves_mmboe is None
+
+
+# --- chain wiring: fetch -> to_fdas_production -> cashflow; concept -> screen -
+
+
+def test_chain_slice_runs_and_returns_finite_metrics():
+    adapter = SodirAdapter(loader=_FakeLoader(_loader_frame()))
+    unified = adapter.fetch(ProductionQuery(regions=["ncs"]))
+    fdas_prod = to_fdas_production(unified)
+    assert list(fdas_prod.columns) == list(FDAS_PRODUCTION_COLUMNS)
+
+    # pre-tax plumbing only (NOT a published Norway NPV — 78% regime, B3)
+    engine = CashflowEngine(AssumptionsManager(), dev_system="subsea15")
+    cashflows = engine.generate_monthly_cashflow(
+        fdas_prod,
+        {"drilling_monthly": {}},
+        {"2024-01": 75.0, "2024-02": 76.0},
+        datetime(2024, 1, 1),
+    )
+    assert cashflows
+    assert all(np.isfinite(cf.net_cashflow_usd) for cf in cashflows)
+
+
+def test_concept_screening_returns_ranked_list():
+    from worldenergydata.field_development.recommendation import recommend
+
+    fc = sodir_field_to_concept(_processed_field())
+    scored = recommend(fc)
+    assert isinstance(scored, list) and len(scored) > 0

--- a/tests/unit/sodir/test_norway_reference_chain.py
+++ b/tests/unit/sodir/test_norway_reference_chain.py
@@ -1,0 +1,114 @@
+"""Norway SODIR reference-chain tests (#716)."""
+
+import math
+
+import pandas as pd
+import pytest
+
+from worldenergydata.common.units import OilUnits
+from worldenergydata.fdas.adapters.contract import FDAS_PRODUCTION_COLUMNS
+from worldenergydata.production.unified.adapters.sodir_adapter import SodirAdapter
+from worldenergydata.sodir.reference_chain import (
+    build_norway_field_concept,
+    run_norway_reference_chain,
+)
+
+
+class FixtureMonthlyLoader:
+    def load_field_production(self, field_name):
+        return pd.DataFrame(
+            [
+                {
+                    "field_name": field_name,
+                    "year": 2024,
+                    "month": 1,
+                    "oil_sm3": 1000.0,
+                    "gas_sm3": 2_000_000.0,
+                    "ngl_sm3": 0.0,
+                    "condensate_sm3": 10.0,
+                    "water_injected_sm3": 999_999.0,
+                    "oil_bbl": 1000.0 * OilUnits.SM3_TO_BBL,
+                    "gas_mcf": 70_629.4,
+                },
+                {
+                    "field_name": field_name,
+                    "year": 2024,
+                    "month": 2,
+                    "oil_sm3": 900.0,
+                    "gas_sm3": 1_900_000.0,
+                    "ngl_sm3": 0.0,
+                    "condensate_sm3": 8.0,
+                    "water_injected_sm3": 888_888.0,
+                    "oil_bbl": 900.0 * OilUnits.SM3_TO_BBL,
+                    "gas_mcf": 67_097.93,
+                },
+            ]
+        )
+
+
+def _processed_field_meta():
+    return {
+        "field_name": "JOHAN SVERDRUP",
+        "operator": "Equinor",
+        "water_depth_m": 110.0,
+        "production_start_year": 2019,
+        "recoverable_oil_mmbbl": 2700.0,
+        "recoverable_gas_bcf": 600.0,
+        "source": "SODIR",
+    }
+
+
+def test_norway_field_meta_mapping_consumes_processed_field_keys():
+    concept = build_norway_field_concept(_processed_field_meta())
+
+    assert concept.name == "JOHAN SVERDRUP"
+    assert concept.operator == "Equinor"
+    assert concept.region == "norway"
+    assert concept.water_depth_m == 110.0
+    assert concept.year_first_oil == 2019
+    assert concept.recoverable_reserves_mmboe == pytest.approx(2800.0)
+    assert concept.data_source == "SODIR"
+
+
+def test_sparse_norway_concept_screen_is_deterministic():
+    concept = build_norway_field_concept(_processed_field_meta())
+
+    first = run_norway_reference_chain(
+        adapter=SodirAdapter(loader=FixtureMonthlyLoader()),
+        field_meta=_processed_field_meta(),
+        field_name="JOHAN SVERDRUP",
+        start="2024-01",
+        end="2024-02",
+    )
+    second = run_norway_reference_chain(
+        adapter=SodirAdapter(loader=FixtureMonthlyLoader()),
+        field_meta=_processed_field_meta(),
+        field_name="JOHAN SVERDRUP",
+        start="2024-01",
+        end="2024-02",
+    )
+
+    assert first["field_concept"] == concept
+    assert [r.concept_type for r in first["ranked_concepts"]]
+    assert [r.concept_type for r in first["ranked_concepts"]] == [
+        r.concept_type for r in second["ranked_concepts"]
+    ]
+
+
+def test_reference_chain_returns_labeled_finite_pre_tax_metrics():
+    result = run_norway_reference_chain(
+        adapter=SodirAdapter(loader=FixtureMonthlyLoader()),
+        field_meta=_processed_field_meta(),
+        field_name="JOHAN SVERDRUP",
+        start="2024-01",
+        end="2024-02",
+        oil_price_usd_bbl=75.0,
+    )
+
+    assert result["economics_label"] == "chain_plumbing_pre_tax"
+    assert list(result["fdas_production"].columns) == list(FDAS_PRODUCTION_COLUMNS)
+    assert result["pre_tax_metrics"]["months"] >= 2
+    assert math.isfinite(result["pre_tax_metrics"]["gross_revenue_usd"])
+    assert math.isfinite(result["pre_tax_metrics"]["net_cashflow_usd"])
+    assert result["pre_tax_metrics"]["gross_revenue_usd"] > 0.0
+    assert result["ranked_concepts"]


### PR DESCRIPTION
## Summary
- add a loader-backed Sodir production adapter path that maps direct-source Norway data into the unified production schema
- add Norway field metadata to FDAS FieldConcept mapping plus a reference-chain runner through concept screening and pre-tax cashflow plumbing
- document the approved #716 scope and code-stage adversarial review result

## Scope notes
- Direct-source loader data is used when a Sodir loader is supplied.
- The existing no-loader synthetic adapter fallback remains for legacy adapter compatibility tests only.
- Economics are explicitly labeled chain_plumbing_pre_tax; this is not an investment-grade NPV deliverable.

## Verification
- PYTHONPATH=src:packages/worldenergydata-core/src:packages/worldenergydata-production/src:packages/worldenergydata-fdas/src:packages/worldenergydata-sodir/src /usr/bin/python3 -m pytest tests/unit/production/unified/test_adapters.py tests/unit/production/unified/test_unified_client.py tests/unit/production/unified/test_router.py tests/unit/fdas/adapters/test_contract.py tests/unit/fdas/adapters/test_field_concept_normalizer.py tests/unit/fdas/adapters/test_conformance.py tests/unit/sodir/test_norway_716.py tests/unit/sodir/test_norway_reference_chain.py tests/unit/production/unified/test_sodir_adapter_loader.py --noconftest -o addopts="" -q
- /home/vamsee/.local/bin/black --check --diff <touched Python files>
- /home/vamsee/.local/bin/isort --check-only --diff <touched Python files>
- /home/vamsee/miniforge3/bin/flake8 <touched Python files> --max-line-length=100 --extend-ignore=E203,W503
- /home/vamsee/miniforge3/bin/ruff check <touched Python files>
- scripts/legal/legal-sanity-scan.sh

Closes #716