### PR TITLE
docs(plan): add Brazil ANP reference-chain plan

### DIFF
--- a/docs/plans/2026-07-04-issue-718-brazil-anp-reference-chain.md
+++ b/docs/plans/2026-07-04-issue-718-brazil-anp-reference-chain.md
@@ -1,0 +1,288 @@
+# Plan — worldenergydata #718: Brazil ANP Reference-Chain Slice
+
+- **Issue:** https://github.com/vamseeachanta/worldenergydata/issues/718
+- **Date:** 2026-07-04
+- **Status:** plan-review
+- **Client:** N/A
+- **Project:** N/A
+- **Lane:** lane:codex
+- **Complexity:** T2
+- **Dependencies:** #714, #715
+- **Closes:** #459
+- **Execution mode:** single-lane implementation after approval; source probes,
+  review, and validation may run in parallel.
+
+## Resource Intelligence Summary
+
+Brazil will be the next international country chain after Norway #716 and UKCS
+#717. This plan will subsume #459 because the current Brazil scheduler failure
+is the same stale endpoint/schema defect that must be fixed before the Brazil
+reference chain can run against direct ANP sources.
+
+Current repo state:
+
+- `packages/worldenergydata-production/src/worldenergydata/production/unified/adapters/brazil_anp_adapter.py`
+  emits synthetic benchmark profiles for Lula, Búzios, Mero, and Marlim with
+  `source="brazil_anp_mock"`.
+- `packages/worldenergydata-brazil_anp/src/worldenergydata/brazil_anp/production/anp_client.py`
+  still builds
+  `https://cdp.anp.gov.br/ords/r/cdp_apex/consulta-dados-publicos-cdp/consulta-producao-por-poco?year=YYYY&semester=S`.
+- Reproduction proof for #459 on 2026-07-04:
+  `curl -L -sS -o /tmp/anp-old-cdp.html -w '%{http_code} %{url_effective}\n' '<old-url>'`
+  returns `404` with `Application "117" Page "consulta-producao-por-poco" not found`.
+- `WellProductionLoader` currently expects old lowercase Sm3-style columns
+  (`oleo_sm3`, `condensado_sm3`, `gas_mm3`, `agua_sm3`). The current official
+  ANP production-by-well metadata exposes daily-rate columns such as
+  `Óleo (bbl/dia)`, `Condensado (bbl/dia)`, `Gás Natural (Mm³/dia) Total`,
+  `Água (bbl/dia)`, `Período`, `Campo`, and `Nome Poço ANP`.
+- `FieldProductionAggregator` already provides the correct aggregation shape
+  for well rows into field-month totals, but it will need the current ANP
+  normalized columns.
+- `packages/worldenergydata-scheduler/src/worldenergydata/scheduler/jobs/brazil_anp_refresh.py`
+  imports `ANPClient` and `WellProductionLoader`, calls the current semester
+  API, and will be updated in this issue rather than left as a broken caller.
+- `field_development.basin` already maps `region="brazil"` to a Brazil basin
+  prior that favors FPSO and disfavors fixed jackets, spars, TLPs, and compliant
+  towers.
+- FDAS #714/#715 are on main. `to_fdas_production` requires unified rows with
+  `region`, `field_name`, `year`, `month`, `oil_bbl`, `gas_mcf`, and `water_bbl`.
+
+Official direct-source evidence:
+
+- ANP "Produção de Petróleo e Gás Natural por Poço" says monthly production by
+  well has been published since 2010, carries field/basin/state/operator/contract
+  and production-period metadata, and is released with a two-month publication
+  lag. It publishes separate files for `terra`, `mar`, and `pré-sal`.
+- The ANP production-by-well metadata PDF identifies the file format as CSV,
+  update frequency as monthly, and the source as ANP SDT/SIGEP.
+- The official monthly archive URL
+  `https://www.gov.br/anp/pt-br/centrais-de-conteudo/dados-abertos/arquivos/arquivos-producao-de-petroleo-e-gas-natural-por-poco/2023/producao-01.zip`
+  returns HTTP 200 `application/zip` and contains `2023_01_producao_Mar.csv`,
+  `2023_01_producao_Presal.csv`, and `2023_01_producao_Terra.csv`.
+- ANP "Fase de Desenvolvimento e Produção" exposes open CSVs for fields,
+  returned fields, concessionaires, production-phase vertices, producing wells,
+  rigs in operation, well interventions, offshore production units, forecast
+  activity/investment/production, and realized activity/investment.
+- Direct official CSV probes on 2026-07-04 returned HTTP 200 for:
+  - fields:
+    `.../informacoes-sobre-campos/extracao-campo.csv`
+    with header fields including `CAMPO`, `BACIA`, `OPERADOR`, `AMBIENTE`,
+    and `DATA_INICIO_PRODUCAO`;
+  - well status:
+    `.../informacoes-sobre-pocos/situacao-pocos-1939-2026.csv`
+    with header fields including `Nome_poço_anp`, `Campo`, `Bacia`,
+    `Data_início_perfuração`, `Data_início_produção_(mês/ano)`, and
+    `Ambiente`;
+  - offshore production units:
+    `.../lpo/dados-abertos-plataformas-operacao.csv`
+    with header fields including `[CAMPOS]`, `[BACIA]`,
+    `[LÂMINA D'ÁGUA (m)]`, `[CLASSIFICAÇÃO]`, and production/gas capacity.
+
+Runtime baseline:
+
+- `PYTHONPATH=packages/worldenergydata-brazil_anp/src:packages/worldenergydata-production/src:packages/worldenergydata-common/src /mnt/local-analysis/worldenergydata/.venv/bin/python -m pytest tests/unit/brazil_anp tests/unit/production/unified/test_adapters.py --noconftest -o addopts=''`
+  reports `155 passed`.
+
+## Artifact Map
+
+- `packages/worldenergydata-brazil_anp/src/worldenergydata/brazil_anp/production/anp_client.py`
+  will add a monthly direct-source API (`download_month`) that resolves official
+  gov.br production-by-well ZIP links and will replace the stale CDP APEX
+  year/semester download path. Any retained legacy `download(year, semester)`
+  wrapper will be tested as compatibility behavior over monthly files; otherwise
+  all callers will be migrated in this issue.
+- `packages/worldenergydata-brazil_anp/src/worldenergydata/brazil_anp/production/well_production.py`
+  will parse the current ANP CSV schema, including decimal-comma numeric fields,
+  daily-rate to monthly-volume conversion, and a `location_source` marker for
+  `mar`, `terra`, and `presal`.
+- `packages/worldenergydata-brazil_anp/src/worldenergydata/brazil_anp/production/field_production.py`
+  will aggregate current well rows to field-month totals with gas converted to
+  `gas_mcf`.
+- `packages/worldenergydata-scheduler/src/worldenergydata/scheduler/jobs/brazil_anp_refresh.py`
+  will switch from semester refresh semantics to a monthly refresh contract and
+  will write raw/normalized artifacts for one ANP production month.
+- `packages/worldenergydata-production/src/worldenergydata/production/unified/adapters/brazil_anp_adapter.py`
+  will gain an injectable loader-backed ANP path while retaining the no-loader
+  synthetic compatibility fallback.
+- New `packages/worldenergydata-brazil_anp/src/worldenergydata/brazil_anp/field_concept.py`
+  will map official ANP field/platform/well metadata into a sparse but useful
+  `FieldConcept` and will provide `build_brazil_field_meta` plus
+  `build_brazil_field_concept`.
+- New `packages/worldenergydata-brazil_anp/src/worldenergydata/brazil_anp/reference_chain.py`
+  will run one fixture Brazil field through production normalization, concept
+  screening, and FDAS cashflow plumbing.
+- Tests will pin the source resolver, current CSV schema bridge, unified adapter
+  bridge, scheduler refresh behavior, Brazil FieldConcept mapping, and one-field
+  reference-chain output.
+
+## Deliverable
+
+This slice will prove one Brazil field through:
+
+1. Official ANP direct-source resolution for production-by-well monthly files.
+2. Current ANP CSV normalization from well rows to field-month totals.
+3. `BrazilAnpAdapter.fetch` using fixture-backed real ANP loader output.
+4. `to_fdas_production` producing the FDAS monthly-production schema.
+5. Brazil `FieldMetaMapping` producing a `FieldConcept` with `region="brazil"`.
+6. `recommend()` returning a deterministic Brazil/FPSO-prior ranked list.
+7. `CashflowEngine` returning finite metrics labeled `chain_plumbing_pre_tax`.
+
+The implementation will not publish a Brazil investment NPV headline. Unified
+production will preserve `condensate_bbl`, but `to_fdas_production` currently
+maps only `oil_bbl` into `MONTHLY_OIL_BBL`; therefore the first FDAS cashflow
+pass will be oil-only and will not claim full-liquids revenue for pre-salt
+fields. Brazil fiscal terms are not yet representable by the current FDAS deck
+schema because
+`royalty.model="sliding_scale"` is reserved and rejected. The first economics
+pass will therefore be explicitly pre-tax chain plumbing, while royalty/special
+participation and PSC/concession after-tax semantics remain deferred to #737 or
+a reviewed successor to #737.
+
+## Pseudocode
+
+```python
+client = ANPClient(cache_dir=raw_cache)
+raw = client.download_month(year=2023, month=1, force_refresh=False)
+
+well_rows = WellProductionLoader().load(raw)
+field_rows = FieldProductionAggregator().aggregate(well_rows)
+
+adapter = BrazilAnpAdapter(loader=FakeBrazilProductionLoader(field_rows))
+unified = adapter.fetch(ProductionQuery(regions=["brazil"], fields=["Marlim"]))
+fdas_production = to_fdas_production(unified)
+
+field_meta = build_brazil_field_meta(fields_csv, platforms_csv, wells_csv, "Marlim")
+concept = build_brazil_field_concept(field_meta)
+ranked = recommend(concept)
+
+result = run_brazil_reference_chain(
+    adapter=adapter,
+    field_meta=field_meta,
+    field_name="Marlim",
+)
+assert result["economics_label"] == "chain_plumbing_pre_tax"
+```
+
+## Files to Change
+
+- `packages/worldenergydata-brazil_anp/src/worldenergydata/brazil_anp/production/anp_client.py`
+- `packages/worldenergydata-brazil_anp/src/worldenergydata/brazil_anp/production/well_production.py`
+- `packages/worldenergydata-brazil_anp/src/worldenergydata/brazil_anp/production/field_production.py`
+- `packages/worldenergydata-production/src/worldenergydata/production/unified/adapters/brazil_anp_adapter.py`
+- `packages/worldenergydata-scheduler/src/worldenergydata/scheduler/jobs/brazil_anp_refresh.py`
+- `packages/worldenergydata-brazil_anp/src/worldenergydata/brazil_anp/field_concept.py`
+- `packages/worldenergydata-brazil_anp/src/worldenergydata/brazil_anp/reference_chain.py`
+- `tests/unit/brazil_anp/test_anp_client.py`
+- `tests/unit/brazil_anp/test_well_production.py`
+- `tests/unit/brazil_anp/test_field_production.py`
+- `tests/unit/scheduler/test_brazil_anp_refresh.py`
+- `tests/unit/brazil_anp/test_brazil_field_concept.py`
+- `tests/unit/brazil_anp/test_reference_chain.py`
+- `tests/unit/production/unified/test_brazil_anp_adapter_loader.py`
+- Existing compatibility tests in `tests/unit/production/unified/test_adapters.py`
+
+## TDD Test List
+
+- ANP client source resolver:
+  - old CDP APEX URL is not used for downloads;
+  - official gov.br monthly ZIP URL is accepted and cached by year/month;
+  - a fixture ZIP with `Mar`, `Presal`, and `Terra` CSVs is parsed as mutually
+    exclusive ANP partitions and concatenated with `location_source`;
+  - duplicate `(field, well, date)` keys across partitions fail closed to protect
+    against future upstream overlap.
+- Current ANP well-production schema:
+  - Portuguese columns with accents and decimal commas parse correctly;
+  - `Período` becomes `year`, `month`, and `date`;
+  - oil/condensate/water daily bbl rates become monthly bbl volumes;
+  - gas daily `Mm³/dia` becomes monthly `gas_mcf`;
+  - field/well/operator/basin/environment columns are preserved.
+- Field aggregation:
+  - field-month well rows sum oil, condensate, gas, and water;
+  - `well_count` and `water_cut` remain deterministic.
+- Scheduler refresh:
+  - `BrazilAnpRefreshJob` uses the monthly direct-source API;
+  - old semester configuration does not call the stale CDP APEX URL;
+  - raw and normalized output paths carry year/month identifiers;
+  - #459's configured 404 path is covered by a regression test.
+- Brazil adapter bridge:
+  - loader-backed `BrazilAnpAdapter.fetch` emits all `STANDARD_COLUMNS`;
+  - `region="brazil"` and `source="anp_producao_poco"`;
+  - field/date filters still work;
+  - the no-loader synthetic fallback keeps existing adapter compatibility tests
+    green.
+- Brazil FieldConcept:
+  - source CSV header fixtures cover the field/platform/well columns used by
+    `build_brazil_field_meta`;
+  - fields/platform/well metadata maps field name, operator, basin, environment,
+    first production year, water depth, well count, and region;
+  - `region="brazil"` triggers a deterministic FPSO-favored recommendation.
+- Reference chain:
+  - one fixture field runs `fetch -> to_fdas_production -> CashflowEngine`;
+  - one fixture field runs `FieldConcept -> recommend`;
+  - output metrics are finite and labeled `chain_plumbing_pre_tax`.
+
+## Acceptance Criteria
+
+- The #459 endpoint/schema failure is fixed by this implementation and the PR
+  will close #459 together with #718.
+- `ANPClient` uses official gov.br direct-source downloads, not the stale APEX
+  year/semester endpoint.
+- `BrazilAnpRefreshJob` uses the same direct-source API and no longer attempts
+  the stale CDP APEX year/semester URL.
+- Current ANP production-by-well CSVs normalize into field-month totals that can
+  feed the unified production adapter.
+- ANP `Mar`, `Presal`, and `Terra` monthly files are treated as disjoint
+  partitions, with a duplicate-key guard to prevent double counting if upstream
+  semantics change.
+- Loader-backed `BrazilAnpAdapter.fetch` emits exactly the unified
+  `STANDARD_COLUMNS` contract for supplied ANP loader data.
+- Existing Brazil adapter compatibility tests stay green through the no-loader
+  fallback.
+- Brazil FieldConcept mapping ships with clear sparse metadata boundaries and
+  `region="brazil"`.
+- The reference-chain runner returns finite pre-tax plumbing metrics and a
+  deterministic concept ranking.
+- No Brazil after-tax economics, full-liquids revenue, or investor-value headline
+  is claimed until the condensate FDAS seam plus sliding-scale royalty and
+  special-participation fiscal seam are reviewed.
+- Focused local tests, format/lint on touched Python files, whitespace/diff
+  checks, legal scan, adversarial code review, PR CI, and issue closeout comment
+  pass before merge.
+
+## Risks
+
+- ANP monthly direct-source links may change path conventions. The resolver will
+  prefer scraping the official page for monthly links over hardcoding a single
+  guessed URL pattern.
+- The production-by-well ZIP separates `mar`, `terra`, and `pré-sal` files. The
+  implementation will treat them as ANP's disjoint monthly partitions and will
+  include a duplicate-key guard so any future upstream overlap fails closed
+  before aggregation.
+- The current loader column names are stale and use different units than current
+  ANP metadata. Tests will pin current daily-rate columns and monthly conversion
+  explicitly.
+- Brazil fiscal modeling is materially more complex than Norway/UK royalty
+  plumbing. This plan will fail closed as pre-tax plumbing until #737 or its
+  successor extends FDAS to sliding-scale royalty and special participation.
+- Sparse field metadata can still produce coarse concept rankings. Acceptance is
+  deterministic screening output, not a final engineering concept-select report.
+
+## Review Evidence
+
+- r1 adversarial review:
+  `scripts/review/results/2026-07-04-plan-718-claude-r1.md` returned MAJOR.
+  Blockers folded into this revision:
+  scheduler caller/test coverage, ANP partition semantics, concrete #459
+  ownership, explicit new `download_month` API, condensate oil-only boundary,
+  single `source="anp_producao_poco"` value, and Búzios spelling.
+- r2 focused adversarial review:
+  `scripts/review/results/2026-07-04-plan-718-claude.md` returned MINOR with no
+  blockers. Minor findings folded after r2: r1 artifact citation,
+  Norway/UKCS-style `run_brazil_reference_chain(adapter, field_meta, field_name)`
+  contract, and explicit header evidence for field/platform/well metadata.
+- Codex and Gemini provider artifacts were UNAVAILABLE in r1:
+  `scripts/review/results/2026-07-04-plan-718-codex.md` and
+  `scripts/review/results/2026-07-04-plan-718-gemini.md`.
+- Implementation will remain blocked until final review artifacts report no
+  unresolved MAJOR findings and the user applies the `status:plan-approved`
+  gate.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -85,6 +85,7 @@ This directory contains issue-plan artifacts created during the issue-planning-m
 | [#709](https://github.com/vamseeachanta/worldenergydata/issues/709) | [texas-rrc-pressure-observations](2026-07-03-issue-709-texas-rrc-pressure-observations.md) | implemented | 2026-07-03 |
 | [#716](https://github.com/vamseeachanta/worldenergydata/issues/716) | [norway-sodir-reference-chain](2026-07-04-issue-716-norway-sodir-reference-chain.md) | plan-approved | 2026-07-04 |
 | [#717](https://github.com/vamseeachanta/worldenergydata/issues/717) | [ukcs-nsta-reference-chain](2026-07-04-issue-717-ukcs-nsta-reference-chain.md) | plan-approved | 2026-07-04 |
+| [#718](https://github.com/vamseeachanta/worldenergydata/issues/718) | [brazil-anp-reference-chain](2026-07-04-issue-718-brazil-anp-reference-chain.md) | plan-review | 2026-07-04 |
 | [#732](https://github.com/vamseeachanta/worldenergydata/issues/732) | [texas-rrc-underpressured-screen](2026-07-03-issue-732-texas-rrc-underpressured-screen.md) | implemented | 2026-07-03 |
 | [#740](https://github.com/vamseeachanta/worldenergydata/issues/740) | [oklahoma-occ-pressure-observations](2026-07-03-issue-740-oklahoma-occ-pressure-observations.md) | implemented | 2026-07-03 |
 | [#745](https://github.com/vamseeachanta/worldenergydata/issues/745) | [colorado-ecmc-wellhead-pressure-observations](2026-07-03-issue-745-colorado-ecmc-wellhead-pressure-observations.md) | implemented | 2026-07-03 |

--- a/scripts/review/results/2026-07-04-plan-718-claude-r1.md
+++ b/scripts/review/results/2026-07-04-plan-718-claude-r1.md
@@ -1,0 +1,48 @@
+I have enough to write the review. All the plan's structural claims verified true (file paths, class names, column names, `155 passed` baseline exact, `FieldConcept` cross-package identity sound, dependency issue states). The defects are in coordination and data-partition semantics.
+
+`★ Insight ─────────────────────────────────────`
+- The plan's cleanest engineering move is real: fdas `to_field_concept()` deliberately returns the *same* `field_development.models.FieldConcept` that `recommend()` consumes (the normalizer even documents the import-direction to avoid a cycle), so the Brazil chain reuses the proven SODIR/#716 seam rather than inventing a parallel type. That's verified, not assumed.
+- The load-bearing risk in multi-file public datasets like ANP's is *partition semantics* (disjoint vs. overlapping files), not schema parsing — and that's exactly where the plan contradicts itself.
+- A plan that changes a class's granularity (semester→month) must audit callers of the old signature; the scheduler job is the silent casualty here, and it's the very subsystem the "dependency" issue #459 is about.
+`─────────────────────────────────────────────────`
+
+## Verdict
+MAJOR
+
+## Retrieval
+- Read the full plan `docs/plans/2026-07-04-issue-718-brazil-anp-reference-chain.md` (lines 1–234).
+- `brazil_anp_adapter.py` — confirmed `_FIELDS` = Lula/**Búzios**/Mero/Marlim, `source="brazil_anp_mock"` (line 103), `class BrazilAnpAdapter(AbstractProductionAdapter)`, `fetch(query)` — **no `__init__(loader=...)` today**.
+- `anp_client.py` — confirmed CDP APEX URL, `class ANPClient`, public surface keyed on `(year, semester)`: `_cache_key`, `is_cached`, `load_cached`, `download`, `_build_url`. **No `download_month` method.**
+- `well_production.py` — confirmed `WellProductionLoader.load` reads `oleo_sm3/condensado_sm3/gas_mm3/agua_sm3`, emits `gas_m3` (not `gas_mcf`).
+- `field_production.py` — confirmed `FieldProductionAggregator.aggregate`.
+- `fdas/adapters/contract.py` (lines 42–109) — `to_fdas_production` requires `UNIFIED_REQUIRED_COLUMNS`; maps `oil_bbl/water_bbl/gas_mcf` only — **condensate not mapped**.
+- `field_development/recommendation.py` (lines 401–429) — `recommend(concept: FieldConcept, ...) -> list[ScoredConcept]`; imports `FieldConcept` from `field_development.models`.
+- `fdas/adapters/field_concept_normalizer.py` + `sodir/field_concept.py` — confirmed `to_field_concept`/`FieldMetaMapping` produce the same `field_development` `FieldConcept`; SODIR is the precedent.
+- `fiscal/terms.py:34` + `fiscal/schema.py:10` — confirmed `RESERVED_ROYALTY_MODELS = ("sliding_scale",)`, rejected.
+- `field_development/basin.py:58,87` — confirmed `"brazil"` basin prior.
+- `scheduler/jobs/brazil_anp_refresh.py` — imports `ANPClient` + `WellProductionLoader`, calls `_resolve_year_semester(config)`.
+- `gh issue view` 714/715/716/717 (CLOSED), 459 (OPEN), 737 (OPEN).
+- Ran the plan's baseline test command verbatim → `155 passed in 4.35s` (claim exact).
+
+## Findings
+
+1. **The scheduler job `brazil_anp_refresh.py` is a caller of both changing interfaces and is absent from the plan.** `packages/worldenergydata-scheduler/src/worldenergydata/scheduler/jobs/brazil_anp_refresh.py` imports `ANPClient` and `WellProductionLoader` and is built on `_resolve_year_semester(config)`. The plan replaces `ANPClient`'s semester model with monthly resolution (Artifact Map, line 77–79) and rewrites `WellProductionLoader`'s expected columns (line 80–83), but this file appears in neither "Files to Change" (lines 145–157) nor the baseline test command (line 72, which covers only `tests/unit/brazil_anp` + `test_adapters.py`). This silently breaks the refresh job. It is doubly pointed because the plan's own listed dependency **#459 is a scheduler-refresh bug** — the plan is changing the exact subsystem #459 lives in without touching or testing it.
+
+2. **The plan's Mar/Presal/Terra partition mitigation contradicts its own concatenation step.** Risks (lines 217–219) assert "`pré-sal` is a subset of offshore data, so aggregation must avoid double counting." But the TDD (lines 164–165) commits to concatenating all three CSVs (`Mar`, `Presal`, `Terra`) with a `location_source` marker. If the Risk's "subset" claim is true, concatenation double-counts every pre-salt well — i.e. Lula, Búzios, and Mero, the marquee fields. In reality ANP publishes these as *disjoint* location partitions (onshore / offshore-post-salt / pre-salt), so concatenation is correct and the Risk statement is factually wrong. Either way the plan is internally inconsistent and one statement is wrong. Resolve empirically (sum one known field across the three files vs. ANP's published field total) before writing the aggregation, and fix whichever statement is false.
+
+3. **Acceptance Criterion #1 is non-actionable and the #459 relationship is unresolved.** AC#1 (lines 192–193): "#459 endpoint/schema failure is fixed **or this issue remains blocked** until #459 is closed." A criterion satisfied by the work remaining blocked is not a completion gate. Meanwhile the plan body *is* the #459 fix (Artifact Map line 77–79 replaces the stale CDP endpoint), and Execution mode (lines 11–12) offers "landed first as a dependency" as an alternative. Decide one of: (a) #718 subsumes and closes #459 (drop it from Dependencies, add "Closes #459"), or (b) #459 is a hard precondition owned elsewhere and #718 does not touch the endpoint. As written, ownership of the endpoint fix and the definition of "done" are ambiguous.
+
+4. **Pseudocode calls a method that does not exist and does not flag the breaking interface change.** Line 122: `client.download_month(year=2023, month=1, force_refresh=False)`. The current `ANPClient` public surface is entirely `(year, semester)`-keyed (`download`, `is_cached`, `load_cached`, `_cache_key`, `_build_url`). Introducing month-granularity replaces this surface. The plan should state explicitly that `download(year, semester)` and its cache-key scheme are being removed/replaced (relevant to Finding 1's caller audit), rather than presenting `download_month` as if it already exists.
+
+5. **Condensate is silently dropped from FDAS liquids, unaddressed for pre-salt.** `to_fdas_production` (contract.py:51–55) maps only `oil_bbl→MONTHLY_OIL_BBL`; the unified schema carries `condensate_bbl` separately (confirmed in `sodir_adapter.py:105,125`). Brazil pre-salt streams carry a material condensate fraction, so FDAS liquids for Lula/Búzios/Mero understate actual liquids. This matches the Norway precedent and the slice is explicitly "pre-tax plumbing" (lines 110–116), so it is not a correctness bug in the chain — but the plan should state that unified `oil_bbl` = oil only (condensate excluded) so a later economics pass does not inherit an unflagged understatement. (MINOR.)
+
+6. **The unified `source` label is under-specified.** TDD (lines 177–178) accepts `source="anp"` **or** `source="anp_producao_poco"`. The `source` marker is a contract value downstream consumers key on; an acceptance test permitting either value pins nothing. Choose exactly one. (MINOR.)
+
+7. **Plan text drops the diacritic on "Búzios".** Lines 24, 42-adjacent — plan writes "Buzios"; the code (`brazil_anp_adapter.py:31`) uses `"Búzios"`. Per this repo's orthographic rule and because field-name string matching is exact (`fields=["Marlim"]`-style filters), any hardcoded fixture/filter using the unaccented spelling will silently miss the field. (MINOR, but verify no ASCII "Buzios" literal reaches a matcher.)
+
+## Blockers
+- Finding 1 — scheduler `brazil_anp_refresh.py` break: add it to Files to Change (or explicitly preserve the old signatures) and extend the baseline/CI test scope to the scheduler package.
+- Finding 2 — resolve the Mar/Presal/Terra partition semantics empirically and fix the contradicting statement before implementing aggregation (double-count risk on the marquee fields).
+- Finding 3 — replace the non-actionable AC#1 with a concrete #459 ownership decision (subsume-and-close vs. hard precondition).
+
+Findings 4–7 are MINOR and need not block, but 4 should be folded into the Finding 1 caller audit.

--- a/scripts/review/results/2026-07-04-plan-718-claude.md
+++ b/scripts/review/results/2026-07-04-plan-718-claude.md
@@ -1,0 +1,39 @@
+I've verified every load-bearing claim in the plan against the actual codebase. Here is my adversarial review.
+
+`★ Insight ─────────────────────────────────────`
+- This plan is a *revision* — it was already run through an r1 adversarial pass (`-claude-r1.md`, MAJOR). The high-value review move here isn't re-deriving the r1 findings; it's checking whether each r1 blocker was *actually* folded into the code-verified claims, then hunting for *new* defects the revision introduced. All three r1 blockers (scheduler caller break, partition-semantics contradiction, #459 ownership) verifiably closed.
+- The plan's cleverest claim — that Brazil reuses the *same* `field_development.models.FieldConcept` that `recommend()` consumes — is real, not hand-waved: `sodir/reference_chain.py` on `main` already imports `recommend` and `build_norway_field_concept`, so the seam is proven, not speculative.
+- The most important thing an adversarial reviewer can confirm on a scope-narrowing plan is that the deferred work is *owned*, not orphaned: issue #737's title literally reads "sliding-scale royalty seam … feeds #718 Brazil," so the descope is a legitimate split, not a dropped deliverable.
+`─────────────────────────────────────────────────`
+
+## VERDICT
+MINOR
+
+## RETRIEVAL
+- Read the full plan `docs/plans/2026-07-04-issue-718-brazil-anp-reference-chain.md` (lines 1–274).
+- `gh issue view 718` — confirmed scope ("FDAS economics with Brazil fiscal deck (royalties + special participation; concession vs PSC flag) → report"), lane:codex, T2, deps.
+- `gh issue view 737` — confirmed OPEN, title "sliding-scale royalty seam (production-rate bands) — feeds #718 Brazil"; owns the deferred fiscal seam.
+- File existence sweep: confirmed `brazil_anp_adapter.py`, `anp_client.py`, `well_production.py`, `field_production.py`, `brazil_anp_refresh.py`, `test_adapters.py` all exist; `field_concept.py` and `reference_chain.py` under `brazil_anp/` correctly do **not** exist yet (net-new, as planned).
+- `brazil_anp_adapter.py` (full) — confirmed `_FIELDS` = Lula/Búzios/Mero/Marlim, `source="brazil_anp_mock"` (line 103), `class BrazilAnpAdapter(AbstractProductionAdapter)`, `fetch(query)` only — **no `__init__(loader=...)` today**.
+- `anp_client.py` (lines 1–79) — confirmed CDP APEX URL, `(year, semester)` surface (`_cache_key`, `is_cached`, `load_cached`, `download`, `_build_url`); **no `download_month`**.
+- `well_production.py` (lines 26–65) — confirmed `COLUMN_MAP` reads `oleo_sm3/condensado_sm3/gas_mm3/agua_sm3`, emits `gas_m3` (not `gas_mcf`).
+- `fdas/adapters/contract.py` (lines 42–90) — `_UNIFIED_TO_FDAS` maps `oil_bbl/water_bbl/gas_mcf` only; **`condensate_bbl` not mapped** (plan's oil-only claim confirmed).
+- `production/unified/query.py` (lines 16–30) — `STANDARD_COLUMNS` = region/field_name/year/month/oil_bbl/gas_mcf/water_bbl/condensate_bbl/source.
+- `fiscal/terms.py` (lines 1–34) — confirmed `RESERVED_ROYALTY_MODELS = ("sliding_scale",)`, rejected; roadmap comment line 8 "sliding-scale royalty in #718."
+- `field_development/recommendation.py` (lines 401–430) — `recommend(concept: FieldConcept, …) -> list[ScoredConcept]`.
+- `field_development/basin.py` (lines 15–114) — confirmed `"brazil"` prior: FPSO FAVOURED; FIXED_JACKET/SPAR/TLP/COMPLIANT_TOWER DISFAVOURED.
+- `sodir/reference_chain.py` (full) + `sodir/field_concept.py` (lines 79–87) + `ukcs/field_concept.py` — established `run_norway_reference_chain(*, adapter, field_meta, field_name, …)` and `build_*_field_concept` / `FieldMetaMapping` precedent.
+- `git show --stat` #792 (#716 Sodir) and #794 (#717 UKCS) — confirmed the reference-chain file set the plan mirrors.
+- `scripts/review/results/` directory listing + read of `2026-07-04-plan-718-claude-r1.md` (full) — confirmed r1 verdict MAJOR and its 7 findings.
+
+## FINDINGS
+1. **[MINOR] Review-evidence citation points to an empty file.** §Review Evidence (lines 262–263) states `scripts/review/results/2026-07-04-plan-718-claude.md` "returned MAJOR." That file is **0 bytes** (`ls`: `0 … 2026-07-04-plan-718-claude.md`). The actual r1 review with the MAJOR verdict and 7 findings lives in `2026-07-04-plan-718-claude-r1.md` (8392 bytes). The plan's traceability link to its own prior review is broken — a reader following the citation finds nothing. Fix the path to the `-r1.md` variant.
+
+2. **[MINOR] The two Pseudocode blocks disagree on the reference-chain runner's contract, and it diverges from precedent.** Lines 142–148 construct `adapter = BrazilAnpAdapter(loader=…)`, call `adapter.fetch(…)` and `build_brazil_field_concept(field_meta)` directly — matching the proven seam in `sodir/reference_chain.py`, where `run_norway_reference_chain(*, adapter, field_meta, field_name, …)` takes a *ready adapter* and a *field_meta dict*. But lines 150–154 then call `run_brazil_reference_chain(production_loader=…, field_meta_loader=…, field_name=…)` — a loader-injection signature with **no precedent** in `sodir/reference_chain.py`. So the runner's parameter contract is ambiguous: adapter+meta (precedent) or loaders (novel). Pin one; if loaders are intentional, state why Brazil deviates from the Norway/UKCS runner shape.
+
+3. **[MINOR] `build_brazil_field_meta` is net-new CSV→metadata surface, and the plan never verifies the probed CSVs actually carry the FieldConcept attributes.** Pseudocode line 146 introduces `build_brazil_field_meta(fields_csv, platforms_csv, wells_csv, "Marlim")` — no Norway/UKCS analogue exists (those consume a pre-processed dict from a `FieldProcessor`). TDD (lines 205–208) asserts the mapping yields water depth, well count, first-production year, operator, basin, environment — but the RIS only proves the three source CSVs (`extracao-campo.csv`, `situacao-pocos-1939-2026.csv`, `dados-abertos-plataformas-operacao.csv`) return **HTTP 200**, never that they *contain* per-field water depth or first-production year. Per retrieval-skepticism, a 200 on a URL is not evidence the needed columns exist. The plan partly self-absorbs this (AC line 231–232 and Risk 255–256 accept "sparse" metadata), which is why this stays MINOR — but the column→attribute crosswalk is the load-bearing unknown and should be probed (dump one CSV header) before implementation, not discovered mid-code.
+
+4. **[MINOR / note] The plan narrows issue #718's stated scope, but the descope is legitimately owned.** Issue #718's body asks for "FDAS economics with Brazil fiscal deck (royalties + special participation; concession vs PSC flag) → report," and `fiscal/terms.py:8` earmarks "sliding-scale royalty in #718." The plan delivers *pre-tax plumbing only* and defers all fiscal terms to #737. I verified #737 is OPEN and its title is "sliding-scale royalty seam … **feeds #718 Brazil**," so the deferral is a sound split, not orphaned work, and the plan flags it transparently (Deliverable 123–131, AC #9). No action required beyond keeping the #737 link in the closeout; recorded so the owner sees #718-as-planned does not itself satisfy the issue's economics/report line.
+
+## BLOCKERS
+None. All three r1 blockers (scheduler `brazil_anp_refresh.py` caller break; Mar/Presal/Terra disjoint-partition semantics with duplicate-key guard; #459 subsume-and-close ownership) are verifiably resolved in this revision against the actual code. Findings 1–4 are all MINOR and do not gate implementation — though Finding 3 (dump the three ANP CSV headers to confirm the FieldConcept attributes are present) is worth doing before writing `build_brazil_field_meta`, since it is the plan's one unverified data-availability assumption.

--- a/scripts/review/results/2026-07-04-plan-718-codex-r1-unavailable.md
+++ b/scripts/review/results/2026-07-04-plan-718-codex-r1-unavailable.md
@@ -1,0 +1,11 @@
+## Verdict
+UNAVAILABLE (codex CLI failed, rc=124: Reading additional input from stdin... OpenAI Codex v0.142.5 -------- workdir: /mnt/local-analysis/wt-wed-718-brazil-plan model: gpt-5.5 provider: openai approval: on-request sandbox: workspace-write [workdir, /tmp, $TMPDIR] (network access enabled) reasoning effort: xhigh reasoning summaries: none session id: 019f2d95-788b-73b0-b832-162060792a38 -------- user # Adversarial plan review  You are an)
+
+## Retrieval
+(none — invocation failed before the provider could return a usable review)
+
+## Findings
+(none)
+
+## Blockers
+(none — this provider contributed no signal to the review)

--- a/scripts/review/results/2026-07-04-plan-718-codex.md
+++ b/scripts/review/results/2026-07-04-plan-718-codex.md
@@ -1,0 +1,11 @@
+## Verdict
+UNAVAILABLE (codex CLI failed, rc=124: Reading additional input from stdin... OpenAI Codex v0.142.5 -------- workdir: /mnt/local-analysis/wt-wed-718-brazil-plan model: gpt-5.5 provider: openai approval: on-request sandbox: workspace-write [workdir, /tmp, $TMPDIR] (network access enabled) reasoning effort: xhigh reasoning summaries: none session id: 019f2d95-788b-73b0-b832-162060792a38 -------- user # Adversarial plan review  You are an)
+
+## Retrieval
+(none — invocation failed before the provider could return a usable review)
+
+## Findings
+(none)
+
+## Blockers
+(none — this provider contributed no signal to the review)

--- a/scripts/review/results/2026-07-04-plan-718-disagreement-r1.md
+++ b/scripts/review/results/2026-07-04-plan-718-disagreement-r1.md
@@ -1,0 +1,32 @@
+# Disagreement report — plan #718 (2026-07-04)
+
+## Verdicts
+
+| Provider | Verdict |
+|---|---|
+| claude | MAJOR |
+| codex | UNAVAILABLE (codex CLI failed, rc=124: Reading additional input from stdin... OpenAI Codex v0.142.5 -------- workdir: /mnt/local-analysis/wt-wed-718-brazil-plan model: gpt-5.5 provider: openai approval: on-request sandbox: workspace-write [workdir, /tmp, $TMPDIR] (network access enabled) reasoning effort: xhigh reasoning summaries: none session id: 019f2d95-788b-73b0-b832-162060792a38 -------- user # Adversarial plan review  You are an) |
+| gemini | UNAVAILABLE (gemini CLI failed, rc=1: Warning: Basic terminal detected (TERM=dumb). Visual rendering will be limited. For the best experience, use a terminal emulator with truecolor support. Warning: 256-color support not detected. Using a terminal with at least 256-color support is recommended for a better visual experience. Error authenticating: IneligibleTierError: This client is no longer supported for Gemini Code Assist for indiv) |
+
+## Findings unique to each provider
+
+A finding is 'unique to X' if its text appears in X's artifact but not
+verbatim in any other provider's artifact.
+
+### claude
+
+- **The scheduler job `brazil_anp_refresh.py` is a caller of both changing interfaces and is absent from the plan.** `packages/worldenergydata-scheduler/src/worldenergydata/scheduler/jobs/brazil_anp_refresh.py` imports `ANPClient` and `WellProductionLoader` and is built on `_resolve_year_semester(config)`. The plan replaces `ANPClient`'s semester model with monthly resolution (Artifact Map, line 77–79) and rewrites `WellProductionLoader`'s expected columns (line 80–83), but this file appears in neither "Files to Change" (lines 145–157) nor the baseline test command (line 72, which covers only `tests/unit/brazil_anp` + `test_adapters.py`). This silently breaks the refresh job. It is doubly pointed because the plan's own listed dependency **#459 is a scheduler-refresh bug** — the plan is changing the exact subsystem #459 lives in without touching or testing it.
+- **The plan's Mar/Presal/Terra partition mitigation contradicts its own concatenation step.** Risks (lines 217–219) assert "`pré-sal` is a subset of offshore data, so aggregation must avoid double counting." But the TDD (lines 164–165) commits to concatenating all three CSVs (`Mar`, `Presal`, `Terra`) with a `location_source` marker. If the Risk's "subset" claim is true, concatenation double-counts every pre-salt well — i.e. Lula, Búzios, and Mero, the marquee fields. In reality ANP publishes these as *disjoint* location partitions (onshore / offshore-post-salt / pre-salt), so concatenation is correct and the Risk statement is factually wrong. Either way the plan is internally inconsistent and one statement is wrong. Resolve empirically (sum one known field across the three files vs. ANP's published field total) before writing the aggregation, and fix whichever statement is false.
+- **Acceptance Criterion #1 is non-actionable and the #459 relationship is unresolved.** AC#1 (lines 192–193): "#459 endpoint/schema failure is fixed **or this issue remains blocked** until #459 is closed." A criterion satisfied by the work remaining blocked is not a completion gate. Meanwhile the plan body *is* the #459 fix (Artifact Map line 77–79 replaces the stale CDP endpoint), and Execution mode (lines 11–12) offers "landed first as a dependency" as an alternative. Decide one of: (a) #718 subsumes and closes #459 (drop it from Dependencies, add "Closes #459"), or (b) #459 is a hard precondition owned elsewhere and #718 does not touch the endpoint. As written, ownership of the endpoint fix and the definition of "done" are ambiguous.
+- **Pseudocode calls a method that does not exist and does not flag the breaking interface change.** Line 122: `client.download_month(year=2023, month=1, force_refresh=False)`. The current `ANPClient` public surface is entirely `(year, semester)`-keyed (`download`, `is_cached`, `load_cached`, `_cache_key`, `_build_url`). Introducing month-granularity replaces this surface. The plan should state explicitly that `download(year, semester)` and its cache-key scheme are being removed/replaced (relevant to Finding 1's caller audit), rather than presenting `download_month` as if it already exists.
+- **Condensate is silently dropped from FDAS liquids, unaddressed for pre-salt.** `to_fdas_production` (contract.py:51–55) maps only `oil_bbl→MONTHLY_OIL_BBL`; the unified schema carries `condensate_bbl` separately (confirmed in `sodir_adapter.py:105,125`). Brazil pre-salt streams carry a material condensate fraction, so FDAS liquids for Lula/Búzios/Mero understate actual liquids. This matches the Norway precedent and the slice is explicitly "pre-tax plumbing" (lines 110–116), so it is not a correctness bug in the chain — but the plan should state that unified `oil_bbl` = oil only (condensate excluded) so a later economics pass does not inherit an unflagged understatement. (MINOR.)
+- **The unified `source` label is under-specified.** TDD (lines 177–178) accepts `source="anp"` **or** `source="anp_producao_poco"`. The `source` marker is a contract value downstream consumers key on; an acceptance test permitting either value pins nothing. Choose exactly one. (MINOR.)
+- **Plan text drops the diacritic on "Búzios".** Lines 24, 42-adjacent — plan writes "Buzios"; the code (`brazil_anp_adapter.py:31`) uses `"Búzios"`. Per this repo's orthographic rule and because field-name string matching is exact (`fields=["Marlim"]`-style filters), any hardcoded fixture/filter using the unaccented spelling will silently miss the field. (MINOR, but verify no ASCII "Buzios" literal reaches a matcher.)
+
+### codex
+
+(no findings unique to this provider)
+
+### gemini
+
+(no findings unique to this provider)

--- a/scripts/review/results/2026-07-04-plan-718-disagreement.md
+++ b/scripts/review/results/2026-07-04-plan-718-disagreement.md
@@ -1,0 +1,52 @@
+# Disagreement report — plan #718 (2026-07-04)
+
+## Verdicts
+
+| Provider | Verdict |
+|---|---|
+| claude-r1 | MAJOR |
+| claude | UNKNOWN |
+| codex-r1-unavailable | UNAVAILABLE (codex CLI failed, rc=124: Reading additional input from stdin... OpenAI Codex v0.142.5 -------- workdir: /mnt/local-analysis/wt-wed-718-brazil-plan model: gpt-5.5 provider: openai approval: on-request sandbox: workspace-write [workdir, /tmp, $TMPDIR] (network access enabled) reasoning effort: xhigh reasoning summaries: none session id: 019f2d95-788b-73b0-b832-162060792a38 -------- user # Adversarial plan review  You are an) |
+| codex | UNAVAILABLE (codex CLI failed, rc=124: Reading additional input from stdin... OpenAI Codex v0.142.5 -------- workdir: /mnt/local-analysis/wt-wed-718-brazil-plan model: gpt-5.5 provider: openai approval: on-request sandbox: workspace-write [workdir, /tmp, $TMPDIR] (network access enabled) reasoning effort: xhigh reasoning summaries: none session id: 019f2d95-788b-73b0-b832-162060792a38 -------- user # Adversarial plan review  You are an) |
+| disagreement-r1 | | Provider | Verdict | |
+| gemini-r1-unavailable | UNAVAILABLE (gemini CLI failed, rc=1: Warning: Basic terminal detected (TERM=dumb). Visual rendering will be limited. For the best experience, use a terminal emulator with truecolor support. Warning: 256-color support not detected. Using a terminal with at least 256-color support is recommended for a better visual experience. Error authenticating: IneligibleTierError: This client is no longer supported for Gemini Code Assist for indiv) |
+| gemini | UNAVAILABLE (gemini CLI failed, rc=1: Warning: Basic terminal detected (TERM=dumb). Visual rendering will be limited. For the best experience, use a terminal emulator with truecolor support. Warning: 256-color support not detected. Using a terminal with at least 256-color support is recommended for a better visual experience. Error authenticating: IneligibleTierError: This client is no longer supported for Gemini Code Assist for indiv) |
+
+## Findings unique to each provider
+
+A finding is 'unique to X' if its text appears in X's artifact but not
+verbatim in any other provider's artifact.
+
+### claude-r1
+
+(no findings unique to this provider)
+
+### claude
+
+(no findings unique to this provider)
+
+### codex-r1-unavailable
+
+(no findings unique to this provider)
+
+### codex
+
+(no findings unique to this provider)
+
+### disagreement-r1
+
+- A finding is 'unique to X' if its text appears in X's artifact but not
+- verbatim in any other provider's artifact.
+- ### claude
+- ### codex
+- (no findings unique to this provider)
+- ### gemini
+- (no findings unique to this provider)
+
+### gemini-r1-unavailable
+
+(no findings unique to this provider)
+
+### gemini
+
+(no findings unique to this provider)

--- a/scripts/review/results/2026-07-04-plan-718-gemini-r1-unavailable.md
+++ b/scripts/review/results/2026-07-04-plan-718-gemini-r1-unavailable.md
@@ -1,0 +1,11 @@
+## Verdict
+UNAVAILABLE (gemini CLI failed, rc=1: Warning: Basic terminal detected (TERM=dumb). Visual rendering will be limited. For the best experience, use a terminal emulator with truecolor support. Warning: 256-color support not detected. Using a terminal with at least 256-color support is recommended for a better visual experience. Error authenticating: IneligibleTierError: This client is no longer supported for Gemini Code Assist for indiv)
+
+## Retrieval
+(none — invocation failed before the provider could return a usable review)
+
+## Findings
+(none)
+
+## Blockers
+(none — this provider contributed no signal to the review)

--- a/scripts/review/results/2026-07-04-plan-718-gemini.md
+++ b/scripts/review/results/2026-07-04-plan-718-gemini.md
@@ -1,0 +1,11 @@
+## Verdict
+UNAVAILABLE (gemini CLI failed, rc=1: Warning: Basic terminal detected (TERM=dumb). Visual rendering will be limited. For the best experience, use a terminal emulator with truecolor support. Warning: 256-color support not detected. Using a terminal with at least 256-color support is recommended for a better visual experience. Error authenticating: IneligibleTierError: This client is no longer supported for Gemini Code Assist for indiv)
+
+## Retrieval
+(none — invocation failed before the provider could return a usable review)
+
+## Findings
+(none)
+
+## Blockers
+(none — this provider contributed no signal to the review)


### PR DESCRIPTION
## Summary
- Adds the #718 Brazil ANP reference-chain issue plan.
- Folds r1 MAJOR review blockers: scheduler caller coverage, ANP partition semantics, and #459 ownership.
- Records r2 MINOR/no-blocker review plus Codex/Gemini unavailable artifacts.

## Verification
- `PYTHONPATH=packages/worldenergydata-brazil_anp/src:packages/worldenergydata-production/src:packages/worldenergydata-common/src /mnt/local-analysis/worldenergydata/.venv/bin/python -m pytest tests/unit/brazil_anp tests/unit/production/unified/test_adapters.py --noconftest -o addopts=''` -> 155 passed
- `git diff --cached --check` -> clean before commit
- `bash scripts/legal/legal-sanity-scan.sh` -> no files to scan

## Gate
This is plan-review publication only. Implementation remains blocked until the user applies `status:plan-approved`.

Refs #718
Refs #459