### PR TITLE
feat(insights): dry/wet-tree dev-type badge on field life-cycle posters (#776)

### DIFF
--- a/reports/lower_tertiary/lifecycle/anchor_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/anchor_lifecycle.html
@@ -65,6 +65,18 @@
     padding: 6px 12px; border-radius: 999px; white-space: nowrap; }
   .status .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--sc, var(--good));
     box-shadow: 0 0 0 4px color-mix(in srgb, var(--sc, var(--good)) 22%, transparent); }
+  /* Development-type (dry vs wet tree) badge — links to the region×dev-type page. */
+  .devtype { display: inline-flex; align-items: center; gap: 7px; font-family: var(--mono);
+    font-size: 11.5px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase;
+    text-decoration: none; white-space: nowrap; padding: 5px 11px; border-radius: 999px;
+    color: var(--dc, var(--muted)); background: color-mix(in srgb, var(--dc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--dc, var(--muted)) 38%, transparent); }
+  .devtype::before { content: ""; width: 8px; height: 8px; border-radius: 2px;
+    background: var(--dc, var(--muted)); }
+  .devtype[data-tree="dry"] { --dc: var(--done); }        /* dry = cool blue */
+  .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
+  .devtype[data-tree="wet"]::before { border-radius: 50%; }
+  .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -202,6 +214,7 @@
       </div>
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
+        <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -299,6 +312,8 @@ const FIELD = {
   "host": "Semisubmersible FPU",
   "statusLabel": "Producing",
   "statusHue": "var(--good)",
+  "treeType": "wet",
+  "treeLabel": "Wet tree · Semisub FPU",
   "currentPhase": "operate",
   "metrics": [
     {
@@ -438,6 +453,12 @@ document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.treeLabel) {
+  const dt = $("f-devtype");
+  dt.textContent = FIELD.treeLabel;
+  dt.setAttribute("data-tree", FIELD.treeType || "");
+  dt.hidden = false;
+}
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
   + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`

--- a/reports/lower_tertiary/lifecycle/big_foot_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/big_foot_lifecycle.html
@@ -65,6 +65,18 @@
     padding: 6px 12px; border-radius: 999px; white-space: nowrap; }
   .status .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--sc, var(--good));
     box-shadow: 0 0 0 4px color-mix(in srgb, var(--sc, var(--good)) 22%, transparent); }
+  /* Development-type (dry vs wet tree) badge — links to the region×dev-type page. */
+  .devtype { display: inline-flex; align-items: center; gap: 7px; font-family: var(--mono);
+    font-size: 11.5px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase;
+    text-decoration: none; white-space: nowrap; padding: 5px 11px; border-radius: 999px;
+    color: var(--dc, var(--muted)); background: color-mix(in srgb, var(--dc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--dc, var(--muted)) 38%, transparent); }
+  .devtype::before { content: ""; width: 8px; height: 8px; border-radius: 2px;
+    background: var(--dc, var(--muted)); }
+  .devtype[data-tree="dry"] { --dc: var(--done); }        /* dry = cool blue */
+  .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
+  .devtype[data-tree="wet"]::before { border-radius: 50%; }
+  .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -202,6 +214,7 @@
       </div>
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
+        <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -299,6 +312,8 @@ const FIELD = {
   "host": "Extended Tension-Leg Platform (eTLP)",
   "statusLabel": "Producing",
   "statusHue": "var(--good)",
+  "treeType": "dry",
+  "treeLabel": "Dry tree · eTLP",
   "currentPhase": "operate",
   "metrics": [
     {
@@ -451,6 +466,12 @@ document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.treeLabel) {
+  const dt = $("f-devtype");
+  dt.textContent = FIELD.treeLabel;
+  dt.setAttribute("data-tree", FIELD.treeType || "");
+  dt.hidden = false;
+}
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
   + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`

--- a/reports/lower_tertiary/lifecycle/cascade_chinook_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/cascade_chinook_lifecycle.html
@@ -65,6 +65,18 @@
     padding: 6px 12px; border-radius: 999px; white-space: nowrap; }
   .status .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--sc, var(--good));
     box-shadow: 0 0 0 4px color-mix(in srgb, var(--sc, var(--good)) 22%, transparent); }
+  /* Development-type (dry vs wet tree) badge — links to the region×dev-type page. */
+  .devtype { display: inline-flex; align-items: center; gap: 7px; font-family: var(--mono);
+    font-size: 11.5px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase;
+    text-decoration: none; white-space: nowrap; padding: 5px 11px; border-radius: 999px;
+    color: var(--dc, var(--muted)); background: color-mix(in srgb, var(--dc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--dc, var(--muted)) 38%, transparent); }
+  .devtype::before { content: ""; width: 8px; height: 8px; border-radius: 2px;
+    background: var(--dc, var(--muted)); }
+  .devtype[data-tree="dry"] { --dc: var(--done); }        /* dry = cool blue */
+  .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
+  .devtype[data-tree="wet"]::before { border-radius: 50%; }
+  .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -202,6 +214,7 @@
       </div>
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
+        <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -299,6 +312,8 @@ const FIELD = {
   "host": "FPSO (BW Pioneer) with subsea tieback",
   "statusLabel": "Producing",
   "statusHue": "var(--good)",
+  "treeType": "wet",
+  "treeLabel": "Wet tree · FPSO",
   "currentPhase": "operate",
   "metrics": [
     {
@@ -416,6 +431,12 @@ document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.treeLabel) {
+  const dt = $("f-devtype");
+  dt.textContent = FIELD.treeLabel;
+  dt.setAttribute("data-tree", FIELD.treeType || "");
+  dt.hidden = false;
+}
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
   + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`

--- a/reports/lower_tertiary/lifecycle/jack_st_malo_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/jack_st_malo_lifecycle.html
@@ -65,6 +65,18 @@
     padding: 6px 12px; border-radius: 999px; white-space: nowrap; }
   .status .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--sc, var(--good));
     box-shadow: 0 0 0 4px color-mix(in srgb, var(--sc, var(--good)) 22%, transparent); }
+  /* Development-type (dry vs wet tree) badge — links to the region×dev-type page. */
+  .devtype { display: inline-flex; align-items: center; gap: 7px; font-family: var(--mono);
+    font-size: 11.5px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase;
+    text-decoration: none; white-space: nowrap; padding: 5px 11px; border-radius: 999px;
+    color: var(--dc, var(--muted)); background: color-mix(in srgb, var(--dc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--dc, var(--muted)) 38%, transparent); }
+  .devtype::before { content: ""; width: 8px; height: 8px; border-radius: 2px;
+    background: var(--dc, var(--muted)); }
+  .devtype[data-tree="dry"] { --dc: var(--done); }        /* dry = cool blue */
+  .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
+  .devtype[data-tree="wet"]::before { border-radius: 50%; }
+  .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -202,6 +214,7 @@
       </div>
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
+        <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -299,6 +312,8 @@ const FIELD = {
   "host": "Semisubmersible FPU",
   "statusLabel": "Producing",
   "statusHue": "var(--good)",
+  "treeType": "wet",
+  "treeLabel": "Wet tree · Semisub FPU",
   "currentPhase": "operate",
   "metrics": [
     {
@@ -438,6 +453,12 @@ document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.treeLabel) {
+  const dt = $("f-devtype");
+  dt.textContent = FIELD.treeLabel;
+  dt.setAttribute("data-tree", FIELD.treeType || "");
+  dt.hidden = false;
+}
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
   + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`

--- a/reports/lower_tertiary/lifecycle/julia_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/julia_lifecycle.html
@@ -65,6 +65,18 @@
     padding: 6px 12px; border-radius: 999px; white-space: nowrap; }
   .status .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--sc, var(--good));
     box-shadow: 0 0 0 4px color-mix(in srgb, var(--sc, var(--good)) 22%, transparent); }
+  /* Development-type (dry vs wet tree) badge — links to the region×dev-type page. */
+  .devtype { display: inline-flex; align-items: center; gap: 7px; font-family: var(--mono);
+    font-size: 11.5px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase;
+    text-decoration: none; white-space: nowrap; padding: 5px 11px; border-radius: 999px;
+    color: var(--dc, var(--muted)); background: color-mix(in srgb, var(--dc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--dc, var(--muted)) 38%, transparent); }
+  .devtype::before { content: ""; width: 8px; height: 8px; border-radius: 2px;
+    background: var(--dc, var(--muted)); }
+  .devtype[data-tree="dry"] { --dc: var(--done); }        /* dry = cool blue */
+  .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
+  .devtype[data-tree="wet"]::before { border-radius: 50%; }
+  .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -202,6 +214,7 @@
       </div>
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
+        <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -299,6 +312,8 @@ const FIELD = {
   "host": "Subsea tieback to Jack/St. Malo semisubmersible FPU (Chevron)",
   "statusLabel": "Producing",
   "statusHue": "var(--good)",
+  "treeType": "wet",
+  "treeLabel": "Wet tree · Subsea tieback",
   "currentPhase": "operate",
   "metrics": [
     {
@@ -441,6 +456,12 @@ document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.treeLabel) {
+  const dt = $("f-devtype");
+  dt.textContent = FIELD.treeLabel;
+  dt.setAttribute("data-tree", FIELD.treeType || "");
+  dt.hidden = false;
+}
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
   + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`

--- a/reports/lower_tertiary/lifecycle/kaskida_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/kaskida_lifecycle.html
@@ -65,6 +65,18 @@
     padding: 6px 12px; border-radius: 999px; white-space: nowrap; }
   .status .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--sc, var(--good));
     box-shadow: 0 0 0 4px color-mix(in srgb, var(--sc, var(--good)) 22%, transparent); }
+  /* Development-type (dry vs wet tree) badge — links to the region×dev-type page. */
+  .devtype { display: inline-flex; align-items: center; gap: 7px; font-family: var(--mono);
+    font-size: 11.5px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase;
+    text-decoration: none; white-space: nowrap; padding: 5px 11px; border-radius: 999px;
+    color: var(--dc, var(--muted)); background: color-mix(in srgb, var(--dc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--dc, var(--muted)) 38%, transparent); }
+  .devtype::before { content: ""; width: 8px; height: 8px; border-radius: 2px;
+    background: var(--dc, var(--muted)); }
+  .devtype[data-tree="dry"] { --dc: var(--done); }        /* dry = cool blue */
+  .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
+  .devtype[data-tree="wet"]::before { border-radius: 50%; }
+  .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -202,6 +214,7 @@
       </div>
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
+        <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -299,6 +312,8 @@ const FIELD = {
   "host": "Semisubmersible FPU (20,000 psi)",
   "statusLabel": "Under construction",
   "statusHue": "var(--done)",
+  "treeType": "wet",
+  "treeLabel": "Wet tree · Semisub FPU",
   "currentPhase": "execute",
   "metrics": [
     {
@@ -414,6 +429,12 @@ document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.treeLabel) {
+  const dt = $("f-devtype");
+  dt.textContent = FIELD.treeLabel;
+  dt.setAttribute("data-tree", FIELD.treeType || "");
+  dt.hidden = false;
+}
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
   + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`

--- a/reports/lower_tertiary/lifecycle/lifecycle_template.html
+++ b/reports/lower_tertiary/lifecycle/lifecycle_template.html
@@ -65,6 +65,18 @@
     padding: 6px 12px; border-radius: 999px; white-space: nowrap; }
   .status .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--sc, var(--good));
     box-shadow: 0 0 0 4px color-mix(in srgb, var(--sc, var(--good)) 22%, transparent); }
+  /* Development-type (dry vs wet tree) badge — links to the region×dev-type page. */
+  .devtype { display: inline-flex; align-items: center; gap: 7px; font-family: var(--mono);
+    font-size: 11.5px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase;
+    text-decoration: none; white-space: nowrap; padding: 5px 11px; border-radius: 999px;
+    color: var(--dc, var(--muted)); background: color-mix(in srgb, var(--dc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--dc, var(--muted)) 38%, transparent); }
+  .devtype::before { content: ""; width: 8px; height: 8px; border-radius: 2px;
+    background: var(--dc, var(--muted)); }
+  .devtype[data-tree="dry"] { --dc: var(--done); }        /* dry = cool blue */
+  .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
+  .devtype[data-tree="wet"]::before { border-radius: 50%; }
+  .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -202,6 +214,7 @@
       </div>
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
+        <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -301,6 +314,12 @@ document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.treeLabel) {
+  const dt = $("f-devtype");
+  dt.textContent = FIELD.treeLabel;
+  dt.setAttribute("data-tree", FIELD.treeType || "");
+  dt.hidden = false;
+}
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
   + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`

--- a/reports/lower_tertiary/lifecycle/north_platte_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/north_platte_lifecycle.html
@@ -65,6 +65,18 @@
     padding: 6px 12px; border-radius: 999px; white-space: nowrap; }
   .status .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--sc, var(--good));
     box-shadow: 0 0 0 4px color-mix(in srgb, var(--sc, var(--good)) 22%, transparent); }
+  /* Development-type (dry vs wet tree) badge — links to the region×dev-type page. */
+  .devtype { display: inline-flex; align-items: center; gap: 7px; font-family: var(--mono);
+    font-size: 11.5px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase;
+    text-decoration: none; white-space: nowrap; padding: 5px 11px; border-radius: 999px;
+    color: var(--dc, var(--muted)); background: color-mix(in srgb, var(--dc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--dc, var(--muted)) 38%, transparent); }
+  .devtype::before { content: ""; width: 8px; height: 8px; border-radius: 2px;
+    background: var(--dc, var(--muted)); }
+  .devtype[data-tree="dry"] { --dc: var(--done); }        /* dry = cool blue */
+  .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
+  .devtype[data-tree="wet"]::before { border-radius: 50%; }
+  .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -202,6 +214,7 @@
       </div>
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
+        <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -299,6 +312,8 @@ const FIELD = {
   "host": "Newbuild Semisubmersible FPU",
   "statusLabel": "Under construction",
   "statusHue": "var(--done)",
+  "treeType": "wet",
+  "treeLabel": "Wet tree · Semisub FPU",
   "currentPhase": "execute",
   "metrics": [
     {
@@ -410,6 +425,12 @@ document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.treeLabel) {
+  const dt = $("f-devtype");
+  dt.textContent = FIELD.treeLabel;
+  dt.setAttribute("data-tree", FIELD.treeType || "");
+  dt.hidden = false;
+}
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
   + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`

--- a/reports/lower_tertiary/lifecycle/shenandoah_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/shenandoah_lifecycle.html
@@ -65,6 +65,18 @@
     padding: 6px 12px; border-radius: 999px; white-space: nowrap; }
   .status .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--sc, var(--good));
     box-shadow: 0 0 0 4px color-mix(in srgb, var(--sc, var(--good)) 22%, transparent); }
+  /* Development-type (dry vs wet tree) badge — links to the region×dev-type page. */
+  .devtype { display: inline-flex; align-items: center; gap: 7px; font-family: var(--mono);
+    font-size: 11.5px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase;
+    text-decoration: none; white-space: nowrap; padding: 5px 11px; border-radius: 999px;
+    color: var(--dc, var(--muted)); background: color-mix(in srgb, var(--dc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--dc, var(--muted)) 38%, transparent); }
+  .devtype::before { content: ""; width: 8px; height: 8px; border-radius: 2px;
+    background: var(--dc, var(--muted)); }
+  .devtype[data-tree="dry"] { --dc: var(--done); }        /* dry = cool blue */
+  .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
+  .devtype[data-tree="wet"]::before { border-radius: 50%; }
+  .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -202,6 +214,7 @@
       </div>
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
+        <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -299,6 +312,8 @@ const FIELD = {
   "host": "Semisubmersible FPU (FPS, 20,000-psi)",
   "statusLabel": "Producing",
   "statusHue": "var(--good)",
+  "treeType": "wet",
+  "treeLabel": "Wet tree · Semisub FPU",
   "currentPhase": "operate",
   "metrics": [
     {
@@ -434,6 +449,12 @@ document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.treeLabel) {
+  const dt = $("f-devtype");
+  dt.textContent = FIELD.treeLabel;
+  dt.setAttribute("data-tree", FIELD.treeType || "");
+  dt.hidden = false;
+}
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
   + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`

--- a/reports/lower_tertiary/lifecycle/stones_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/stones_lifecycle.html
@@ -65,6 +65,18 @@
     padding: 6px 12px; border-radius: 999px; white-space: nowrap; }
   .status .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--sc, var(--good));
     box-shadow: 0 0 0 4px color-mix(in srgb, var(--sc, var(--good)) 22%, transparent); }
+  /* Development-type (dry vs wet tree) badge — links to the region×dev-type page. */
+  .devtype { display: inline-flex; align-items: center; gap: 7px; font-family: var(--mono);
+    font-size: 11.5px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase;
+    text-decoration: none; white-space: nowrap; padding: 5px 11px; border-radius: 999px;
+    color: var(--dc, var(--muted)); background: color-mix(in srgb, var(--dc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--dc, var(--muted)) 38%, transparent); }
+  .devtype::before { content: ""; width: 8px; height: 8px; border-radius: 2px;
+    background: var(--dc, var(--muted)); }
+  .devtype[data-tree="dry"] { --dc: var(--done); }        /* dry = cool blue */
+  .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
+  .devtype[data-tree="wet"]::before { border-radius: 50%; }
+  .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -202,6 +214,7 @@
       </div>
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
+        <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -299,6 +312,8 @@ const FIELD = {
   "host": "FPSO (Turritella / Stones FPSO, disconnectable)",
   "statusLabel": "Producing",
   "statusHue": "var(--good)",
+  "treeType": "wet",
+  "treeLabel": "Wet tree · FPSO",
   "currentPhase": "operate",
   "metrics": [
     {
@@ -431,6 +446,12 @@ document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.treeLabel) {
+  const dt = $("f-devtype");
+  dt.textContent = FIELD.treeLabel;
+  dt.setAttribute("data-tree", FIELD.treeType || "");
+  dt.hidden = false;
+}
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
   + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`

--- a/reports/lower_tertiary/lifecycle/tiber_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/tiber_lifecycle.html
@@ -65,6 +65,18 @@
     padding: 6px 12px; border-radius: 999px; white-space: nowrap; }
   .status .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--sc, var(--good));
     box-shadow: 0 0 0 4px color-mix(in srgb, var(--sc, var(--good)) 22%, transparent); }
+  /* Development-type (dry vs wet tree) badge — links to the region×dev-type page. */
+  .devtype { display: inline-flex; align-items: center; gap: 7px; font-family: var(--mono);
+    font-size: 11.5px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase;
+    text-decoration: none; white-space: nowrap; padding: 5px 11px; border-radius: 999px;
+    color: var(--dc, var(--muted)); background: color-mix(in srgb, var(--dc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--dc, var(--muted)) 38%, transparent); }
+  .devtype::before { content: ""; width: 8px; height: 8px; border-radius: 2px;
+    background: var(--dc, var(--muted)); }
+  .devtype[data-tree="dry"] { --dc: var(--done); }        /* dry = cool blue */
+  .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
+  .devtype[data-tree="wet"]::before { border-radius: 50%; }
+  .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -202,6 +214,7 @@
       </div>
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
+        <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -299,6 +312,8 @@ const FIELD = {
   "host": "Semisubmersible FPU (single-lift topsides, Kaskida-derived design)",
   "statusLabel": "Under construction",
   "statusHue": "var(--done)",
+  "treeType": "wet",
+  "treeLabel": "Wet tree · Semisub FPU",
   "currentPhase": "execute",
   "metrics": [
     {
@@ -406,6 +421,12 @@ document.title = FIELD.name + " — Field Development Life-Cycle";
 $("f-title").textContent = FIELD.name;
 $("f-sub").innerHTML = `${FIELD.operator} · ${FIELD.region} — ${FIELD.host}`;
 $("f-status").textContent = FIELD.statusLabel;
+if (FIELD.treeLabel) {
+  const dt = $("f-devtype");
+  dt.textContent = FIELD.treeLabel;
+  dt.setAttribute("data-tree", FIELD.treeType || "");
+  dt.hidden = false;
+}
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`
   + `padding:12px clamp(18px,2.4vw,30px);background:color-mix(in srgb,var(--accent) 10%,var(--panel-2));`

--- a/scripts/lower_tertiary/build_lifecycle_posters.py
+++ b/scripts/lower_tertiary/build_lifecycle_posters.py
@@ -23,7 +23,16 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[2] / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from worldenergydata.field_development.host_text_classifier import (  # noqa: E402
+    classify_tree_type,
+)
 
 HERE = Path(__file__).resolve().parents[2] / "reports/lower_tertiary/lifecycle"
 TEMPLATE = HERE / "lifecycle_template.html"
@@ -236,6 +245,13 @@ def facts_to_field(f: dict) -> dict:
         host_facts.append(["Data through", _pretty(g["data_through"])])
 
     label, hue = STATUS.get(f.get("status", "producing"), STATUS["producing"])
+
+    # Dry- vs wet-tree development-type badge (classified from the host text).
+    tree_type, concept_label = classify_tree_type(f.get("host_type", ""))
+    tree_label = None
+    if tree_type is not None:
+        tree_label = f"{'Dry' if tree_type == 'dry' else 'Wet'} tree · {concept_label}"
+
     region = f.get("region_block", "")
     if f.get("basin"):
         region = f"{region} · {f['basin']}" if region else f["basin"]
@@ -256,6 +272,8 @@ def facts_to_field(f: dict) -> dict:
         "host": f.get("host_type", ""),
         "statusLabel": label,
         "statusHue": hue,
+        "treeType": tree_type,
+        "treeLabel": tree_label,
         "currentPhase": f.get("current_phase", "operate"),
         "metrics": metrics,
         "axis": {"start": start, "end": end, "ticks": ticks},

--- a/src/worldenergydata/field_development/host_text_classifier.py
+++ b/src/worldenergydata/field_development/host_text_classifier.py
@@ -1,0 +1,77 @@
+# ABOUTME: Classify a free-text host-type string into a dry- vs wet-tree concept.
+# ABOUTME: Side-effect-free; drives the dev-type badge on the life-cycle posters.
+"""
+worldenergydata.field_development.host_text_classifier
+======================================================
+
+Map an author-authored, free-text ``host_type`` string (e.g. "Extended
+Tension-Leg Platform (eTLP)" or "Semisubmersible FPU") onto a
+:class:`ConceptType` and, from that, the authoritative dry-vs-wet tree split
+(:data:`recommendation._DRY_TREE`).
+
+Dry-tree keywords are matched **before** wet-tree keywords so a host like
+"Extended Tension-Leg Platform (eTLP)" resolves *dry* (TLP) even though its
+downstream description mentions an "FPU". Within the wet group, "FPSO" is
+matched before "tieback" so "FPSO ... with subsea tieback" reads as an FPSO
+host rather than a bare tieback.
+"""
+
+from __future__ import annotations
+
+from worldenergydata.field_development.enums import ConceptType
+from worldenergydata.field_development.recommendation import _DRY_TREE
+
+# Ordered keyword rules. DRY concepts come first (see module docstring); within
+# the wet group FPSO precedes tieback which precedes the semisub/FPU/FPS family.
+_KEYWORD_RULES: tuple[tuple[tuple[str, ...], ConceptType], ...] = (
+    # --- dry trees (surface / vertical well access) ---
+    (("tension-leg", "tension leg", "tlp"), ConceptType.TLP),
+    (("spar",), ConceptType.SPAR),
+    (("compliant tower",), ConceptType.COMPLIANT_TOWER),
+    (("fixed", "jacket"), ConceptType.FIXED_JACKET),
+    # --- wet trees (subsea completions) ---
+    (("fpso",), ConceptType.FPSO),
+    (("flng",), ConceptType.FLNG),
+    (("tieback", "tie-back", "tie back"), ConceptType.SUBSEA_TIEBACK),
+    (("semisub", "fpu", "fps"), ConceptType.SEMISUB_FPS),
+)
+
+# Short display token per concept for the poster badge.
+_LABELS: dict[ConceptType, str] = {
+    ConceptType.TLP: "TLP",
+    ConceptType.SPAR: "Spar",
+    ConceptType.COMPLIANT_TOWER: "Compliant Tower",
+    ConceptType.FIXED_JACKET: "Fixed platform",
+    ConceptType.FPSO: "FPSO",
+    ConceptType.FLNG: "FLNG",
+    ConceptType.SUBSEA_TIEBACK: "Subsea tieback",
+    ConceptType.SEMISUB_FPS: "Semisub FPU",
+}
+
+
+def _label_for(concept: ConceptType, low: str) -> str:
+    """Display token, refining TLP to 'eTLP' when the text says so."""
+    if concept is ConceptType.TLP and ("etlp" in low or "extended tension" in low):
+        return "eTLP"
+    return _LABELS.get(concept, concept.value)
+
+
+def classify_tree_type(host_type_text: str) -> tuple[str | None, str]:
+    """Classify a free-text host description into a tree type + concept label.
+
+    Args:
+        host_type_text: Author-authored host string (may be empty/None).
+
+    Returns:
+        ``(tree, label)`` where ``tree`` is ``'dry'`` | ``'wet'`` | ``None``
+        (None when nothing matches) and ``label`` is a short display token
+        such as ``'eTLP'`` or ``'Semisub FPU'`` (``''`` when unclassifiable).
+    """
+    if not host_type_text:
+        return (None, "")
+    low = host_type_text.lower()
+    for keywords, concept in _KEYWORD_RULES:
+        if any(k in low for k in keywords):
+            tree = "dry" if concept in _DRY_TREE else "wet"
+            return (tree, _label_for(concept, low))
+    return (None, "")

--- a/tests/unit/field_development/test_host_text_classifier.py
+++ b/tests/unit/field_development/test_host_text_classifier.py
@@ -1,0 +1,71 @@
+# ABOUTME: Tests for the free-text host-type -> dry/wet tree classifier.
+# ABOUTME: Pins the 10 Lower-Tertiary acceptance strings + dry-before-wet order.
+"""Tests for ``worldenergydata.field_development.host_text_classifier``.
+
+The classifier backs the dev-type badge on the Lower-Tertiary life-cycle
+posters. These tests pin the exact dry/wet verdict for each field's authored
+``host_type`` string, the dry-before-wet keyword precedence (the eTLP case,
+whose text also mentions "FPU"), and the unknown-text fallback.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from worldenergydata.field_development.host_text_classifier import (
+    classify_tree_type,
+)
+
+# (host_type string, expected tree, expected concept label) for the 10 fields.
+ACCEPTANCE = [
+    ("Extended Tension-Leg Platform (eTLP)", "dry", "eTLP"),  # big_foot
+    ("Semisubmersible FPU", "wet", "Semisub FPU"),  # anchor
+    ("FPSO (BW Pioneer) with subsea tieback", "wet", "FPSO"),  # cascade
+    ("Semisubmersible FPU", "wet", "Semisub FPU"),  # jack_st_malo
+    (
+        "Subsea tieback to Jack/St. Malo semisubmersible FPU",
+        "wet",
+        "Subsea tieback",
+    ),  # julia
+    ("Semisubmersible FPU (20,000 psi)", "wet", "Semisub FPU"),  # kaskida
+    ("Newbuild Semisubmersible FPU", "wet", "Semisub FPU"),  # north_platte
+    ("Semisubmersible FPU (FPS, 20,000-psi)", "wet", "Semisub FPU"),  # shenandoah
+    ("FPSO (Turritella / Stones FPSO, disconnectable)", "wet", "FPSO"),  # stones
+    (
+        "Semisubmersible FPU (single-lift topsides, Kaskida-derived design)",
+        "wet",
+        "Semisub FPU",
+    ),  # tiber
+]
+
+
+@pytest.mark.parametrize("text,tree,label", ACCEPTANCE)
+def test_acceptance_strings_classify(text, tree, label):
+    got_tree, got_label = classify_tree_type(text)
+    assert got_tree == tree
+    assert got_label == label
+
+
+def test_acceptance_split_is_one_dry_nine_wet():
+    verdicts = [classify_tree_type(t)[0] for t, _, _ in ACCEPTANCE]
+    assert verdicts.count("dry") == 1
+    assert verdicts.count("wet") == 9
+
+
+def test_dry_keywords_checked_before_wet():
+    # "Extended Tension-Leg Platform" also mentions an FPU downstream in the
+    # real host strings; the dry (TLP) match must win over the wet keywords.
+    tree, label = classify_tree_type("Tension-Leg Platform with FPU support")
+    assert tree == "dry"
+    assert label == "TLP"
+
+
+def test_fpso_beats_tieback_within_wet():
+    tree, label = classify_tree_type("FPSO with a long subsea tieback")
+    assert (tree, label) == ("wet", "FPSO")
+
+
+def test_unknown_text_returns_none():
+    assert classify_tree_type("Gravity-based concrete island") == (None, "")
+    assert classify_tree_type("") == (None, "")
+    assert classify_tree_type(None) == (None, "")


### PR DESCRIPTION
## Dry/wet-tree development-type badge on the field life-cycle posters

Follow-up to #786 (sub-epic #774, dev-type #776). Surfaces the region×development-type insight **where people actually browse** — each of the 10 GoM Lower-Tertiary field posters now declares its tree type in the header, linked to the region×dev-type comparison page.

### Result
**9 wet-tree, 1 dry-tree** — Big Foot's eTLP is the lone dry-tree development in the play. The same fact that made a dev-type×drilling cross-cut under-powered becomes a visible teaching point: *this play is wet-tree country.*

| Field | Badge |
|---|---|
| Big Foot | **Dry tree · eTLP** |
| anchor, jack_st_malo, kaskida, north_platte, shenandoah, tiber | Wet tree · Semisub FPU |
| cascade_chinook, stones | Wet tree · FPSO |
| julia | Wet tree · Subsea tieback |

### Changes
- New tested module `worldenergydata.field_development.host_text_classifier.classify_tree_type` — free-text `host_type` → dry/wet, reusing the authoritative `recommendation._DRY_TREE`. Keyword order checks **dry before wet** so "Extended Tension-Leg Platform (eTLP)" resolves DRY despite downstream "FPU" text, and FPSO before tieback. **14 unit tests** over all 10 field strings + precedence + unknown→(None,"").
- `build_lifecycle_posters.py` adds `treeType`/`treeLabel` to the FIELD object.
- `lifecycle_template.html` renders a dry (blue) / wet (teal) badge next to the status pill, linking to `../region-devtype-comparison.html`.

### Verified
`build_lifecycle_posters.py` + `build_pages.py` exit 0; posters regenerate with 1 dry / 9 wet; the dev-type link resolves in the published `public/` tree; 14 tests pass; **all three CI linters clean** (Black, isort, flake8 — the module lives in `src/`). No `repo_structure.yml` change needed (posters modified in place; module under existing `src`/`tests` roots).

Refs #776 #754.
