### PR TITLE
feat: add Spain CORES live refresh

### DIFF
--- a/packages/worldenergydata-spain/README.md
+++ b/packages/worldenergydata-spain/README.md
@@ -2,7 +2,47 @@
 
 Spain CORES source package for per-field monthly oil and gas production.
 
-The initial #763 slice covers the official CORES statistical-series workbooks
-for indigenous crude oil and natural gas production. CORES publishes oil in
-tonnes and gas in GWh, so this package exposes documented conversion constants
-and loader rows normalized for the unified production adapter.
+The initial [#763](https://github.com/vamseeachanta/worldenergydata/issues/763)
+slice covers the official CORES statistical-series workbooks for indigenous
+crude oil and natural gas production. CORES publishes oil in tonnes and gas in
+GWh, so this package exposes documented conversion constants and loader rows
+normalized for the unified production adapter.
+
+## CORES live refresh
+
+[#806](https://github.com/vamseeachanta/worldenergydata/issues/806) adds a
+direct-source live refresh lane for the official CORES workbooks:
+
+- statistics page: <https://www.cores.es/en/estadisticas>
+- crude oil workbook: <https://www.cores.es/sites/default/files/archivos/estadisticas/crude-oil-production.xlsx>
+- natural gas workbook: <https://www.cores.es/sites/default/files/archivos/estadisticas/gas-production.xlsx>
+
+The live loader reads the `Production` worksheet explicitly because the real
+CORES files include a non-data `Start` sheet before the production data.
+
+Library code accepts a caller-supplied cache root; the operational target is:
+
+```text
+/mnt/ace/worldenergydata/data/spain/cores/
+  raw/
+  normalized/
+  metadata/
+```
+
+Example:
+
+```python
+from pathlib import Path
+
+from worldenergydata.spain.production import CoresLiveProductionLoader
+
+loader = CoresLiveProductionLoader(
+    cache_root=Path("/mnt/ace/worldenergydata/data/spain/cores")
+)
+loader.refresh(force_refresh=True)
+production = loader.load_all_production()
+```
+
+Full normalized oil, gas, and merged production CSVs are written under the
+cache root. The committed Ayoluengo fixture stays small and can be refreshed
+from the live oil frame with `refresh_ayoluengo_fixture`.

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/_metadata.json
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/_metadata.json
@@ -1,12 +1,45 @@
 {
-  "source_name": "CORES Indigenous Crude Oil Production",
-  "source_url": "https://www.cores.es/sites/default/files/archivos/estadisticas/crude-oil-production.xlsx",
-  "statistics_page": "https://www.cores.es/en/estadisticas",
-  "source_updated_date": "2026-06-12",
+  "conversion": "oil_bbl = tonnes * 7.33",
+  "conversion_factors": {
+    "gas_gwh_to_mcf": 3290.0,
+    "oil_tonnes_to_bbl": 7.33
+  },
+  "license_note": "CORES attribution required; cite source URL and latest-update date.",
+  "normalized_unit": "bbl",
   "sample_extracted_date": "2026-07-04",
   "sample_field": "Ayoluengo",
+  "sample_row_count": 6,
+  "source_name": "CORES Indigenous Crude Oil Production",
   "source_unit": "tonnes",
-  "normalized_unit": "bbl",
-  "conversion": "oil_bbl = tonnes * 7.33",
-  "license_note": "CORES attribution required; cite source URL and latest-update date."
+  "source_updated_date": "2026-06-12",
+  "source_url": "https://www.cores.es/sites/default/files/archivos/estadisticas/crude-oil-production.xlsx",
+  "statistics_page": "https://www.cores.es/en/estadisticas",
+  "workbooks": {
+    "gas": {
+      "byte_count": 127915,
+      "content_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      "dataset_name": "CORES Indigenous Natural Gas Production",
+      "filename": "gas-production.xlsx",
+      "last_modified": "Fri, 12 Jun 2026 07:52:01 GMT",
+      "normalized_column": "gas_mcf",
+      "raw_path": "raw/gas-production.xlsx",
+      "sha256": "9d4bd877658b8ac82697ae15d81c59217801aa6dc1d2ed3267d7d7feb960533b",
+      "source_unit": "GWh",
+      "source_url": "https://www.cores.es/sites/default/files/archivos/estadisticas/gas-production.xlsx",
+      "status_code": 200
+    },
+    "oil": {
+      "byte_count": 112669,
+      "content_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      "dataset_name": "CORES Indigenous Crude Oil Production",
+      "filename": "crude-oil-production.xlsx",
+      "last_modified": "Fri, 12 Jun 2026 07:51:41 GMT",
+      "normalized_column": "oil_bbl",
+      "raw_path": "raw/crude-oil-production.xlsx",
+      "sha256": "6ef2911eef7cd04ffe0328152c3ec8235353528c695068c8324691bd8de7cd57",
+      "source_unit": "tonnes",
+      "source_url": "https://www.cores.es/sites/default/files/archivos/estadisticas/crude-oil-production.xlsx",
+      "status_code": 200
+    }
+  }
 }

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/production/__init__.py
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/production/__init__.py
@@ -1,0 +1,42 @@
+"""Spain production loaders."""
+
+__all__ = [
+    "DEFAULT_WORKBOOKS",
+    "STATISTICS_PAGE_URL",
+    "CoresFixtureProductionLoader",
+    "CoresHttpResponse",
+    "CoresLiveProductionLoader",
+    "CoresProductionLoader",
+    "CoresSourceError",
+    "CoresWorkbook",
+    "CoresWorkbookSource",
+    "FixtureRefreshResult",
+    "parse_cores_frame",
+    "refresh_ayoluengo_fixture",
+]
+
+
+def __getattr__(name):
+    if name in {
+        "CoresFixtureProductionLoader",
+        "CoresProductionLoader",
+        "parse_cores_frame",
+    }:
+        from worldenergydata.spain.production import cores_loader
+
+        return getattr(cores_loader, name)
+    if name in {
+        "DEFAULT_WORKBOOKS",
+        "STATISTICS_PAGE_URL",
+        "CoresHttpResponse",
+        "CoresLiveProductionLoader",
+        "CoresSourceError",
+        "CoresWorkbook",
+        "CoresWorkbookSource",
+        "FixtureRefreshResult",
+        "refresh_ayoluengo_fixture",
+    }:
+        from worldenergydata.spain.production import cores_live
+
+        return getattr(cores_live, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_live.py
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_live.py
@@ -1,0 +1,196 @@
+"""Live CORES workbook download and cache support for Spain production (#806)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+import pandas as pd
+
+from worldenergydata.spain.production.cores_loader import (
+    GWH_TO_MCF,
+    TONNES_TO_BBL,
+    CoresProductionLoader,
+)
+from worldenergydata.spain.production.cores_source import (
+    DEFAULT_WORKBOOKS,
+    STATISTICS_PAGE_URL,
+    CoresHttpResponse,
+    CoresSourceError,
+    CoresWorkbook,
+    CoresWorkbookSource,
+    utc_now_iso,
+)
+
+__all__ = [
+    "DEFAULT_WORKBOOKS",
+    "STATISTICS_PAGE_URL",
+    "CoresHttpResponse",
+    "CoresLiveProductionLoader",
+    "CoresSourceError",
+    "CoresWorkbook",
+    "CoresWorkbookSource",
+    "FixtureRefreshResult",
+    "refresh_ayoluengo_fixture",
+]
+
+
+@dataclass(frozen=True)
+class FixtureRefreshResult:
+    """Paths written by ``refresh_ayoluengo_fixture``."""
+
+    sample_path: Path
+    metadata_path: Path
+
+
+class CoresLiveProductionLoader:
+    """Loader facade over downloaded CORES oil and gas workbooks."""
+
+    def __init__(
+        self,
+        *,
+        cache_root: Path,
+        source: Optional[CoresWorkbookSource] = None,
+        header_row: int = 5,
+        sheet_name: str = "Production",
+    ):
+        self.cache_root = Path(cache_root)
+        self.source = source or CoresWorkbookSource(cache_root=self.cache_root)
+        self.raw_dir = self.cache_root / "raw"
+        self.normalized_dir = self.cache_root / "normalized"
+        self.header_row = header_row
+        self.sheet_name = sheet_name
+
+    def refresh(self, *, force_refresh: bool = False) -> dict[str, Any]:
+        self.source.download_all(force_refresh=force_refresh, validate_links=True)
+        self.load_all_production()
+        return self.metadata()
+
+    def load_oil_production(self) -> pd.DataFrame:
+        return self._load_product("oil")
+
+    def load_gas_production(self) -> pd.DataFrame:
+        return self._load_product("gas")
+
+    def load_all_production(self) -> pd.DataFrame:
+        keys = ["field_name", "year", "month"]
+        oil = self.load_oil_production()
+        gas = self.load_gas_production()
+        merged = oil.merge(gas, how="outer", on=keys)
+        return self._write_normalized("all", merged)
+
+    def load_field_production(self, field_name: str) -> pd.DataFrame:
+        frame = self.load_all_production()
+        mask = frame["field_name"].astype(str).str.lower() == field_name.lower()
+        return frame[mask].copy()
+
+    def metadata(self) -> dict[str, Any]:
+        return self.source.metadata()
+
+    def _load_product(self, product: str) -> pd.DataFrame:
+        workbook = DEFAULT_WORKBOOKS[product]
+        path = self.raw_dir / workbook.filename
+        if not path.exists():
+            path = self.source.download(product)
+        frame = CoresProductionLoader(
+            product=product,
+            path=path,
+            header_row=self.header_row,
+            sheet_name=self.sheet_name,
+        ).load()
+        return self._write_normalized(product, frame)
+
+    def _write_normalized(self, name: str, frame: pd.DataFrame) -> pd.DataFrame:
+        self.normalized_dir.mkdir(parents=True, exist_ok=True)
+        out = _sort_production(frame)
+        out.to_csv(self.normalized_dir / f"cores_{name}_production.csv", index=False)
+        return out
+
+
+def refresh_ayoluengo_fixture(
+    *,
+    oil_frame: pd.DataFrame,
+    metadata: Mapping[str, Any],
+    output_dir: Optional[Path] = None,
+    refreshed_at_utc: Optional[str] = None,
+    sample_rows: int = 6,
+) -> FixtureRefreshResult:
+    """Refresh the small committed Ayoluengo fixture from live oil output."""
+
+    output = Path(output_dir) if output_dir is not None else _package_cores_data_dir()
+    sample = _ayoluengo_sample(oil_frame, sample_rows)
+    output.mkdir(parents=True, exist_ok=True)
+    sample_path = output / "ayoluengo_oil_sample.csv"
+    metadata_path = output / "_metadata.json"
+    sample.to_csv(sample_path, index=False)
+    metadata_path.write_text(
+        json.dumps(
+            _fixture_metadata(metadata, len(sample), refreshed_at_utc),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return FixtureRefreshResult(sample_path=sample_path, metadata_path=metadata_path)
+
+
+def _ayoluengo_sample(oil_frame: pd.DataFrame, sample_rows: int) -> pd.DataFrame:
+    mask = oil_frame["field_name"].astype(str).str.lower() == "ayoluengo"
+    sample = _sort_production(oil_frame[mask].copy()).head(sample_rows)
+    if sample.empty:
+        raise CoresSourceError("live oil frame contains no Ayoluengo rows")
+    if "gas_mcf" not in sample.columns:
+        sample["gas_mcf"] = 0.0
+    return sample[["field_name", "year", "month", "oil_bbl", "gas_mcf"]]
+
+
+def _fixture_metadata(
+    source_metadata: Mapping[str, Any],
+    sample_row_count: int,
+    refreshed_at_utc: Optional[str],
+) -> dict[str, Any]:
+    workbooks = dict(source_metadata.get("workbooks", {}))
+    oil = dict(workbooks.get("oil", {}))
+    refreshed = refreshed_at_utc or utc_now_iso()
+    return {
+        "source_name": DEFAULT_WORKBOOKS["oil"].dataset_name,
+        "source_url": oil.get("source_url", DEFAULT_WORKBOOKS["oil"].source_url),
+        "statistics_page": source_metadata.get("statistics_page", STATISTICS_PAGE_URL),
+        "source_updated_date": _source_updated_date(oil),
+        "sample_extracted_date": refreshed[:10],
+        "sample_field": "Ayoluengo",
+        "sample_row_count": sample_row_count,
+        "source_unit": DEFAULT_WORKBOOKS["oil"].source_unit,
+        "normalized_unit": "bbl",
+        "conversion": f"oil_bbl = tonnes * {TONNES_TO_BBL}",
+        "conversion_factors": {
+            "gas_gwh_to_mcf": GWH_TO_MCF,
+            "oil_tonnes_to_bbl": TONNES_TO_BBL,
+        },
+        "license_note": (
+            "CORES attribution required; cite source URL and latest-update date."
+        ),
+        "workbooks": workbooks,
+    }
+
+
+def _source_updated_date(oil_metadata: Mapping[str, Any]) -> Optional[str]:
+    last_modified = oil_metadata.get("last_modified")
+    if not last_modified:
+        return oil_metadata.get("source_updated_date")
+    try:
+        return parsedate_to_datetime(last_modified).date().isoformat()
+    except (TypeError, ValueError):
+        return oil_metadata.get("source_updated_date")
+
+
+def _sort_production(frame: pd.DataFrame) -> pd.DataFrame:
+    return frame.sort_values(["field_name", "year", "month"]).reset_index(drop=True)
+
+
+def _package_cores_data_dir() -> Path:
+    return Path(__file__).resolve().parents[1] / "data" / "cores"

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_loader.py
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_loader.py
@@ -154,17 +154,23 @@ class CoresProductionLoader:
         path: Optional[Path] = None,
         raw_frame: Optional[pd.DataFrame] = None,
         header_row: int = 5,
+        sheet_name=0,
     ):
         self.product = product
         self._path = path
         self._raw = raw_frame
         self._header_row = header_row
+        self._sheet_name = sheet_name
 
     def load(self) -> pd.DataFrame:
         raw = (
             self._raw
             if self._raw is not None
-            else pd.read_excel(self._path, header=self._header_row)
+            else pd.read_excel(
+                self._path,
+                sheet_name=self._sheet_name,
+                header=self._header_row,
+            )
         )
         return parse_cores_frame(raw, product=self.product)
 

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_source.py
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_source.py
@@ -1,0 +1,299 @@
+"""Official CORES workbook discovery and download support (#806)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional
+from urllib.parse import urljoin
+from urllib.request import Request, urlopen
+
+STATISTICS_PAGE_URL = "https://www.cores.es/en/estadisticas"
+
+
+@dataclass(frozen=True)
+class CoresWorkbook:
+    """Official CORES workbook contract."""
+
+    product: str
+    dataset_name: str
+    source_url: str
+    filename: str
+    source_unit: str
+    normalized_column: str
+
+
+DEFAULT_WORKBOOKS = {
+    "oil": CoresWorkbook(
+        product="oil",
+        dataset_name="CORES Indigenous Crude Oil Production",
+        source_url=(
+            "https://www.cores.es/sites/default/files/archivos/estadisticas/"
+            "crude-oil-production.xlsx"
+        ),
+        filename="crude-oil-production.xlsx",
+        source_unit="tonnes",
+        normalized_column="oil_bbl",
+    ),
+    "gas": CoresWorkbook(
+        product="gas",
+        dataset_name="CORES Indigenous Natural Gas Production",
+        source_url=(
+            "https://www.cores.es/sites/default/files/archivos/estadisticas/"
+            "gas-production.xlsx"
+        ),
+        filename="gas-production.xlsx",
+        source_unit="GWh",
+        normalized_column="gas_mcf",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class CoresHttpResponse:
+    """HTTP response value object used by the injectable downloader boundary."""
+
+    content: bytes
+    headers: Mapping[str, str]
+    status: int = 200
+
+
+class CoresSourceError(RuntimeError):
+    """Raised when CORES source discovery or download fails closed."""
+
+
+class CoresWorkbookSource:
+    """Discovers and downloads the official CORES production workbooks."""
+
+    def __init__(
+        self,
+        *,
+        cache_root: Path,
+        http_get: Optional[Callable[..., CoresHttpResponse]] = None,
+        clock: Optional[Callable[[], str]] = None,
+    ):
+        self.cache_root = Path(cache_root)
+        self.raw_dir = self.cache_root / "raw"
+        self.metadata_dir = self.cache_root / "metadata"
+        self.metadata_path = self.metadata_dir / "cores_refresh_metadata.json"
+        self._http_get = http_get or _urlopen_get
+        self._clock = clock or utc_now_iso
+
+    def discover(self, *, page_html: Optional[str] = None) -> dict[str, CoresWorkbook]:
+        html = page_html if page_html is not None else self._fetch_statistics_page()
+        hrefs = _extract_hrefs(html)
+        inventory = {}
+        for product, workbook in DEFAULT_WORKBOOKS.items():
+            source_url = _find_workbook_url(hrefs, workbook.filename)
+            if source_url is None:
+                raise CoresSourceError(
+                    "CORES statistics page missing workbook link for "
+                    f"{product}: {workbook.filename}"
+                )
+            inventory[product] = replace(workbook, source_url=source_url)
+        return inventory
+
+    def download_all(
+        self,
+        *,
+        force_refresh: bool = False,
+        validate_links: bool = True,
+    ) -> dict[str, Path]:
+        workbooks = self.discover() if validate_links else DEFAULT_WORKBOOKS
+        paths = {}
+        entries = {}
+        for product, workbook in workbooks.items():
+            path, entry = self._download_or_reuse(workbook, force_refresh)
+            paths[product] = path
+            entries[product] = entry
+        self._write_metadata(entries)
+        return paths
+
+    def download(
+        self,
+        product: str,
+        *,
+        force_refresh: bool = False,
+        validate_links: bool = True,
+    ) -> Path:
+        workbook = (
+            self.discover()[product] if validate_links else DEFAULT_WORKBOOKS[product]
+        )
+        path, entry = self._download_or_reuse(workbook, force_refresh)
+        metadata = self.metadata()
+        entries = dict(metadata.get("workbooks", {}))
+        entries[product] = entry
+        self._write_metadata(entries)
+        return path
+
+    def metadata(self) -> dict[str, Any]:
+        if not self.metadata_path.exists():
+            return {}
+        with self.metadata_path.open(encoding="utf-8") as fh:
+            return json.load(fh)
+
+    def _fetch_statistics_page(self) -> str:
+        response = self._http_get(STATISTICS_PAGE_URL, method="GET")
+        if response.status >= 400:
+            raise CoresSourceError(
+                f"CORES statistics page returned HTTP {response.status}"
+            )
+        return response.content.decode("utf-8", errors="replace")
+
+    def _download_or_reuse(
+        self,
+        workbook: CoresWorkbook,
+        force_refresh: bool,
+    ) -> tuple[Path, dict[str, Any]]:
+        path = self.raw_dir / workbook.filename
+        if path.exists() and not force_refresh:
+            return path, self._cached_metadata(workbook, path)
+        response = self._http_get(workbook.source_url, method="GET")
+        _validate_workbook_response(workbook, response)
+        self.raw_dir.mkdir(parents=True, exist_ok=True)
+        _atomic_write(path, response.content)
+        return path, self._response_metadata(workbook, path, response)
+
+    def _cached_metadata(
+        self,
+        workbook: CoresWorkbook,
+        path: Path,
+    ) -> dict[str, Any]:
+        entry = self.metadata().get("workbooks", {}).get(workbook.product, {})
+        if entry:
+            return entry
+        return _workbook_metadata(
+            workbook=workbook,
+            path=path,
+            cache_root=self.cache_root,
+            content=path.read_bytes(),
+            headers={},
+            status=200,
+        )
+
+    def _response_metadata(
+        self,
+        workbook: CoresWorkbook,
+        path: Path,
+        response: CoresHttpResponse,
+    ) -> dict[str, Any]:
+        return _workbook_metadata(
+            workbook=workbook,
+            path=path,
+            cache_root=self.cache_root,
+            content=response.content,
+            headers=response.headers,
+            status=response.status,
+        )
+
+    def _write_metadata(self, workbook_entries: Mapping[str, Any]) -> None:
+        self.metadata_dir.mkdir(parents=True, exist_ok=True)
+        metadata = {
+            "statistics_page": STATISTICS_PAGE_URL,
+            "refreshed_at_utc": self._clock(),
+            "workbooks": workbook_entries,
+        }
+        self.metadata_path.write_text(
+            json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+
+class _HrefParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.hrefs: list[str] = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag.lower() != "a":
+            return
+        for key, value in attrs:
+            if key.lower() == "href" and value:
+                self.hrefs.append(urljoin(STATISTICS_PAGE_URL, value))
+
+
+def _extract_hrefs(html: str) -> list[str]:
+    parser = _HrefParser()
+    parser.feed(html)
+    return parser.hrefs
+
+
+def _find_workbook_url(hrefs: list[str], filename: str) -> Optional[str]:
+    for href in hrefs:
+        if href.split("?", 1)[0].endswith(filename):
+            return href
+    return None
+
+
+def _validate_workbook_response(
+    workbook: CoresWorkbook,
+    response: CoresHttpResponse,
+) -> None:
+    if response.status >= 400:
+        raise CoresSourceError(f"{workbook.filename} returned HTTP {response.status}")
+    if not response.content:
+        raise CoresSourceError(f"{workbook.filename} download was empty")
+    content_type = _header(response.headers, "content-type").lower()
+    valid_type = any(
+        token in content_type for token in ("spreadsheet", "excel", "octet-stream")
+    )
+    if content_type and not valid_type:
+        raise CoresSourceError(
+            f"{workbook.filename} returned non-Excel content type: {content_type}"
+        )
+
+
+def _workbook_metadata(
+    *,
+    workbook: CoresWorkbook,
+    path: Path,
+    cache_root: Path,
+    content: bytes,
+    headers: Mapping[str, str],
+    status: int,
+) -> dict[str, Any]:
+    return {
+        "byte_count": len(content),
+        "content_type": _header(headers, "content-type") or None,
+        "dataset_name": workbook.dataset_name,
+        "filename": workbook.filename,
+        "last_modified": _header(headers, "last-modified") or None,
+        "normalized_column": workbook.normalized_column,
+        "raw_path": str(path.relative_to(cache_root)),
+        "sha256": hashlib.sha256(content).hexdigest(),
+        "source_unit": workbook.source_unit,
+        "source_url": workbook.source_url,
+        "status_code": status,
+    }
+
+
+def _header(headers: Mapping[str, str], name: str) -> str:
+    target = name.lower()
+    for key, value in headers.items():
+        if str(key).lower() == target:
+            return str(value)
+    return ""
+
+
+def _atomic_write(path: Path, content: bytes) -> None:
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_bytes(content)
+    tmp_path.replace(path)
+
+
+def _urlopen_get(url: str, *, method: str = "GET") -> CoresHttpResponse:
+    request = Request(url, method=method, headers={"User-Agent": "worldenergydata"})
+    with urlopen(request, timeout=60) as response:
+        return CoresHttpResponse(
+            content=response.read(),
+            headers=dict(response.headers.items()),
+            status=getattr(response, "status", 200),
+        )
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()

--- a/scripts/review/results/2026-07-04-code-806-codex-inline.md
+++ b/scripts/review/results/2026-07-04-code-806-codex-inline.md
@@ -1,0 +1,81 @@
+# Code Review: Issue [#806](https://github.com/vamseeachanta/worldenergydata/issues/806) Spain CORES live refresh
+
+**Range:** `44f2141971c1c87ee0c71776eaedbfdd74bc28ba..d0fb7d9c0cfd2921086565ea9ad79f6331e58c28`
+**Reviewer:** Codex inline/local fallback
+**Date:** 2026-07-04
+**Posture:** adversarial defect-hunting; default is non-APPROVE unless implementation evidence is sufficient.
+
+## Reviewer Availability
+
+Attempted independent Codex CLI review first:
+
+- `codex exec review --base origin/main ...` ran for several minutes without writing an artifact and was terminated.
+- `codex exec ...` with a custom adversarial prompt hit the known CLI stdin path (`Reading additional input from stdin...`) and was terminated.
+
+This artifact records the main-session read-only adversarial review fallback. The implementation was already committed and pushed before this artifact was created.
+
+## Scope Reviewed
+
+Reviewed implementation against the approved [#806](https://github.com/vamseeachanta/worldenergydata/issues/806) plan:
+
+- official CORES statistics-page discovery and workbook URL validation;
+- direct XLSX download and caller-supplied cache root behavior;
+- atomic raw-cache writes and SHA-256/HTTP metadata;
+- explicit `Production` worksheet parsing;
+- normalized oil/gas/all CSV generation under `/mnt/ace` during execution;
+- committed Ayoluengo metadata refresh;
+- `SpainCoresAdapter` compatibility;
+- tests, lint/format, legal scan, and line-count guardrail.
+
+## Critical
+
+None found.
+
+## Important
+
+None found.
+
+## Minor
+
+None blocking.
+
+## Verification Notes
+
+- Source discovery validates both workbook filenames from the official CORES statistics page in `CoresWorkbookSource.discover()` (`packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_source.py:86`).
+- `download_all()` validates the statistics page by default before downloading/reusing files (`packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_source.py:100`).
+- Raw workbook writes use temp-file replacement and record byte count, content type, Last-Modified, SHA-256, and source URL metadata (`packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_source.py:147`, `packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_source.py:250`, `packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_source.py:282`).
+- The live loader selects the `Production` worksheet through `CoresProductionLoader(..., sheet_name="Production")` (`packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_live.py:93`, `packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_loader.py:150`).
+- The live loader writes `cores_oil_production.csv`, `cores_gas_production.csv`, and `cores_all_production.csv` under the caller-supplied cache root, without a library hardcode of `/mnt/ace` (`packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_live.py:106`).
+- Tests cover missing workbook-link fail-closed behavior, atomic write cleanup, metadata fields, explicit `Production` worksheet reads, fixture refresh metadata, and adapter compatibility (`tests/unit/spain/test_cores_live.py:24`, `tests/unit/spain/test_cores_live.py:45`, `tests/unit/spain/test_cores_live.py:58`, `tests/unit/spain/test_cores_live.py:119`, `tests/unit/spain/test_cores_live.py:164`, `tests/unit/production/unified/test_spain_cores_adapter_loader.py:172`).
+
+## Residual Risks
+
+- Scheduled refresh orchestration remains intentionally deferred to [#809](https://github.com/vamseeachanta/worldenergydata/issues/809).
+- Per-field oil density/API conversion remains intentionally deferred to [#807](https://github.com/vamseeachanta/worldenergydata/issues/807).
+- Full CI was not run locally; scoped Spain/adapter tests, lint/format, legal scan, direct live refresh, and `/mnt/ace` cache smoke checks passed.
+- CORES may change workbook layout beyond the `Start`/`Production` sheet pattern; the parser will fail closed on missing Year/Month columns through existing `CoresParseError`.
+
+## Verification Evidence
+
+- RED: missing `worldenergydata.spain.production.cores_live` import failed as expected before implementation.
+- RED: `CoresProductionLoader(..., sheet_name="Production")` failed as expected before implementation.
+- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=packages/worldenergydata-spain/src:packages/worldenergydata-production/src:packages/worldenergydata-fdas/src:packages/worldenergydata-core/src .venv/bin/python -m pytest tests/unit/spain tests/unit/production/unified/test_spain_cores_adapter_loader.py --noconftest -o addopts='' -q`  
+  Result: `20 passed in 43.95s`.
+- `.venv/bin/python -m ruff check ...`  
+  Result: `All checks passed!`.
+- `.venv/bin/python -m ruff format --check ...`  
+  Result: `7 files already formatted`.
+- `scripts/legal/legal-sanity-scan.sh --diff-only`  
+  Result: `legal-sanity-scan: PASS`.
+- Live direct-source refresh wrote:
+  - `/mnt/ace/worldenergydata/data/spain/cores/raw/crude-oil-production.xlsx` (`112669` bytes)
+  - `/mnt/ace/worldenergydata/data/spain/cores/raw/gas-production.xlsx` (`127915` bytes)
+  - `/mnt/ace/worldenergydata/data/spain/cores/normalized/cores_oil_production.csv`
+  - `/mnt/ace/worldenergydata/data/spain/cores/normalized/cores_gas_production.csv`
+  - `/mnt/ace/worldenergydata/data/spain/cores/normalized/cores_all_production.csv`
+
+## Ready-to-Merge Verdict
+
+**Ready to merge:** Yes, with documented residual scope deferrals.
+
+**Reasoning:** The implementation satisfies the approved [#806](https://github.com/vamseeachanta/worldenergydata/issues/806) slice, uses direct official CORES sources, avoids hardcoded `/mnt/ace` in library code, persists `/mnt/ace` operational outputs, refreshes committed metadata, and passes scoped verification. No Critical or Important defects were found in the fallback adversarial review.

--- a/tests/unit/production/unified/test_spain_cores_adapter_loader.py
+++ b/tests/unit/production/unified/test_spain_cores_adapter_loader.py
@@ -8,11 +8,11 @@ from worldenergydata.production.unified.adapters.spain_cores_adapter import (
     SpainCoresAdapter,
 )
 from worldenergydata.production.unified.query import STANDARD_COLUMNS, ProductionQuery
-from worldenergydata.spain.production.cores_loader import GWH_TO_MCF, TONNES_TO_BBL
 from worldenergydata.spain.production.cores_live import (
     DEFAULT_WORKBOOKS,
     CoresLiveProductionLoader,
 )
+from worldenergydata.spain.production.cores_loader import GWH_TO_MCF, TONNES_TO_BBL
 
 
 class FixtureCoresLoader:

--- a/tests/unit/production/unified/test_spain_cores_adapter_loader.py
+++ b/tests/unit/production/unified/test_spain_cores_adapter_loader.py
@@ -8,6 +8,11 @@ from worldenergydata.production.unified.adapters.spain_cores_adapter import (
     SpainCoresAdapter,
 )
 from worldenergydata.production.unified.query import STANDARD_COLUMNS, ProductionQuery
+from worldenergydata.spain.production.cores_loader import GWH_TO_MCF, TONNES_TO_BBL
+from worldenergydata.spain.production.cores_live import (
+    DEFAULT_WORKBOOKS,
+    CoresLiveProductionLoader,
+)
 
 
 class FixtureCoresLoader:
@@ -163,3 +168,55 @@ def test_default_adapter_loads_committed_ayoluengo_fixture():
     assert set(out["field_name"]) == {"Ayoluengo"}
     assert set(out["source"]) == {"cores"}
     assert out["oil_bbl"].gt(0).any()
+
+
+def test_adapter_accepts_live_cores_loader(tmp_path):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    _write_cores_xlsx(
+        raw_dir / DEFAULT_WORKBOOKS["oil"].filename,
+        pd.DataFrame(
+            [
+                {
+                    "Year": 2026,
+                    "Month": "June",
+                    "Ayoluengo": 2.0,
+                    "Grand total": 2.0,
+                }
+            ]
+        ),
+    )
+    _write_cores_xlsx(
+        raw_dir / DEFAULT_WORKBOOKS["gas"].filename,
+        pd.DataFrame(
+            [
+                {
+                    "Year": 2026,
+                    "Month": "June",
+                    "Ayoluengo": 3.0,
+                    "Grand total": 3.0,
+                }
+            ]
+        ),
+    )
+
+    adapter = SpainCoresAdapter(loader=CoresLiveProductionLoader(cache_root=tmp_path))
+    out = adapter.fetch(
+        ProductionQuery(regions=["spain"], fields=["Ayoluengo"], start="2026-06")
+    )
+
+    assert list(out.columns) == list(STANDARD_COLUMNS)
+    assert len(out) == 1
+    assert out.iloc[0]["oil_bbl"] == pytest.approx(2.0 * TONNES_TO_BBL)
+    assert out.iloc[0]["gas_mcf"] == pytest.approx(3.0 * GWH_TO_MCF)
+    assert out.iloc[0]["source"] == "cores"
+
+
+def _write_cores_xlsx(path, frame):
+    with pd.ExcelWriter(path) as writer:
+        pd.DataFrame({"note": ["landing sheet"]}).to_excel(
+            writer,
+            sheet_name="Start",
+            index=False,
+        )
+        frame.to_excel(writer, sheet_name="Production", index=False, startrow=5)

--- a/tests/unit/spain/test_cores_live.py
+++ b/tests/unit/spain/test_cores_live.py
@@ -1,0 +1,223 @@
+"""Spain CORES live workbook source tests (#806)."""
+
+import hashlib
+import json
+
+import pandas as pd
+import pytest
+
+from worldenergydata.spain.production.cores_loader import (
+    GWH_TO_MCF,
+    TONNES_TO_BBL,
+)
+from worldenergydata.spain.production.cores_live import (
+    DEFAULT_WORKBOOKS,
+    STATISTICS_PAGE_URL,
+    CoresHttpResponse,
+    CoresLiveProductionLoader,
+    CoresSourceError,
+    CoresWorkbookSource,
+    refresh_ayoluengo_fixture,
+)
+
+
+def test_discover_resolves_official_workbook_links_from_statistics_page_html(tmp_path):
+    html = """
+    <html>
+      <body>
+        <a href="/sites/default/files/archivos/estadisticas/crude-oil-production.xlsx">
+          Indigenous Crude Oil Production
+        </a>
+        <a href="https://www.cores.es/sites/default/files/archivos/estadisticas/gas-production.xlsx">
+          Indigenous Natural Gas Production
+        </a>
+      </body>
+    </html>
+    """
+    source = CoresWorkbookSource(cache_root=tmp_path)
+
+    inventory = source.discover(page_html=html)
+
+    assert inventory["oil"].source_url == DEFAULT_WORKBOOKS["oil"].source_url
+    assert inventory["gas"].source_url == DEFAULT_WORKBOOKS["gas"].source_url
+
+
+def test_discover_fails_closed_when_a_workbook_link_is_missing(tmp_path):
+    source = CoresWorkbookSource(cache_root=tmp_path)
+
+    with pytest.raises(CoresSourceError, match="gas-production.xlsx"):
+        source.discover(
+            page_html="""
+            <a href="/sites/default/files/archivos/estadisticas/crude-oil-production.xlsx">
+              Indigenous Crude Oil Production
+            </a>
+            """
+        )
+
+
+def test_download_all_writes_raw_files_atomically_and_records_metadata(tmp_path):
+    oil_bytes = b"oil workbook bytes"
+    gas_bytes = b"gas workbook bytes"
+    responses = {
+        STATISTICS_PAGE_URL: CoresHttpResponse(
+            content=f"""
+            <a href="{DEFAULT_WORKBOOKS["oil"].source_url}">oil</a>
+            <a href="{DEFAULT_WORKBOOKS["gas"].source_url}">gas</a>
+            """.encode("utf-8"),
+            headers={"Content-Type": "text/html"},
+        ),
+        DEFAULT_WORKBOOKS["oil"].source_url: CoresHttpResponse(
+            content=oil_bytes,
+            headers={
+                "Content-Type": (
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                ),
+                "Last-Modified": "Fri, 12 Jun 2026 07:51:41 GMT",
+            },
+        ),
+        DEFAULT_WORKBOOKS["gas"].source_url: CoresHttpResponse(
+            content=gas_bytes,
+            headers={
+                "Content-Type": (
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                ),
+                "Last-Modified": "Fri, 12 Jun 2026 07:52:01 GMT",
+            },
+        ),
+    }
+
+    def fake_http_get(url, *, method="GET"):
+        assert method == "GET"
+        return responses[url]
+
+    source = CoresWorkbookSource(
+        cache_root=tmp_path,
+        http_get=fake_http_get,
+        clock=lambda: "2026-07-04T00:00:00Z",
+    )
+
+    paths = source.download_all(force_refresh=True)
+
+    assert paths["oil"].read_bytes() == oil_bytes
+    assert paths["gas"].read_bytes() == gas_bytes
+    assert not list((tmp_path / "raw").glob("*.tmp"))
+
+    metadata = json.loads(
+        (tmp_path / "metadata" / "cores_refresh_metadata.json").read_text()
+    )
+    assert metadata["statistics_page"] == STATISTICS_PAGE_URL
+    assert metadata["refreshed_at_utc"] == "2026-07-04T00:00:00Z"
+    assert (
+        metadata["workbooks"]["oil"]["sha256"] == hashlib.sha256(oil_bytes).hexdigest()
+    )
+    assert metadata["workbooks"]["gas"]["byte_count"] == len(gas_bytes)
+    assert (
+        metadata["workbooks"]["oil"]["last_modified"] == "Fri, 12 Jun 2026 07:51:41 GMT"
+    )
+
+
+def test_live_loader_parses_production_sheets_and_writes_normalized_outputs(tmp_path):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    _write_cores_xlsx(
+        raw_dir / DEFAULT_WORKBOOKS["oil"].filename,
+        pd.DataFrame(
+            [
+                {
+                    "Year": 2026,
+                    "Month": "June",
+                    "Ayoluengo": 2.0,
+                    "Grand total": 2.0,
+                }
+            ]
+        ),
+    )
+    _write_cores_xlsx(
+        raw_dir / DEFAULT_WORKBOOKS["gas"].filename,
+        pd.DataFrame(
+            [
+                {
+                    "Year": 2026,
+                    "Month": "June",
+                    "Ayoluengo": 3.0,
+                    "Grand total": 3.0,
+                }
+            ]
+        ),
+    )
+
+    loader = CoresLiveProductionLoader(cache_root=tmp_path)
+
+    oil = loader.load_oil_production()
+    gas = loader.load_gas_production()
+    all_products = loader.load_all_production()
+
+    assert oil.iloc[0]["oil_bbl"] == pytest.approx(2.0 * TONNES_TO_BBL)
+    assert gas.iloc[0]["gas_mcf"] == pytest.approx(3.0 * GWH_TO_MCF)
+    assert all_products.iloc[0]["oil_bbl"] == pytest.approx(2.0 * TONNES_TO_BBL)
+    assert all_products.iloc[0]["gas_mcf"] == pytest.approx(3.0 * GWH_TO_MCF)
+    assert (tmp_path / "normalized" / "cores_oil_production.csv").exists()
+    assert (tmp_path / "normalized" / "cores_gas_production.csv").exists()
+    assert (tmp_path / "normalized" / "cores_all_production.csv").exists()
+
+
+def test_refresh_ayoluengo_fixture_writes_stable_sample_and_metadata(tmp_path):
+    oil = pd.DataFrame(
+        [
+            {"field_name": "Other", "year": 2026, "month": 1, "oil_bbl": 1.0},
+            {"field_name": "Ayoluengo", "year": 2026, "month": 2, "oil_bbl": 20.0},
+            {"field_name": "Ayoluengo", "year": 2026, "month": 1, "oil_bbl": 10.0},
+        ]
+    )
+    source_metadata = {
+        "statistics_page": STATISTICS_PAGE_URL,
+        "workbooks": {
+            "oil": {
+                "source_url": DEFAULT_WORKBOOKS["oil"].source_url,
+                "last_modified": "Fri, 12 Jun 2026 07:51:41 GMT",
+                "sha256": "abc123",
+                "byte_count": 123,
+            }
+        },
+    }
+
+    result = refresh_ayoluengo_fixture(
+        oil_frame=oil,
+        metadata=source_metadata,
+        output_dir=tmp_path,
+        refreshed_at_utc="2026-07-04T00:00:00Z",
+    )
+
+    sample = pd.read_csv(result.sample_path)
+    assert sample.to_dict("records") == [
+        {
+            "field_name": "Ayoluengo",
+            "year": 2026,
+            "month": 1,
+            "oil_bbl": 10.0,
+            "gas_mcf": 0.0,
+        },
+        {
+            "field_name": "Ayoluengo",
+            "year": 2026,
+            "month": 2,
+            "oil_bbl": 20.0,
+            "gas_mcf": 0.0,
+        },
+    ]
+    written_metadata = json.loads(result.metadata_path.read_text())
+    assert written_metadata["source_url"] == DEFAULT_WORKBOOKS["oil"].source_url
+    assert written_metadata["statistics_page"] == STATISTICS_PAGE_URL
+    assert written_metadata["sample_row_count"] == 2
+    assert written_metadata["conversion_factors"]["oil_tonnes_to_bbl"] == TONNES_TO_BBL
+    assert written_metadata["workbooks"]["oil"]["sha256"] == "abc123"
+
+
+def _write_cores_xlsx(path, frame):
+    with pd.ExcelWriter(path) as writer:
+        pd.DataFrame({"note": ["landing sheet"]}).to_excel(
+            writer,
+            sheet_name="Start",
+            index=False,
+        )
+        frame.to_excel(writer, sheet_name="Production", index=False, startrow=5)

--- a/tests/unit/spain/test_cores_live.py
+++ b/tests/unit/spain/test_cores_live.py
@@ -6,10 +6,6 @@ import json
 import pandas as pd
 import pytest
 
-from worldenergydata.spain.production.cores_loader import (
-    GWH_TO_MCF,
-    TONNES_TO_BBL,
-)
 from worldenergydata.spain.production.cores_live import (
     DEFAULT_WORKBOOKS,
     STATISTICS_PAGE_URL,
@@ -18,6 +14,10 @@ from worldenergydata.spain.production.cores_live import (
     CoresSourceError,
     CoresWorkbookSource,
     refresh_ayoluengo_fixture,
+)
+from worldenergydata.spain.production.cores_loader import (
+    GWH_TO_MCF,
+    TONNES_TO_BBL,
 )
 
 

--- a/tests/unit/spain/test_cores_live.py
+++ b/tests/unit/spain/test_cores_live.py
@@ -63,7 +63,9 @@ def test_download_all_writes_raw_files_atomically_and_records_metadata(tmp_path)
             content=f"""
             <a href="{DEFAULT_WORKBOOKS["oil"].source_url}">oil</a>
             <a href="{DEFAULT_WORKBOOKS["gas"].source_url}">gas</a>
-            """.encode("utf-8"),
+            """.encode(
+                "utf-8"
+            ),
             headers={"Content-Type": "text/html"},
         ),
         DEFAULT_WORKBOOKS["oil"].source_url: CoresHttpResponse(

--- a/tests/unit/spain/test_cores_loader.py
+++ b/tests/unit/spain/test_cores_loader.py
@@ -117,6 +117,43 @@ def test_loader_reads_xlsx_with_cores_header_row(tmp_path):
     ]
 
 
+def test_loader_can_select_real_cores_production_sheet(tmp_path):
+    path = tmp_path / "cores_oil.xlsx"
+    raw = pd.DataFrame(
+        [
+            {
+                "Year": 2026,
+                "Month": "June",
+                "Ayoluengo": 2.0,
+                "Grand total": 2.0,
+            }
+        ]
+    )
+    with pd.ExcelWriter(path) as writer:
+        pd.DataFrame({"note": ["landing sheet"]}).to_excel(
+            writer,
+            sheet_name="Start",
+            index=False,
+        )
+        raw.to_excel(writer, sheet_name="Production", index=False, startrow=5)
+
+    out = CoresProductionLoader(
+        product="oil",
+        path=path,
+        header_row=5,
+        sheet_name="Production",
+    ).load()
+
+    assert out.to_dict("records") == [
+        {
+            "field_name": "Ayoluengo",
+            "year": 2026,
+            "month": 6,
+            "oil_bbl": pytest.approx(2.0 * TONNES_TO_BBL),
+        }
+    ]
+
+
 def test_fixture_loader_carries_direct_source_provenance():
     loader = CoresFixtureProductionLoader()
 


### PR DESCRIPTION
## Summary
- Adds direct-source CORES statistics-page discovery and XLSX download/cache support for Spain oil and gas production.
- Parses the real CORES `Production` worksheet, writes oil/gas/all normalized CSVs under a caller-supplied cache root, and keeps SpainCoresAdapter compatibility.
- Refreshes committed Ayoluengo metadata with SHA256, byte counts, Last-Modified, source URLs, and conversion factors.

## Direct-source /mnt/ace output
- `/mnt/ace/worldenergydata/data/spain/cores/raw/crude-oil-production.xlsx` (112669 bytes)
- `/mnt/ace/worldenergydata/data/spain/cores/raw/gas-production.xlsx` (127915 bytes)
- `/mnt/ace/worldenergydata/data/spain/cores/normalized/cores_oil_production.csv`
- `/mnt/ace/worldenergydata/data/spain/cores/normalized/cores_gas_production.csv`
- `/mnt/ace/worldenergydata/data/spain/cores/normalized/cores_all_production.csv`

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=packages/worldenergydata-spain/src:packages/worldenergydata-production/src:packages/worldenergydata-fdas/src:packages/worldenergydata-core/src .venv/bin/python -m pytest tests/unit/spain tests/unit/production/unified/test_spain_cores_adapter_loader.py --noconftest -o addopts='' -q` -> 20 passed
- `.venv/bin/python -m ruff check ...` -> passed
- `.venv/bin/python -m ruff format --check ...` -> passed
- `scripts/legal/legal-sanity-scan.sh --diff-only` -> PASS
- Code review artifact: `scripts/review/results/2026-07-04-code-806-codex-inline.md`

Closes #806