### PR TITLE
feat(insights): reservoir & HPHT panel on field life-cycle posters (#761)

### DIFF
--- a/reports/lower_tertiary/lifecycle/_facts.json
+++ b/reports/lower_tertiary/lifecycle/_facts.json
@@ -47,7 +47,19 @@
       "Chevron public disclosures",
       "BSEE"
     ],
-    "provenance": "Data: big_foot.yml + Chevron public disclosures + BSEE (dates to be reconciled in #375)"
+    "provenance": "Data: big_foot.yml + Chevron public disclosures + BSEE (dates to be reconciled in #375)",
+    "reservoir": {
+      "formation": "Wilcox / Paleogene (Lower Tertiary)",
+      "hpht_class": null,
+      "pressure_psi": null,
+      "pressure_qual": "",
+      "equip_rating_psi": null,
+      "temp_f": null,
+      "tvd_ft": null,
+      "fluid": "black oil",
+      "api": null,
+      "source_note": "Wilcox oil field (Offshore Technology; Chevron). Field-specific reservoir pressure/temperature not publicly disclosed — shown as — rather than borrowed from neighbouring fields."
+    }
   },
   {
     "id": "anchor",
@@ -97,7 +109,19 @@
       "https://www.rigzone.com/news/57b_deepwater_project_wins_chevron_approval-12-dec-2019-160556-article/",
       "https://www.nsenergybusiness.com/projects/anchor-field-development-project/"
     ],
-    "provenance": "Primary facts (operator, working interests, capex $5.6B, plateau 75 mbopd, GOR 1100 scf/bbl, opex $15/boe, first oil 2024-08, data_through 2024-12-31) from in-repo anchor.yml. Life-cycle dates corroborated by public sources: discovery well Anchor-2 drilled 2014 (Green Canyon 807, ~5,180 ft), FID December 2019 (~$5.7B sanction), first oil August 2024 — world's first 20,000-psi HPHT deepwater development on a semisubmersible FPU, Lower Tertiary Wilcox play. Working interests (Chevron 62.5% / Equinor 25% / TotalEnergies 12.5%) per YAML; note older Offshore Technology page still lists pre-Equinor split (Chevron 62.86% / Total 37.14%). water_depth_ft ~5,180 (block-level estimate). projected_cop_year and lease_year left null (not confidently sourced); incident null."
+    "provenance": "Primary facts (operator, working interests, capex $5.6B, plateau 75 mbopd, GOR 1100 scf/bbl, opex $15/boe, first oil 2024-08, data_through 2024-12-31) from in-repo anchor.yml. Life-cycle dates corroborated by public sources: discovery well Anchor-2 drilled 2014 (Green Canyon 807, ~5,180 ft), FID December 2019 (~$5.7B sanction), first oil August 2024 — world's first 20,000-psi HPHT deepwater development on a semisubmersible FPU, Lower Tertiary Wilcox play. Working interests (Chevron 62.5% / Equinor 25% / TotalEnergies 12.5%) per YAML; note older Offshore Technology page still lists pre-Equinor split (Chevron 62.86% / Total 37.14%). water_depth_ft ~5,180 (block-level estimate). projected_cop_year and lease_year left null (not confidently sourced); incident null.",
+    "reservoir": {
+      "formation": "Paleocene Wilcox (Wilcox 1–4)",
+      "hpht_class": "ultra-HPHT",
+      "pressure_psi": 25000,
+      "pressure_qual": "",
+      "equip_rating_psi": 20000,
+      "temp_f": 275,
+      "tvd_ft": 30000,
+      "fluid": "black oil",
+      "api": null,
+      "source_note": "OGJ 2024: initial reservoir (BHP) 23,000–27,000 psi — higher than the 20,000-psi equipment rating; 275F max flowing temp; pay 30,000–34,000 ft TVD (Wilcox 1–4)."
+    }
   },
   {
     "id": "cascade_chinook",
@@ -144,7 +168,19 @@
       "https://www.rigzone.com/news/murphy_and_petrobras_award_fiveyear_fpso_contract-19-mar-2020-161433-article/",
       "https://www.offshore-mag.com/production/article/14170050/cascade-and-chinook-fpso-secures-long-term-extension-in-the-gulf-of-mexico"
     ],
-    "provenance": "Life-cycle dates and ownership from public sources (Offshore Technology, Offshore Magazine, OGJ, Heerema, Rigzone); economics (capex $2.9B, plateau 75 mbopd, GOR 1400 scf/bbl, opex $18/boe) and data_through from in-repo YAML. IMPORTANT: two YAML values were overridden as demonstrably wrong vs. well-documented public record — YAML first_oil \"2021-08\" corrected to 2012-02 (Cascade first oil Feb 2012, Chinook Sep 2012; BW Pioneer was the first FPSO in the US GoM), and YAML operator/WI \"TotalEnergies 60% / Equinor 40%\" corrected to current MP Gulf of Mexico LLC (Murphy EXPRO 80% operator, Petrobras America 20%; originally Petrobras-operated with Total 33.33% in Chinook). LOW CONFIDENCE: fid_year (sanction ~mid-2000s, no firm public citation → null), lease_year and projected_cop_year (null); water_depth 8,200 ft is the Cascade value (Chinook ~8,600 ft); capex is a YAML assumption not independently verified."
+    "provenance": "Life-cycle dates and ownership from public sources (Offshore Technology, Offshore Magazine, OGJ, Heerema, Rigzone); economics (capex $2.9B, plateau 75 mbopd, GOR 1400 scf/bbl, opex $18/boe) and data_through from in-repo YAML. IMPORTANT: two YAML values were overridden as demonstrably wrong vs. well-documented public record — YAML first_oil \"2021-08\" corrected to 2012-02 (Cascade first oil Feb 2012, Chinook Sep 2012; BW Pioneer was the first FPSO in the US GoM), and YAML operator/WI \"TotalEnergies 60% / Equinor 40%\" corrected to current MP Gulf of Mexico LLC (Murphy EXPRO 80% operator, Petrobras America 20%; originally Petrobras-operated with Total 33.33% in Chinook). LOW CONFIDENCE: fid_year (sanction ~mid-2000s, no firm public citation → null), lease_year and projected_cop_year (null); water_depth 8,200 ft is the Cascade value (Chinook ~8,600 ft); capex is a YAML assumption not independently verified.",
+    "reservoir": {
+      "formation": "Wilcox 1 (Eocene) / Wilcox 2 (Paleocene)",
+      "hpht_class": "HPHT",
+      "pressure_psi": 19500,
+      "pressure_qual": "~",
+      "equip_rating_psi": null,
+      "temp_f": 260,
+      "tvd_ft": 25600,
+      "fluid": "black oil (low GOR; CO₂ <1.5%, no H₂S)",
+      "api": null,
+      "source_note": "OTC-24162/24163 + JPT: initial reservoir pressure ~19,500 psi, BHT ~256–260F, reservoir mid-point ~25,600 ft TVD."
+    }
   },
   {
     "id": "jack_st_malo",
@@ -194,7 +230,19 @@
       "https://www.offshore-mag.com/field-development/article/16758344/chevron-advances-deepwater-frontier-with-jack-st-malo-project",
       "https://naturalgasintel.com/news/chevrons-jackst-malo-project-underway-in-lower-tertiary/"
     ],
-    "provenance": "Facts from in-repo YAML (operator, WI Chevron 51%/Equinor 24.5%/Suncor 24.5%, capex $7.5B, opex $15/boe, plateau 94 mbopd, GOR 1200, status producing, data_through 2024-12-31). Life-cycle dates from public sources: St. Malo discovered Oct 2003 and Jack Jul 2004 (discovery_year=2003, earliest of pair); FID/sanction Oct 2010; first oil per Chevron press release Dec 2014 (\"2014-12\") — this OVERRIDES the YAML's first_oil \"2014-02-01\", which appears erroneous. Water depth ~7000 ft at the FPU (Jack WR758/759 ~7000 ft, St. Malo WR678). host_type = Semisubmersible FPU. projected_cop_year left null (not confidently estimable). lease_year null; no schedule-driving incident."
+    "provenance": "Facts from in-repo YAML (operator, WI Chevron 51%/Equinor 24.5%/Suncor 24.5%, capex $7.5B, opex $15/boe, plateau 94 mbopd, GOR 1200, status producing, data_through 2024-12-31). Life-cycle dates from public sources: St. Malo discovered Oct 2003 and Jack Jul 2004 (discovery_year=2003, earliest of pair); FID/sanction Oct 2010; first oil per Chevron press release Dec 2014 (\"2014-12\") — this OVERRIDES the YAML's first_oil \"2014-02-01\", which appears erroneous. Water depth ~7000 ft at the FPU (Jack WR758/759 ~7000 ft, St. Malo WR678). host_type = Semisubmersible FPU. projected_cop_year left null (not confidently estimable). lease_year null; no schedule-driving incident.",
+    "reservoir": {
+      "formation": "Wilcox (Lower Tertiary)",
+      "hpht_class": "HPHT",
+      "pressure_psi": 19374,
+      "pressure_qual": "",
+      "equip_rating_psi": null,
+      "temp_f": 224,
+      "tvd_ft": 26500,
+      "fluid": "black oil",
+      "api": null,
+      "source_note": "Dice regional Wilcox reservoir study: Jack initial pressure 19,374 psi @ 224F, St. Malo 19,023 psi @ 225F; reservoir ~26,500 ft TVD."
+    }
   },
   {
     "id": "julia",
@@ -242,7 +290,19 @@
       "https://www.offshore-mag.com/production/article/16770401/exxonmobil-starts-up-julia-oil-field-in-the-deepwater-gulf-of-mexico",
       "https://www.oedigital.com/news/449613-exxonmobil-starts-up-us-4-billion-julia-project"
     ],
-    "provenance": "Primary facts (capex $4.7B, plateau 34 mbopd, GOR 1000, opex $18/boe, first_oil, WI 50/50) from in-repo julia.yml; first_oil = BSEE OGOR-A first production (2016-03) per YAML — note ExxonMobil press release states production start April 2016. Operator corrected to ExxonMobil (YAML flagged its \"Equinor\" operator field as disputed; public record = ExxonMobil-operated, Equinor/Statoil 50% partner). Discovery 2007, FID May 2013, water depth 7000+ ft, Walker Ridge blocks, and Jack/St. Malo tieback from Offshore Technology and operator/trade press. lease_year and projected_cop_year left null (not confidently sourced)."
+    "provenance": "Primary facts (capex $4.7B, plateau 34 mbopd, GOR 1000, opex $18/boe, first_oil, WI 50/50) from in-repo julia.yml; first_oil = BSEE OGOR-A first production (2016-03) per YAML — note ExxonMobil press release states production start April 2016. Operator corrected to ExxonMobil (YAML flagged its \"Equinor\" operator field as disputed; public record = ExxonMobil-operated, Equinor/Statoil 50% partner). Discovery 2007, FID May 2013, water depth 7000+ ft, Walker Ridge blocks, and Jack/St. Malo tieback from Offshore Technology and operator/trade press. lease_year and projected_cop_year left null (not confidently sourced).",
+    "reservoir": {
+      "formation": "Wilcox (Lower Tertiary)",
+      "hpht_class": "HPHT",
+      "pressure_psi": 13500,
+      "pressure_qual": "~",
+      "equip_rating_psi": 15000,
+      "temp_f": null,
+      "tvd_ft": 30000,
+      "fluid": "black oil",
+      "api": 24.7,
+      "source_note": "Offshore Mag: subsea pressures ~13,500 psi (15,000-psi-rated trees + first permanent HIPPS); Hart Energy production test: 24.7°API oil."
+    }
   },
   {
     "id": "kaskida",
@@ -287,7 +347,19 @@
       "https://www.bp.com/en/global/corporate/news-and-insights/press-releases/bp-announces-significant-discovery-in-the-deepwater-gulf-of-mexi.html",
       "https://earthjustice.org/press/2025/federal-government-rejects-development-plan-for-bps-first-completely-new-oilfield-in-gulf-of-mexico-since-deepwater-horizon"
     ],
-    "provenance": "Discovery 2006 (Keathley Canyon 292, Lower Tertiary Wilcox), FID/sanction July 30 2024 (BP 100%, Devon's original 30% exited), first oil targeted 2029 but kept null as no oil has flowed and the Aug-2025 BOEM DPP rejection likely pushes it out. Public sanctioned figures used over YAML where they diverge: plateau/nameplate 80 mbopd (YAML said 120) and capex ~$5bn for Phase 1 (<$5B per BP; YAML total_mm_usd 10000 = $10bn is a full-field/multi-phase estimate). GOR 1000 scf/bbl and data_through 2024-12-31 from YAML. Water depth ~6,000 ft, 20,000-psi semisubmersible FPU. Low-confidence: capex (phase-1 vs full-field ambiguity), water_depth (rounded), lease_year unknown (null), opex unknown (null)."
+    "provenance": "Discovery 2006 (Keathley Canyon 292, Lower Tertiary Wilcox), FID/sanction July 30 2024 (BP 100%, Devon's original 30% exited), first oil targeted 2029 but kept null as no oil has flowed and the Aug-2025 BOEM DPP rejection likely pushes it out. Public sanctioned figures used over YAML where they diverge: plateau/nameplate 80 mbopd (YAML said 120) and capex ~$5bn for Phase 1 (<$5B per BP; YAML total_mm_usd 10000 = $10bn is a full-field/multi-phase estimate). GOR 1000 scf/bbl and data_through 2024-12-31 from YAML. Water depth ~6,000 ft, 20,000-psi semisubmersible FPU. Low-confidence: capex (phase-1 vs full-field ambiguity), water_depth (rounded), lease_year unknown (null), opex unknown (null).",
+    "reservoir": {
+      "formation": "Wilcox / Paleogene",
+      "hpht_class": "ultra-HPHT",
+      "pressure_psi": 20000,
+      "pressure_qual": "≥",
+      "equip_rating_psi": 20000,
+      "temp_f": null,
+      "tvd_ft": null,
+      "fluid": "black oil",
+      "api": null,
+      "source_note": "AAPG: deep Wilcox is a '20,000 psi or higher' reservoir environment (matches the 20K equipment rating); JPT/BOEM: BP 20,000-psi FPU. Exact pore pressure not published — shown as ≥20,000."
+    }
   },
   {
     "id": "north_platte",
@@ -337,7 +409,19 @@
       "https://totalenergies.com/media/news/press-releases/us-gulf-mexico-totalenergies-withdraws-north-platte-deep-water-project",
       "https://www.offshore-mag.com/drilling-completion/article/16785459/total-reports-deepwater-gom-oil-discovery-at-north-platte"
     ],
-    "provenance": "Basis: in-repo YAML (superseded TotalEnergies pre-FID case) reconciled against current public record. North Platte was discovered 2012 (Cobalt/Total, Garden Banks). TotalEnergies (then 60% op, Equinor 40%) withdrew Feb 2022; Shell bought 51% and took operatorship from Equinor (49%), redesigned and renamed the project \"Sparta.\" Shell took FID Dec 2023; first oil projected 2028 (kept null — not yet producing). Water depth ~4,265 ft, subsalt Wilcox, newbuild semisubmersible FPU (8 subsea wells) with ~90,000 boe/d peak (~75 mbopd oil plateau; GOR 1100 scf/bbl from YAML). LOW-CONFIDENCE/NULLED: capex — YAML's $6B reflects the abandoned TotalEnergies ~$5-7B concept, not Shell's simplified Sparta scope (not publicly disclosed), so set null; opex and projected COP year not publicly defensible."
+    "provenance": "Basis: in-repo YAML (superseded TotalEnergies pre-FID case) reconciled against current public record. North Platte was discovered 2012 (Cobalt/Total, Garden Banks). TotalEnergies (then 60% op, Equinor 40%) withdrew Feb 2022; Shell bought 51% and took operatorship from Equinor (49%), redesigned and renamed the project \"Sparta.\" Shell took FID Dec 2023; first oil projected 2028 (kept null — not yet producing). Water depth ~4,265 ft, subsalt Wilcox, newbuild semisubmersible FPU (8 subsea wells) with ~90,000 boe/d peak (~75 mbopd oil plateau; GOR 1100 scf/bbl from YAML). LOW-CONFIDENCE/NULLED: capex — YAML's $6B reflects the abandoned TotalEnergies ~$5-7B concept, not Shell's simplified Sparta scope (not publicly disclosed), so set null; opex and projected COP year not publicly defensible.",
+    "reservoir": {
+      "formation": "Wilcox (subsalt Paleogene)",
+      "hpht_class": "ultra-HPHT",
+      "pressure_psi": null,
+      "pressure_qual": "",
+      "equip_rating_psi": 20000,
+      "temp_f": null,
+      "tvd_ft": null,
+      "fluid": "black oil",
+      "api": null,
+      "source_note": "World Oil/JPT: Sparta (ex-North Platte) is a 20,000-psi-rated development. All public '20,000 psi' figures are the equipment rating; true reservoir pore pressure not publicly disclosed — shown as —."
+    }
   },
   {
     "id": "shenandoah",
@@ -389,7 +473,19 @@
       "https://worldoil.com/news/2025/10/10/shenandoah-field-reaches-100-000-bpd-milestone-in-deepwater-u-s-gulf/",
       "https://www.offshore-mag.com/production/news/55305650/beacon-starts-oil-and-gas-production-at-offshore-shenandoah-field-in-the-gom"
     ],
-    "provenance": "Base facts (operator, capex, plateau, GOR, data_through) from in-repo YAML; discovery 2009 (Anadarko Shenandoah-1, WR52), FID/sanction Aug 2021 (Beacon+Navitas), and actual first oil (first of 4 wells online 25 Jul 2025; ramped to 100 kbopd plateau Oct 2025) from public sources — first_oil corrected to 2025-07 vs YAML's placeholder 2025-10. Current WI (Beacon 31% op / Navitas 49% / HEQ 20%) post-2021 restructuring. capex_bn_usd 1.8 is YAML-stated and largely reflects pre-development E&A spend (LOW CONFIDENCE for full development cost); opex_boe and projected_cop_year null (not defensibly sourced); water depth ~5,800 ft."
+    "provenance": "Base facts (operator, capex, plateau, GOR, data_through) from in-repo YAML; discovery 2009 (Anadarko Shenandoah-1, WR52), FID/sanction Aug 2021 (Beacon+Navitas), and actual first oil (first of 4 wells online 25 Jul 2025; ramped to 100 kbopd plateau Oct 2025) from public sources — first_oil corrected to 2025-07 vs YAML's placeholder 2025-10. Current WI (Beacon 31% op / Navitas 49% / HEQ 20%) post-2021 restructuring. capex_bn_usd 1.8 is YAML-stated and largely reflects pre-development E&A spend (LOW CONFIDENCE for full development cost); opex_boe and projected_cop_year null (not defensibly sourced); water depth ~5,800 ft.",
+    "reservoir": {
+      "formation": "Inboard Wilcox (Lower Wilcox)",
+      "hpht_class": "ultra-HPHT",
+      "pressure_psi": 22000,
+      "pressure_qual": "≥",
+      "equip_rating_psi": 20000,
+      "temp_f": 200,
+      "tvd_ft": 30000,
+      "fluid": "black oil",
+      "api": null,
+      "source_note": "Clariant/World Oil: reservoir/formation pressures above 22,000 psi at ~200F (ultra-high-PRESSURE, moderate temp), ~30,000 ft TVD; 20,000-psi equipment rating separate."
+    }
   },
   {
     "id": "stones",
@@ -428,7 +524,19 @@
       "https://www.offshore-mag.com/subsea/article/16754767/shell-takes-ultra-deepwater-to-record-depths-with-stones",
       "https://www.nsenergybusiness.com/projects/stones-oil-and-gas-project/"
     ],
-    "provenance": "Capex ($3.8bn), plateau (50 mbopd), GOR (850 scf/bbl), opex ($15/boe), first_oil (2016-09) and status from in-repo stones.yml (Shell FPSO development config). Discovery (2005), FID/sanction (May 2013, Shell 100% owner-operator), Walker Ridge Block 508, ~9,500 ft water depth, and Turritella/Stones FPSO host (world's deepest FPSO) confirmed via Offshore Technology, Offshore Magazine, and NS Energy public sources. lease_year and projected_cop_year unknown -> null; no notable schedule-driving incident identified."
+    "provenance": "Capex ($3.8bn), plateau (50 mbopd), GOR (850 scf/bbl), opex ($15/boe), first_oil (2016-09) and status from in-repo stones.yml (Shell FPSO development config). Discovery (2005), FID/sanction (May 2013, Shell 100% owner-operator), Walker Ridge Block 508, ~9,500 ft water depth, and Turritella/Stones FPSO host (world's deepest FPSO) confirmed via Offshore Technology, Offshore Magazine, and NS Energy public sources. lease_year and projected_cop_year unknown -> null; no notable schedule-driving incident identified.",
+    "reservoir": {
+      "formation": "Paleogene Wilcox (turbidite)",
+      "hpht_class": "HPHT",
+      "pressure_psi": null,
+      "pressure_qual": "",
+      "equip_rating_psi": null,
+      "temp_f": null,
+      "tvd_ft": 26500,
+      "fluid": "black oil",
+      "api": null,
+      "source_note": "Offshore Mag/S&D: Paleogene Wilcox, reservoir ~26,500 ft TVD (17,000 ft below mudline). Reservoir pressure/temperature not cleanly sourced — shown as —."
+    }
   },
   {
     "id": "tiber",
@@ -470,6 +578,18 @@
       "https://en.wikipedia.org/wiki/Tiber_Oil_Field",
       "https://www.bp.com/en/global/corporate/news-and-insights/press-releases/bp-announces-significant-discovery-in-the-deepwater-gulf-of-mexi.html"
     ],
-    "provenance": "Basis: in-repo tiber.yml (operator BP, plateau 80 mbopd, GOR 900 scf/bbl, data_through 2024-12-31) plus public sources. BP discovered Tiber Sept 2009 in Keathley Canyon 102, 4,132 ft water. BP reached FID on the combined Tiber-Guadalupe hub 29 Sep 2025 (fid_year=2025); Seatrium awarded FPU EPCC. Ownership is now 100% BP (original discovery split BP 62% / Petrobras 20% / ConocoPhillips 18% no longer reflects current WI). Status=execution/execute (post-FID, construction underway). capex set to the sanctioned public figure of $5.0bn for the Tiber-Guadalupe project (YAML's $8bn was a pre-FID Tiber-only planning assumption); note $5bn covers both fields. first_oil kept null — oil has not flowed; projected first production is 2030. opex_boe null (not publicly disclosed; the \"$3/bbl below Kaskida\" figure is development cost, not opex). projected_cop_year and lease_year null (not confidently sourced)."
+    "provenance": "Basis: in-repo tiber.yml (operator BP, plateau 80 mbopd, GOR 900 scf/bbl, data_through 2024-12-31) plus public sources. BP discovered Tiber Sept 2009 in Keathley Canyon 102, 4,132 ft water. BP reached FID on the combined Tiber-Guadalupe hub 29 Sep 2025 (fid_year=2025); Seatrium awarded FPU EPCC. Ownership is now 100% BP (original discovery split BP 62% / Petrobras 20% / ConocoPhillips 18% no longer reflects current WI). Status=execution/execute (post-FID, construction underway). capex set to the sanctioned public figure of $5.0bn for the Tiber-Guadalupe project (YAML's $8bn was a pre-FID Tiber-only planning assumption); note $5bn covers both fields. first_oil kept null — oil has not flowed; projected first production is 2030. opex_boe null (not publicly disclosed; the \"$3/bbl below Kaskida\" figure is development cost, not opex). projected_cop_year and lease_year null (not confidently sourced).",
+    "reservoir": {
+      "formation": "Paleogene Wilcox",
+      "hpht_class": "ultra-HPHT",
+      "pressure_psi": 20000,
+      "pressure_qual": "up to",
+      "equip_rating_psi": 20000,
+      "temp_f": null,
+      "tvd_ft": 28000,
+      "fluid": "black oil (light)",
+      "api": null,
+      "source_note": "BP FID 2025 (Tiber-Guadalupe): reservoirs 'under pressures of up to 20,000 psi', Paleogene Wilcox; ~28,000 ft TVD. Temperature not field-specific."
+    }
   }
 ]

--- a/reports/lower_tertiary/lifecycle/anchor_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/anchor_lifecycle.html
@@ -189,6 +189,21 @@
     color: var(--accent-ink); letter-spacing:.02em; }
   :root[data-theme="dark"] .wi-row .op.lead::after { color: var(--accent); }
 
+  /* ---- Reservoir & HPHT card ---- */
+  .rcol { display:flex; flex-direction:column; gap:22px; }
+  .mut { color: var(--muted); font-weight: 400; }
+  .hpht { display:inline-flex; align-items:center; font-family:var(--mono); font-size:11px;
+    font-weight:700; letter-spacing:.04em; text-transform:uppercase; padding:2px 9px;
+    border-radius:999px; }
+  .hpht.ultra { color: var(--alert);
+    background: color-mix(in srgb, var(--alert) 14%, transparent);
+    border:1px solid color-mix(in srgb, var(--alert) 42%, transparent); }
+  .hpht.hot { color: var(--accent-ink);
+    background: color-mix(in srgb, var(--accent) 16%, transparent);
+    border:1px solid color-mix(in srgb, var(--accent) 44%, transparent); }
+  :root[data-theme="dark"] .hpht.hot { color: var(--accent); }
+  @media (prefers-color-scheme: dark){ .hpht.hot { color: var(--accent); } }
+
   /* ---- Legend + footer ---- */
   .legend { display:flex; flex-wrap:wrap; gap: 8px 18px; font-size:11.5px; color:var(--muted);
     font-family:var(--mono); }
@@ -243,10 +258,16 @@
           <h3>Key phase activities</h3>
           <div class="act" id="f-activities"></div>
         </div>
-        <div class="card">
-          <h3>Host concept &amp; ownership</h3>
-          <dl class="kv" id="f-host"></dl>
-          <div class="wi" id="f-wi"></div>
+        <div class="rcol">
+          <div class="card">
+            <h3>Host concept &amp; ownership</h3>
+            <dl class="kv" id="f-host"></dl>
+            <div class="wi" id="f-wi"></div>
+          </div>
+          <div class="card" id="f-reservoir-card" hidden>
+            <h3>Reservoir &amp; HPHT</h3>
+            <dl class="kv" id="f-reservoir"></dl>
+          </div>
         </div>
       </section>
 
@@ -442,6 +463,18 @@ const FIELD = {
       "Dec 2024"
     ]
   ],
+  "reservoir": {
+    "formation": "Paleocene Wilcox (Wilcox 1–4)",
+    "hpht_class": "ultra-HPHT",
+    "pressure_psi": 25000,
+    "pressure_qual": "",
+    "equip_rating_psi": 20000,
+    "temp_f": 275,
+    "tvd_ft": 30000,
+    "fluid": "black oil",
+    "api": null,
+    "source_note": "OGJ 2024: initial reservoir (BHP) 23,000–27,000 psi — higher than the 20,000-psi equipment rating; 275F max flowing temp; pay 30,000–34,000 ft TVD (Wilcox 1–4)."
+  },
   "provenance": "Primary facts (operator, working interests, capex $5.6B, plateau 75 mbopd, GOR 1100 scf/bbl, opex $15/boe, first oil 2024-08, data_through 2024-12-31) from in-repo anchor.yml. Life-cycle dates corroborated by public sources: discovery well Anchor-2 drilled 2014 (Green Canyon 807, ~5,180 ft), FID December 2019 (~$5.7B sanction), first oil August 2024 — world's first 20,000-psi HPHT deepwater development on a semisubmersible FPU, Lower Tertiary Wilcox play. Working interests (Chevron 62.5% / Equinor 25% / TotalEnergies 12.5%) per YAML; note older Offshore Technology page still lists pre-Equinor split (Chevron 62.86% / Total 37.14%). water_depth_ft ~5,180 (block-level estimate). projected_cop_year and lease_year left null (not confidently sourced); incident null."
 };
 
@@ -518,6 +551,48 @@ $("f-activities").innerHTML = showIdx.map(i => {
   const tag = i === curIdx ? " · now" : (i < curIdx ? " · done" : " · next");
   return `<div class="act${cur}"><h4>${p.name}${tag}</h4><ul>${p.activities.map(a=>`<li>${a}</li>`).join("")}</ul></div>`;
 }).join("");
+
+/* reservoir & HPHT — honesty-gated; nulls render as an em dash */
+if (FIELD.reservoir) {
+  const r = FIELD.reservoir;
+  const DASH = "—";
+  const nfmt = (v) => v.toLocaleString("en-US");
+  const rows = [];
+  rows.push(["Formation", r.formation || DASH]);
+
+  let pill;
+  if (r.hpht_class === "ultra-HPHT") pill = `<span class="hpht ultra">ultra-HPHT</span>`;
+  else if (r.hpht_class === "HPHT") pill = `<span class="hpht hot">HPHT</span>`;
+  else pill = `<span class="mut">${DASH}</span>`;
+  rows.push(["HPHT class", pill]);
+
+  let pressure;
+  if (r.pressure_psi == null) {
+    pressure = `<span class="mut">${DASH}</span>`;
+  } else {
+    const q = r.pressure_qual || "";
+    const sep = /[a-z]$/i.test(q) ? " " : "";
+    pressure = `${q}${sep}${nfmt(r.pressure_psi)} psi`;
+  }
+  if (r.equip_rating_psi != null &&
+      (r.pressure_psi == null || r.pressure_psi !== r.equip_rating_psi)) {
+    pressure += ` <span class="mut">· vs ${nfmt(r.equip_rating_psi)}-psi equipment</span>`;
+  }
+  rows.push(["Reservoir pressure", pressure]);
+
+  rows.push(["Reservoir temp",
+    r.temp_f == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.temp_f)}°F`]);
+  rows.push(["Reservoir depth",
+    r.tvd_ft == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.tvd_ft)} ft TVD`]);
+
+  let fluid = r.fluid || DASH;
+  if (r.api != null) fluid += ` <span class="mut">· ${r.api}°API</span>`;
+  rows.push(["Fluid", fluid]);
+
+  $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-reservoir-card").hidden = false;
+  if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
 
 /* host facts + working interest */
 $("f-host").innerHTML = FIELD.hostFacts.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");

--- a/reports/lower_tertiary/lifecycle/big_foot_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/big_foot_lifecycle.html
@@ -189,6 +189,21 @@
     color: var(--accent-ink); letter-spacing:.02em; }
   :root[data-theme="dark"] .wi-row .op.lead::after { color: var(--accent); }
 
+  /* ---- Reservoir & HPHT card ---- */
+  .rcol { display:flex; flex-direction:column; gap:22px; }
+  .mut { color: var(--muted); font-weight: 400; }
+  .hpht { display:inline-flex; align-items:center; font-family:var(--mono); font-size:11px;
+    font-weight:700; letter-spacing:.04em; text-transform:uppercase; padding:2px 9px;
+    border-radius:999px; }
+  .hpht.ultra { color: var(--alert);
+    background: color-mix(in srgb, var(--alert) 14%, transparent);
+    border:1px solid color-mix(in srgb, var(--alert) 42%, transparent); }
+  .hpht.hot { color: var(--accent-ink);
+    background: color-mix(in srgb, var(--accent) 16%, transparent);
+    border:1px solid color-mix(in srgb, var(--accent) 44%, transparent); }
+  :root[data-theme="dark"] .hpht.hot { color: var(--accent); }
+  @media (prefers-color-scheme: dark){ .hpht.hot { color: var(--accent); } }
+
   /* ---- Legend + footer ---- */
   .legend { display:flex; flex-wrap:wrap; gap: 8px 18px; font-size:11.5px; color:var(--muted);
     font-family:var(--mono); }
@@ -243,10 +258,16 @@
           <h3>Key phase activities</h3>
           <div class="act" id="f-activities"></div>
         </div>
-        <div class="card">
-          <h3>Host concept &amp; ownership</h3>
-          <dl class="kv" id="f-host"></dl>
-          <div class="wi" id="f-wi"></div>
+        <div class="rcol">
+          <div class="card">
+            <h3>Host concept &amp; ownership</h3>
+            <dl class="kv" id="f-host"></dl>
+            <div class="wi" id="f-wi"></div>
+          </div>
+          <div class="card" id="f-reservoir-card" hidden>
+            <h3>Reservoir &amp; HPHT</h3>
+            <dl class="kv" id="f-reservoir"></dl>
+          </div>
         </div>
       </section>
 
@@ -455,6 +476,18 @@ const FIELD = {
       "Dec 2024"
     ]
   ],
+  "reservoir": {
+    "formation": "Wilcox / Paleogene (Lower Tertiary)",
+    "hpht_class": null,
+    "pressure_psi": null,
+    "pressure_qual": "",
+    "equip_rating_psi": null,
+    "temp_f": null,
+    "tvd_ft": null,
+    "fluid": "black oil",
+    "api": null,
+    "source_note": "Wilcox oil field (Offshore Technology; Chevron). Field-specific reservoir pressure/temperature not publicly disclosed — shown as — rather than borrowed from neighbouring fields."
+  },
   "provenance": "Data: big_foot.yml + Chevron public disclosures + BSEE (dates to be reconciled in #375)"
 };
 
@@ -531,6 +564,48 @@ $("f-activities").innerHTML = showIdx.map(i => {
   const tag = i === curIdx ? " · now" : (i < curIdx ? " · done" : " · next");
   return `<div class="act${cur}"><h4>${p.name}${tag}</h4><ul>${p.activities.map(a=>`<li>${a}</li>`).join("")}</ul></div>`;
 }).join("");
+
+/* reservoir & HPHT — honesty-gated; nulls render as an em dash */
+if (FIELD.reservoir) {
+  const r = FIELD.reservoir;
+  const DASH = "—";
+  const nfmt = (v) => v.toLocaleString("en-US");
+  const rows = [];
+  rows.push(["Formation", r.formation || DASH]);
+
+  let pill;
+  if (r.hpht_class === "ultra-HPHT") pill = `<span class="hpht ultra">ultra-HPHT</span>`;
+  else if (r.hpht_class === "HPHT") pill = `<span class="hpht hot">HPHT</span>`;
+  else pill = `<span class="mut">${DASH}</span>`;
+  rows.push(["HPHT class", pill]);
+
+  let pressure;
+  if (r.pressure_psi == null) {
+    pressure = `<span class="mut">${DASH}</span>`;
+  } else {
+    const q = r.pressure_qual || "";
+    const sep = /[a-z]$/i.test(q) ? " " : "";
+    pressure = `${q}${sep}${nfmt(r.pressure_psi)} psi`;
+  }
+  if (r.equip_rating_psi != null &&
+      (r.pressure_psi == null || r.pressure_psi !== r.equip_rating_psi)) {
+    pressure += ` <span class="mut">· vs ${nfmt(r.equip_rating_psi)}-psi equipment</span>`;
+  }
+  rows.push(["Reservoir pressure", pressure]);
+
+  rows.push(["Reservoir temp",
+    r.temp_f == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.temp_f)}°F`]);
+  rows.push(["Reservoir depth",
+    r.tvd_ft == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.tvd_ft)} ft TVD`]);
+
+  let fluid = r.fluid || DASH;
+  if (r.api != null) fluid += ` <span class="mut">· ${r.api}°API</span>`;
+  rows.push(["Fluid", fluid]);
+
+  $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-reservoir-card").hidden = false;
+  if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
 
 /* host facts + working interest */
 $("f-host").innerHTML = FIELD.hostFacts.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");

--- a/reports/lower_tertiary/lifecycle/cascade_chinook_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/cascade_chinook_lifecycle.html
@@ -189,6 +189,21 @@
     color: var(--accent-ink); letter-spacing:.02em; }
   :root[data-theme="dark"] .wi-row .op.lead::after { color: var(--accent); }
 
+  /* ---- Reservoir & HPHT card ---- */
+  .rcol { display:flex; flex-direction:column; gap:22px; }
+  .mut { color: var(--muted); font-weight: 400; }
+  .hpht { display:inline-flex; align-items:center; font-family:var(--mono); font-size:11px;
+    font-weight:700; letter-spacing:.04em; text-transform:uppercase; padding:2px 9px;
+    border-radius:999px; }
+  .hpht.ultra { color: var(--alert);
+    background: color-mix(in srgb, var(--alert) 14%, transparent);
+    border:1px solid color-mix(in srgb, var(--alert) 42%, transparent); }
+  .hpht.hot { color: var(--accent-ink);
+    background: color-mix(in srgb, var(--accent) 16%, transparent);
+    border:1px solid color-mix(in srgb, var(--accent) 44%, transparent); }
+  :root[data-theme="dark"] .hpht.hot { color: var(--accent); }
+  @media (prefers-color-scheme: dark){ .hpht.hot { color: var(--accent); } }
+
   /* ---- Legend + footer ---- */
   .legend { display:flex; flex-wrap:wrap; gap: 8px 18px; font-size:11.5px; color:var(--muted);
     font-family:var(--mono); }
@@ -243,10 +258,16 @@
           <h3>Key phase activities</h3>
           <div class="act" id="f-activities"></div>
         </div>
-        <div class="card">
-          <h3>Host concept &amp; ownership</h3>
-          <dl class="kv" id="f-host"></dl>
-          <div class="wi" id="f-wi"></div>
+        <div class="rcol">
+          <div class="card">
+            <h3>Host concept &amp; ownership</h3>
+            <dl class="kv" id="f-host"></dl>
+            <div class="wi" id="f-wi"></div>
+          </div>
+          <div class="card" id="f-reservoir-card" hidden>
+            <h3>Reservoir &amp; HPHT</h3>
+            <dl class="kv" id="f-reservoir"></dl>
+          </div>
         </div>
       </section>
 
@@ -420,6 +441,18 @@ const FIELD = {
       "Dec 2024"
     ]
   ],
+  "reservoir": {
+    "formation": "Wilcox 1 (Eocene) / Wilcox 2 (Paleocene)",
+    "hpht_class": "HPHT",
+    "pressure_psi": 19500,
+    "pressure_qual": "~",
+    "equip_rating_psi": null,
+    "temp_f": 260,
+    "tvd_ft": 25600,
+    "fluid": "black oil (low GOR; CO₂ <1.5%, no H₂S)",
+    "api": null,
+    "source_note": "OTC-24162/24163 + JPT: initial reservoir pressure ~19,500 psi, BHT ~256–260F, reservoir mid-point ~25,600 ft TVD."
+  },
   "provenance": "Life-cycle dates and ownership from public sources (Offshore Technology, Offshore Magazine, OGJ, Heerema, Rigzone); economics (capex $2.9B, plateau 75 mbopd, GOR 1400 scf/bbl, opex $18/boe) and data_through from in-repo YAML. IMPORTANT: two YAML values were overridden as demonstrably wrong vs. well-documented public record — YAML first_oil \"2021-08\" corrected to 2012-02 (Cascade first oil Feb 2012, Chinook Sep 2012; BW Pioneer was the first FPSO in the US GoM), and YAML operator/WI \"TotalEnergies 60% / Equinor 40%\" corrected to current MP Gulf of Mexico LLC (Murphy EXPRO 80% operator, Petrobras America 20%; originally Petrobras-operated with Total 33.33% in Chinook). LOW CONFIDENCE: fid_year (sanction ~mid-2000s, no firm public citation → null), lease_year and projected_cop_year (null); water_depth 8,200 ft is the Cascade value (Chinook ~8,600 ft); capex is a YAML assumption not independently verified."
 };
 
@@ -496,6 +529,48 @@ $("f-activities").innerHTML = showIdx.map(i => {
   const tag = i === curIdx ? " · now" : (i < curIdx ? " · done" : " · next");
   return `<div class="act${cur}"><h4>${p.name}${tag}</h4><ul>${p.activities.map(a=>`<li>${a}</li>`).join("")}</ul></div>`;
 }).join("");
+
+/* reservoir & HPHT — honesty-gated; nulls render as an em dash */
+if (FIELD.reservoir) {
+  const r = FIELD.reservoir;
+  const DASH = "—";
+  const nfmt = (v) => v.toLocaleString("en-US");
+  const rows = [];
+  rows.push(["Formation", r.formation || DASH]);
+
+  let pill;
+  if (r.hpht_class === "ultra-HPHT") pill = `<span class="hpht ultra">ultra-HPHT</span>`;
+  else if (r.hpht_class === "HPHT") pill = `<span class="hpht hot">HPHT</span>`;
+  else pill = `<span class="mut">${DASH}</span>`;
+  rows.push(["HPHT class", pill]);
+
+  let pressure;
+  if (r.pressure_psi == null) {
+    pressure = `<span class="mut">${DASH}</span>`;
+  } else {
+    const q = r.pressure_qual || "";
+    const sep = /[a-z]$/i.test(q) ? " " : "";
+    pressure = `${q}${sep}${nfmt(r.pressure_psi)} psi`;
+  }
+  if (r.equip_rating_psi != null &&
+      (r.pressure_psi == null || r.pressure_psi !== r.equip_rating_psi)) {
+    pressure += ` <span class="mut">· vs ${nfmt(r.equip_rating_psi)}-psi equipment</span>`;
+  }
+  rows.push(["Reservoir pressure", pressure]);
+
+  rows.push(["Reservoir temp",
+    r.temp_f == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.temp_f)}°F`]);
+  rows.push(["Reservoir depth",
+    r.tvd_ft == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.tvd_ft)} ft TVD`]);
+
+  let fluid = r.fluid || DASH;
+  if (r.api != null) fluid += ` <span class="mut">· ${r.api}°API</span>`;
+  rows.push(["Fluid", fluid]);
+
+  $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-reservoir-card").hidden = false;
+  if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
 
 /* host facts + working interest */
 $("f-host").innerHTML = FIELD.hostFacts.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");

--- a/reports/lower_tertiary/lifecycle/jack_st_malo_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/jack_st_malo_lifecycle.html
@@ -189,6 +189,21 @@
     color: var(--accent-ink); letter-spacing:.02em; }
   :root[data-theme="dark"] .wi-row .op.lead::after { color: var(--accent); }
 
+  /* ---- Reservoir & HPHT card ---- */
+  .rcol { display:flex; flex-direction:column; gap:22px; }
+  .mut { color: var(--muted); font-weight: 400; }
+  .hpht { display:inline-flex; align-items:center; font-family:var(--mono); font-size:11px;
+    font-weight:700; letter-spacing:.04em; text-transform:uppercase; padding:2px 9px;
+    border-radius:999px; }
+  .hpht.ultra { color: var(--alert);
+    background: color-mix(in srgb, var(--alert) 14%, transparent);
+    border:1px solid color-mix(in srgb, var(--alert) 42%, transparent); }
+  .hpht.hot { color: var(--accent-ink);
+    background: color-mix(in srgb, var(--accent) 16%, transparent);
+    border:1px solid color-mix(in srgb, var(--accent) 44%, transparent); }
+  :root[data-theme="dark"] .hpht.hot { color: var(--accent); }
+  @media (prefers-color-scheme: dark){ .hpht.hot { color: var(--accent); } }
+
   /* ---- Legend + footer ---- */
   .legend { display:flex; flex-wrap:wrap; gap: 8px 18px; font-size:11.5px; color:var(--muted);
     font-family:var(--mono); }
@@ -243,10 +258,16 @@
           <h3>Key phase activities</h3>
           <div class="act" id="f-activities"></div>
         </div>
-        <div class="card">
-          <h3>Host concept &amp; ownership</h3>
-          <dl class="kv" id="f-host"></dl>
-          <div class="wi" id="f-wi"></div>
+        <div class="rcol">
+          <div class="card">
+            <h3>Host concept &amp; ownership</h3>
+            <dl class="kv" id="f-host"></dl>
+            <div class="wi" id="f-wi"></div>
+          </div>
+          <div class="card" id="f-reservoir-card" hidden>
+            <h3>Reservoir &amp; HPHT</h3>
+            <dl class="kv" id="f-reservoir"></dl>
+          </div>
         </div>
       </section>
 
@@ -442,6 +463,18 @@ const FIELD = {
       "Dec 2024"
     ]
   ],
+  "reservoir": {
+    "formation": "Wilcox (Lower Tertiary)",
+    "hpht_class": "HPHT",
+    "pressure_psi": 19374,
+    "pressure_qual": "",
+    "equip_rating_psi": null,
+    "temp_f": 224,
+    "tvd_ft": 26500,
+    "fluid": "black oil",
+    "api": null,
+    "source_note": "Dice regional Wilcox reservoir study: Jack initial pressure 19,374 psi @ 224F, St. Malo 19,023 psi @ 225F; reservoir ~26,500 ft TVD."
+  },
   "provenance": "Facts from in-repo YAML (operator, WI Chevron 51%/Equinor 24.5%/Suncor 24.5%, capex $7.5B, opex $15/boe, plateau 94 mbopd, GOR 1200, status producing, data_through 2024-12-31). Life-cycle dates from public sources: St. Malo discovered Oct 2003 and Jack Jul 2004 (discovery_year=2003, earliest of pair); FID/sanction Oct 2010; first oil per Chevron press release Dec 2014 (\"2014-12\") — this OVERRIDES the YAML's first_oil \"2014-02-01\", which appears erroneous. Water depth ~7000 ft at the FPU (Jack WR758/759 ~7000 ft, St. Malo WR678). host_type = Semisubmersible FPU. projected_cop_year left null (not confidently estimable). lease_year null; no schedule-driving incident."
 };
 
@@ -518,6 +551,48 @@ $("f-activities").innerHTML = showIdx.map(i => {
   const tag = i === curIdx ? " · now" : (i < curIdx ? " · done" : " · next");
   return `<div class="act${cur}"><h4>${p.name}${tag}</h4><ul>${p.activities.map(a=>`<li>${a}</li>`).join("")}</ul></div>`;
 }).join("");
+
+/* reservoir & HPHT — honesty-gated; nulls render as an em dash */
+if (FIELD.reservoir) {
+  const r = FIELD.reservoir;
+  const DASH = "—";
+  const nfmt = (v) => v.toLocaleString("en-US");
+  const rows = [];
+  rows.push(["Formation", r.formation || DASH]);
+
+  let pill;
+  if (r.hpht_class === "ultra-HPHT") pill = `<span class="hpht ultra">ultra-HPHT</span>`;
+  else if (r.hpht_class === "HPHT") pill = `<span class="hpht hot">HPHT</span>`;
+  else pill = `<span class="mut">${DASH}</span>`;
+  rows.push(["HPHT class", pill]);
+
+  let pressure;
+  if (r.pressure_psi == null) {
+    pressure = `<span class="mut">${DASH}</span>`;
+  } else {
+    const q = r.pressure_qual || "";
+    const sep = /[a-z]$/i.test(q) ? " " : "";
+    pressure = `${q}${sep}${nfmt(r.pressure_psi)} psi`;
+  }
+  if (r.equip_rating_psi != null &&
+      (r.pressure_psi == null || r.pressure_psi !== r.equip_rating_psi)) {
+    pressure += ` <span class="mut">· vs ${nfmt(r.equip_rating_psi)}-psi equipment</span>`;
+  }
+  rows.push(["Reservoir pressure", pressure]);
+
+  rows.push(["Reservoir temp",
+    r.temp_f == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.temp_f)}°F`]);
+  rows.push(["Reservoir depth",
+    r.tvd_ft == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.tvd_ft)} ft TVD`]);
+
+  let fluid = r.fluid || DASH;
+  if (r.api != null) fluid += ` <span class="mut">· ${r.api}°API</span>`;
+  rows.push(["Fluid", fluid]);
+
+  $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-reservoir-card").hidden = false;
+  if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
 
 /* host facts + working interest */
 $("f-host").innerHTML = FIELD.hostFacts.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");

--- a/reports/lower_tertiary/lifecycle/julia_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/julia_lifecycle.html
@@ -189,6 +189,21 @@
     color: var(--accent-ink); letter-spacing:.02em; }
   :root[data-theme="dark"] .wi-row .op.lead::after { color: var(--accent); }
 
+  /* ---- Reservoir & HPHT card ---- */
+  .rcol { display:flex; flex-direction:column; gap:22px; }
+  .mut { color: var(--muted); font-weight: 400; }
+  .hpht { display:inline-flex; align-items:center; font-family:var(--mono); font-size:11px;
+    font-weight:700; letter-spacing:.04em; text-transform:uppercase; padding:2px 9px;
+    border-radius:999px; }
+  .hpht.ultra { color: var(--alert);
+    background: color-mix(in srgb, var(--alert) 14%, transparent);
+    border:1px solid color-mix(in srgb, var(--alert) 42%, transparent); }
+  .hpht.hot { color: var(--accent-ink);
+    background: color-mix(in srgb, var(--accent) 16%, transparent);
+    border:1px solid color-mix(in srgb, var(--accent) 44%, transparent); }
+  :root[data-theme="dark"] .hpht.hot { color: var(--accent); }
+  @media (prefers-color-scheme: dark){ .hpht.hot { color: var(--accent); } }
+
   /* ---- Legend + footer ---- */
   .legend { display:flex; flex-wrap:wrap; gap: 8px 18px; font-size:11.5px; color:var(--muted);
     font-family:var(--mono); }
@@ -243,10 +258,16 @@
           <h3>Key phase activities</h3>
           <div class="act" id="f-activities"></div>
         </div>
-        <div class="card">
-          <h3>Host concept &amp; ownership</h3>
-          <dl class="kv" id="f-host"></dl>
-          <div class="wi" id="f-wi"></div>
+        <div class="rcol">
+          <div class="card">
+            <h3>Host concept &amp; ownership</h3>
+            <dl class="kv" id="f-host"></dl>
+            <div class="wi" id="f-wi"></div>
+          </div>
+          <div class="card" id="f-reservoir-card" hidden>
+            <h3>Reservoir &amp; HPHT</h3>
+            <dl class="kv" id="f-reservoir"></dl>
+          </div>
         </div>
       </section>
 
@@ -445,6 +466,18 @@ const FIELD = {
       "Dec 2024"
     ]
   ],
+  "reservoir": {
+    "formation": "Wilcox (Lower Tertiary)",
+    "hpht_class": "HPHT",
+    "pressure_psi": 13500,
+    "pressure_qual": "~",
+    "equip_rating_psi": 15000,
+    "temp_f": null,
+    "tvd_ft": 30000,
+    "fluid": "black oil",
+    "api": 24.7,
+    "source_note": "Offshore Mag: subsea pressures ~13,500 psi (15,000-psi-rated trees + first permanent HIPPS); Hart Energy production test: 24.7°API oil."
+  },
   "provenance": "Primary facts (capex $4.7B, plateau 34 mbopd, GOR 1000, opex $18/boe, first_oil, WI 50/50) from in-repo julia.yml; first_oil = BSEE OGOR-A first production (2016-03) per YAML — note ExxonMobil press release states production start April 2016. Operator corrected to ExxonMobil (YAML flagged its \"Equinor\" operator field as disputed; public record = ExxonMobil-operated, Equinor/Statoil 50% partner). Discovery 2007, FID May 2013, water depth 7000+ ft, Walker Ridge blocks, and Jack/St. Malo tieback from Offshore Technology and operator/trade press. lease_year and projected_cop_year left null (not confidently sourced)."
 };
 
@@ -521,6 +554,48 @@ $("f-activities").innerHTML = showIdx.map(i => {
   const tag = i === curIdx ? " · now" : (i < curIdx ? " · done" : " · next");
   return `<div class="act${cur}"><h4>${p.name}${tag}</h4><ul>${p.activities.map(a=>`<li>${a}</li>`).join("")}</ul></div>`;
 }).join("");
+
+/* reservoir & HPHT — honesty-gated; nulls render as an em dash */
+if (FIELD.reservoir) {
+  const r = FIELD.reservoir;
+  const DASH = "—";
+  const nfmt = (v) => v.toLocaleString("en-US");
+  const rows = [];
+  rows.push(["Formation", r.formation || DASH]);
+
+  let pill;
+  if (r.hpht_class === "ultra-HPHT") pill = `<span class="hpht ultra">ultra-HPHT</span>`;
+  else if (r.hpht_class === "HPHT") pill = `<span class="hpht hot">HPHT</span>`;
+  else pill = `<span class="mut">${DASH}</span>`;
+  rows.push(["HPHT class", pill]);
+
+  let pressure;
+  if (r.pressure_psi == null) {
+    pressure = `<span class="mut">${DASH}</span>`;
+  } else {
+    const q = r.pressure_qual || "";
+    const sep = /[a-z]$/i.test(q) ? " " : "";
+    pressure = `${q}${sep}${nfmt(r.pressure_psi)} psi`;
+  }
+  if (r.equip_rating_psi != null &&
+      (r.pressure_psi == null || r.pressure_psi !== r.equip_rating_psi)) {
+    pressure += ` <span class="mut">· vs ${nfmt(r.equip_rating_psi)}-psi equipment</span>`;
+  }
+  rows.push(["Reservoir pressure", pressure]);
+
+  rows.push(["Reservoir temp",
+    r.temp_f == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.temp_f)}°F`]);
+  rows.push(["Reservoir depth",
+    r.tvd_ft == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.tvd_ft)} ft TVD`]);
+
+  let fluid = r.fluid || DASH;
+  if (r.api != null) fluid += ` <span class="mut">· ${r.api}°API</span>`;
+  rows.push(["Fluid", fluid]);
+
+  $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-reservoir-card").hidden = false;
+  if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
 
 /* host facts + working interest */
 $("f-host").innerHTML = FIELD.hostFacts.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");

--- a/reports/lower_tertiary/lifecycle/kaskida_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/kaskida_lifecycle.html
@@ -189,6 +189,21 @@
     color: var(--accent-ink); letter-spacing:.02em; }
   :root[data-theme="dark"] .wi-row .op.lead::after { color: var(--accent); }
 
+  /* ---- Reservoir & HPHT card ---- */
+  .rcol { display:flex; flex-direction:column; gap:22px; }
+  .mut { color: var(--muted); font-weight: 400; }
+  .hpht { display:inline-flex; align-items:center; font-family:var(--mono); font-size:11px;
+    font-weight:700; letter-spacing:.04em; text-transform:uppercase; padding:2px 9px;
+    border-radius:999px; }
+  .hpht.ultra { color: var(--alert);
+    background: color-mix(in srgb, var(--alert) 14%, transparent);
+    border:1px solid color-mix(in srgb, var(--alert) 42%, transparent); }
+  .hpht.hot { color: var(--accent-ink);
+    background: color-mix(in srgb, var(--accent) 16%, transparent);
+    border:1px solid color-mix(in srgb, var(--accent) 44%, transparent); }
+  :root[data-theme="dark"] .hpht.hot { color: var(--accent); }
+  @media (prefers-color-scheme: dark){ .hpht.hot { color: var(--accent); } }
+
   /* ---- Legend + footer ---- */
   .legend { display:flex; flex-wrap:wrap; gap: 8px 18px; font-size:11.5px; color:var(--muted);
     font-family:var(--mono); }
@@ -243,10 +258,16 @@
           <h3>Key phase activities</h3>
           <div class="act" id="f-activities"></div>
         </div>
-        <div class="card">
-          <h3>Host concept &amp; ownership</h3>
-          <dl class="kv" id="f-host"></dl>
-          <div class="wi" id="f-wi"></div>
+        <div class="rcol">
+          <div class="card">
+            <h3>Host concept &amp; ownership</h3>
+            <dl class="kv" id="f-host"></dl>
+            <div class="wi" id="f-wi"></div>
+          </div>
+          <div class="card" id="f-reservoir-card" hidden>
+            <h3>Reservoir &amp; HPHT</h3>
+            <dl class="kv" id="f-reservoir"></dl>
+          </div>
         </div>
       </section>
 
@@ -418,6 +439,18 @@ const FIELD = {
       "Dec 2024"
     ]
   ],
+  "reservoir": {
+    "formation": "Wilcox / Paleogene",
+    "hpht_class": "ultra-HPHT",
+    "pressure_psi": 20000,
+    "pressure_qual": "≥",
+    "equip_rating_psi": 20000,
+    "temp_f": null,
+    "tvd_ft": null,
+    "fluid": "black oil",
+    "api": null,
+    "source_note": "AAPG: deep Wilcox is a '20,000 psi or higher' reservoir environment (matches the 20K equipment rating); JPT/BOEM: BP 20,000-psi FPU. Exact pore pressure not published — shown as ≥20,000."
+  },
   "provenance": "Discovery 2006 (Keathley Canyon 292, Lower Tertiary Wilcox), FID/sanction July 30 2024 (BP 100%, Devon's original 30% exited), first oil targeted 2029 but kept null as no oil has flowed and the Aug-2025 BOEM DPP rejection likely pushes it out. Public sanctioned figures used over YAML where they diverge: plateau/nameplate 80 mbopd (YAML said 120) and capex ~$5bn for Phase 1 (<$5B per BP; YAML total_mm_usd 10000 = $10bn is a full-field/multi-phase estimate). GOR 1000 scf/bbl and data_through 2024-12-31 from YAML. Water depth ~6,000 ft, 20,000-psi semisubmersible FPU. Low-confidence: capex (phase-1 vs full-field ambiguity), water_depth (rounded), lease_year unknown (null), opex unknown (null)."
 };
 
@@ -494,6 +527,48 @@ $("f-activities").innerHTML = showIdx.map(i => {
   const tag = i === curIdx ? " · now" : (i < curIdx ? " · done" : " · next");
   return `<div class="act${cur}"><h4>${p.name}${tag}</h4><ul>${p.activities.map(a=>`<li>${a}</li>`).join("")}</ul></div>`;
 }).join("");
+
+/* reservoir & HPHT — honesty-gated; nulls render as an em dash */
+if (FIELD.reservoir) {
+  const r = FIELD.reservoir;
+  const DASH = "—";
+  const nfmt = (v) => v.toLocaleString("en-US");
+  const rows = [];
+  rows.push(["Formation", r.formation || DASH]);
+
+  let pill;
+  if (r.hpht_class === "ultra-HPHT") pill = `<span class="hpht ultra">ultra-HPHT</span>`;
+  else if (r.hpht_class === "HPHT") pill = `<span class="hpht hot">HPHT</span>`;
+  else pill = `<span class="mut">${DASH}</span>`;
+  rows.push(["HPHT class", pill]);
+
+  let pressure;
+  if (r.pressure_psi == null) {
+    pressure = `<span class="mut">${DASH}</span>`;
+  } else {
+    const q = r.pressure_qual || "";
+    const sep = /[a-z]$/i.test(q) ? " " : "";
+    pressure = `${q}${sep}${nfmt(r.pressure_psi)} psi`;
+  }
+  if (r.equip_rating_psi != null &&
+      (r.pressure_psi == null || r.pressure_psi !== r.equip_rating_psi)) {
+    pressure += ` <span class="mut">· vs ${nfmt(r.equip_rating_psi)}-psi equipment</span>`;
+  }
+  rows.push(["Reservoir pressure", pressure]);
+
+  rows.push(["Reservoir temp",
+    r.temp_f == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.temp_f)}°F`]);
+  rows.push(["Reservoir depth",
+    r.tvd_ft == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.tvd_ft)} ft TVD`]);
+
+  let fluid = r.fluid || DASH;
+  if (r.api != null) fluid += ` <span class="mut">· ${r.api}°API</span>`;
+  rows.push(["Fluid", fluid]);
+
+  $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-reservoir-card").hidden = false;
+  if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
 
 /* host facts + working interest */
 $("f-host").innerHTML = FIELD.hostFacts.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");

--- a/reports/lower_tertiary/lifecycle/lifecycle_template.html
+++ b/reports/lower_tertiary/lifecycle/lifecycle_template.html
@@ -189,6 +189,21 @@
     color: var(--accent-ink); letter-spacing:.02em; }
   :root[data-theme="dark"] .wi-row .op.lead::after { color: var(--accent); }
 
+  /* ---- Reservoir & HPHT card ---- */
+  .rcol { display:flex; flex-direction:column; gap:22px; }
+  .mut { color: var(--muted); font-weight: 400; }
+  .hpht { display:inline-flex; align-items:center; font-family:var(--mono); font-size:11px;
+    font-weight:700; letter-spacing:.04em; text-transform:uppercase; padding:2px 9px;
+    border-radius:999px; }
+  .hpht.ultra { color: var(--alert);
+    background: color-mix(in srgb, var(--alert) 14%, transparent);
+    border:1px solid color-mix(in srgb, var(--alert) 42%, transparent); }
+  .hpht.hot { color: var(--accent-ink);
+    background: color-mix(in srgb, var(--accent) 16%, transparent);
+    border:1px solid color-mix(in srgb, var(--accent) 44%, transparent); }
+  :root[data-theme="dark"] .hpht.hot { color: var(--accent); }
+  @media (prefers-color-scheme: dark){ .hpht.hot { color: var(--accent); } }
+
   /* ---- Legend + footer ---- */
   .legend { display:flex; flex-wrap:wrap; gap: 8px 18px; font-size:11.5px; color:var(--muted);
     font-family:var(--mono); }
@@ -243,10 +258,16 @@
           <h3>Key phase activities</h3>
           <div class="act" id="f-activities"></div>
         </div>
-        <div class="card">
-          <h3>Host concept &amp; ownership</h3>
-          <dl class="kv" id="f-host"></dl>
-          <div class="wi" id="f-wi"></div>
+        <div class="rcol">
+          <div class="card">
+            <h3>Host concept &amp; ownership</h3>
+            <dl class="kv" id="f-host"></dl>
+            <div class="wi" id="f-wi"></div>
+          </div>
+          <div class="card" id="f-reservoir-card" hidden>
+            <h3>Reservoir &amp; HPHT</h3>
+            <dl class="kv" id="f-reservoir"></dl>
+          </div>
         </div>
       </section>
 
@@ -378,6 +399,48 @@ $("f-activities").innerHTML = showIdx.map(i => {
   const tag = i === curIdx ? " · now" : (i < curIdx ? " · done" : " · next");
   return `<div class="act${cur}"><h4>${p.name}${tag}</h4><ul>${p.activities.map(a=>`<li>${a}</li>`).join("")}</ul></div>`;
 }).join("");
+
+/* reservoir & HPHT — honesty-gated; nulls render as an em dash */
+if (FIELD.reservoir) {
+  const r = FIELD.reservoir;
+  const DASH = "—";
+  const nfmt = (v) => v.toLocaleString("en-US");
+  const rows = [];
+  rows.push(["Formation", r.formation || DASH]);
+
+  let pill;
+  if (r.hpht_class === "ultra-HPHT") pill = `<span class="hpht ultra">ultra-HPHT</span>`;
+  else if (r.hpht_class === "HPHT") pill = `<span class="hpht hot">HPHT</span>`;
+  else pill = `<span class="mut">${DASH}</span>`;
+  rows.push(["HPHT class", pill]);
+
+  let pressure;
+  if (r.pressure_psi == null) {
+    pressure = `<span class="mut">${DASH}</span>`;
+  } else {
+    const q = r.pressure_qual || "";
+    const sep = /[a-z]$/i.test(q) ? " " : "";
+    pressure = `${q}${sep}${nfmt(r.pressure_psi)} psi`;
+  }
+  if (r.equip_rating_psi != null &&
+      (r.pressure_psi == null || r.pressure_psi !== r.equip_rating_psi)) {
+    pressure += ` <span class="mut">· vs ${nfmt(r.equip_rating_psi)}-psi equipment</span>`;
+  }
+  rows.push(["Reservoir pressure", pressure]);
+
+  rows.push(["Reservoir temp",
+    r.temp_f == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.temp_f)}°F`]);
+  rows.push(["Reservoir depth",
+    r.tvd_ft == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.tvd_ft)} ft TVD`]);
+
+  let fluid = r.fluid || DASH;
+  if (r.api != null) fluid += ` <span class="mut">· ${r.api}°API</span>`;
+  rows.push(["Fluid", fluid]);
+
+  $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-reservoir-card").hidden = false;
+  if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
 
 /* host facts + working interest */
 $("f-host").innerHTML = FIELD.hostFacts.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");

--- a/reports/lower_tertiary/lifecycle/north_platte_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/north_platte_lifecycle.html
@@ -189,6 +189,21 @@
     color: var(--accent-ink); letter-spacing:.02em; }
   :root[data-theme="dark"] .wi-row .op.lead::after { color: var(--accent); }
 
+  /* ---- Reservoir & HPHT card ---- */
+  .rcol { display:flex; flex-direction:column; gap:22px; }
+  .mut { color: var(--muted); font-weight: 400; }
+  .hpht { display:inline-flex; align-items:center; font-family:var(--mono); font-size:11px;
+    font-weight:700; letter-spacing:.04em; text-transform:uppercase; padding:2px 9px;
+    border-radius:999px; }
+  .hpht.ultra { color: var(--alert);
+    background: color-mix(in srgb, var(--alert) 14%, transparent);
+    border:1px solid color-mix(in srgb, var(--alert) 42%, transparent); }
+  .hpht.hot { color: var(--accent-ink);
+    background: color-mix(in srgb, var(--accent) 16%, transparent);
+    border:1px solid color-mix(in srgb, var(--accent) 44%, transparent); }
+  :root[data-theme="dark"] .hpht.hot { color: var(--accent); }
+  @media (prefers-color-scheme: dark){ .hpht.hot { color: var(--accent); } }
+
   /* ---- Legend + footer ---- */
   .legend { display:flex; flex-wrap:wrap; gap: 8px 18px; font-size:11.5px; color:var(--muted);
     font-family:var(--mono); }
@@ -243,10 +258,16 @@
           <h3>Key phase activities</h3>
           <div class="act" id="f-activities"></div>
         </div>
-        <div class="card">
-          <h3>Host concept &amp; ownership</h3>
-          <dl class="kv" id="f-host"></dl>
-          <div class="wi" id="f-wi"></div>
+        <div class="rcol">
+          <div class="card">
+            <h3>Host concept &amp; ownership</h3>
+            <dl class="kv" id="f-host"></dl>
+            <div class="wi" id="f-wi"></div>
+          </div>
+          <div class="card" id="f-reservoir-card" hidden>
+            <h3>Reservoir &amp; HPHT</h3>
+            <dl class="kv" id="f-reservoir"></dl>
+          </div>
         </div>
       </section>
 
@@ -414,6 +435,18 @@ const FIELD = {
       "Dec 2024"
     ]
   ],
+  "reservoir": {
+    "formation": "Wilcox (subsalt Paleogene)",
+    "hpht_class": "ultra-HPHT",
+    "pressure_psi": null,
+    "pressure_qual": "",
+    "equip_rating_psi": 20000,
+    "temp_f": null,
+    "tvd_ft": null,
+    "fluid": "black oil",
+    "api": null,
+    "source_note": "World Oil/JPT: Sparta (ex-North Platte) is a 20,000-psi-rated development. All public '20,000 psi' figures are the equipment rating; true reservoir pore pressure not publicly disclosed — shown as —."
+  },
   "provenance": "Basis: in-repo YAML (superseded TotalEnergies pre-FID case) reconciled against current public record. North Platte was discovered 2012 (Cobalt/Total, Garden Banks). TotalEnergies (then 60% op, Equinor 40%) withdrew Feb 2022; Shell bought 51% and took operatorship from Equinor (49%), redesigned and renamed the project \"Sparta.\" Shell took FID Dec 2023; first oil projected 2028 (kept null — not yet producing). Water depth ~4,265 ft, subsalt Wilcox, newbuild semisubmersible FPU (8 subsea wells) with ~90,000 boe/d peak (~75 mbopd oil plateau; GOR 1100 scf/bbl from YAML). LOW-CONFIDENCE/NULLED: capex — YAML's $6B reflects the abandoned TotalEnergies ~$5-7B concept, not Shell's simplified Sparta scope (not publicly disclosed), so set null; opex and projected COP year not publicly defensible."
 };
 
@@ -490,6 +523,48 @@ $("f-activities").innerHTML = showIdx.map(i => {
   const tag = i === curIdx ? " · now" : (i < curIdx ? " · done" : " · next");
   return `<div class="act${cur}"><h4>${p.name}${tag}</h4><ul>${p.activities.map(a=>`<li>${a}</li>`).join("")}</ul></div>`;
 }).join("");
+
+/* reservoir & HPHT — honesty-gated; nulls render as an em dash */
+if (FIELD.reservoir) {
+  const r = FIELD.reservoir;
+  const DASH = "—";
+  const nfmt = (v) => v.toLocaleString("en-US");
+  const rows = [];
+  rows.push(["Formation", r.formation || DASH]);
+
+  let pill;
+  if (r.hpht_class === "ultra-HPHT") pill = `<span class="hpht ultra">ultra-HPHT</span>`;
+  else if (r.hpht_class === "HPHT") pill = `<span class="hpht hot">HPHT</span>`;
+  else pill = `<span class="mut">${DASH}</span>`;
+  rows.push(["HPHT class", pill]);
+
+  let pressure;
+  if (r.pressure_psi == null) {
+    pressure = `<span class="mut">${DASH}</span>`;
+  } else {
+    const q = r.pressure_qual || "";
+    const sep = /[a-z]$/i.test(q) ? " " : "";
+    pressure = `${q}${sep}${nfmt(r.pressure_psi)} psi`;
+  }
+  if (r.equip_rating_psi != null &&
+      (r.pressure_psi == null || r.pressure_psi !== r.equip_rating_psi)) {
+    pressure += ` <span class="mut">· vs ${nfmt(r.equip_rating_psi)}-psi equipment</span>`;
+  }
+  rows.push(["Reservoir pressure", pressure]);
+
+  rows.push(["Reservoir temp",
+    r.temp_f == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.temp_f)}°F`]);
+  rows.push(["Reservoir depth",
+    r.tvd_ft == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.tvd_ft)} ft TVD`]);
+
+  let fluid = r.fluid || DASH;
+  if (r.api != null) fluid += ` <span class="mut">· ${r.api}°API</span>`;
+  rows.push(["Fluid", fluid]);
+
+  $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-reservoir-card").hidden = false;
+  if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
 
 /* host facts + working interest */
 $("f-host").innerHTML = FIELD.hostFacts.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");

--- a/reports/lower_tertiary/lifecycle/shenandoah_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/shenandoah_lifecycle.html
@@ -189,6 +189,21 @@
     color: var(--accent-ink); letter-spacing:.02em; }
   :root[data-theme="dark"] .wi-row .op.lead::after { color: var(--accent); }
 
+  /* ---- Reservoir & HPHT card ---- */
+  .rcol { display:flex; flex-direction:column; gap:22px; }
+  .mut { color: var(--muted); font-weight: 400; }
+  .hpht { display:inline-flex; align-items:center; font-family:var(--mono); font-size:11px;
+    font-weight:700; letter-spacing:.04em; text-transform:uppercase; padding:2px 9px;
+    border-radius:999px; }
+  .hpht.ultra { color: var(--alert);
+    background: color-mix(in srgb, var(--alert) 14%, transparent);
+    border:1px solid color-mix(in srgb, var(--alert) 42%, transparent); }
+  .hpht.hot { color: var(--accent-ink);
+    background: color-mix(in srgb, var(--accent) 16%, transparent);
+    border:1px solid color-mix(in srgb, var(--accent) 44%, transparent); }
+  :root[data-theme="dark"] .hpht.hot { color: var(--accent); }
+  @media (prefers-color-scheme: dark){ .hpht.hot { color: var(--accent); } }
+
   /* ---- Legend + footer ---- */
   .legend { display:flex; flex-wrap:wrap; gap: 8px 18px; font-size:11.5px; color:var(--muted);
     font-family:var(--mono); }
@@ -243,10 +258,16 @@
           <h3>Key phase activities</h3>
           <div class="act" id="f-activities"></div>
         </div>
-        <div class="card">
-          <h3>Host concept &amp; ownership</h3>
-          <dl class="kv" id="f-host"></dl>
-          <div class="wi" id="f-wi"></div>
+        <div class="rcol">
+          <div class="card">
+            <h3>Host concept &amp; ownership</h3>
+            <dl class="kv" id="f-host"></dl>
+            <div class="wi" id="f-wi"></div>
+          </div>
+          <div class="card" id="f-reservoir-card" hidden>
+            <h3>Reservoir &amp; HPHT</h3>
+            <dl class="kv" id="f-reservoir"></dl>
+          </div>
         </div>
       </section>
 
@@ -438,6 +459,18 @@ const FIELD = {
       "Dec 2024"
     ]
   ],
+  "reservoir": {
+    "formation": "Inboard Wilcox (Lower Wilcox)",
+    "hpht_class": "ultra-HPHT",
+    "pressure_psi": 22000,
+    "pressure_qual": "≥",
+    "equip_rating_psi": 20000,
+    "temp_f": 200,
+    "tvd_ft": 30000,
+    "fluid": "black oil",
+    "api": null,
+    "source_note": "Clariant/World Oil: reservoir/formation pressures above 22,000 psi at ~200F (ultra-high-PRESSURE, moderate temp), ~30,000 ft TVD; 20,000-psi equipment rating separate."
+  },
   "provenance": "Base facts (operator, capex, plateau, GOR, data_through) from in-repo YAML; discovery 2009 (Anadarko Shenandoah-1, WR52), FID/sanction Aug 2021 (Beacon+Navitas), and actual first oil (first of 4 wells online 25 Jul 2025; ramped to 100 kbopd plateau Oct 2025) from public sources — first_oil corrected to 2025-07 vs YAML's placeholder 2025-10. Current WI (Beacon 31% op / Navitas 49% / HEQ 20%) post-2021 restructuring. capex_bn_usd 1.8 is YAML-stated and largely reflects pre-development E&A spend (LOW CONFIDENCE for full development cost); opex_boe and projected_cop_year null (not defensibly sourced); water depth ~5,800 ft."
 };
 
@@ -514,6 +547,48 @@ $("f-activities").innerHTML = showIdx.map(i => {
   const tag = i === curIdx ? " · now" : (i < curIdx ? " · done" : " · next");
   return `<div class="act${cur}"><h4>${p.name}${tag}</h4><ul>${p.activities.map(a=>`<li>${a}</li>`).join("")}</ul></div>`;
 }).join("");
+
+/* reservoir & HPHT — honesty-gated; nulls render as an em dash */
+if (FIELD.reservoir) {
+  const r = FIELD.reservoir;
+  const DASH = "—";
+  const nfmt = (v) => v.toLocaleString("en-US");
+  const rows = [];
+  rows.push(["Formation", r.formation || DASH]);
+
+  let pill;
+  if (r.hpht_class === "ultra-HPHT") pill = `<span class="hpht ultra">ultra-HPHT</span>`;
+  else if (r.hpht_class === "HPHT") pill = `<span class="hpht hot">HPHT</span>`;
+  else pill = `<span class="mut">${DASH}</span>`;
+  rows.push(["HPHT class", pill]);
+
+  let pressure;
+  if (r.pressure_psi == null) {
+    pressure = `<span class="mut">${DASH}</span>`;
+  } else {
+    const q = r.pressure_qual || "";
+    const sep = /[a-z]$/i.test(q) ? " " : "";
+    pressure = `${q}${sep}${nfmt(r.pressure_psi)} psi`;
+  }
+  if (r.equip_rating_psi != null &&
+      (r.pressure_psi == null || r.pressure_psi !== r.equip_rating_psi)) {
+    pressure += ` <span class="mut">· vs ${nfmt(r.equip_rating_psi)}-psi equipment</span>`;
+  }
+  rows.push(["Reservoir pressure", pressure]);
+
+  rows.push(["Reservoir temp",
+    r.temp_f == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.temp_f)}°F`]);
+  rows.push(["Reservoir depth",
+    r.tvd_ft == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.tvd_ft)} ft TVD`]);
+
+  let fluid = r.fluid || DASH;
+  if (r.api != null) fluid += ` <span class="mut">· ${r.api}°API</span>`;
+  rows.push(["Fluid", fluid]);
+
+  $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-reservoir-card").hidden = false;
+  if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
 
 /* host facts + working interest */
 $("f-host").innerHTML = FIELD.hostFacts.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");

--- a/reports/lower_tertiary/lifecycle/stones_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/stones_lifecycle.html
@@ -189,6 +189,21 @@
     color: var(--accent-ink); letter-spacing:.02em; }
   :root[data-theme="dark"] .wi-row .op.lead::after { color: var(--accent); }
 
+  /* ---- Reservoir & HPHT card ---- */
+  .rcol { display:flex; flex-direction:column; gap:22px; }
+  .mut { color: var(--muted); font-weight: 400; }
+  .hpht { display:inline-flex; align-items:center; font-family:var(--mono); font-size:11px;
+    font-weight:700; letter-spacing:.04em; text-transform:uppercase; padding:2px 9px;
+    border-radius:999px; }
+  .hpht.ultra { color: var(--alert);
+    background: color-mix(in srgb, var(--alert) 14%, transparent);
+    border:1px solid color-mix(in srgb, var(--alert) 42%, transparent); }
+  .hpht.hot { color: var(--accent-ink);
+    background: color-mix(in srgb, var(--accent) 16%, transparent);
+    border:1px solid color-mix(in srgb, var(--accent) 44%, transparent); }
+  :root[data-theme="dark"] .hpht.hot { color: var(--accent); }
+  @media (prefers-color-scheme: dark){ .hpht.hot { color: var(--accent); } }
+
   /* ---- Legend + footer ---- */
   .legend { display:flex; flex-wrap:wrap; gap: 8px 18px; font-size:11.5px; color:var(--muted);
     font-family:var(--mono); }
@@ -243,10 +258,16 @@
           <h3>Key phase activities</h3>
           <div class="act" id="f-activities"></div>
         </div>
-        <div class="card">
-          <h3>Host concept &amp; ownership</h3>
-          <dl class="kv" id="f-host"></dl>
-          <div class="wi" id="f-wi"></div>
+        <div class="rcol">
+          <div class="card">
+            <h3>Host concept &amp; ownership</h3>
+            <dl class="kv" id="f-host"></dl>
+            <div class="wi" id="f-wi"></div>
+          </div>
+          <div class="card" id="f-reservoir-card" hidden>
+            <h3>Reservoir &amp; HPHT</h3>
+            <dl class="kv" id="f-reservoir"></dl>
+          </div>
         </div>
       </section>
 
@@ -435,6 +456,18 @@ const FIELD = {
       "Dec 2024"
     ]
   ],
+  "reservoir": {
+    "formation": "Paleogene Wilcox (turbidite)",
+    "hpht_class": "HPHT",
+    "pressure_psi": null,
+    "pressure_qual": "",
+    "equip_rating_psi": null,
+    "temp_f": null,
+    "tvd_ft": 26500,
+    "fluid": "black oil",
+    "api": null,
+    "source_note": "Offshore Mag/S&D: Paleogene Wilcox, reservoir ~26,500 ft TVD (17,000 ft below mudline). Reservoir pressure/temperature not cleanly sourced — shown as —."
+  },
   "provenance": "Capex ($3.8bn), plateau (50 mbopd), GOR (850 scf/bbl), opex ($15/boe), first_oil (2016-09) and status from in-repo stones.yml (Shell FPSO development config). Discovery (2005), FID/sanction (May 2013, Shell 100% owner-operator), Walker Ridge Block 508, ~9,500 ft water depth, and Turritella/Stones FPSO host (world's deepest FPSO) confirmed via Offshore Technology, Offshore Magazine, and NS Energy public sources. lease_year and projected_cop_year unknown -> null; no notable schedule-driving incident identified."
 };
 
@@ -511,6 +544,48 @@ $("f-activities").innerHTML = showIdx.map(i => {
   const tag = i === curIdx ? " · now" : (i < curIdx ? " · done" : " · next");
   return `<div class="act${cur}"><h4>${p.name}${tag}</h4><ul>${p.activities.map(a=>`<li>${a}</li>`).join("")}</ul></div>`;
 }).join("");
+
+/* reservoir & HPHT — honesty-gated; nulls render as an em dash */
+if (FIELD.reservoir) {
+  const r = FIELD.reservoir;
+  const DASH = "—";
+  const nfmt = (v) => v.toLocaleString("en-US");
+  const rows = [];
+  rows.push(["Formation", r.formation || DASH]);
+
+  let pill;
+  if (r.hpht_class === "ultra-HPHT") pill = `<span class="hpht ultra">ultra-HPHT</span>`;
+  else if (r.hpht_class === "HPHT") pill = `<span class="hpht hot">HPHT</span>`;
+  else pill = `<span class="mut">${DASH}</span>`;
+  rows.push(["HPHT class", pill]);
+
+  let pressure;
+  if (r.pressure_psi == null) {
+    pressure = `<span class="mut">${DASH}</span>`;
+  } else {
+    const q = r.pressure_qual || "";
+    const sep = /[a-z]$/i.test(q) ? " " : "";
+    pressure = `${q}${sep}${nfmt(r.pressure_psi)} psi`;
+  }
+  if (r.equip_rating_psi != null &&
+      (r.pressure_psi == null || r.pressure_psi !== r.equip_rating_psi)) {
+    pressure += ` <span class="mut">· vs ${nfmt(r.equip_rating_psi)}-psi equipment</span>`;
+  }
+  rows.push(["Reservoir pressure", pressure]);
+
+  rows.push(["Reservoir temp",
+    r.temp_f == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.temp_f)}°F`]);
+  rows.push(["Reservoir depth",
+    r.tvd_ft == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.tvd_ft)} ft TVD`]);
+
+  let fluid = r.fluid || DASH;
+  if (r.api != null) fluid += ` <span class="mut">· ${r.api}°API</span>`;
+  rows.push(["Fluid", fluid]);
+
+  $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-reservoir-card").hidden = false;
+  if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
 
 /* host facts + working interest */
 $("f-host").innerHTML = FIELD.hostFacts.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");

--- a/reports/lower_tertiary/lifecycle/tiber_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/tiber_lifecycle.html
@@ -189,6 +189,21 @@
     color: var(--accent-ink); letter-spacing:.02em; }
   :root[data-theme="dark"] .wi-row .op.lead::after { color: var(--accent); }
 
+  /* ---- Reservoir & HPHT card ---- */
+  .rcol { display:flex; flex-direction:column; gap:22px; }
+  .mut { color: var(--muted); font-weight: 400; }
+  .hpht { display:inline-flex; align-items:center; font-family:var(--mono); font-size:11px;
+    font-weight:700; letter-spacing:.04em; text-transform:uppercase; padding:2px 9px;
+    border-radius:999px; }
+  .hpht.ultra { color: var(--alert);
+    background: color-mix(in srgb, var(--alert) 14%, transparent);
+    border:1px solid color-mix(in srgb, var(--alert) 42%, transparent); }
+  .hpht.hot { color: var(--accent-ink);
+    background: color-mix(in srgb, var(--accent) 16%, transparent);
+    border:1px solid color-mix(in srgb, var(--accent) 44%, transparent); }
+  :root[data-theme="dark"] .hpht.hot { color: var(--accent); }
+  @media (prefers-color-scheme: dark){ .hpht.hot { color: var(--accent); } }
+
   /* ---- Legend + footer ---- */
   .legend { display:flex; flex-wrap:wrap; gap: 8px 18px; font-size:11.5px; color:var(--muted);
     font-family:var(--mono); }
@@ -243,10 +258,16 @@
           <h3>Key phase activities</h3>
           <div class="act" id="f-activities"></div>
         </div>
-        <div class="card">
-          <h3>Host concept &amp; ownership</h3>
-          <dl class="kv" id="f-host"></dl>
-          <div class="wi" id="f-wi"></div>
+        <div class="rcol">
+          <div class="card">
+            <h3>Host concept &amp; ownership</h3>
+            <dl class="kv" id="f-host"></dl>
+            <div class="wi" id="f-wi"></div>
+          </div>
+          <div class="card" id="f-reservoir-card" hidden>
+            <h3>Reservoir &amp; HPHT</h3>
+            <dl class="kv" id="f-reservoir"></dl>
+          </div>
         </div>
       </section>
 
@@ -410,6 +431,18 @@ const FIELD = {
       "Dec 2024"
     ]
   ],
+  "reservoir": {
+    "formation": "Paleogene Wilcox",
+    "hpht_class": "ultra-HPHT",
+    "pressure_psi": 20000,
+    "pressure_qual": "up to",
+    "equip_rating_psi": 20000,
+    "temp_f": null,
+    "tvd_ft": 28000,
+    "fluid": "black oil (light)",
+    "api": null,
+    "source_note": "BP FID 2025 (Tiber-Guadalupe): reservoirs 'under pressures of up to 20,000 psi', Paleogene Wilcox; ~28,000 ft TVD. Temperature not field-specific."
+  },
   "provenance": "Basis: in-repo tiber.yml (operator BP, plateau 80 mbopd, GOR 900 scf/bbl, data_through 2024-12-31) plus public sources. BP discovered Tiber Sept 2009 in Keathley Canyon 102, 4,132 ft water. BP reached FID on the combined Tiber-Guadalupe hub 29 Sep 2025 (fid_year=2025); Seatrium awarded FPU EPCC. Ownership is now 100% BP (original discovery split BP 62% / Petrobras 20% / ConocoPhillips 18% no longer reflects current WI). Status=execution/execute (post-FID, construction underway). capex set to the sanctioned public figure of $5.0bn for the Tiber-Guadalupe project (YAML's $8bn was a pre-FID Tiber-only planning assumption); note $5bn covers both fields. first_oil kept null — oil has not flowed; projected first production is 2030. opex_boe null (not publicly disclosed; the \"$3/bbl below Kaskida\" figure is development cost, not opex). projected_cop_year and lease_year null (not confidently sourced)."
 };
 
@@ -486,6 +519,48 @@ $("f-activities").innerHTML = showIdx.map(i => {
   const tag = i === curIdx ? " · now" : (i < curIdx ? " · done" : " · next");
   return `<div class="act${cur}"><h4>${p.name}${tag}</h4><ul>${p.activities.map(a=>`<li>${a}</li>`).join("")}</ul></div>`;
 }).join("");
+
+/* reservoir & HPHT — honesty-gated; nulls render as an em dash */
+if (FIELD.reservoir) {
+  const r = FIELD.reservoir;
+  const DASH = "—";
+  const nfmt = (v) => v.toLocaleString("en-US");
+  const rows = [];
+  rows.push(["Formation", r.formation || DASH]);
+
+  let pill;
+  if (r.hpht_class === "ultra-HPHT") pill = `<span class="hpht ultra">ultra-HPHT</span>`;
+  else if (r.hpht_class === "HPHT") pill = `<span class="hpht hot">HPHT</span>`;
+  else pill = `<span class="mut">${DASH}</span>`;
+  rows.push(["HPHT class", pill]);
+
+  let pressure;
+  if (r.pressure_psi == null) {
+    pressure = `<span class="mut">${DASH}</span>`;
+  } else {
+    const q = r.pressure_qual || "";
+    const sep = /[a-z]$/i.test(q) ? " " : "";
+    pressure = `${q}${sep}${nfmt(r.pressure_psi)} psi`;
+  }
+  if (r.equip_rating_psi != null &&
+      (r.pressure_psi == null || r.pressure_psi !== r.equip_rating_psi)) {
+    pressure += ` <span class="mut">· vs ${nfmt(r.equip_rating_psi)}-psi equipment</span>`;
+  }
+  rows.push(["Reservoir pressure", pressure]);
+
+  rows.push(["Reservoir temp",
+    r.temp_f == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.temp_f)}°F`]);
+  rows.push(["Reservoir depth",
+    r.tvd_ft == null ? `<span class="mut">${DASH}</span>` : `${nfmt(r.tvd_ft)} ft TVD`]);
+
+  let fluid = r.fluid || DASH;
+  if (r.api != null) fluid += ` <span class="mut">· ${r.api}°API</span>`;
+  rows.push(["Fluid", fluid]);
+
+  $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-reservoir-card").hidden = false;
+  if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
 
 /* host facts + working interest */
 $("f-host").innerHTML = FIELD.hostFacts.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");

--- a/scripts/lower_tertiary/build_lifecycle_posters.py
+++ b/scripts/lower_tertiary/build_lifecycle_posters.py
@@ -292,6 +292,7 @@ def facts_to_field(f: dict) -> dict:
             for w in wi
         ],
         "hostFacts": host_facts,
+        "reservoir": f.get("reservoir"),
         "provenance": f.get(
             "provenance", "Data: field YAML + public disclosures + BSEE"
         ),

--- a/tests/unit/lower_tertiary/test_facts_reservoir.py
+++ b/tests/unit/lower_tertiary/test_facts_reservoir.py
@@ -1,0 +1,89 @@
+"""Data-integrity tests for the reservoir/HPHT block merged into the Lower
+Tertiary life-cycle poster facts (reports/lower_tertiary/lifecycle/_facts.json).
+
+These guard the honesty-gated reservoir spec: required keys present, HPHT class
+constrained, numeric-or-null fields well typed, and the two vetted anchors
+(Big Foot pressure withheld; Anchor 25,000-psi reservoir vs 20,000-psi
+equipment) preserved verbatim.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from tests.test_markers import unit  # noqa: E402
+
+FACTS_PATH = PROJECT_ROOT / "reports" / "lower_tertiary" / "lifecycle" / "_facts.json"
+
+REQUIRED_KEYS = {
+    "formation",
+    "hpht_class",
+    "pressure_psi",
+    "pressure_qual",
+    "equip_rating_psi",
+    "temp_f",
+    "tvd_ft",
+    "fluid",
+    "api",
+    "source_note",
+}
+
+NUMERIC_OR_NULL = ("pressure_psi", "temp_f", "tvd_ft", "api")
+
+
+def _load_facts():
+    return json.loads(FACTS_PATH.read_text())
+
+
+def _by_id(facts, field_id):
+    return next(rec for rec in facts if rec["id"] == field_id)
+
+
+@unit
+class TestFactsReservoir:
+    """Validate the merged reservoir block on every field record."""
+
+    def test_every_record_has_reservoir_dict(self):
+        facts = _load_facts()
+        assert len(facts) == 10
+        for rec in facts:
+            assert isinstance(
+                rec.get("reservoir"), dict
+            ), f"{rec['id']} missing reservoir dict"
+
+    def test_reservoir_has_all_required_keys(self):
+        for rec in _load_facts():
+            res = rec["reservoir"]
+            missing = REQUIRED_KEYS - set(res)
+            assert not missing, f"{rec['id']} reservoir missing keys: {missing}"
+
+    def test_hpht_class_constrained(self):
+        for rec in _load_facts():
+            assert rec["reservoir"]["hpht_class"] in {"ultra-HPHT", "HPHT", None}
+
+    def test_numeric_fields_none_or_number(self):
+        for rec in _load_facts():
+            res = rec["reservoir"]
+            for key in NUMERIC_OR_NULL:
+                val = res[key]
+                assert val is None or isinstance(
+                    val, (int, float)
+                ), f"{rec['id']} reservoir.{key} not None-or-number: {val!r}"
+
+    def test_big_foot_pressure_withheld(self):
+        # Honesty anchor: Big Foot reservoir pressure is not publicly disclosed.
+        big_foot = _by_id(_load_facts(), "big_foot")
+        assert big_foot["reservoir"]["pressure_psi"] is None
+
+    def test_anchor_reservoir_vs_equipment_distinction(self):
+        # Vetted distinction: 25,000-psi reservoir vs 20,000-psi equipment rating.
+        anchor = _by_id(_load_facts(), "anchor")
+        assert anchor["reservoir"]["pressure_psi"] == 25000
+        assert anchor["reservoir"]["equip_rating_psi"] == 20000


### PR DESCRIPTION
## Reservoir & HPHT panel on the field life-cycle posters

Follow-up to #786 (sub-epic #774; #761 structured reservoir attrs). Each of the 10 GoM Lower-Tertiary posters now carries a **Reservoir & HPHT** card — formation, HPHT class, reservoir pressure / temperature / TVD, fluid / API — researched by **10 parallel agents**, each required to cite a public source or return null.

### Honesty is the design
- **Reservoir pressure ≠ equipment rating.** The card shows the reservoir pore/formation pressure, distinct from the "20,000-psi" wellhead rating. **Anchor reads "25,000 psi · vs 20,000-psi equipment"** (initial BHP 23–27k, OGJ 2024) — the distinction most public write-ups blur.
- **Nulls are honest, not lazy.** Big Foot, North Platte, and Stones render reservoir pressure as an em dash (—) because no field-specific value is publicly disclosed; the agents refused to substitute a neighbour's figure or the equipment rating.

| Field | HPHT | Reservoir pressure | Source |
|---|---|---|---|
| Anchor | ultra-HPHT | 25,000 psi (vs 20k equip) | OGJ |
| Shenandoah | ultra-HPHT | ≥22,000 psi @ ~200°F | Clariant/World Oil |
| Cascade/Chinook | HPHT | ~19,500 psi @ 260°F | OTC-24162/3 |
| Jack/St. Malo | HPHT | 19,374 psi @ 224°F | Dice Wilcox study |
| Julia | HPHT | ~13,500 psi · 24.7°API | Offshore Mag / Hart |
| Kaskida / Tiber | ultra-HPHT | ≥ / up to 20,000 psi | AAPG / BP FID |
| North Platte / Big Foot / Stones | (class where sourced) | **—** | not publicly disclosed |

### Changes
- Merged a `reservoir` block into all 10 records in `_facts.json`; `build_lifecycle_posters.py` carries it onto the FIELD object; `lifecycle_template.html` renders the card (ultra-HPHT/HPHT pills, em-dash for nulls, `source_note` appended to provenance).
- **Data-integrity test** (6 cases) guards block shape + the anchor/big_foot honesty anchors.

### Verified
Posters + `build_pages.py` build clean; DOM-rendered honesty checks pass (Anchor 25k-vs-20k; Big Foot & North Platte pressure = —; no None/null/NaN leaks); 6 tests pass; **all three CI linters clean** (Black, isort, flake8). No `repo_structure.yml` change (posters modified in place).

Refs #761 #754.
