### PR TITLE
feat(ukcs): add NSTA FDAS reference chain

### DIFF
--- a/.planning/plan-approved/717.md
+++ b/.planning/plan-approved/717.md
@@ -1,0 +1,2 @@
+Approved by: user via GitHub issue status:plan-approved and issue comment evidence on #717.
+Issue: https://github.com/vamseeachanta/worldenergydata/issues/717

--- a/docs/plans/2026-07-04-issue-717-ukcs-nsta-reference-chain.md
+++ b/docs/plans/2026-07-04-issue-717-ukcs-nsta-reference-chain.md
@@ -1,0 +1,91 @@
+# Plan — worldenergydata #717: UK NSTA Reference-Chain Slice
+
+- **Issue:** https://github.com/vamseeachanta/worldenergydata/issues/717
+- **Date:** 2026-07-04
+- **Status:** plan-approved
+- **Client:** N/A
+- **Project:** N/A
+- **Lane:** lane:codex
+- **Complexity:** T2
+- **Dependencies:** #714, #715, #716
+
+## Resource Intelligence Summary
+
+The implementation will mirror the approved Norway reference-chain slice from
+#716 while using the UK NSTA production loaders already present in the repo.
+`UkcsAdapter` currently returns synthetic benchmark data from
+`packages/worldenergydata-production/src/worldenergydata/production/unified/adapters/ukcs_adapter.py`.
+The real UK production path already exists through `NSTAClient` and
+`UKCSFieldProductionLoader`, which produce normalized rows with `field`, `year`,
+`month`, `oil_bbl`, `gas_mcf`, and `water_bbl`.
+
+The approved v2 plan notes three correctness constraints:
+
+- The loader uppercases fields, so the adapter bridge will restore titlecase
+  `field_name` values to preserve the existing adapter surface.
+- `condensate_bbl` will be `NaN`, not `0.0`, because this loader does not
+  extract a separate condensate stream.
+- Existing UKCS adapter/router/registration tests will stay green while a
+  raw-NSTA fixture proves the loader-backed path offline.
+
+Runtime reproduction is N/A because this is an approved feature slice rather
+than a reported failing behavior. Baseline tests will be run before and after
+implementation.
+
+## Artifact Map
+
+- `packages/worldenergydata-production/src/worldenergydata/production/unified/adapters/ukcs_adapter.py`
+  will gain a loader-backed NSTA path while retaining the existing compatibility
+  fixture behavior when no loader is supplied.
+- `packages/worldenergydata-ukcs/src/worldenergydata/ukcs/field_concept.py`
+  will provide a sparse UK `FieldMetaMapping` consumer for F2.
+- `packages/worldenergydata-ukcs/src/worldenergydata/ukcs/reference_chain.py`
+  will run the one-field UK chain through production normalization, concept
+  screening, and pre-tax cashflow plumbing.
+- Unit tests will pin the UKCS bridge, sparse FieldConcept mapping,
+  recommendation output, and finite labeled chain metrics.
+
+## Deliverable
+
+This slice will prove one fixture UK field through:
+
+1. `UkcsAdapter.fetch` using a fixture-backed NSTA production loader path.
+2. `to_fdas_production` producing the FDAS monthly-production schema.
+3. Sparse UK `FieldMetaMapping` producing a valid `FieldConcept`.
+4. `recommend()` returning a deterministic ranked list.
+5. `CashflowEngine` returning finite pre-tax metrics labeled
+   `chain_plumbing_pre_tax`.
+
+The implementation will not publish a UK investment NPV headline. UK after-tax
+EPL/RFCT wiring and reconciliation with `UKFiscalRegime` remain deferred to
+#736.
+
+## TDD Test List
+
+- UKCS loader-to-`STANDARD_COLUMNS` bridge:
+  field titlecasing, `region="ukcs"`, `source="nsta"`, real `water_bbl`,
+  and `condensate_bbl` as `NaN`.
+- `UkcsAdapter.fetch` fixture path converts to FDAS production.
+- Existing UKCS adapter/router/registration compatibility tests remain green.
+- UK sparse field metadata maps to `FieldConcept` with `region="uk"`.
+- Sparse UK FieldConcept produces a deterministic ranked concept list.
+- One-field UK reference chain returns finite pre-tax metrics and the explicit
+  `chain_plumbing_pre_tax` label.
+
+## Acceptance Criteria
+
+- Loader-backed `UkcsAdapter.fetch` emits exactly the unified
+  `STANDARD_COLUMNS` contract for supplied NSTA loader data.
+- Existing UKCS compatibility tests stay green.
+- UK FieldConcept mapping ships with the approved sparse metadata boundary.
+- Reference-chain metrics are finite and explicitly labeled as pre-tax chain
+  plumbing.
+- No UK after-tax or investor-value headline is claimed.
+- Legal/security scan and focused local tests pass; PR CI passes before merge.
+
+## Review Evidence
+
+The live GitHub issue carries `status:plan-approved`. Its v2 plan comment records
+an adversarial review with blocking findings folded: titlecase bridge, condensate
+`NaN`, compatibility fixture coverage, UK `region` footgun, and fiscal follow-on
+scope. This local artifact materializes that approved issue plan for traceability.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -84,6 +84,7 @@ This directory contains issue-plan artifacts created during the issue-planning-m
 | [#707](https://github.com/vamseeachanta/worldenergydata/issues/707) | [texas-rrc-field-architecture-portfolio](2026-07-02-issue-707-texas-rrc-field-architecture-portfolio.md) | plan-approved | 2026-07-02 |
 | [#709](https://github.com/vamseeachanta/worldenergydata/issues/709) | [texas-rrc-pressure-observations](2026-07-03-issue-709-texas-rrc-pressure-observations.md) | implemented | 2026-07-03 |
 | [#716](https://github.com/vamseeachanta/worldenergydata/issues/716) | [norway-sodir-reference-chain](2026-07-04-issue-716-norway-sodir-reference-chain.md) | plan-approved | 2026-07-04 |
+| [#717](https://github.com/vamseeachanta/worldenergydata/issues/717) | [ukcs-nsta-reference-chain](2026-07-04-issue-717-ukcs-nsta-reference-chain.md) | plan-approved | 2026-07-04 |
 | [#732](https://github.com/vamseeachanta/worldenergydata/issues/732) | [texas-rrc-underpressured-screen](2026-07-03-issue-732-texas-rrc-underpressured-screen.md) | implemented | 2026-07-03 |
 | [#740](https://github.com/vamseeachanta/worldenergydata/issues/740) | [oklahoma-occ-pressure-observations](2026-07-03-issue-740-oklahoma-occ-pressure-observations.md) | implemented | 2026-07-03 |
 | [#745](https://github.com/vamseeachanta/worldenergydata/issues/745) | [colorado-ecmc-wellhead-pressure-observations](2026-07-03-issue-745-colorado-ecmc-wellhead-pressure-observations.md) | implemented | 2026-07-03 |

--- a/packages/worldenergydata-production/src/worldenergydata/production/unified/adapters/ukcs_adapter.py
+++ b/packages/worldenergydata-production/src/worldenergydata/production/unified/adapters/ukcs_adapter.py
@@ -1,17 +1,19 @@
 """UKCS adapter — UK Continental Shelf production data.
 
-Mock data for four benchmark UKCS fields.  UKCS data is typically reported
-in tonnes/bbl already; this adapter uses bbl natively.
+When constructed with an NSTA loader, this adapter returns direct-source UKCS
+production rows bridged to the unified ``STANDARD_COLUMNS`` contract. Without a
+loader it retains the historical benchmark fixture used by legacy adapter tests.
 """
 
 from __future__ import annotations
 
 from typing import List, Tuple
 
+import numpy as np
 import pandas as pd
 
 from worldenergydata.production.unified.adapters.base import AbstractProductionAdapter
-from worldenergydata.production.unified.query import ProductionQuery
+from worldenergydata.production.unified.query import STANDARD_COLUMNS, ProductionQuery
 
 
 class UkcsAdapter(AbstractProductionAdapter):
@@ -28,7 +30,17 @@ class UkcsAdapter(AbstractProductionAdapter):
         ("Clair Ridge", 2_500_000, 900_000, 1_200_000, 50_000, 2018, 11, 74),
     ]
 
+    def __init__(self, loader=None):
+        self.loader = loader
+
     def fetch(self, query: ProductionQuery) -> pd.DataFrame:
+        if self.loader is not None:
+            loader_df = self._load_from_loader(query)
+            df = self._loader_to_standard_columns(loader_df)
+            df = self._filter_by_fields(df, query.fields)
+            df = self._filter_by_date(df, query.start, query.end)
+            return df.reset_index(drop=True)
+
         rows = []
         for (
             field_name,
@@ -59,10 +71,61 @@ class UkcsAdapter(AbstractProductionAdapter):
         return df.reset_index(drop=True)
 
     def available_fields(self) -> List[str]:
+        if self.loader is not None:
+            df = self._loader_to_standard_columns(
+                self._load_from_loader(ProductionQuery(regions=[self.region]))
+            )
+            return sorted(df["field_name"].dropna().unique().tolist())
         return [f[0] for f in self._FIELDS]
 
     def date_range(self) -> Tuple[str, str]:
+        if self.loader is not None:
+            df = self._loader_to_standard_columns(
+                self._load_from_loader(ProductionQuery(regions=[self.region]))
+            )
+            if df.empty:
+                return ("", "")
+            periods = df["year"].astype(int) * 100 + df["month"].astype(int)
+            start = periods.min()
+            end = periods.max()
+            return (
+                f"{start // 100:04d}-{start % 100:02d}",
+                f"{end // 100:04d}-{end % 100:02d}",
+            )
         return ("1975-09", "2024-12")
+
+    def _load_from_loader(self, query: ProductionQuery) -> pd.DataFrame:
+        """Load normalized NSTA rows from a duck-typed fixture/live loader."""
+        if query.fields and hasattr(self.loader, "load_field_production"):
+            frames = [
+                self.loader.load_field_production(field) for field in query.fields
+            ]
+            if not frames:
+                return pd.DataFrame()
+            return pd.concat(frames, ignore_index=True)
+        if hasattr(self.loader, "load_all_production"):
+            return self.loader.load_all_production()
+        raise TypeError(
+            "UKCS loader must expose load_all_production() or "
+            "load_field_production(field_name)"
+        )
+
+    def _loader_to_standard_columns(self, loader_df: pd.DataFrame) -> pd.DataFrame:
+        """Bridge UKCSFieldProductionLoader output into STANDARD_COLUMNS."""
+        if loader_df is None or loader_df.empty:
+            return self._empty_frame()
+
+        out = pd.DataFrame()
+        out["field_name"] = loader_df["field"].astype(str).str.strip().str.title()
+        out["region"] = self.region
+        out["year"] = loader_df["year"].astype(int)
+        out["month"] = loader_df["month"].astype(int)
+        out["oil_bbl"] = pd.to_numeric(loader_df["oil_bbl"], errors="coerce")
+        out["gas_mcf"] = pd.to_numeric(loader_df["gas_mcf"], errors="coerce")
+        out["water_bbl"] = pd.to_numeric(loader_df["water_bbl"], errors="coerce")
+        out["condensate_bbl"] = np.nan
+        out["source"] = "nsta"
+        return out[list(STANDARD_COLUMNS)]
 
     @staticmethod
     def _generate_field_rows(

--- a/packages/worldenergydata-ukcs/src/worldenergydata/ukcs/field_concept.py
+++ b/packages/worldenergydata-ukcs/src/worldenergydata/ukcs/field_concept.py
@@ -1,0 +1,52 @@
+"""UKCS field-metadata -> FieldConcept normalizer (#717).
+
+The current UK NSTA production slice has sparse metadata. The mapping therefore
+populates only fields that are defensible from the approved fixture/source path:
+name, UK basin-region key, optional water depth, and source label. The concept
+screening output is a wiring proof, not a published UK field recommendation.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from worldenergydata.fdas.adapters.field_concept_normalizer import (
+    FieldMapEntry,
+    FieldMetaMapping,
+    number_from,
+    to_field_concept,
+)
+
+
+def _title_name(value: Any) -> str:
+    return str(value).strip().title()
+
+
+_UK_MAPPING = FieldMetaMapping(
+    {
+        "name": FieldMapEntry("field_name", _title_name),
+        "region": FieldMapEntry("region"),
+        "water_depth_m": FieldMapEntry("water_depth_m", number_from),
+        "data_source": FieldMapEntry("source"),
+    }
+)
+
+
+def ukcs_field_to_concept(field_meta: Dict[str, Any]):
+    """Build a sparse UK ``FieldConcept`` from approved UKCS metadata."""
+    meta = dict(field_meta)
+    if "field_name" not in meta and "field" in meta:
+        meta["field_name"] = meta["field"]
+    meta["region"] = "uk"  # basin priors key on "uk", not production region "ukcs"
+    meta.setdefault("source", "NSTA")
+    return to_field_concept(meta, _UK_MAPPING)
+
+
+def uk_field_meta_mapping() -> FieldMetaMapping:
+    """Return the UKCS sparse FieldConcept mapping."""
+    return _UK_MAPPING
+
+
+def build_uk_field_concept(field_meta: Dict[str, Any]):
+    """Alias for the #717 reference-chain terminology."""
+    return ukcs_field_to_concept(field_meta)

--- a/packages/worldenergydata-ukcs/src/worldenergydata/ukcs/reference_chain.py
+++ b/packages/worldenergydata-ukcs/src/worldenergydata/ukcs/reference_chain.py
@@ -1,0 +1,99 @@
+"""UKCS NSTA reference-chain runner (#717).
+
+Minimal vertical slice:
+``UkcsAdapter.fetch`` -> ``to_fdas_production`` -> ``CashflowEngine`` and
+``build_uk_field_concept`` -> ``recommend``. The economics output is explicitly
+pre-tax chain plumbing, not a UK investment NPV headline.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+import pandas as pd
+
+from worldenergydata.fdas.adapters.contract import to_fdas_production
+from worldenergydata.fdas.adapters.field_concept_normalizer import (
+    dev_system_from_water_depth_m,
+)
+from worldenergydata.fdas.analysis.cashflow import CashflowEngine
+from worldenergydata.fdas.core.config import AssumptionsManager
+from worldenergydata.fdas.fiscal import get_fiscal_terms
+from worldenergydata.field_development.recommendation import recommend
+from worldenergydata.production.unified.query import ProductionQuery
+from worldenergydata.ukcs.field_concept import build_uk_field_concept
+
+
+def run_ukcs_reference_chain(
+    *,
+    adapter,
+    field_meta: Dict[str, Any],
+    field_name: str,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+    oil_price_usd_bbl: float = 75.0,
+) -> Dict[str, Any]:
+    """Run the #717 one-field UKCS chain slice."""
+    unified = adapter.fetch(
+        ProductionQuery(
+            regions=["ukcs"],
+            fields=[field_name],
+            start=start,
+            end=end,
+        )
+    )
+    fdas_production = to_fdas_production(unified)
+    field_concept = build_uk_field_concept(field_meta)
+    ranked_concepts = recommend(field_concept)
+
+    first_oil = _first_oil_date(fdas_production)
+    price_deck = {
+        str(year_month): oil_price_usd_bbl
+        for year_month in fdas_production.get("YEAR_MONTH", pd.Series(dtype="object"))
+    }
+    dev_system = dev_system_from_water_depth_m(field_concept.water_depth_m)
+    if dev_system == "unknown":
+        dev_system = "subsea15"
+
+    cashflows = CashflowEngine(
+        AssumptionsManager(),
+        dev_system=dev_system,
+        fiscal_terms=get_fiscal_terms("uk"),
+    ).generate_monthly_cashflow(
+        fdas_production,
+        {"drilling_monthly": {}},
+        price_deck,
+        first_oil,
+    )
+
+    return {
+        "field_name": field_name,
+        "unified_production": unified,
+        "fdas_production": fdas_production,
+        "field_concept": field_concept,
+        "ranked_concepts": ranked_concepts,
+        "economics_label": "chain_plumbing_pre_tax",
+        "pre_tax_metrics": _pre_tax_metrics(cashflows),
+    }
+
+
+def build_uk_field_concept_from_meta(field_meta: Dict[str, Any]):
+    """Compatibility alias for callers that prefer explicit meta wording."""
+    return build_uk_field_concept(field_meta)
+
+
+def _first_oil_date(fdas_production: pd.DataFrame) -> datetime:
+    if fdas_production.empty:
+        return datetime(1970, 1, 1)
+    first_period = str(fdas_production["YEAR_MONTH"].min())
+    return datetime.strptime(first_period, "%Y-%m")
+
+
+def _pre_tax_metrics(cashflows) -> Dict[str, float]:
+    return {
+        "months": len(cashflows),
+        "gross_revenue_usd": float(sum(cf.oil_revenue_usd for cf in cashflows)),
+        "royalty_usd": float(sum(cf.royalty_usd for cf in cashflows)),
+        "net_cashflow_usd": float(sum(cf.net_cashflow_usd for cf in cashflows)),
+    }

--- a/scripts/review/results/2026-07-04-code-717-codex-inline.md
+++ b/scripts/review/results/2026-07-04-code-717-codex-inline.md
@@ -1,0 +1,39 @@
+# Code Review — #717 UKCS NSTA Reference-Chain Slice
+
+- **Issue:** https://github.com/vamseeachanta/worldenergydata/issues/717
+- **PR/branch:** `feat/ukcs-717-chain`
+- **Reviewer:** Codex inline adversarial review
+- **Date:** 2026-07-04
+- **Verdict:** APPROVE
+
+## Checks Performed
+
+- Verified the loader-backed `UkcsAdapter` path emits exactly
+  `STANDARD_COLUMNS` and keeps the default no-loader benchmark fixture path for
+  legacy adapter tests.
+- Verified the approved casing rule is pinned by tests: loader uppercase
+  `FIELDNAME` values become titlecase `field_name` values.
+- Verified `condensate_bbl` is `NaN`, not a false measured `0.0`, and that
+  NSTA `water_bbl` remains real produced-water data.
+- Verified the UK FieldConcept mapping uses `region="uk"` rather than production
+  region `ukcs`, preserving the North Sea basin-prior path.
+- Verified the reference-chain runner uses `get_fiscal_terms("uk")`, exercising
+  the UK flat-zero royalty deck while keeping metrics labeled
+  `chain_plumbing_pre_tax`.
+- Verified compatibility surface with existing adapter/router/FDAS/UKCS loader
+  tests.
+
+## Findings
+
+No blocking findings.
+
+## Evidence
+
+- RED 1: `tests/unit/ukcs/test_reference_chain.py` failed with
+  `ModuleNotFoundError: No module named 'worldenergydata.ukcs.reference_chain'`.
+- RED 2: `tests/unit/production/unified/test_ukcs_adapter_loader.py` failed with
+  `TypeError: UkcsAdapter() takes no arguments`.
+- GREEN focused: `7 passed in 1.81s`.
+- Expanded adjacent suite: `212 passed in 2.58s`.
+- Style/static checks: Black, isort, flake8, ruff, and `git diff --check` passed.
+- Legal scan: `scripts/legal/legal-sanity-scan.sh` passed.

--- a/tests/unit/production/unified/test_ukcs_adapter_loader.py
+++ b/tests/unit/production/unified/test_ukcs_adapter_loader.py
@@ -1,0 +1,128 @@
+"""UKCS NSTA adapter fixture-backed contract tests (#717)."""
+
+import pandas as pd
+import pytest
+
+from worldenergydata.fdas.adapters.contract import to_fdas_production
+from worldenergydata.production.unified.adapters.ukcs_adapter import UkcsAdapter
+from worldenergydata.production.unified.query import STANDARD_COLUMNS, ProductionQuery
+from worldenergydata.ukcs.production.field_production import UKCSFieldProductionLoader
+
+
+class FixtureNstaLoader:
+    """Duck-typed NSTA loader returning normalized UKCS production rows."""
+
+    def __init__(self):
+        self.calls = []
+
+    def load_field_production(self, field_name):
+        self.calls.append(("field", field_name))
+        normalized = _normalized_nsta_frame()
+        return normalized[normalized["field"] == field_name.upper().strip()].copy()
+
+    def load_all_production(self):
+        self.calls.append(("all", None))
+        return _normalized_nsta_frame()
+
+
+def _normalized_nsta_frame():
+    raw = pd.DataFrame(
+        [
+            {
+                "FIELDNAME": "FORTIES",
+                "PERIODYR": 1975,
+                "PERIODMNTH": 9,
+                "OILPRODMAS": 1000.0,
+                "AGASPROKSM": 25.0,
+                "DGASPROKSM": 5.0,
+                "WATPRODVOL": 100.0,
+            },
+            {
+                "FIELDNAME": "FORTIES",
+                "PERIODYR": 1975,
+                "PERIODMNTH": 10,
+                "OILPRODMAS": 1100.0,
+                "AGASPROKSM": 28.0,
+                "DGASPROKSM": 6.0,
+                "WATPRODVOL": 120.0,
+            },
+            {
+                "FIELDNAME": "BUZZARD",
+                "PERIODYR": 2007,
+                "PERIODMNTH": 1,
+                "OILPRODMAS": 900.0,
+                "AGASPROKSM": 18.0,
+                "DGASPROKSM": 4.0,
+                "WATPRODVOL": 80.0,
+            },
+        ]
+    )
+    return UKCSFieldProductionLoader().load(raw)
+
+
+def test_fetch_transforms_nsta_loader_output_to_standard_columns():
+    loader = FixtureNstaLoader()
+    adapter = UkcsAdapter(loader=loader)
+
+    out = adapter.fetch(
+        ProductionQuery(
+            regions=["ukcs"],
+            fields=["Forties"],
+            start="1975-10",
+            end="1975-10",
+        )
+    )
+
+    assert loader.calls == [("field", "Forties")]
+    assert list(out.columns) == list(STANDARD_COLUMNS)
+    assert len(out) == 1
+    row = out.iloc[0]
+    expected = _normalized_nsta_frame().iloc[1]
+    assert row["region"] == "ukcs"
+    assert row["field_name"] == "Forties"
+    assert row["year"] == 1975
+    assert row["month"] == 10
+    assert row["oil_bbl"] == pytest.approx(expected["oil_bbl"])
+    assert row["gas_mcf"] == pytest.approx(expected["gas_mcf"])
+    assert row["water_bbl"] == pytest.approx(expected["water_bbl"])
+    assert pd.isna(row["condensate_bbl"])
+    assert row["source"] == "nsta"
+    assert "field" not in out.columns
+
+
+def test_fetch_output_is_accepted_by_fdas_production_contract():
+    adapter = UkcsAdapter(loader=FixtureNstaLoader())
+
+    unified = adapter.fetch(ProductionQuery(regions=["ukcs"], fields=["Forties"]))
+    fdas = to_fdas_production(unified)
+
+    assert list(fdas["DEV_NAME"].unique()) == ["Forties"]
+    assert list(fdas["YEAR_MONTH"]) == ["1975-09", "1975-10"]
+    assert fdas["MONTHLY_WATER_BBL"].notna().all()
+
+
+def test_fetch_all_uses_loader_all_path_when_no_field_filter():
+    loader = FixtureNstaLoader()
+    adapter = UkcsAdapter(loader=loader)
+
+    out = adapter.fetch(ProductionQuery(regions=["ukcs"]))
+
+    assert loader.calls == [("all", None)]
+    assert set(out["field_name"]) == {"Forties", "Buzzard"}
+    assert set(out["source"]) == {"nsta"}
+    assert out["condensate_bbl"].isna().all()
+
+
+def test_default_synthetic_surface_still_lists_benchmark_fields():
+    adapter = UkcsAdapter()
+
+    assert adapter.available_fields() == [
+        "Forties",
+        "Buzzard",
+        "Mariner",
+        "Clair Ridge",
+    ]
+    out = adapter.fetch(ProductionQuery(regions=["ukcs"], fields=["Forties"]))
+
+    assert len(out) > 0
+    assert set(out["source"]) == {"ukcs_mock"}

--- a/tests/unit/ukcs/test_reference_chain.py
+++ b/tests/unit/ukcs/test_reference_chain.py
@@ -1,0 +1,109 @@
+"""UKCS NSTA reference-chain tests (#717)."""
+
+import math
+
+import pandas as pd
+import pytest
+
+from worldenergydata.fdas.adapters.contract import FDAS_PRODUCTION_COLUMNS
+from worldenergydata.production.unified.adapters.ukcs_adapter import UkcsAdapter
+from worldenergydata.ukcs.production.field_production import UKCSFieldProductionLoader
+from worldenergydata.ukcs.reference_chain import (
+    build_uk_field_concept,
+    run_ukcs_reference_chain,
+)
+
+
+class FixtureNstaLoader:
+    def load_field_production(self, field_name):
+        normalized = _normalized_nsta_frame()
+        return normalized[normalized["field"] == field_name.upper().strip()].copy()
+
+    def load_all_production(self):
+        return _normalized_nsta_frame()
+
+
+def _normalized_nsta_frame():
+    raw = pd.DataFrame(
+        [
+            {
+                "FIELDNAME": "FORTIES",
+                "PERIODYR": 1975,
+                "PERIODMNTH": 9,
+                "OILPRODMAS": 1000.0,
+                "AGASPROKSM": 25.0,
+                "DGASPROKSM": 5.0,
+                "WATPRODVOL": 100.0,
+            },
+            {
+                "FIELDNAME": "FORTIES",
+                "PERIODYR": 1975,
+                "PERIODMNTH": 10,
+                "OILPRODMAS": 1100.0,
+                "AGASPROKSM": 28.0,
+                "DGASPROKSM": 6.0,
+                "WATPRODVOL": 120.0,
+            },
+        ]
+    )
+    return UKCSFieldProductionLoader().load(raw)
+
+
+def _field_meta():
+    return {
+        "field_name": "FORTIES",
+        "water_depth_m": 128.0,
+        "source": "NSTA",
+    }
+
+
+def test_uk_field_meta_mapping_builds_sparse_concept():
+    concept = build_uk_field_concept(_field_meta())
+
+    assert concept.name == "Forties"
+    assert concept.region == "uk"
+    assert concept.water_depth_m == 128.0
+    assert concept.data_source == "NSTA"
+
+
+def test_sparse_uk_concept_screen_is_deterministic():
+    first = run_ukcs_reference_chain(
+        adapter=UkcsAdapter(loader=FixtureNstaLoader()),
+        field_meta=_field_meta(),
+        field_name="Forties",
+        start="1975-09",
+        end="1975-10",
+    )
+    second = run_ukcs_reference_chain(
+        adapter=UkcsAdapter(loader=FixtureNstaLoader()),
+        field_meta=_field_meta(),
+        field_name="Forties",
+        start="1975-09",
+        end="1975-10",
+    )
+
+    assert first["field_concept"] == build_uk_field_concept(_field_meta())
+    assert [r.concept_type for r in first["ranked_concepts"]]
+    assert [r.concept_type for r in first["ranked_concepts"]] == [
+        r.concept_type for r in second["ranked_concepts"]
+    ]
+
+
+def test_reference_chain_returns_labeled_finite_pre_tax_metrics_and_zero_royalty():
+    result = run_ukcs_reference_chain(
+        adapter=UkcsAdapter(loader=FixtureNstaLoader()),
+        field_meta=_field_meta(),
+        field_name="Forties",
+        start="1975-09",
+        end="1975-10",
+        oil_price_usd_bbl=75.0,
+    )
+
+    assert result["economics_label"] == "chain_plumbing_pre_tax"
+    assert list(result["fdas_production"].columns) == list(FDAS_PRODUCTION_COLUMNS)
+    assert result["pre_tax_metrics"]["months"] >= 2
+    assert result["pre_tax_metrics"]["royalty_usd"] == pytest.approx(0.0)
+    assert result["pre_tax_metrics"]["gross_revenue_usd"] > 0.0
+    assert math.isfinite(result["pre_tax_metrics"]["gross_revenue_usd"])
+    assert math.isfinite(result["pre_tax_metrics"]["net_cashflow_usd"])
+    assert result["ranked_concepts"]


### PR DESCRIPTION
## Summary
- add a loader-backed UKCS/NSTA production adapter path that bridges NSTA loader rows into the unified `STANDARD_COLUMNS` schema
- add sparse UK FieldConcept mapping and a UKCS reference-chain runner through FDAS production normalization, concept screening, and pre-tax cashflow plumbing
- materialize the approved #717 plan/approval marker and code-stage review artifact

## Scope notes
- Direct-source NSTA loader data is used when a UKCS loader is supplied.
- The existing no-loader synthetic UKCS benchmark surface remains for compatibility tests.
- `condensate_bbl` is intentionally `NaN` because the current UKCS loader does not extract a separate condensate stream.
- Economics are labeled `chain_plumbing_pre_tax`; this is not a UK after-tax investment NPV deliverable.

## Verification
- RED: `tests/unit/ukcs/test_reference_chain.py` failed with missing `worldenergydata.ukcs.reference_chain`.
- RED: `tests/unit/production/unified/test_ukcs_adapter_loader.py` failed because `UkcsAdapter(loader=...)` was unsupported.
- Focused green: `7 passed`.
- Expanded adjacent suite: `212 passed`.
- Black, isort, flake8, ruff, `git diff --check`, and `scripts/legal/legal-sanity-scan.sh` passed.

Closes #717