### PR TITLE
feat(insights): regional decommissioning liability — multiplier vs mix (#777)

### DIFF
--- a/config/repo_structure.yml
+++ b/config/repo_structure.yml
@@ -177,6 +177,8 @@ temporary_exceptions:
       - reports/capabilities/insights.html
       - reports/decommissioning/pa_liability_wave.csv
       - reports/decommissioning/pa_liability_wave.html
+      - reports/decommissioning/regional_liability.csv
+      - reports/decommissioning/regional_liability.html
       - reports/field_development/all_regions_atlas.html
       - reports/field_development/all_regions_coverage.csv
       - reports/field_development/region_devtype_comparison.html

--- a/packages/worldenergydata-decommissioning/src/worldenergydata/decommissioning/facility_liability.py
+++ b/packages/worldenergydata-decommissioning/src/worldenergydata/decommissioning/facility_liability.py
@@ -1,0 +1,144 @@
+# ABOUTME: Facility-level regional decommissioning liability from curated offshore assets.
+# ABOUTME: Maps HOST_TYPE->asset, COUNTRY/GoM->region, prices each with the cost model.
+
+"""Regional decommissioning-liability roll-up for the offshore-assets portfolio.
+
+Two forces set a decommissioning bill and they pull opposite ways: the regional
+multiplier (North Sea 25-30% dearer per identical asset) and the asset mix (the
+money is in floating production, concentrated in Brazil / West-Africa deepwater).
+This module maps each curated production facility onto the parametric
+``DecommissioningCostEstimator`` and rolls the priced portfolio up by region and
+asset type so both effects can be shown side by side.
+
+Side-effect free: pure functions over a DataFrame; no file IO, no printing.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from worldenergydata.decommissioning.cost_model import DecommissioningCostEstimator
+
+# HOST_TYPE (curated production_facilities) -> cost-model asset_type. Types not
+# listed here (e.g. "Artificial Island") are excluded: not an offshore structure
+# removal the parametric model prices.
+_ASSET_MAP: dict[str, str] = {
+    "Fixed Platform": "jacket",
+    "Compliant Tower": "jacket",
+    "MOPU": "jacket",
+    "TLP": "tlp",
+    "Mini-TLP": "tlp",
+    "SPAR": "spar",
+    "DDCV": "spar",
+    "FPSO": "fpso",
+    "FLNG": "fpso",
+    "FSO/FSU": "fpso",
+    "Semisub": "fpso",
+    "FPU/FPS": "fpso",
+    "Subsea Tieback": "subsea_tree",
+}
+
+# COUNTRY -> region multiplier key. Only the five regions the cost model carries
+# a multiplier for are modeled; everything else is unmodeled (excluded).
+_UKCS = {"United Kingdom", "UK"}
+_US = {"United States", "USA", "US"}
+_WEST_AFRICA = {
+    "Nigeria", "Angola", "Ghana", "Congo", "Republic of Congo",
+    "Equatorial Guinea", "Gabon", "Ivory Coast", "Cameroon",
+    "Côte d'Ivoire", "Cote d'Ivoire",
+}
+_GOM_TRUE = {"Y", "YES", "TRUE", "1"}
+
+
+def classify_asset_type(host_type: object) -> str | None:
+    """Map a facility HOST_TYPE onto a cost-model asset type, or None if unmapped."""
+    if host_type is None:
+        return None
+    return _ASSET_MAP.get(str(host_type).strip())
+
+
+def region_of(country: object, us_gom_flag: object = None) -> str | None:
+    """Map (COUNTRY, US_GOM_FLAG) onto a cost-model region, or None if unmodeled."""
+    if str(us_gom_flag).strip().upper() in _GOM_TRUE:
+        return "gom"
+    c = str(country).strip()
+    if c in _US:
+        return "gom"  # US non-GoM offshore is tiny; GoM baseline
+    if c in _UKCS:
+        return "ukcs"
+    if c == "Norway":
+        return "ncs"
+    if c == "Brazil":
+        return "brazil"
+    if c in _WEST_AFRICA:
+        return "west_africa"
+    return None
+
+
+def price_portfolio(df: pd.DataFrame) -> dict:
+    """Price every facility and roll up by region and asset type.
+
+    Returns a dict with:
+        total_musd                    - sum of modeled liability (MUSD)
+        by_region                     - {region: {"sum_musd", "count"}}
+        by_asset                      - {asset: {"sum_musd", "count"}}
+        mean_per_facility_by_region   - {region: mean MUSD/facility}
+        counts                        - {"modeled", "unmodeled_region", "unmapped_asset"}
+        rows                          - per-facility priced records (list of dict)
+    """
+    est = DecommissioningCostEstimator()
+    rows: list[dict] = []
+    unmodeled_region = 0
+    unmapped_asset = 0
+    for _, r in df.iterrows():
+        reg = region_of(r.get("COUNTRY"), r.get("US_GOM_FLAG"))
+        if reg is None:
+            unmodeled_region += 1
+            continue
+        asset = classify_asset_type(r.get("HOST_TYPE"))
+        if asset is None:
+            unmapped_asset += 1
+            continue
+        wd = r.get("WATER_DEPTH_M")
+        wd = 0.0 if pd.isna(wd) else float(wd)
+        e = est.estimate(asset_type=asset, water_depth_m=wd, weight_tonnes=0.0, region=reg)
+        rows.append(
+            {
+                "facility_id": r.get("FACILITY_ID"),
+                "facility_name": r.get("FACILITY_NAME"),
+                "country": r.get("COUNTRY"),
+                "region": reg,
+                "asset": asset,
+                "host_type": str(r.get("HOST_TYPE")).strip(),
+                "water_depth_m": wd,
+                "cost_musd": e.estimated_cost_musd,
+            }
+        )
+
+    res = pd.DataFrame(rows)
+    by_region: dict[str, dict] = {}
+    by_asset: dict[str, dict] = {}
+    mean_per_facility_by_region: dict[str, float] = {}
+    total_musd = 0.0
+    if not res.empty:
+        total_musd = round(float(res["cost_musd"].sum()), 4)
+        gr = res.groupby("region")["cost_musd"].agg(["sum", "count", "mean"])
+        for reg, row in gr.iterrows():
+            by_region[reg] = {"sum_musd": round(float(row["sum"]), 4), "count": int(row["count"])}
+            mean_per_facility_by_region[reg] = round(float(row["mean"]), 4)
+        ga = res.groupby("asset")["cost_musd"].agg(["sum", "count"])
+        for asset, row in ga.iterrows():
+            by_asset[asset] = {"sum_musd": round(float(row["sum"]), 4), "count": int(row["count"])}
+
+    return {
+        "total_musd": total_musd,
+        "by_region": by_region,
+        "by_asset": by_asset,
+        "mean_per_facility_by_region": mean_per_facility_by_region,
+        "counts": {
+            "modeled": len(rows),
+            "unmodeled_region": unmodeled_region,
+            "unmapped_asset": unmapped_asset,
+        },
+        "rows": rows,
+    }

--- a/reports/capabilities/insights.html
+++ b/reports/capabilities/insights.html
@@ -159,6 +159,14 @@
     <section>
       <p class="lane-label">Cross-cutting comparisons &middot; <b>orthogonal to the spine</b></p>
       <div class="cards">
+        <a class="card" href="../decommissioning/regional-liability.html">
+          <div class="tag">Decommission &middot; region &times; asset</div>
+          <h3>Regional decommissioning liability</h3>
+          <div class="num">$17.5B &middot; 421 facilities</div>
+          <p>Two forces pull opposite ways: the North Sea costs 25&ndash;30% more per identical asset, but 159 FPSOs
+          carry $14.8B of the $17.5B modeled bill &mdash; the asset mix, concentrated in Brazil / West-Africa deepwater,
+          not the multiplier, sets the realized total.</p>
+          <div class="go">Open regional liability &rarr;</div></a>
         <a class="card" href="../region-devtype-comparison.html">
           <div class="tag">Region &times; development-type</div>
           <h3>Dry-tree vs wet-tree by water depth</h3>

--- a/reports/decommissioning/pa_liability_wave.html
+++ b/reports/decommissioning/pa_liability_wave.html
@@ -111,11 +111,16 @@
     </p>
 
     <p class="note"><b>Forward P&amp;A demand context.</b> The
-    <a href="../intervention-db/intervention-stats-brief.html">GoM intervention-access brief</a>
+    <a href="../../docs/intervention-db/intervention-stats-brief.html">GoM intervention-access brief</a>
     already flags heavy dead-well work — tubing pull / recompletion / <b>P&amp;A</b> — as forward-looking
     rig-day demand across every water-depth band, with the deep bands short of GoM-resident heavy-intervention
     units (e.g. 5,000–10,000&nbsp;ft: ~4.4× the resident rig-days). That access gap is the SUPPLY side of the same
     wave this page prices on the LIABILITY side; the demand figures are cited from the brief, not recomputed here.</p>
+
+    <p class="note"><b>Global companion.</b> This page is the Gulf-of-Mexico <em>well</em> P&amp;A wave. The
+    <a href="regional-liability.html">regional decommissioning-liability view</a> prices the global <em>facility</em>
+    portfolio (836 offshore facilities, 5 regions) and shows why floating production — not the North Sea's
+    fixed jackets — carries most of the modeled $17.5B removal bill.</p>
 
     <div class="foot">
       <b>Source.</b> BSEE curated borehole inventory <code>data/modules/bsee/current/wells/well_data.csv</code>

--- a/reports/decommissioning/regional_liability.csv
+++ b/reports/decommissioning/regional_liability.csv
@@ -1,0 +1,427 @@
+# Regional decommissioning liability (facility-level, offshore-assets)
+# source: data/modules/offshore_assets/curated/production_facilities.csv | 836 facilities
+# modeled=421 (5 regions with a cost multiplier); unmodeled-region=414 excluded; unmapped-asset=1 (Artificial Island) excluded
+# total modeled liability = $17.5B (17,505 MUSD)
+# pricing: DecommissioningCostEstimator, weight=0, depth floor; FPSO base low-confidence
+facility_id,facility_name,country,region,asset,host_type,water_depth_m,cost_musd
+720,Aasta Hansteen Spar,Norway,ncs,spar,SPAR,1300.0,70.07
+760,Abo FPSO,Nigeria,west_africa,fpso,FPSO,550.0,92.0
+249,Agbami FPSO,Nigeria,west_africa,fpso,FPSO,1462.0,92.0
+668,Akepo FSO,Nigeria,west_africa,fpso,FSO/FSU,8.0,92.0
+252,Akpo FPSO,Nigeria,west_africa,fpso,FPSO,1325.0,92.0
+1467,Alba (EG) B2 Platform,Equatorial Guinea,west_africa,jacket,Fixed Platform,75.0,2.7312
+1467,Alba (EG) B3 Compression Platform,Equatorial Guinea,west_africa,jacket,Fixed Platform,75.0,2.7312
+226,Alba Northern Platform,UK,ukcs,jacket,Fixed Platform,158.0,3.4875
+226,Alba Southern Platform,UK,ukcs,jacket,Fixed Platform,138.0,3.3625
+477,Alen Platform,Equatorial Guinea,west_africa,jacket,Fixed Platform,530.0,5.3475
+305,Alima FPU,Congo,west_africa,fpso,FPU/FPS,1200.0,92.0
+116,Allegheny SeaStar Mini-TLP,US,gom,tlp,Mini-TLP,1005.0,42.01
+212,Alvheim FPSO,Norway,ncs,fpso,FPSO,130.0,104.0
+227,Alwyn North A Platform,UK,ukcs,jacket,Fixed Platform,126.0,3.2875
+227,Alwyn North B Platform,UK,ukcs,jacket,Fixed Platform,126.0,3.2875
+168,Amberjack Fixed Platform,US,gom,jacket,Fixed Platform,314.0,3.57
+318,Amenam Kpono Production Platform (Phase I),Nigeria,west_africa,jacket,Fixed Platform,40.0,2.53
+318,Amenam Kpono Production Platform (Phase II),Nigeria,west_africa,jacket,Fixed Platform,40.0,2.53
+783,Amethyst Platforms,UK,ukcs,jacket,Fixed Platform,30.0,2.6875
+1269,Anasuria FPSO,UK,ukcs,fpso,FPSO,0.0,100.0
+786,Andrew Platform,UK,ukcs,jacket,Fixed Platform,117.0,3.2313
+868,Anglia Fixed Platform,UK,ukcs,jacket,Fixed Platform,26.0,2.6625
+238,Aoka Mizu FPSO,UK,ukcs,fpso,FPSO,110.0,100.0
+398,Appaloosa Subsea,US,gom,subsea_tree,Subsea Tieback,853.0,2.0
+1402,Arbroath Platform,UK,ukcs,jacket,Fixed Platform,93.0,3.0812
+488,Armada Perdana FPSO,Nigeria,west_africa,fpso,FPSO,350.0,92.0
+771,Armada Platform,UK,ukcs,jacket,Fixed Platform,88.0,3.05
+477,Aseng FPSO,Equatorial Guinea,west_africa,fpso,FPSO,945.0,92.0
+357,Asgard A FPSO,Norway,ncs,fpso,FPSO,300.0,104.0
+357,Asgard B Semisubmersible,Norway,ncs,fpso,Semisub,310.0,104.0
+358,Asgard C FSO,Norway,ncs,fpso,FSO/FSU,300.0,104.0
+357,Asgard Subsea Compression,Norway,ncs,subsea_tree,Subsea Tieback,300.0,2.6
+144,Atlantis Semisub,US,gom,fpso,Semisub,2160.0,80.0
+971,Audrey,UK,ukcs,jacket,Fixed Platform,24.0,2.65
+139,Auger TLP,US,gom,tlp,TLP,872.0,41.744
+908,Auk A Platform,UK,ukcs,jacket,Fixed Platform,84.0,3.025
+348,Autonomous Re-Pumping Platform (PRA-1),Brazil,brazil,jacket,Fixed Platform,106.0,2.783
+767,Avouma Fixed Platform,Gabon,west_africa,jacket,Fixed Platform,137.0,3.0877
+622,Awawa Wellhead Platform,Nigeria,west_africa,jacket,Fixed Platform,95.0,2.8462
+551,Babbage Fixed Platform,UK,ukcs,jacket,Fixed Platform,42.0,2.7625
+1142,Balder FPU,Norway,ncs,fpso,FPU/FPS,125.0,104.0
+131,Baldpate Compliant Tower,US,gom,jacket,Compliant Tower,502.0,4.51
+778,Balmoral FPS,UK,ukcs,fpso,FPU/FPS,150.0,100.0
+766,Bardolino Subsea,UK,ukcs,subsea_tree,Subsea Tieback,92.0,2.5
+272,Barracuda FPSO P-43,Brazil,brazil,fpso,FPSO,1100.0,88.0
+323,Beatrice Alpha Platform,UK,ukcs,jacket,Fixed Platform,40.0,2.75
+323,Beatrice Bravo Platform,UK,ukcs,jacket,Fixed Platform,40.0,2.75
+1210,Benguela-Belize Lobito-Tomboco Compliant Tower,Angola,west_africa,jacket,Compliant Tower,396.0,4.577
+719,Bentley FSO,UK,ukcs,fpso,FSO/FSU,113.0,100.0
+719,Bentley Platform,UK,ukcs,jacket,Fixed Platform,113.0,3.2062
+343,Big Foot TLP,US,gom,tlp,Mini-TLP,1615.0,43.23
+319,Bleo Holm FPSO,UK,ukcs,fpso,FPSO,105.0,100.0
+119,Blind Faith Semisub,US,gom,fpso,Semisub,1981.0,80.0
+250,Bonga FPSO,Nigeria,west_africa,fpso,FPSO,1030.0,92.0
+118,Boomvang Spar Platform,US,gom,spar,SPAR,1052.0,53.156
+1143,Brae Alpha,UK,ukcs,jacket,Fixed Platform,112.0,3.2
+479,Brage Fixed Platform,Norway,ncs,jacket,Fixed Platform,140.0,3.51
+520,Breagh Alpha Platform,UK,ukcs,jacket,Fixed Platform,59.0,2.8687
+1579,Bressay FSU,UK,ukcs,fpso,FSO/FSU,102.0,100.0
+1579,Bressay PDQ,UK,ukcs,jacket,Fixed Platform,102.0,3.1375
+322,Brigantine BG Fixed Platform,UK,ukcs,jacket,Fixed Platform,29.0,2.6812
+322,Brigantine BR Fixed Platform,UK,ukcs,jacket,Fixed Platform,0.0,2.5
+1605,BritSats BLP,UK,ukcs,jacket,Fixed Platform,148.0,3.425
+1452,Bruce CR,UK,ukcs,jacket,Fixed Platform,121.0,3.2563
+1452,Bruce D,UK,ukcs,jacket,Fixed Platform,121.0,3.2563
+1452,Bruce PUQ,UK,ukcs,jacket,Fixed Platform,121.0,3.2563
+140,Brutus TLP,US,gom,tlp,TLP,1036.0,42.072
+175,Bud Lite Platform,US,gom,jacket,Fixed Platform,84.0,2.42
+175,Bud Production Platform,US,gom,jacket,Fixed Platform,84.0,2.42
+136,Bullwinkle Fixed Platform,US,gom,jacket,Fixed Platform,412.0,4.06
+778,Burghley Subsea,UK,ukcs,subsea_tree,Subsea Tieback,0.0,2.5
+237,Buzzard Platform,UK,ukcs,jacket,Fixed Platform,100.0,3.125
+651,BW Athena FPSO,UK,ukcs,fpso,FPSO,134.0,100.0
+124,BW Pioneer FPSO,US,gom,fpso,FPSO,2690.0,80.0
+1545,Caister,UK,ukcs,jacket,Fixed Platform,41.0,2.7563
+115,Canyon Express Subsea,US,gom,subsea_tree,Subsea Tieback,2195.0,2.0
+115,Canyon Station Production Platform,US,gom,jacket,Fixed Platform,2346.0,13.73
+243,Captain FPSO,UK,ukcs,fpso,FPSO,106.0,100.0
+272,Caratinga FPSO P-48,Brazil,brazil,fpso,FPSO,1350.0,88.0
+646,Catcher FPSO,UK,ukcs,fpso,FPSO,90.0,100.0
+1105,Ceres Subsea Tieback,UK,ukcs,subsea_tree,Subsea Tieback,32.0,2.5
+1128,Cheviot Octabuoy Platform,UK,ukcs,fpso,Semisub,152.0,100.0
+274,Cidade de Angra dos Reis FPSO,Brazil,brazil,fpso,FPSO,2150.0,88.0
+536,Cidade de Ilhabela FPSO,Brazil,brazil,fpso,FPSO,2140.0,88.0
+1478,Cidade de Itajai FPSO,Brazil,brazil,fpso,FPSO,275.0,88.0
+703,Cidade de Macae FSO,Brazil,brazil,fpso,FSO/FSU,0.0,88.0
+703,Cidade de Niteroi MV18 FPSO,Brazil,brazil,fpso,FPSO,1500.0,88.0
+274,Cidade de Paraty FPSO,Brazil,brazil,fpso,FPSO,2120.0,88.0
+729,Cidade de Rio das Ostras FPSO,Brazil,brazil,fpso,FPSO,977.0,88.0
+352,Cidade de Sao Mateus FPSO,Brazil,brazil,fpso,FPSO,763.0,88.0
+536,Cidade de Sao Paulo FPSO,Brazil,brazil,fpso,FPSO,2141.0,88.0
+274,Cidade de Sao Vicente FPSO,Brazil,brazil,fpso,FPSO,2170.0,88.0
+364,Cidade de Vitoria FPSO,Brazil,brazil,fpso,FPSO,1400.0,88.0
+282,Cidade do Rio de Janeiro FPSO,Brazil,brazil,fpso,FPSO,0.0,88.0
+242,Clair Platform,UK,ukcs,jacket,Fixed Platform,140.0,3.375
+242,Clair Ridge Drilling Platform,UK,ukcs,jacket,Fixed Platform,140.0,3.375
+242,Clair Ridge PUQ,UK,ukcs,jacket,Fixed Platform,140.0,3.375
+1700,Claymore Platform,UK,ukcs,jacket,Fixed Platform,111.0,3.1938
+404,Clipper South Platform,UK,ukcs,jacket,Fixed Platform,24.0,2.65
+354,Clipper Subsea Tie-Back,US,gom,subsea_tree,Subsea Tieback,1055.0,2.0
+324,CLOV FPSO,Angola,west_africa,fpso,FPSO,0.0,92.0
+1095,Clyde,UK,ukcs,jacket,Fixed Platform,79.0,2.9937
+137,Cognac Fixed Platform,US,gom,jacket,Fixed Platform,312.0,3.56
+150,Constitution Truss Spar,US,gom,spar,SPAR,1554.0,54.662
+1108,Conwy Platform,UK,ukcs,jacket,Fixed Platform,0.0,2.5
+227,Cormorant Alpha Platform,UK,ukcs,jacket,Fixed Platform,126.0,3.2875
+579,Corral Platform (Formerly Crystal),US,gom,jacket,Fixed Platform,619.0,5.095
+695,Crawford Subsea Tieback,UK,ukcs,subsea_tree,Subsea Tieback,117.0,2.5
+514,Cygnus Complex,UK,ukcs,jacket,Fixed Platform,23.0,2.6438
+248,Dalia FPSO,Angola,west_africa,fpso,FPSO,1500.0,92.0
+1253,Delta House FPU,US,gom,fpso,FPU/FPS,1371.0,80.0
+152,Devils Tower SPAR Platform,US,gom,spar,SPAR,1710.0,55.13
+1108,Douglas Platform,UK,ukcs,jacket,Fixed Platform,33.0,2.7062
+799,Draugen,Norway,ncs,jacket,Fixed Platform,250.0,4.225
+136,Droshky Subsea,US,gom,subsea_tree,Subsea Tieback,884.0,2.0
+227,Dunbar Platform,UK,ukcs,jacket,Fixed Platform,145.0,3.4062
+1149,Dunlin Alpha Platform,UK,ukcs,jacket,Fixed Platform,152.0,3.45
+695,East Brae Platform,UK,ukcs,jacket,Fixed Platform,113.0,3.2062
+170,East Breaks 110 Fixed Platform,US,gom,jacket,Fixed Platform,213.0,3.065
+1843,East Hub FPSO,Angola,west_africa,fpso,FPSO,500.0,92.0
+767,Ebouri Production Platform,Gabon,west_africa,jacket,Fixed Platform,0.0,2.3
+156,EC 373,US,gom,jacket,Fixed Platform,670.0,5.35
+662,Egina FPSO,Nigeria,west_africa,fpso,FPSO,1600.0,92.0
+822,Eider Platform,UK,ukcs,jacket,Fixed Platform,159.0,3.4937
+556,Ekofisk 2/4 Z,Norway,ncs,jacket,Fixed Platform,75.0,3.0875
+556,Ekofisk Center,Norway,ncs,jacket,Fixed Platform,75.0,3.0875
+556,Ekofisk South Wellhead Platform,Norway,ncs,jacket,Fixed Platform,75.0,3.0875
+556,Eldfisk 2/7 B,Norway,ncs,jacket,Fixed Platform,75.0,3.0875
+556,Eldfisk 2/7A,Norway,ncs,jacket,Fixed Platform,75.0,3.0875
+287,Elgin Platform,UK,ukcs,jacket,Fixed Platform,93.0,3.0812
+287,Elgin PUQ,UK,ukcs,jacket,Fixed Platform,93.0,3.0812
+737,Ellen Platform,US,gom,jacket,Fixed Platform,81.0,2.405
+737,Elly Platform,US,gom,jacket,Fixed Platform,81.0,2.405
+155,Enchilada Fixed Platform,US,gom,jacket,Fixed Platform,215.0,3.075
+1190,EnQuest Producer,UK,ukcs,fpso,FPSO,74.0,100.0
+658,Erha FPSO,Nigeria,west_africa,fpso,FPSO,1200.0,92.0
+282,Espadarte FPSO,Brazil,brazil,fpso,FPSO,850.0,88.0
+365,Espirito Santo FPSO,Brazil,brazil,fpso,FPSO,1780.0,88.0
+737,Eureka Platform,US,gom,jacket,Fixed Platform,213.0,3.065
+483,EW 910 Platform A,US,gom,jacket,Fixed Platform,168.0,2.84
+1111,Falcon Subsea,UK,ukcs,subsea_tree,Subsea Tieback,0.0,2.5
+443,Forties Alpha Fixed Platform,UK,ukcs,jacket,Fixed Platform,107.0,3.1688
+443,Forties Alpha Satellite Platform,UK,ukcs,jacket,Fixed Platform,107.0,3.1688
+443,Forties Bravo Fixed Platform,UK,ukcs,jacket,Fixed Platform,107.0,3.1688
+443,Forties Charlie Fixed Platform,UK,ukcs,jacket,Fixed Platform,107.0,3.1688
+443,Forties Delta Fixed Platform,UK,ukcs,jacket,Fixed Platform,107.0,3.1688
+443,Forties Echo Fixed Platform,UK,ukcs,jacket,Fixed Platform,107.0,3.1688
+443,Forties Unity Riser Platform,UK,ukcs,jacket,Fixed Platform,107.0,3.1688
+586,FPF-1,UK,ukcs,fpso,FPU/FPS,85.0,100.0
+313,Frade FPSO,Brazil,brazil,fpso,FPSO,1128.0,88.0
+287,Franklin Platform,UK,ukcs,jacket,Fixed Platform,93.0,3.0812
+120,Front Runner SPAR,US,gom,spar,SPAR,1006.0,53.018
+410,Fulla Subsea,Norway,ncs,subsea_tree,Subsea Tieback,111.0,2.6
+908,Fulmar A Platform,UK,ukcs,jacket,Fixed Platform,81.0,3.0063
+1029,Fyne Production Facility,UK,ukcs,fpso,FPSO,283.0,100.0
+361,Gamma Subsea,Norway,ncs,subsea_tree,Subsea Tieback,226.0,2.6
+169,GB 236 Platform,US,gom,jacket,Fixed Platform,209.0,3.045
+159,Genesis SPAR Platform,US,gom,spar,SPAR,790.0,52.37
+306,Gimboa FPSO,Angola,west_africa,fpso,FPSO,700.0,92.0
+821,Gina Krog FSO,Norway,ncs,fpso,FSO/FSU,120.0,104.0
+821,Gina Krog Platform,Norway,ncs,jacket,Fixed Platform,119.0,3.3735
+325,Girassol FPSO,Angola,west_africa,fpso,FPSO,1350.0,92.0
+286,Gjoa FPU,Norway,ncs,fpso,FPU/FPS,360.0,104.0
+629,Global Producer III FPSO,UK,ukcs,fpso,FPSO,140.0,100.0
+157,Global Producer VII Truss Spar,US,gom,spar,SPAR,945.0,52.835
+924,Golden Eagle PUQ,UK,ukcs,jacket,Fixed Platform,114.0,3.2125
+924,Golden Eagle WHP,UK,ukcs,jacket,Fixed Platform,114.0,3.2125
+309,Goldeneye FSO,UK,ukcs,fpso,FSO/FSU,122.0,100.0
+400,Goliat FPSO,Norway,ncs,fpso,FPSO,400.0,104.0
+161,Gomez Hub (ATP Innovator),US,gom,fpso,FPU/FPS,914.0,80.0
+1526,Grane Platform,Norway,ncs,jacket,Fixed Platform,127.0,3.4255
+1390,Greater Plutonio FPSO,Angola,west_africa,fpso,FPSO,1450.0,92.0
+1529,Gryphon Alpha FPSO,UK,ukcs,fpso,FPSO,112.0,100.0
+374,Gudrun Platform,Norway,ncs,jacket,Fixed Platform,110.0,3.315
+198,Gullfaks A Platform,Norway,ncs,jacket,Fixed Platform,138.0,3.497
+198,Gullfaks B Platform,Norway,ncs,jacket,Fixed Platform,143.0,3.5295
+198,Gullfaks C Platform,Norway,ncs,jacket,Fixed Platform,143.0,3.5295
+1420,Gyda PDQ,Norway,ncs,jacket,Fixed Platform,66.0,3.029
+723,Haewene Brim FPSO,UK,ukcs,fpso,FPSO,85.0,100.0
+1533,Harding Platform,UK,ukcs,jacket,Fixed Platform,111.0,3.1938
+347,Harmony Fixed Platform,US,gom,jacket,Fixed Platform,365.0,3.825
+1738,Heather A Platform,UK,ukcs,jacket,Fixed Platform,144.0,3.4
+427,Heidelberg Spar,US,gom,spar,SPAR,1608.0,54.824
+437,Heidrun FSU,Norway,ncs,fpso,FSO/FSU,351.0,104.0
+437,Heidrun TLP,Norway,ncs,tlp,TLP,351.0,52.9126
+1698,Heimdal Gas Center,Norway,ncs,jacket,Fixed Platform,122.0,3.393
+607,Helix Producer I,US,gom,fpso,FPU/FPS,2679.0,80.0
+347,Heritage Fixed Platform,US,gom,jacket,Fixed Platform,328.0,3.64
+1515,High Island A Platform,US,gom,jacket,Fixed Platform,11.0,2.055
+1515,High Island B Platform,US,gom,jacket,Fixed Platform,11.0,2.055
+307,Holstein Spar Platform,US,gom,spar,SPAR,1324.0,53.972
+347,Hondo Fixed Platform,US,gom,jacket,Fixed Platform,259.0,3.295
+315,Hoover Deep Draft Caisson Vessel platform (DDCV),US,gom,spar,DDCV,1420.0,54.26
+146,Horn Mountain SPAR Platform,US,gom,spar,SPAR,1653.0,54.959
+549,Huldra Wellhead Platform,Norway,ncs,jacket,Fixed Platform,125.0,3.4125
+378,Hummingbird Spirit FPSO,UK,ukcs,fpso,FPSO,120.0,100.0
+434,Inde AC Platform,UK,ukcs,jacket,Fixed Platform,23.0,2.6438
+121,Independence Hub Semisub,US,gom,fpso,Semisub,2700.0,80.0
+1252,Ivar Aasen (Draupne) Platform,Norway,ncs,jacket,Fixed Platform,111.0,3.3215
+340,Jack/St. Malo FPU,US,gom,fpso,FPU/FPS,2134.0,80.0
+323,Jacky Platform,UK,ukcs,jacket,Fixed Platform,40.0,2.75
+316,Janice A Platform,UK,ukcs,fpso,FPU/FPS,90.0,100.0
+675,Jasmine WHP,UK,ukcs,jacket,Fixed Platform,80.0,3.0
+1424,Jotun A FPSO,Norway,ncs,fpso,FPSO,126.0,104.0
+1424,Jotun B,Norway,ncs,jacket,Fixed Platform,126.0,3.419
+675,Judy,UK,ukcs,jacket,Fixed Platform,80.0,3.0
+764,Juscelino Kubitschek Petrobras-34,Brazil,brazil,fpso,FPSO,1300.0,88.0
+130,K2 Subsea,US,gom,subsea_tree,Subsea Tieback,1189.0,2.0
+1854,Kaombo FPSO 1,Angola,west_africa,fpso,FPSO,1600.0,92.0
+1854,Kaombo FPSO 2,Angola,west_africa,fpso,FPSO,1600.0,92.0
+1545,Katy Satellite Platform,UK,ukcs,jacket,Fixed Platform,26.0,2.6625
+1881,Ketch Platform,UK,ukcs,jacket,Fixed Platform,50.0,2.8125
+639,Kizomba A FPSO,Angola,west_africa,fpso,FPSO,1203.0,92.0
+639,Kizomba B FPSO,Angola,west_africa,fpso,FPSO,1036.0,92.0
+639,Kizomba C FPSO,Angola,west_africa,fpso,FPSO,732.0,92.0
+301,Knarr (Jordbaer) FPSO,Norway,ncs,fpso,FPSO,400.0,104.0
+406,Knock Allan FPSO,Gabon,west_africa,fpso,FPSO,50.0,92.0
+412,Kraken FPSO,UK,ukcs,fpso,FPSO,120.0,100.0
+202,Kristin Semisub,Norway,ncs,fpso,Semisub,370.0,104.0
+451,Kungulo Water Injection Platform,Angola,west_africa,jacket,Fixed Platform,40.0,2.53
+1425,Kvitebjorn Platform,Norway,ncs,jacket,Fixed Platform,190.0,3.835
+382,Kwame Nkrumah MV21 FPSO,Ghana,west_africa,fpso,FPSO,1100.0,92.0
+653,Laggan-Tormore Subsea Tie-back,UK,ukcs,subsea_tree,Subsea Tieback,600.0,2.5
+663,Lapa FPSO,Brazil,brazil,fpso,FPSO,2000.0,88.0
+1801,Litchendjili Platform,Congo,west_africa,jacket,Fixed Platform,30.0,2.4725
+1250,Liverpool Bay FSO,UK,ukcs,fpso,FSO/FSU,33.0,100.0
+912,Lomond,UK,ukcs,jacket,Fixed Platform,86.0,3.0375
+572,Lucius Spar,US,gom,spar,SPAR,2172.0,56.516
+573,Luno Platform,Norway,ncs,jacket,Fixed Platform,108.0,3.302
+148,Mad Dog Spar,US,gom,spar,SPAR,1311.0,53.933
+330,Maersk Curlew FPSO,UK,ukcs,fpso,FPSO,92.0,100.0
+451,Mafumeira Norte,Angola,west_africa,jacket,Fixed Platform,49.0,2.5817
+451,Mafumeira Norte Platform,Angola,west_africa,jacket,Fixed Platform,49.0,2.5817
+151,Magnolia TLP,US,gom,tlp,TLP,1433.0,42.866
+1514,Main Pass 108 Platform,US,gom,jacket,Fixed Platform,25.0,2.125
+1516,Main Pass 98 Platform,US,gom,jacket,Fixed Platform,28.0,2.14
+1254,Manati Platform,Brazil,brazil,jacket,Fixed Platform,46.0,2.453
+130,Marco Polo TLP,US,gom,tlp,TLP,1311.0,42.622
+1110,Mariner FSU,UK,ukcs,fpso,FSO/FSU,110.0,100.0
+1110,Mariner PDQ,UK,ukcs,jacket,Fixed Platform,0.0,2.5
+371,Marlim Sul (South) FPSO,Brazil,brazil,fpso,FPSO,1430.0,88.0
+147,Marlin TLP,US,gom,tlp,TLP,986.0,41.972
+141,Mars B Olympus TLP,US,gom,tlp,TLP,914.0,41.828
+758,Mars TLP,US,gom,tlp,TLP,896.0,41.792
+461,Martin Linge (Hild) Platform,Norway,ncs,jacket,Fixed Platform,120.0,3.38
+171,Matterhorn TLP,US,gom,tlp,TLP,869.0,41.738
+158,Medusa Spar Facility,US,gom,spar,SPAR,762.0,52.286
+305,Moho Nord TLP,Congo,west_africa,tlp,TLP,780.0,47.794
+305,Moho-Bilondo FPU,Congo,west_africa,fpso,FPU/FPS,1100.0,92.0
+1402,Montrose Alpha,UK,ukcs,jacket,Fixed Platform,91.0,3.0688
+153,Morpeth TLP,US,gom,tlp,Mini-TLP,518.0,41.036
+1391,Murchison Unit,Norway,ncs,jacket,Fixed Platform,156.0,3.614
+1545,Murdoch Complex,UK,ukcs,jacket,Fixed Platform,32.0,2.7
+126,Na Kika FPU,US,gom,fpso,FPU/FPS,2000.0,80.0
+166,Nansen Spar,US,gom,spar,SPAR,1120.0,53.36
+304,Natalia Subsea,Norway,ncs,subsea_tree,Subsea Tieback,299.0,2.6
+1532,Navion Saga,Norway,ncs,fpso,FSO/FSU,80.0,104.0
+766,Nelson Platform,UK,ukcs,jacket,Fixed Platform,0.0,2.5
+176,Neptune SPAR,US,gom,spar,SPAR,588.0,51.764
+123,Neptune TLP,US,gom,tlp,TLP,1295.0,42.59
+1393,Ninian,UK,ukcs,jacket,Fixed Platform,135.0,3.3438
+1393,Ninian Central,UK,ukcs,jacket,Fixed Platform,139.0,3.3688
+1393,Ninian South,UK,ukcs,jacket,Fixed Platform,139.0,3.3688
+705,Njord A,Norway,ncs,fpso,FPU/FPS,330.0,104.0
+1612,Nkossa Platform,Congo,west_africa,fpso,FPU/FPS,305.0,92.0
+1449,Norne FPSO,Norway,ncs,fpso,FPSO,380.0,104.0
+1111,North Cormorant Platform,UK,ukcs,jacket,Fixed Platform,530.0,5.8125
+1296,North Nemba,Angola,west_africa,jacket,Fixed Platform,120.0,2.99
+300,North Sea Producer FPSO,UK,ukcs,fpso,FPSO,125.0,100.0
+345,Northern Producer FPU,UK,ukcs,fpso,FPU/FPS,152.0,100.0
+582,Northstar Sea Island,US,gom,subsea_tree,Subsea Tieback,12.0,2.0
+227,Nuggets Subsea,UK,ukcs,subsea_tree,Subsea Tieback,125.0,2.5
+1408,Ofon 2,Nigeria,west_africa,jacket,Fixed Platform,40.0,2.53
+1408,Ofon AMD1,Nigeria,west_africa,jacket,Fixed Platform,40.0,2.53
+1159,Okoro FPSO,Nigeria,west_africa,fpso,FPSO,0.0,92.0
+1159,Okoro Further Field Development WHP,Nigeria,west_africa,jacket,Fixed Platform,0.0,2.3
+1159,Okoro MOPU,Nigeria,west_africa,jacket,MOPU,0.0,2.3
+1159,Okoro Platform,Nigeria,west_africa,jacket,Fixed Platform,0.0,2.3
+296,Okume/Ebano TLP,Equatorial Guinea,west_africa,tlp,TLP,500.0,47.15
+406,Olowi Platform 1,Gabon,west_africa,jacket,Fixed Platform,50.0,2.5875
+406,Olowi Platform 2,Gabon,west_africa,jacket,Fixed Platform,50.0,2.5875
+406,Olowi Platform 3,Gabon,west_africa,jacket,Fixed Platform,50.0,2.5875
+406,Olowi Platform 4,Gabon,west_africa,jacket,Fixed Platform,50.0,2.5875
+555,Oooguruk Subsea Tieback,US,gom,subsea_tree,Subsea Tieback,2.0,2.0
+222,Ormen Lange Subsea,Norway,ncs,subsea_tree,Subsea Tieback,850.0,2.6
+479,Oseberg A Fixed Platform,Norway,ncs,jacket,Fixed Platform,100.0,3.25
+479,Oseberg B Fixed Platform,Norway,ncs,jacket,Fixed Platform,0.0,2.6
+479,Oseberg C Fixed Platform,Norway,ncs,jacket,Fixed Platform,0.0,2.6
+479,Oseberg D Fixed Platform,Norway,ncs,jacket,Fixed Platform,100.0,3.25
+479,Oseberg South (Sor) Fixed Platform,Norway,ncs,jacket,Fixed Platform,100.0,3.25
+479,Oseberg Vestflanken Subsea,Norway,ncs,subsea_tree,Subsea Tieback,0.0,2.6
+1223,OSX-1 FPSO,Brazil,brazil,fpso,FPSO,130.0,88.0
+1223,OSX-2 FPSO,Brazil,brazil,fpso,FPSO,0.0,88.0
+865,OSX-3 FPSO,Brazil,brazil,fpso,FPSO,105.0,88.0
+296,Oveng TLP,Equatorial Guinea,west_africa,tlp,TLP,280.0,46.644
+299,P-18 Semisub,Brazil,brazil,fpso,Semisub,910.0,88.0
+299,P-19 Semisub,Brazil,brazil,fpso,Semisub,940.0,88.0
+299,P-20 Semisub,Brazil,brazil,fpso,Semisub,700.0,88.0
+299,P-26 Semisub,Brazil,brazil,fpso,Semisub,990.0,88.0
+299,P-32 FPSO,Brazil,brazil,fpso,FPSO,160.0,88.0
+299,P-33 FPSO,Brazil,brazil,fpso,FPSO,330.0,88.0
+299,P-35 FPSO,Brazil,brazil,fpso,FPSO,860.0,88.0
+299,P-37 FPSO,Brazil,brazil,fpso,FPSO,905.0,88.0
+371,P-38 Semisub,Brazil,brazil,fpso,Semisub,0.0,88.0
+371,P-40 Semisub,Brazil,brazil,fpso,Semisub,0.0,88.0
+299,P-47 FPSO,Brazil,brazil,fpso,FPSO,189.0,88.0
+371,P-51 FPU,Brazil,brazil,fpso,FPU/FPS,1650.0,88.0
+348,P-52 Semisub,Brazil,brazil,fpso,Semisub,1800.0,88.0
+703,P-53 FPU,Brazil,brazil,fpso,FPU/FPS,1080.0,88.0
+348,P-54 FPSO,Brazil,brazil,fpso,FPSO,1400.0,88.0
+348,P-55 Semisub,Brazil,brazil,fpso,Semisub,1795.0,88.0
+371,P-56 Semisub,Brazil,brazil,fpso,Semisub,1650.0,88.0
+764,P-57 FPSO,Brazil,brazil,fpso,FPSO,1300.0,88.0
+282,P-58 FPSO,Brazil,brazil,fpso,FPSO,1400.0,88.0
+568,P-61 TLP,Brazil,brazil,tlp,Mini-TLP,1200.0,46.64
+568,P-61 TLWP,Brazil,brazil,tlp,Mini-TLP,1200.0,46.64
+348,P-62 FPSO,Brazil,brazil,fpso,FPSO,1545.0,88.0
+568,P-63 FPSO,Brazil,brazil,fpso,FPSO,0.0,88.0
+1474,P-76 FPSO,Brazil,brazil,fpso,FPSO,1860.0,88.0
+1474,P-77 FPSO,Brazil,brazil,fpso,FPSO,1860.0,88.0
+326,Pazflor FPSO,Angola,west_africa,fpso,FPSO,762.0,92.0
+125,Perdido SPAR Platform,US,gom,spar,SPAR,2377.0,57.131
+432,Peregrino FPSO,Brazil,brazil,fpso,FPSO,120.0,88.0
+432,Peregrino Wellhead Platform A,Brazil,brazil,jacket,Fixed Platform,120.0,2.86
+432,Peregrino Wellhead Platform B,Brazil,brazil,jacket,Fixed Platform,120.0,2.86
+1129,Perth FPSO,UK,ukcs,fpso,FPSO,127.0,100.0
+1145,Petrojarl Banff FPSO,UK,ukcs,fpso,FPSO,89.0,100.0
+436,Petrojarl Foinaven FPSO,UK,ukcs,fpso,FPSO,450.0,100.0
+194,Petrojarl I FPSO,Norway,ncs,fpso,FPSO,100.0,104.0
+664,Petrojarl Varg FPSO,Norway,ncs,fpso,FPSO,84.0,104.0
+767,Petroleo Nautipa FPSO,Gabon,west_africa,fpso,FPSO,137.0,92.0
+117,Petronius Compliant Tower,US,gom,jacket,Compliant Tower,535.0,4.675
+805,Pickerill A Platform,UK,ukcs,jacket,Fixed Platform,21.0,2.6313
+1348,Piranema Spirit FPSO,Brazil,brazil,fpso,FPSO,1600.0,88.0
+1512,Polvo A Platform,Brazil,brazil,jacket,Fixed Platform,85.0,2.6675
+1512,Polvo FPSO,Brazil,brazil,fpso,FPSO,85.0,88.0
+162,Pompano Production Platform,US,gom,jacket,Fixed Platform,393.0,3.965
+186,Prince TLP,US,gom,tlp,TLP,454.0,40.908
+253,PSVM FPSO,Angola,west_africa,fpso,FPSO,2000.0,92.0
+627,Quad 204 FPSO,UK,ukcs,fpso,FPSO,400.0,100.0
+188,Ram Powell TLP,US,gom,tlp,TLP,980.0,41.96
+173,Red Hawk SPAR Platform,US,gom,spar,SPAR,1615.0,54.845
+247,Rosa Subsea,Angola,west_africa,subsea_tree,Subsea Tieback,1350.0,2.3
+413,Rosebank,UK,ukcs,fpso,FPSO,1128.0,100.0
+155,Salsa FIxed Platform,US,gom,jacket,Fixed Platform,453.0,4.265
+1700,Scapa Subsea,UK,ukcs,subsea_tree,Subsea Tieback,111.0,2.5
+627,Schiehallion FPSO,UK,ukcs,fpso,FPSO,400.0,100.0
+909,Schooner Platform,UK,ukcs,jacket,Fixed Platform,71.0,2.9438
+1693,Scott Platform,UK,ukcs,jacket,Fixed Platform,142.0,3.3875
+764,Seillean FPSO,Brazil,brazil,fpso,FPSO,1365.0,88.0
+295,Sendje Ceiba FPSO,Equatorial Guinea,west_africa,fpso,FPSO,2200.0,92.0
+133,Shenzi TLP,US,gom,tlp,TLP,1341.0,42.682
+203,Sigyn Subsea,Norway,ncs,subsea_tree,Subsea Tieback,70.0,2.6
+373,Skarv FPSO,Norway,ncs,fpso,FPSO,391.0,104.0
+374,Sleipner A,Norway,ncs,jacket,Fixed Platform,80.0,3.12
+374,Sleipner B,Norway,ncs,jacket,Fixed Platform,0.0,2.6
+374,Sleipner T,Norway,ncs,jacket,Fixed Platform,0.0,2.6
+223,Snohvit Subsea,Norway,ncs,subsea_tree,Subsea Tieback,340.0,2.6
+204,Snorre A TLP,Norway,ncs,tlp,TLP,350.0,52.91
+204,Snorre B Platform,Norway,ncs,fpso,Semisub,0.0,104.0
+1296,SNX Platform,Angola,west_africa,jacket,Fixed Platform,118.0,2.9785
+1113,Solan Platform,UK,ukcs,jacket,Fixed Platform,135.0,3.3438
+1463,South Morecambe Cluster,UK,ukcs,jacket,Fixed Platform,32.0,2.7
+1296,South Nemba,Angola,west_africa,jacket,Fixed Platform,119.0,2.9842
+140,South Timbalier 301,US,gom,jacket,Fixed Platform,101.0,2.505
+419,Spectacular Bid (GB 72 Platform A),US,gom,jacket,Fixed Platform,541.0,4.705
+1338,SS349 A Platform,US,gom,jacket,Fixed Platform,113.0,2.565
+128,Stampede TLP,US,gom,fpso,FPU/FPS,1000.0,80.0
+208,Statfjord A Platform,Norway,ncs,jacket,Fixed Platform,150.0,3.575
+208,Statfjord B Platform,Norway,ncs,jacket,Fixed Platform,0.0,2.6
+208,Statfjord C Platform,Norway,ncs,jacket,Fixed Platform,290.0,4.485
+350,Stones FPSO,US,gom,fpso,FPSO,2896.0,80.0
+127,Tahiti Spar Platform,US,gom,spar,SPAR,1339.0,54.017
+1324,Takula Platform,Angola,west_africa,jacket,Fixed Platform,57.0,2.6277
+1146,Tartan Platform,UK,ukcs,jacket,Fixed Platform,138.0,3.3625
+407,Telemark Hub (ATP Titan),US,gom,fpso,FPU/FPS,1201.0,80.0
+1038,TEN FPSO,Ghana,west_africa,fpso,FPSO,1425.0,92.0
+1503,Tern Alpha Platform,UK,ukcs,jacket,Fixed Platform,167.0,3.5438
+1312,Thistle Alpha Platform,UK,ukcs,jacket,Fixed Platform,160.0,3.5
+368,Thunder Hawk FPU,US,gom,fpso,FPU/FPS,1850.0,80.0
+129,Thunder Horse Semisub,US,gom,fpso,Semisub,1841.0,80.0
+1392,Tiffany Platform,UK,ukcs,jacket,Fixed Platform,0.0,2.5
+539,Tombua Landana Compliant Tower,Angola,west_africa,jacket,Compliant Tower,369.0,4.4217
+1028,Triton FPSO,UK,ukcs,fpso,FPSO,91.0,100.0
+770,Troll A,Norway,ncs,jacket,Fixed Platform,340.0,4.81
+770,Troll B & C,Norway,ncs,fpso,Semisub,350.0,104.0
+353,Tubular Bells FPS,US,gom,fpso,FPU/FPS,1311.0,80.0
+479,Tune South (Sor) Subsea,Norway,ncs,subsea_tree,Subsea Tieback,0.0,2.6
+479,Tune Subsea,Norway,ncs,subsea_tree,Subsea Tieback,95.0,2.6
+317,Tyrihans Subsea,Norway,ncs,subsea_tree,Subsea Tieback,270.0,2.6
+433,Ula Fixed Platform,Norway,ncs,jacket,Fixed Platform,70.0,3.055
+318,Unity FSO,Nigeria,west_africa,fpso,FSO/FSU,40.0,92.0
+149,Ursa TLP,US,gom,tlp,TLP,1222.0,42.444
+341,Usan FPSO,Nigeria,west_africa,fpso,FPSO,750.0,92.0
+1104,Valemon Fixed Platform,Norway,ncs,jacket,Fixed Platform,0.0,2.6
+462,Valhall Flank North Platform,Norway,ncs,jacket,Fixed Platform,70.0,3.055
+462,Valhall Flank South Platform,Norway,ncs,jacket,Fixed Platform,70.0,3.055
+462,Valhall Production Platform,Norway,ncs,jacket,Fixed Platform,70.0,3.055
+462,Valhall Quarters Platform,Norway,ncs,jacket,Fixed Platform,70.0,3.055
+462,Valhall Water Injection Platform,Norway,ncs,jacket,Fixed Platform,70.0,3.055
+664,Varg Wellhead Platform,Norway,ncs,jacket,Fixed Platform,84.0,3.146
+379,Veer Prem MOPU,Nigeria,west_africa,fpso,Semisub,41.0,92.0
+549,Veslefrikk A,Norway,ncs,jacket,Fixed Platform,185.0,3.8025
+549,Veslefrikk B,Norway,ncs,fpso,Semisub,185.0,104.0
+1197,Viking Complex,UK,ukcs,jacket,Fixed Platform,0.0,2.5
+138,Virgo Platform,US,gom,jacket,Fixed Platform,345.0,3.725
+379,Virini Prem FSO,Nigeria,west_africa,fpso,FSO/FSU,41.0,92.0
+198,Visund A,Norway,ncs,fpso,FPU/FPS,335.0,104.0
+198,Visund North Subsea,Norway,ncs,subsea_tree,Subsea Tieback,0.0,2.6
+902,Voyageur Spirit FPSO,UK,ukcs,fpso,FPSO,91.0,100.0
+963,West Sole Alpha Platform,UK,ukcs,jacket,Fixed Platform,0.0,2.5
+1107,Western Isles FPSO,UK,ukcs,fpso,FPSO,155.0,100.0
+954,Who Dat FPS,US,gom,fpso,FPU/FPS,914.0,80.0
+865,WHP-2,Brazil,brazil,jacket,Fixed Platform,105.0,2.7775
+639,Xikomba FPSO,Angola,west_africa,fpso,FPSO,1341.0,92.0
+873,Yme MOPU,Norway,ncs,jacket,MOPU,93.0,3.2045
+622,Yoho FSO,Nigeria,west_africa,fpso,FSO/FSU,95.0,92.0
+622,Yoho Wellhead Platform I,Nigeria,west_africa,jacket,Fixed Platform,95.0,2.8462
+622,Yoho Wellhead Platform II,Nigeria,west_africa,jacket,Fixed Platform,95.0,2.8462
+1417,York Platform,UK,ukcs,jacket,Fixed Platform,43.0,2.7687
+359,Yttergryta Subsea,Norway,ncs,subsea_tree,Subsea Tieback,297.0,2.6

--- a/reports/decommissioning/regional_liability.html
+++ b/reports/decommissioning/regional_liability.html
@@ -1,0 +1,131 @@
+<meta charset="utf-8">
+<title>Regional Decommissioning Liability</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root {
+    --bg:#eef2f6; --panel:#fff; --panel-2:#f6f9fc; --ink:#0c1a28; --muted:#5a6b7b;
+    --line:#d6e0ea; --accent:#d9822b; --accent-ink:#7a4410; --done:#1d5fa8;
+    --future:#a9bccd; --good:#2e9e6b; --alert:#c0453b;
+    --shadow:0 1px 2px rgba(12,26,40,.06),0 8px 24px rgba(12,26,40,.06);
+    --mono:ui-monospace,"SF Mono","Cascadia Code",Consolas,monospace;
+    --sans:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#0a141f; --panel:#10202f; --panel-2:#0d1b28; --ink:#e8eef4; --muted:#8ca0b3;
+    --line:#24384b; --accent:#f0a24a; --accent-ink:#f7c489; --done:#4d91d6;
+    --future:#3a5064; --good:#43b982; --alert:#e0685e;
+    --shadow:0 1px 2px rgba(0,0,0,.4),0 10px 30px rgba(0,0,0,.35);
+  }}
+  :root[data-theme="light"]{--bg:#eef2f6;--panel:#fff;--panel-2:#f6f9fc;--ink:#0c1a28;--muted:#5a6b7b;--line:#d6e0ea;--accent:#d9822b;--done:#1d5fa8;--future:#a9bccd;--good:#2e9e6b;--alert:#c0453b;}
+  :root[data-theme="dark"]{--bg:#0a141f;--panel:#10202f;--panel-2:#0d1b28;--ink:#e8eef4;--muted:#8ca0b3;--line:#24384b;--accent:#f0a24a;--done:#4d91d6;--future:#3a5064;--good:#43b982;--alert:#e0685e;}
+  *{box-sizing:border-box;} body{margin:0;}
+  .wrap{background:var(--bg);color:var(--ink);font-family:var(--sans);padding:clamp(16px,3vw,40px);min-height:100%;-webkit-font-smoothing:antialiased;}
+  .sheet{max-width:1080px;margin:0 auto;background:var(--panel);border:1px solid var(--line);border-radius:14px;box-shadow:var(--shadow);overflow:hidden;}
+  .head{padding:clamp(20px,2.6vw,34px);border-bottom:1px solid var(--line);}
+  .crumb{font-size:12.5px;margin:0 0 12px;} .crumb a{color:var(--done);text-decoration:none;}
+  .eyebrow{font-family:var(--mono);font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--muted);margin:0 0 8px;}
+  .title{font-size:clamp(26px,3.6vw,40px);font-weight:800;letter-spacing:-.02em;margin:0;line-height:1.03;text-wrap:balance;}
+  .thesis{color:var(--ink);margin:14px 0 0;font-size:clamp(15px,1.6vw,18px);max-width:74ch;line-height:1.5;}
+  .thesis b{color:var(--accent-ink,var(--accent));}
+  @media (prefers-color-scheme:dark){.thesis b{color:var(--accent);}}
+  .body{padding:clamp(20px,2.6vw,34px);}
+  .kpis{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:14px;margin:0 0 26px;}
+  .kpi{background:var(--panel-2);border:1px solid var(--line);border-radius:10px;padding:14px 16px;}
+  .kpi .n{font-size:clamp(22px,3vw,30px);font-weight:800;letter-spacing:-.02em;line-height:1;}
+  .kpi .n.accent{color:var(--accent);} .kpi .n.done{color:var(--done);}
+  .kpi .l{color:var(--muted);font-size:12px;margin-top:7px;line-height:1.35;}
+  h2{font-size:13px;font-family:var(--mono);letter-spacing:.12em;text-transform:uppercase;color:var(--muted);margin:30px 0 12px;font-weight:600;}
+  .chartwrap{overflow-x:auto;border:1px solid var(--line);border-radius:10px;background:var(--panel-2);padding:16px;}
+  .bl{fill:var(--ink);font-family:var(--sans);font-size:15px;font-weight:800;}
+  .bm{fill:var(--muted);font-family:var(--mono);font-size:11px;}
+  .bx{fill:var(--ink);font-family:var(--sans);font-size:12.5px;font-weight:600;}
+  .bxm{fill:var(--muted);font-family:var(--mono);font-size:10.5px;}
+  .legend{display:flex;gap:18px;flex-wrap:wrap;margin:12px 2px 0;font-size:12px;color:var(--muted);}
+  .legend i,.lab i{display:inline-block;width:11px;height:11px;border-radius:2px;margin-right:6px;vertical-align:-1px;}
+  .callout{background:var(--panel-2);border-left:3px solid var(--accent);border-radius:0 8px 8px 0;padding:14px 18px;margin:16px 0;font-size:14px;line-height:1.55;}
+  .callout b{color:var(--accent-ink,var(--accent));}
+  @media (prefers-color-scheme:dark){.callout b{color:var(--accent);}}
+  table{width:100%;border-collapse:collapse;font-size:14px;margin-top:6px;}
+  thead th{text-align:right;font-family:var(--mono);font-size:11px;letter-spacing:.04em;text-transform:uppercase;color:var(--muted);font-weight:600;padding:8px 10px;border-bottom:1px solid var(--line);}
+  thead th:first-child{text-align:left;}
+  td{padding:8px 10px;border-bottom:1px solid var(--line);}
+  td.lab{font-weight:600;} td.num{text-align:right;font-variant-numeric:tabular-nums;font-family:var(--mono);}
+  td.strong{font-weight:800;} td.muted{color:var(--muted);}
+  tbody tr:last-child td{border-bottom:none;}
+  .grid2{display:grid;grid-template-columns:1fr 1fr;gap:24px;}
+  @media (max-width:720px){.grid2{grid-template-columns:1fr;}}
+  .note{color:var(--muted);font-size:12.5px;line-height:1.55;margin:10px 0 0;}
+  .foot{margin-top:30px;padding-top:16px;border-top:1px solid var(--line);color:var(--muted);font-size:12px;line-height:1.6;}
+  code{font-family:var(--mono);font-size:.92em;background:var(--panel-2);padding:1px 5px;border-radius:4px;}
+  a{color:var(--done);}
+</style>
+<div class="wrap"><div class="sheet">
+  <div class="head">
+    <p class="crumb"><a href="../capabilities/insights.html">&larr; Life-cycle insights hub</a> &middot; <a href="pa-liability-wave.html">GoM P&amp;A liability wave</a></p>
+    <p class="eyebrow">World Energy Data · Decommissioning · Regional liability</p>
+    <h1 class="title">Two forces set the decommissioning bill — and they pull opposite ways</h1>
+    <p class="thesis">Per <em>identical</em> asset the North Sea costs 25–30% more to remove (the regional multiplier).
+    But the money is in floating production: <b>159 FPSOs carry $14.8B of the $17.5B modeled liability</b>
+    (84%), concentrated in Brazil and West-Africa deepwater — <em>not</em> the North Sea's cheap-to-remove fixed jackets.
+    At portfolio level the asset mix, not the multiplier, sets the realized bill.</p>
+  </div>
+  <div class="body">
+    <div class="kpis">
+      <div class="kpi"><div class="n">$17.5B</div><div class="l">Total modeled liability (421 facilities, 5 regions)</div></div>
+      <div class="kpi"><div class="n accent">$14.8B</div><div class="l">FPSO share = 84% of the bill (159 units)</div></div>
+      <div class="kpi"><div class="n done">+30% / +25%</div><div class="l">NCS / UKCS like-for-like premium per identical jacket vs GoM</div></div>
+      <div class="kpi"><div class="n">421/836</div><div class="l">Facilities modeled; 414 unmodeled-region excluded</div></div>
+    </div>
+
+    <h2>Modeled liability by region &times; asset type</h2>
+    <div class="chartwrap"><svg viewBox="0 0 818 320" width="100%" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Modeled decommissioning liability by region and asset type"><rect x="18" y="35.4" width="118" height="218.6" fill="var(--accent)" rx="2"><title>Brazil · FPSO / floating production: $4.4B</title></rect><rect x="18" y="30.8" width="118" height="4.6" fill="var(--good)" rx="2"><title>Brazil · TLP: $0.1B</title></rect><rect x="18" y="30.0" width="118" height="0.8" fill="var(--future)" rx="2"><title>Brazil · Fixed jacket: $0.0B</title></rect><text x="77" y="10" text-anchor="middle" class="bl">$4.5B</text><text x="77" y="24" text-anchor="middle" class="bm">n=58</text><text x="77" y="274" text-anchor="middle" class="bx">Brazil</text><text x="77" y="290" text-anchor="middle" class="bxm">×1.1 · $78M/fac</text><rect x="176" y="85.1" width="118" height="168.9" fill="var(--accent)" rx="2"><title>UK (UKCS) · FPSO / floating production: $3.4B</title></rect><rect x="176" y="72.6" width="118" height="12.5" fill="var(--future)" rx="2"><title>UK (UKCS) · Fixed jacket: $0.3B</title></rect><rect x="176" y="71.6" width="118" height="1.0" fill="var(--muted)" rx="2"><title>UK (UKCS) · Subsea tree: $0.0B</title></rect><text x="235" y="52" text-anchor="middle" class="bl">$3.7B</text><text x="235" y="66" text-anchor="middle" class="bm">n=124</text><text x="235" y="274" text-anchor="middle" class="bx">UK (UKCS)</text><text x="235" y="290" text-anchor="middle" class="bxm">×1.25 · $30M/fac</text><rect x="334" y="84.9" width="118" height="169.1" fill="var(--accent)" rx="2"><title>West Africa · FPSO / floating production: $3.4B</title></rect><rect x="334" y="77.9" width="118" height="7.0" fill="var(--good)" rx="2"><title>West Africa · TLP: $0.1B</title></rect><rect x="334" y="73.8" width="118" height="4.1" fill="var(--future)" rx="2"><title>West Africa · Fixed jacket: $0.1B</title></rect><rect x="334" y="73.7" width="118" height="0.1" fill="var(--muted)" rx="2"><title>West Africa · Subsea tree: $0.0B</title></rect><text x="393" y="54" text-anchor="middle" class="bl">$3.6B</text><text x="393" y="68" text-anchor="middle" class="bm">n=70</text><text x="393" y="274" text-anchor="middle" class="bx">West Africa</text><text x="393" y="290" text-anchor="middle" class="bxm">×1.15 · $52M/fac</text><rect x="492" y="190.4" width="118" height="63.6" fill="var(--accent)" rx="2"><title>Gulf of Mexico · FPSO / floating production: $1.3B</title></rect><rect x="492" y="142.1" width="118" height="48.3" fill="var(--done)" rx="2"><title>Gulf of Mexico · Spar: $1.0B</title></rect><rect x="492" y="108.6" width="118" height="33.5" fill="var(--good)" rx="2"><title>Gulf of Mexico · TLP: $0.7B</title></rect><rect x="492" y="103.2" width="118" height="5.5" fill="var(--future)" rx="2"><title>Gulf of Mexico · Fixed jacket: $0.1B</title></rect><rect x="492" y="102.5" width="118" height="0.7" fill="var(--muted)" rx="2"><title>Gulf of Mexico · Subsea tree: $0.0B</title></rect><text x="551" y="82" text-anchor="middle" class="bl">$3.1B</text><text x="551" y="96" text-anchor="middle" class="bm">n=87</text><text x="551" y="274" text-anchor="middle" class="bx">Gulf of Mexico</text><text x="551" y="290" text-anchor="middle" class="bxm">×1 · $35M/fac</text><rect x="650" y="140.4" width="118" height="113.6" fill="var(--accent)" rx="2"><title>Norway (NCS) · FPSO / floating production: $2.3B</title></rect><rect x="650" y="136.9" width="118" height="3.5" fill="var(--done)" rx="2"><title>Norway (NCS) · Spar: $0.1B</title></rect><rect x="650" y="131.6" width="118" height="5.3" fill="var(--good)" rx="2"><title>Norway (NCS) · TLP: $0.1B</title></rect><rect x="650" y="124.4" width="118" height="7.2" fill="var(--future)" rx="2"><title>Norway (NCS) · Fixed jacket: $0.1B</title></rect><rect x="650" y="122.8" width="118" height="1.7" fill="var(--muted)" rx="2"><title>Norway (NCS) · Subsea tree: $0.0B</title></rect><text x="709" y="103" text-anchor="middle" class="bl">$2.6B</text><text x="709" y="117" text-anchor="middle" class="bm">n=82</text><text x="709" y="274" text-anchor="middle" class="bx">Norway (NCS)</text><text x="709" y="290" text-anchor="middle" class="bxm">×1.3 · $32M/fac</text><line x1="8" y1="254" x2="808" y2="254" stroke="var(--line)" stroke-width="1"/></svg></div>
+    <div class="legend"><span><i style="background:var(--accent)"></i>FPSO / floating production</span><span><i style="background:var(--done)"></i>Spar</span><span><i style="background:var(--good)"></i>TLP</span><span><i style="background:var(--future)"></i>Fixed jacket</span><span><i style="background:var(--muted)"></i>Subsea tree</span><span>Bar = total $ liability · label under bar = region multiplier &amp; mean $/facility</span></div>
+    <p class="note">Regions are ordered by total modeled liability. The stacked segments are the asset-type $ split within each
+    region — the tall floating-production (FPSO) blocks in Brazil and West Africa, not the North Sea's higher multiplier,
+    are what set the totals.</p>
+
+    <div class="callout"><b>Multiplier vs mix.</b> Hold the asset constant — one jacket at 100&nbsp;m — and the pure regional
+    premium is exactly the multiplier: <b>NCS +30%</b> and <b>UKCS +25%</b> over GoM.
+    Yet the realized <em>mean $/facility</em> inverts that ranking — GoM&nbsp;$35.1M &gt; NCS&nbsp;$32.2M
+    &gt; UKCS&nbsp;$29.6M — because the GoM sample carries a heavier floating-production mix than the North Sea's
+    fixed jackets. The mix dominates the multiplier. So "the North Sea is most expensive" is true per structure and
+    <em>false</em> at portfolio level.</p>
+
+    <div class="grid2">
+      <div>
+        <h2>By asset type — the money is floating</h2>
+        <table>
+          <thead><tr><th>Asset type</th><th>n</th><th>Liability</th><th>Share</th></tr></thead>
+          <tbody><tr><td class="lab"><i style="background:var(--accent)"></i>FPSO / floating production</td><td class="num">159</td><td class="num strong">$14.8B</td><td class="num muted">84%</td></tr><tr><td class="lab"><i style="background:var(--done)"></i>Spar</td><td class="num">19</td><td class="num strong">$1.0B</td><td class="num muted">6%</td></tr><tr><td class="lab"><i style="background:var(--good)"></i>TLP</td><td class="num">23</td><td class="num strong">$1.0B</td><td class="num muted">6%</td></tr><tr><td class="lab"><i style="background:var(--future)"></i>Fixed jacket</td><td class="num">191</td><td class="num strong">$0.6B</td><td class="num muted">3%</td></tr><tr><td class="lab"><i style="background:var(--muted)"></i>Subsea tree</td><td class="num">29</td><td class="num strong">$0.1B</td><td class="num muted">0%</td></tr>
+          <tr><td class="lab strong">Total</td><td class="num strong">421</td>
+          <td class="num strong">$17.5B</td><td class="num muted">100%</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div>
+        <h2>By region — multiplier &amp; realized mean</h2>
+        <table>
+          <thead><tr><th>Region</th><th>Mult</th><th>n</th><th>Liability</th><th>Mean/fac</th></tr></thead>
+          <tbody><tr><td class="lab">Brazil</td><td class="num muted">×1.1</td><td class="num">58</td><td class="num strong">$4.5B</td><td class="num muted">$77.8M</td></tr><tr><td class="lab">UK (UKCS)</td><td class="num muted">×1.25</td><td class="num">124</td><td class="num strong">$3.7B</td><td class="num muted">$29.6M</td></tr><tr><td class="lab">West Africa</td><td class="num muted">×1.15</td><td class="num">70</td><td class="num strong">$3.6B</td><td class="num muted">$51.9M</td></tr><tr><td class="lab">Gulf of Mexico</td><td class="num muted">×1</td><td class="num">87</td><td class="num strong">$3.1B</td><td class="num muted">$35.1M</td></tr><tr><td class="lab">Norway (NCS)</td><td class="num muted">×1.3</td><td class="num">82</td><td class="num strong">$2.6B</td><td class="num muted">$32.2M</td></tr></tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="foot">
+      <b>Source.</b> Curated offshore-asset inventory
+      <code>data/modules/offshore_assets/curated/production_facilities.csv</code> — 836 facilities.
+      <b>421 modeled</b> across the five regions the cost model carries a multiplier for
+      (GoM&nbsp;×1.0, NCS&nbsp;×1.3, UKCS&nbsp;×1.25, Brazil&nbsp;×1.1, West&nbsp;Africa&nbsp;×1.15);
+      <b>414 facilities in unmodeled regions are excluded</b> (no cost factor), and the
+      1 Artificial Island is not a priced offshore-structure removal.<br>
+      <b>Data limits.</b> Facilities are priced at the cost model's base + water-depth floor with
+      <b>weight = 0</b> (per-facility topside weight is not carried), so totals are conservative on the tonnage term.
+      The <b>FPSO base cost is model confidence "low"</b>; because FPSOs dominate the bill, the headline total is
+      most sensitive to that one factor. Region multipliers and asset base costs are parametric industry benchmarks,
+      not project quotes.<br>
+      Generated by <code>scripts/decommissioning/build_regional_liability.py</code> · logic
+      <code>worldenergydata.decommissioning.facility_liability</code> · cost model
+      <code>worldenergydata.decommissioning.cost_model</code>.
+    </div>
+  </div>
+</div></div>

--- a/scripts/build_pages.py
+++ b/scripts/build_pages.py
@@ -624,12 +624,20 @@ def build_decommissioning(available_viz: dict[str, bool]) -> list[tuple]:
     from the frozen BSEE well inventory; copied verbatim into
     ``public/decommissioning/pa-liability-wave.html``. Returns ``[]`` &mdash; the
     landing index keys off what exists in ``public/``."""
-    src = REPORTS / "decommissioning" / "pa_liability_wave.html"
-    if not src.exists():
-        return []
     dst = PUBLIC / "decommissioning"
-    dst.mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(src, dst / "pa-liability-wave.html")
+    pages = {
+        "pa_liability_wave.html": "pa-liability-wave.html",
+        "regional_liability.html": "regional-liability.html",
+    }
+    made = False
+    for src_name, dst_name in pages.items():
+        src = REPORTS / "decommissioning" / src_name
+        if not src.exists():
+            continue
+        if not made:
+            dst.mkdir(parents=True, exist_ok=True)
+            made = True
+        shutil.copyfile(src, dst / dst_name)
     return []
 
 

--- a/scripts/decommissioning/build_pa_liability_wave.py
+++ b/scripts/decommissioning/build_pa_liability_wave.py
@@ -385,6 +385,11 @@ def render_html(**k) -> str:
     units (e.g. 5,000–10,000&nbsp;ft: ~4.4× the resident rig-days). That access gap is the SUPPLY side of the same
     wave this page prices on the LIABILITY side; the demand figures are cited from the brief, not recomputed here.</p>
 
+    <p class="note"><b>Global companion.</b> This page is the Gulf-of-Mexico <em>well</em> P&amp;A wave. The
+    <a href="regional-liability.html">regional decommissioning-liability view</a> prices the global <em>facility</em>
+    portfolio (836 offshore facilities, 5 regions) and shows why floating production — not the North Sea's
+    fixed jackets — carries most of the modeled $17.5B removal bill.</p>
+
     <div class="foot">
       <b>Source.</b> BSEE curated borehole inventory <code>data/modules/bsee/current/wells/well_data.csv</code>
       — {k['n_total']:,} boreholes. Status mix: PA {scget('PA'):,} · ST {scget('ST'):,} · COM {scget('COM'):,}

--- a/scripts/decommissioning/build_regional_liability.py
+++ b/scripts/decommissioning/build_regional_liability.py
@@ -1,0 +1,364 @@
+"""ABOUTME: Build the regional (facility-level) decommissioning-liability front door.
+ABOUTME: Prices the curated offshore-asset portfolio by region x asset type.
+
+Reads the curated production-facility inventory
+(``data/modules/offshore_assets/curated/production_facilities.csv`` — 836
+facilities) and prices every facility with the parametric
+``DecommissioningCostEstimator`` (region multipliers gom 1.0 / ncs 1.3 /
+ukcs 1.25 / brazil 1.1 / west_africa 1.15).
+
+The honest, non-obvious story: two forces set the bill and pull opposite ways.
+Per identical asset the North Sea costs 25-30% more (the region multiplier), but
+the money is in floating production — 159 FPSOs carry $14.8B of the $17.5B
+modeled liability, concentrated in Brazil and West-Africa deepwater, NOT the
+North Sea's cheap-to-remove fixed jackets (the asset-mix effect). At portfolio
+level the mix dominates the multiplier: mean $/facility runs GoM > NCS > UKCS.
+
+Outputs (self-contained, no external assets):
+    reports/decommissioning/regional_liability.csv
+    reports/decommissioning/regional_liability.html
+
+FLAG-DON'T-FAKE: every number below is computed from the source file via
+``facility_liability.price_portfolio``. 421 of 836 facilities are modeled; the
+414 in regions with no cost multiplier are excluded, and the 1 Artificial Island
+is not a priced offshore-structure removal. Costs use weight=0 and the depth
+floor (per-facility weight is not carried); the FPSO base cost is low-confidence.
+"""
+
+from __future__ import annotations
+
+import html
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(
+    0, str(PROJECT_ROOT / "packages" / "worldenergydata-decommissioning" / "src")
+)
+from worldenergydata.decommissioning.cost_model import (  # noqa: E402
+    DecommissioningCostEstimator,
+)
+from worldenergydata.decommissioning.facility_liability import (  # noqa: E402
+    price_portfolio,
+)
+
+SRC = (
+    PROJECT_ROOT
+    / "data"
+    / "modules"
+    / "offshore_assets"
+    / "curated"
+    / "production_facilities.csv"
+)
+OUT_CSV = PROJECT_ROOT / "reports" / "decommissioning" / "regional_liability.csv"
+OUT_HTML = PROJECT_ROOT / "reports" / "decommissioning" / "regional_liability.html"
+
+REGION_LABEL = {
+    "gom": "Gulf of Mexico",
+    "ncs": "Norway (NCS)",
+    "ukcs": "UK (UKCS)",
+    "brazil": "Brazil",
+    "west_africa": "West Africa",
+}
+REGION_MULT = {"gom": 1.0, "ncs": 1.3, "ukcs": 1.25, "brazil": 1.1, "west_africa": 1.15}
+ASSET_LABEL = {
+    "fpso": "FPSO / floating production",
+    "spar": "Spar",
+    "tlp": "TLP",
+    "jacket": "Fixed jacket",
+    "subsea_tree": "Subsea tree",
+}
+ASSET_COLOR = {
+    "fpso": "var(--accent)",
+    "spar": "var(--done)",
+    "tlp": "var(--good)",
+    "jacket": "var(--future)",
+    "subsea_tree": "var(--muted)",
+}
+ASSET_ORDER = ["fpso", "spar", "tlp", "jacket", "subsea_tree"]
+
+
+def _b(musd: float) -> str:
+    return f"${musd / 1000:.1f}B"
+
+
+def main() -> None:
+    df = pd.read_csv(SRC)
+    n_total = len(df)
+    res = price_portfolio(df)
+
+    # Like-for-like reference: one identical asset (jacket @ 100 m) across regions,
+    # showing the pure multiplier premium with the asset mix held constant.
+    est = DecommissioningCostEstimator()
+    llf = {
+        reg: est.estimate("jacket", water_depth_m=100.0, region=reg).estimated_cost_musd
+        for reg in REGION_MULT
+    }
+
+    # ---- Write per-facility CSV ---------------------------------------------
+    OUT_CSV.parent.mkdir(parents=True, exist_ok=True)
+    counts = res["counts"]
+    with OUT_CSV.open("w", newline="") as fh:
+        fh.write(
+            "# Regional decommissioning liability (facility-level, offshore-assets)\n"
+            f"# source: {SRC.relative_to(PROJECT_ROOT)} | {n_total} facilities\n"
+            f"# modeled={counts['modeled']} (5 regions with a cost multiplier);"
+            f" unmodeled-region={counts['unmodeled_region']} excluded;"
+            f" unmapped-asset={counts['unmapped_asset']} (Artificial Island) excluded\n"
+            f"# total modeled liability = {_b(res['total_musd'])} ({res['total_musd']:,.0f} MUSD)\n"
+            "# pricing: DecommissioningCostEstimator, weight=0, depth floor; FPSO base low-confidence\n"
+        )
+    pd.DataFrame(res["rows"]).to_csv(OUT_CSV, mode="a", index=False)
+
+    html_str = render_html(n_total=n_total, res=res, llf=llf)
+    OUT_HTML.write_text(html_str, encoding="utf-8")
+
+    print(
+        f"facilities={n_total} modeled={counts['modeled']} "
+        f"unmodeled-region={counts['unmodeled_region']} "
+        f"unmapped-asset={counts['unmapped_asset']}"
+    )
+    print(f"TOTAL modeled liability = {_b(res['total_musd'])} ({res['total_musd']:,.0f} MUSD)")
+    for reg, d in sorted(res["by_region"].items(), key=lambda kv: -kv[1]["sum_musd"]):
+        print(f"  {reg:12s} {_b(d['sum_musd'])}  n={d['count']}")
+    for a in ASSET_ORDER:
+        d = res["by_asset"].get(a)
+        if d:
+            print(f"  {a:12s} {_b(d['sum_musd'])}  n={d['count']}")
+    print(f"wrote {OUT_CSV.relative_to(PROJECT_ROOT)} and {OUT_HTML.relative_to(PROJECT_ROOT)}")
+
+
+def render_html(*, n_total: int, res: dict, llf: dict) -> str:
+    by_region = res["by_region"]
+    by_asset = res["by_asset"]
+    means = res["mean_per_facility_by_region"]
+    counts = res["counts"]
+    total = res["total_musd"]
+
+    # region x asset stacked $ bars, regions ordered by total liability desc
+    reg_order = sorted(by_region, key=lambda r: -by_region[r]["sum_musd"])
+    # per-facility rows aggregated into region x asset $ matrix
+    rows_df = pd.DataFrame(res["rows"])
+    mat = (
+        rows_df.groupby(["region", "asset"])["cost_musd"].sum().unstack(fill_value=0.0)
+    )
+    max_reg = max(by_region[r]["sum_musd"] for r in reg_order)
+
+    bar_w, gap, top, bottom, left = 118, 40, 30, 66, 8
+    chart_w = left + len(reg_order) * (bar_w + gap) + 20
+    chart_h = 320
+    plot_h = chart_h - top - bottom
+    bars = []
+    x = left + 10
+    for reg in reg_order:
+        total_reg = by_region[reg]["sum_musd"]
+        full_h = plot_h * (total_reg / max_reg)
+        baseline = top + plot_h
+        y_cursor = baseline
+        for a in ASSET_ORDER:
+            v = float(mat.loc[reg, a]) if a in mat.columns and reg in mat.index else 0.0
+            if v <= 0:
+                continue
+            seg_h = full_h * (v / total_reg)
+            y_cursor -= seg_h
+            bars.append(
+                f'<rect x="{x}" y="{y_cursor:.1f}" width="{bar_w}" height="{seg_h:.1f}" '
+                f'fill="{ASSET_COLOR[a]}" rx="2">'
+                f"<title>{html.escape(REGION_LABEL[reg])} · {html.escape(ASSET_LABEL[a])}: {_b(v)}</title></rect>"
+            )
+        top_y = baseline - full_h
+        bars.append(
+            f'<text x="{x + bar_w / 2:.0f}" y="{top_y - 20:.0f}" text-anchor="middle" class="bl">{_b(total_reg)}</text>'
+            f'<text x="{x + bar_w / 2:.0f}" y="{top_y - 6:.0f}" text-anchor="middle" class="bm">n={by_region[reg]["count"]}</text>'
+            f'<text x="{x + bar_w / 2:.0f}" y="{baseline + 20:.0f}" text-anchor="middle" class="bx">{html.escape(REGION_LABEL[reg])}</text>'
+            f'<text x="{x + bar_w / 2:.0f}" y="{baseline + 36:.0f}" text-anchor="middle" class="bxm">×{REGION_MULT[reg]:g} · ${means[reg]:.0f}M/fac</text>'
+        )
+        x += bar_w + gap
+    svg = (
+        f'<svg viewBox="0 0 {chart_w} {chart_h}" width="100%" preserveAspectRatio="xMidYMid meet" '
+        f'role="img" aria-label="Modeled decommissioning liability by region and asset type">'
+        + "".join(bars)
+        + f'<line x1="{left}" y1="{top + plot_h}" x2="{chart_w - 10}" y2="{top + plot_h}" stroke="var(--line)" stroke-width="1"/>'
+        + "</svg>"
+    )
+
+    legend = "".join(
+        f'<span><i style="background:{ASSET_COLOR[a]}"></i>{html.escape(ASSET_LABEL[a])}</span>'
+        for a in ASSET_ORDER
+        if a in by_asset
+    )
+
+    # asset roll-up table (money-is-in-FPSO)
+    arows = []
+    for a in ASSET_ORDER:
+        d = by_asset.get(a)
+        if not d:
+            continue
+        share = 100 * d["sum_musd"] / total
+        arows.append(
+            "<tr>"
+            f'<td class="lab"><i style="background:{ASSET_COLOR[a]}"></i>{html.escape(ASSET_LABEL[a])}</td>'
+            f'<td class="num">{d["count"]:,}</td>'
+            f'<td class="num strong">{_b(d["sum_musd"])}</td>'
+            f'<td class="num muted">{share:.0f}%</td>'
+            "</tr>"
+        )
+
+    # region roll-up table
+    rrows = []
+    for reg in reg_order:
+        d = by_region[reg]
+        rrows.append(
+            "<tr>"
+            f'<td class="lab">{html.escape(REGION_LABEL[reg])}</td>'
+            f'<td class="num muted">×{REGION_MULT[reg]:g}</td>'
+            f'<td class="num">{d["count"]:,}</td>'
+            f'<td class="num strong">{_b(d["sum_musd"])}</td>'
+            f'<td class="num muted">${means[reg]:.1f}M</td>'
+            "</tr>"
+        )
+
+    fpso = by_asset["fpso"]
+    fpso_share = 100 * fpso["sum_musd"] / total
+    gom_j = llf["gom"]
+    ncs_prem = 100 * (llf["ncs"] / gom_j - 1)
+    ukcs_prem = 100 * (llf["ukcs"] / gom_j - 1)
+
+    return f"""<meta charset="utf-8">
+<title>Regional Decommissioning Liability</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root {{
+    --bg:#eef2f6; --panel:#fff; --panel-2:#f6f9fc; --ink:#0c1a28; --muted:#5a6b7b;
+    --line:#d6e0ea; --accent:#d9822b; --accent-ink:#7a4410; --done:#1d5fa8;
+    --future:#a9bccd; --good:#2e9e6b; --alert:#c0453b;
+    --shadow:0 1px 2px rgba(12,26,40,.06),0 8px 24px rgba(12,26,40,.06);
+    --mono:ui-monospace,"SF Mono","Cascadia Code",Consolas,monospace;
+    --sans:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  }}
+  @media (prefers-color-scheme:dark){{:root{{
+    --bg:#0a141f; --panel:#10202f; --panel-2:#0d1b28; --ink:#e8eef4; --muted:#8ca0b3;
+    --line:#24384b; --accent:#f0a24a; --accent-ink:#f7c489; --done:#4d91d6;
+    --future:#3a5064; --good:#43b982; --alert:#e0685e;
+    --shadow:0 1px 2px rgba(0,0,0,.4),0 10px 30px rgba(0,0,0,.35);
+  }}}}
+  :root[data-theme="light"]{{--bg:#eef2f6;--panel:#fff;--panel-2:#f6f9fc;--ink:#0c1a28;--muted:#5a6b7b;--line:#d6e0ea;--accent:#d9822b;--done:#1d5fa8;--future:#a9bccd;--good:#2e9e6b;--alert:#c0453b;}}
+  :root[data-theme="dark"]{{--bg:#0a141f;--panel:#10202f;--panel-2:#0d1b28;--ink:#e8eef4;--muted:#8ca0b3;--line:#24384b;--accent:#f0a24a;--done:#4d91d6;--future:#3a5064;--good:#43b982;--alert:#e0685e;}}
+  *{{box-sizing:border-box;}} body{{margin:0;}}
+  .wrap{{background:var(--bg);color:var(--ink);font-family:var(--sans);padding:clamp(16px,3vw,40px);min-height:100%;-webkit-font-smoothing:antialiased;}}
+  .sheet{{max-width:1080px;margin:0 auto;background:var(--panel);border:1px solid var(--line);border-radius:14px;box-shadow:var(--shadow);overflow:hidden;}}
+  .head{{padding:clamp(20px,2.6vw,34px);border-bottom:1px solid var(--line);}}
+  .crumb{{font-size:12.5px;margin:0 0 12px;}} .crumb a{{color:var(--done);text-decoration:none;}}
+  .eyebrow{{font-family:var(--mono);font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--muted);margin:0 0 8px;}}
+  .title{{font-size:clamp(26px,3.6vw,40px);font-weight:800;letter-spacing:-.02em;margin:0;line-height:1.03;text-wrap:balance;}}
+  .thesis{{color:var(--ink);margin:14px 0 0;font-size:clamp(15px,1.6vw,18px);max-width:74ch;line-height:1.5;}}
+  .thesis b{{color:var(--accent-ink,var(--accent));}}
+  @media (prefers-color-scheme:dark){{.thesis b{{color:var(--accent);}}}}
+  .body{{padding:clamp(20px,2.6vw,34px);}}
+  .kpis{{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:14px;margin:0 0 26px;}}
+  .kpi{{background:var(--panel-2);border:1px solid var(--line);border-radius:10px;padding:14px 16px;}}
+  .kpi .n{{font-size:clamp(22px,3vw,30px);font-weight:800;letter-spacing:-.02em;line-height:1;}}
+  .kpi .n.accent{{color:var(--accent);}} .kpi .n.done{{color:var(--done);}}
+  .kpi .l{{color:var(--muted);font-size:12px;margin-top:7px;line-height:1.35;}}
+  h2{{font-size:13px;font-family:var(--mono);letter-spacing:.12em;text-transform:uppercase;color:var(--muted);margin:30px 0 12px;font-weight:600;}}
+  .chartwrap{{overflow-x:auto;border:1px solid var(--line);border-radius:10px;background:var(--panel-2);padding:16px;}}
+  .bl{{fill:var(--ink);font-family:var(--sans);font-size:15px;font-weight:800;}}
+  .bm{{fill:var(--muted);font-family:var(--mono);font-size:11px;}}
+  .bx{{fill:var(--ink);font-family:var(--sans);font-size:12.5px;font-weight:600;}}
+  .bxm{{fill:var(--muted);font-family:var(--mono);font-size:10.5px;}}
+  .legend{{display:flex;gap:18px;flex-wrap:wrap;margin:12px 2px 0;font-size:12px;color:var(--muted);}}
+  .legend i,.lab i{{display:inline-block;width:11px;height:11px;border-radius:2px;margin-right:6px;vertical-align:-1px;}}
+  .callout{{background:var(--panel-2);border-left:3px solid var(--accent);border-radius:0 8px 8px 0;padding:14px 18px;margin:16px 0;font-size:14px;line-height:1.55;}}
+  .callout b{{color:var(--accent-ink,var(--accent));}}
+  @media (prefers-color-scheme:dark){{.callout b{{color:var(--accent);}}}}
+  table{{width:100%;border-collapse:collapse;font-size:14px;margin-top:6px;}}
+  thead th{{text-align:right;font-family:var(--mono);font-size:11px;letter-spacing:.04em;text-transform:uppercase;color:var(--muted);font-weight:600;padding:8px 10px;border-bottom:1px solid var(--line);}}
+  thead th:first-child{{text-align:left;}}
+  td{{padding:8px 10px;border-bottom:1px solid var(--line);}}
+  td.lab{{font-weight:600;}} td.num{{text-align:right;font-variant-numeric:tabular-nums;font-family:var(--mono);}}
+  td.strong{{font-weight:800;}} td.muted{{color:var(--muted);}}
+  tbody tr:last-child td{{border-bottom:none;}}
+  .grid2{{display:grid;grid-template-columns:1fr 1fr;gap:24px;}}
+  @media (max-width:720px){{.grid2{{grid-template-columns:1fr;}}}}
+  .note{{color:var(--muted);font-size:12.5px;line-height:1.55;margin:10px 0 0;}}
+  .foot{{margin-top:30px;padding-top:16px;border-top:1px solid var(--line);color:var(--muted);font-size:12px;line-height:1.6;}}
+  code{{font-family:var(--mono);font-size:.92em;background:var(--panel-2);padding:1px 5px;border-radius:4px;}}
+  a{{color:var(--done);}}
+</style>
+<div class="wrap"><div class="sheet">
+  <div class="head">
+    <p class="crumb"><a href="../capabilities/insights.html">&larr; Life-cycle insights hub</a> &middot; <a href="pa-liability-wave.html">GoM P&amp;A liability wave</a></p>
+    <p class="eyebrow">World Energy Data · Decommissioning · Regional liability</p>
+    <h1 class="title">Two forces set the decommissioning bill — and they pull opposite ways</h1>
+    <p class="thesis">Per <em>identical</em> asset the North Sea costs 25–30% more to remove (the regional multiplier).
+    But the money is in floating production: <b>{fpso["count"]} FPSOs carry {_b(fpso["sum_musd"])} of the {_b(total)} modeled liability</b>
+    ({fpso_share:.0f}%), concentrated in Brazil and West-Africa deepwater — <em>not</em> the North Sea's cheap-to-remove fixed jackets.
+    At portfolio level the asset mix, not the multiplier, sets the realized bill.</p>
+  </div>
+  <div class="body">
+    <div class="kpis">
+      <div class="kpi"><div class="n">{_b(total)}</div><div class="l">Total modeled liability ({counts["modeled"]} facilities, 5 regions)</div></div>
+      <div class="kpi"><div class="n accent">{_b(fpso["sum_musd"])}</div><div class="l">FPSO share = {fpso_share:.0f}% of the bill ({fpso["count"]} units)</div></div>
+      <div class="kpi"><div class="n done">+{ncs_prem:.0f}% / +{ukcs_prem:.0f}%</div><div class="l">NCS / UKCS like-for-like premium per identical jacket vs GoM</div></div>
+      <div class="kpi"><div class="n">{counts["modeled"]}/{n_total}</div><div class="l">Facilities modeled; {counts["unmodeled_region"]} unmodeled-region excluded</div></div>
+    </div>
+
+    <h2>Modeled liability by region &times; asset type</h2>
+    <div class="chartwrap">{svg}</div>
+    <div class="legend">{legend}<span>Bar = total $ liability · label under bar = region multiplier &amp; mean $/facility</span></div>
+    <p class="note">Regions are ordered by total modeled liability. The stacked segments are the asset-type $ split within each
+    region — the tall floating-production (FPSO) blocks in Brazil and West Africa, not the North Sea's higher multiplier,
+    are what set the totals.</p>
+
+    <div class="callout"><b>Multiplier vs mix.</b> Hold the asset constant — one jacket at 100&nbsp;m — and the pure regional
+    premium is exactly the multiplier: <b>NCS +{ncs_prem:.0f}%</b> and <b>UKCS +{ukcs_prem:.0f}%</b> over GoM.
+    Yet the realized <em>mean $/facility</em> inverts that ranking — GoM&nbsp;${means["gom"]:.1f}M &gt; NCS&nbsp;${means["ncs"]:.1f}M
+    &gt; UKCS&nbsp;${means["ukcs"]:.1f}M — because the GoM sample carries a heavier floating-production mix than the North Sea's
+    fixed jackets. The mix dominates the multiplier. So "the North Sea is most expensive" is true per structure and
+    <em>false</em> at portfolio level.</p>
+
+    <div class="grid2">
+      <div>
+        <h2>By asset type — the money is floating</h2>
+        <table>
+          <thead><tr><th>Asset type</th><th>n</th><th>Liability</th><th>Share</th></tr></thead>
+          <tbody>{"".join(arows)}
+          <tr><td class="lab strong">Total</td><td class="num strong">{counts["modeled"]:,}</td>
+          <td class="num strong">{_b(total)}</td><td class="num muted">100%</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div>
+        <h2>By region — multiplier &amp; realized mean</h2>
+        <table>
+          <thead><tr><th>Region</th><th>Mult</th><th>n</th><th>Liability</th><th>Mean/fac</th></tr></thead>
+          <tbody>{"".join(rrows)}</tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="foot">
+      <b>Source.</b> Curated offshore-asset inventory
+      <code>data/modules/offshore_assets/curated/production_facilities.csv</code> — {n_total:,} facilities.
+      <b>{counts["modeled"]} modeled</b> across the five regions the cost model carries a multiplier for
+      (GoM&nbsp;×1.0, NCS&nbsp;×1.3, UKCS&nbsp;×1.25, Brazil&nbsp;×1.1, West&nbsp;Africa&nbsp;×1.15);
+      <b>{counts["unmodeled_region"]} facilities in unmodeled regions are excluded</b> (no cost factor), and the
+      {counts["unmapped_asset"]} Artificial Island is not a priced offshore-structure removal.<br>
+      <b>Data limits.</b> Facilities are priced at the cost model's base + water-depth floor with
+      <b>weight = 0</b> (per-facility topside weight is not carried), so totals are conservative on the tonnage term.
+      The <b>FPSO base cost is model confidence "low"</b>; because FPSOs dominate the bill, the headline total is
+      most sensitive to that one factor. Region multipliers and asset base costs are parametric industry benchmarks,
+      not project quotes.<br>
+      Generated by <code>scripts/decommissioning/build_regional_liability.py</code> · logic
+      <code>worldenergydata.decommissioning.facility_liability</code> · cost model
+      <code>worldenergydata.decommissioning.cost_model</code>.
+    </div>
+  </div>
+</div></div>
+"""
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/decommissioning/test_facility_liability.py
+++ b/tests/unit/decommissioning/test_facility_liability.py
@@ -11,7 +11,6 @@ from worldenergydata.decommissioning.facility_liability import (
     region_of,
 )
 
-
 # ---------------------------------------------------------------------------
 # classify_asset_type
 # ---------------------------------------------------------------------------

--- a/tests/unit/decommissioning/test_facility_liability.py
+++ b/tests/unit/decommissioning/test_facility_liability.py
@@ -1,0 +1,115 @@
+# ABOUTME: Unit tests for facility-level regional decommissioning liability mapping.
+# ABOUTME: Pure-logic tests for HOST_TYPE->asset and COUNTRY/GoM->region classifiers.
+
+"""Unit tests for worldenergydata.decommissioning.facility_liability."""
+
+import pandas as pd
+
+from worldenergydata.decommissioning.facility_liability import (
+    classify_asset_type,
+    price_portfolio,
+    region_of,
+)
+
+
+# ---------------------------------------------------------------------------
+# classify_asset_type
+# ---------------------------------------------------------------------------
+
+
+def test_fixed_platform_is_jacket():
+    assert classify_asset_type("Fixed Platform") == "jacket"
+
+
+def test_fpso_is_fpso():
+    assert classify_asset_type("FPSO") == "fpso"
+
+
+def test_tlp_is_tlp():
+    assert classify_asset_type("TLP") == "tlp"
+
+
+def test_spar_is_spar():
+    assert classify_asset_type("SPAR") == "spar"
+
+
+def test_artificial_island_is_unmapped():
+    assert classify_asset_type("Artificial Island") is None
+
+
+def test_asset_type_strips_whitespace():
+    assert classify_asset_type("  FPSO  ") == "fpso"
+
+
+# ---------------------------------------------------------------------------
+# region_of
+# ---------------------------------------------------------------------------
+
+
+def test_us_with_gom_flag_is_gom():
+    assert region_of("United States", "Y") == "gom"
+
+
+def test_united_kingdom_is_ukcs():
+    assert region_of("United Kingdom", None) == "ukcs"
+
+
+def test_norway_is_ncs():
+    assert region_of("Norway", None) == "ncs"
+
+
+def test_brazil_is_brazil():
+    assert region_of("Brazil", None) == "brazil"
+
+
+def test_nigeria_is_west_africa():
+    assert region_of("Nigeria", None) == "west_africa"
+
+
+def test_australia_is_unmodeled():
+    assert region_of("Australia", None) is None
+
+
+def test_gom_flag_overrides_country():
+    # US_GOM_FLAG takes precedence even when country string is empty
+    assert region_of("", "YES") == "gom"
+
+
+# ---------------------------------------------------------------------------
+# price_portfolio (pure logic over a tiny in-memory frame)
+# ---------------------------------------------------------------------------
+
+
+def test_price_portfolio_counts_and_exclusions():
+    df = pd.DataFrame(
+        [
+            {
+                "FACILITY_ID": 1,
+                "HOST_TYPE": "FPSO",
+                "COUNTRY": "Brazil",
+                "US_GOM_FLAG": "N",
+                "WATER_DEPTH_M": 1000.0,
+            },
+            {
+                "FACILITY_ID": 2,
+                "HOST_TYPE": "Artificial Island",
+                "COUNTRY": "United States",
+                "US_GOM_FLAG": "Y",
+                "WATER_DEPTH_M": 5.0,
+            },
+            {
+                "FACILITY_ID": 3,
+                "HOST_TYPE": "Fixed Platform",
+                "COUNTRY": "Australia",
+                "US_GOM_FLAG": "N",
+                "WATER_DEPTH_M": 50.0,
+            },
+        ]
+    )
+    result = price_portfolio(df)
+    assert result["counts"]["modeled"] == 1
+    assert result["counts"]["unmapped_asset"] == 1  # Artificial Island
+    assert result["counts"]["unmodeled_region"] == 1  # Australia
+    assert result["by_region"]["brazil"]["count"] == 1
+    assert result["by_asset"]["fpso"]["count"] == 1
+    assert result["total_musd"] > 0


### PR DESCRIPTION
## Regional decommissioning liability — multiplier vs mix

Follow-up to #786/#789 (sub-epic #774, decommissioning #777). Turns the GoM P&A liability wave into a **global, facility-level comparison** using the real 836-facility `production_facilities.csv` and the existing `DecommissioningCostEstimator` regional multipliers.

### Finding (honest, and it refutes the naive thesis)
Two forces set the decommissioning bill and pull opposite ways:
- **Multiplier (like-for-like):** per identical asset, the North Sea costs more — **NCS +30%, UKCS +25%** vs GoM.
- **Mix (what's actually out there):** the money is in **floating production** — **159 FPSOs carry $14.8B of the $17.5B** modeled liability, concentrated in **Brazil ($4.5B) / West Africa ($3.6B)** deepwater, not the North Sea's cheap-to-remove fixed jackets.
- Net effect: realized mean/facility **inverts** the multiplier — GoM $35.1M > NCS $32.2M > UKCS $29.6M.

A simplistic "North Sea is priciest" page would have been wrong; this argues multiplier *vs* mix.

### By region / asset ($B, n)
| Region | $B | n | | Asset | $B | n |
|---|--|--|--|---|--|--|
| Brazil | 4.5 | 58 | | **FPSO** | **14.8** | **159** |
| UKCS | 3.7 | 124 | | spar | 1.0 | 19 |
| W. Africa | 3.6 | 70 | | tlp | 1.0 | 23 |
| GoM | 3.1 | 87 | | jacket | 0.6 | 191 |
| NCS | 2.6 | 82 | | subsea_tree | 0.1 | 29 |

### Changes
- New tested module `worldenergydata.decommissioning.facility_liability` (`classify_asset_type` / `region_of` / `price_portfolio`) + **14 unit tests**.
- `build_regional_liability.py` → `regional_liability.{csv,html}` (self-contained front door).
- Wired: `build_pages.py` (decommissioning domain), `repo_structure.yml` allowlist (+2 exact paths), linked from the P&A wave page + Life-cycle Insights hub.

### Verified
Script reproduces $17.5B total + the full region/asset breakdown; `build_pages.py` exits 0 and publishes `public/decommissioning/regional-liability.html`; 14 tests pass; Black/ruff clean; 20 links across the 3 touched pages resolve (0 broken).

### Honest floor
Only **421/836** facilities sit in the 5 regions the model prices ($17.5B); **414 unmodeled** (Australia/Malaysia/Indonesia… — no regional factor) are excluded, not forced to a baseline. Pricing is **base+depth only** (per-facility topside weight not carried), and the FPSO base cost is model-confidence "low" — both disclosed on the page. Since FPSOs are ~85% of the bill, the headline is most sensitive to that one factor.

Refs #777 #774.
