### PR TITLE
fix(ci): make Changelog Check always run so required-check ruleset isn't deadlocked

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -102,11 +102,12 @@ jobs:
   changelog-check:
     name: Changelog Check
     runs-on: ubuntu-latest
-    if: |
-      !contains(github.event.pull_request.labels.*.name, 'skip-changelog') &&
-      !startsWith(github.event.pull_request.title, 'chore') &&
-      !startsWith(github.event.pull_request.title, 'ci')
-
+    # NOTE: This job must ALWAYS run. "Changelog Check" is a required status check
+    # in the main branch ruleset, and a required check that is skipped (via a
+    # job-level `if:`) is never "satisfied" — it deadlocks the PR at BLOCKED
+    # forever. That previously made every chore/ci/dependabot PR unmergeable
+    # (#802). The step below is advisory only (it emits a notice, never fails),
+    # so running it unconditionally is safe and satisfies the required context.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
Closes #802. Refs #526.

## Problem
`Changelog Check` is a **required** status check in the `main` branch ruleset, but its job in `.github/workflows/pr-validation.yml` skipped itself for `chore`/`ci`-titled PRs via a job-level `if:`. GitHub rulesets treat a skipped required check as unsatisfied, so **every `chore`/`ci`/dependabot PR sat permanently `BLOCKED`** and could not merge. This is why 6 dependabot PRs (#479, #537, #538, #539, #540, #548) piled up stale since 2026-06-15 — verified live in the 2026-07-04 stale-PR triage (all rebased clean, all substantive checks green, 0 mergeable).

## Fix
Remove the job-level `if:` so the job always runs. The step is advisory-only (`::notice::`, never exits non-zero), so running it unconditionally adds no real gate — it just lets the required context report success on all PRs.

## Why this PR isn't self-blocked
Its title starts with `fix(...)`, not `chore`/`ci`, so `changelog-check` runs normally here.

## After merge
The 6 dependabot PRs (already rebased to current main) become mergeable. Generalizable lesson recorded in #802: never make a conditionally-skipped job a required status check.
