### PR TITLE
feat(canada): C-NLOER offshore live-ingest loader + reference chain (#719)

### DIFF
--- a/packages/worldenergydata-canada/src/worldenergydata/canada/__init__.py
+++ b/packages/worldenergydata-canada/src/worldenergydata/canada/__init__.py
@@ -52,8 +52,9 @@ from worldenergydata.canada.emerging_basins.watch_list import (
     get_emerging_basins,
 )
 from worldenergydata.canada.production.cnloer_loader import (
-    CnloerLoader,
-    CnloerProductionRecord,
+    CnloerFixtureLoader,
+    CnloerProductionLoader,
+    parse_cnloer_production_text,
 )
 from worldenergydata.common.logging import get_logger
 
@@ -77,8 +78,9 @@ __all__ = [
     "CanadaCache",
     "FileDownloadCache",
     # C-NLOER offshore production
-    "CnloerLoader",
-    "CnloerProductionRecord",
+    "CnloerProductionLoader",
+    "CnloerFixtureLoader",
+    "parse_cnloer_production_text",
     # Emerging basins
     "EmergingBasinStub",
     "EMERGING_BASINS",

--- a/packages/worldenergydata-canada/src/worldenergydata/canada/data/cnlopb/_metadata.json
+++ b/packages/worldenergydata-canada/src/worldenergydata/canada/data/cnlopb/_metadata.json
@@ -1,0 +1,17 @@
+{
+  "source_name": "C-NLOER Statistical Information / Production Data",
+  "authority": "Canada-Newfoundland and Labrador Offshore Energy Regulator (formerly C-NLOPB)",
+  "statistics_page": "https://www.cnloer.ca/information/statistics/",
+  "example_field_pdfs": {
+    "Hibernia": "https://www.cnloer.ca/wp-content/uploads/2026hpro.pdf",
+    "Hebron": "https://www.cnloer.ca/wp-content/uploads/2026hepro.pdf",
+    "North Amethyst": "https://www.cnloer.ca/wp-content/uploads/2026npro.pdf",
+    "Terra Nova": "https://www.cnloer.ca/wp-content/uploads/2026tpro.pdf",
+    "White Rose": "https://www.cnloer.ca/wp-content/uploads/2026wpro.pdf"
+  },
+  "source_unit": "oil m3 + bbls; gas 10^3 m3 + MMscf; water m3 + bbls",
+  "normalized_unit": "oil_bbl / gas_mcf / water_bbl",
+  "fixture_nature": "SYNTHETIC (labeled cnloer_fixture_synthetic) — NOT derived real C-NLOER volumes",
+  "sample_extracted_date": "2026-07-04",
+  "LICENCE_NOTE": "C-NLOER production PDFs are public regulator disclosures but NOT open-licensed (no OGL); C-NLOER/CNSOER terms restrict reproduction and commercial/public redistribution. Raw PDFs are NOT committed and derived per-field volumes are NOT published to any public surface (capabilities page / reports) pending an explicit owner legal read. The committed fixture is synthetic so nothing licence-restricted enters git. Cite the source URL + authority + retrieval date on any use."
+}

--- a/packages/worldenergydata-canada/src/worldenergydata/canada/data/cnlopb/cnlopb_offshore_sample.csv
+++ b/packages/worldenergydata-canada/src/worldenergydata/canada/data/cnlopb/cnlopb_offshore_sample.csv
@@ -1,0 +1,11 @@
+field_name,year,month,oil_bbl,gas_mcf,water_bbl,source
+Hibernia,2020,1,3800000,1500000,4200000,cnloer_fixture_synthetic
+Hibernia,2020,2,3550000,1420000,4300000,cnloer_fixture_synthetic
+Hibernia,2020,3,3900000,1560000,4100000,cnloer_fixture_synthetic
+Hibernia,2020,4,3700000,1480000,4350000,cnloer_fixture_synthetic
+Hibernia,2020,5,3600000,1440000,4400000,cnloer_fixture_synthetic
+Hibernia,2020,6,3450000,1380000,4500000,cnloer_fixture_synthetic
+Terra Nova,2020,1,1200000,450000,2100000,cnloer_fixture_synthetic
+Terra Nova,2020,2,1150000,430000,2150000,cnloer_fixture_synthetic
+White Rose,2020,1,980000,360000,1400000,cnloer_fixture_synthetic
+White Rose,2020,2,950000,350000,1450000,cnloer_fixture_synthetic

--- a/packages/worldenergydata-canada/src/worldenergydata/canada/field_concept.py
+++ b/packages/worldenergydata-canada/src/worldenergydata/canada/field_concept.py
@@ -1,0 +1,67 @@
+"""Canada C-NLOER field metadata -> FieldConcept normalizer (#719).
+
+Maps sparse C-NLOER offshore field metadata to a ``FieldConcept`` for concept
+screening, reusing the F2 ``FieldMetaMapping`` (#715). Water depth (metres) comes
+from the C-NLOER ArcGIS Development-Wells layer (a metadata-enrichment follow-on);
+the fixture carries a representative depth per field.
+
+Grand Banks fields are SHALLOW (iceberg zone): Hibernia ~80 m, Hebron ~93 m,
+Terra Nova ~95 m, White Rose ~120 m. Via ``dev_system_from_water_depth_m`` these
+convert to ~262-394 ft, all below the 500 ft ``dry`` cutoff — correct for the
+GBS dry-tree fields (Hibernia, Hebron); a known simplification for the FPSO+subsea
+fields (Terra Nova/White Rose/North Amethyst), refined in a follow-on.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from worldenergydata.fdas.adapters.field_concept_normalizer import (
+    FieldMapEntry,
+    FieldMetaMapping,
+    number_from,
+    to_field_concept,
+)
+
+# Representative water depth (m) per NL offshore field (C-NLOER / public record).
+CANADA_WATER_DEPTH_M = {
+    "hibernia": 80.0,
+    "hebron": 93.0,
+    "terra nova": 95.0,
+    "white rose": 120.0,
+    "north amethyst": 120.0,
+}
+
+_CANADA_MAPPING = FieldMetaMapping(
+    {
+        "name": FieldMapEntry("field_name"),
+        "operator": FieldMapEntry("operator"),
+        "region": FieldMapEntry("region"),
+        "water_depth_m": FieldMapEntry("water_depth_m", number_from),
+        "data_source": FieldMapEntry("source"),
+    }
+)
+
+
+def canada_field_to_concept(field_meta: Dict[str, Any]):
+    """Build a sparse Canada ``FieldConcept`` from C-NLOER metadata."""
+    meta = dict(field_meta)
+    if "field_name" not in meta and "field" in meta:
+        meta["field_name"] = meta["field"]
+    meta["region"] = "canada"
+    meta.setdefault("source", "cnloer")
+    if meta.get("water_depth_m") is None:
+        key = str(meta.get("field_name", "")).strip().lower()
+        if key in CANADA_WATER_DEPTH_M:
+            meta["water_depth_m"] = CANADA_WATER_DEPTH_M[key]
+    return to_field_concept(meta, _CANADA_MAPPING)
+
+
+def canada_field_meta_mapping() -> FieldMetaMapping:
+    """Return the Canada C-NLOER FieldConcept mapping."""
+    return _CANADA_MAPPING
+
+
+def build_canada_field_concept(field_meta: Dict[str, Any]):
+    """Alias for the #719 reference-chain terminology."""
+    return canada_field_to_concept(field_meta)

--- a/packages/worldenergydata-canada/src/worldenergydata/canada/production/__init__.py
+++ b/packages/worldenergydata-canada/src/worldenergydata/canada/production/__init__.py
@@ -1,14 +1,16 @@
 # ABOUTME: Canada offshore production sub-package initialization.
-# ABOUTME: Exports C-NLOER (Newfoundland & Labrador) production loader.
+# ABOUTME: Exports C-NLOER (Newfoundland & Labrador) production loaders.
 
 """Canada offshore production data loaders."""
 
 from worldenergydata.canada.production.cnloer_loader import (
-    CnloerLoader,
-    CnloerProductionRecord,
+    CnloerFixtureLoader,
+    CnloerProductionLoader,
+    parse_cnloer_production_text,
 )
 
 __all__ = [
-    "CnloerLoader",
-    "CnloerProductionRecord",
+    "CnloerProductionLoader",
+    "CnloerFixtureLoader",
+    "parse_cnloer_production_text",
 ]

--- a/packages/worldenergydata-canada/src/worldenergydata/canada/production/cnloer_loader.py
+++ b/packages/worldenergydata-canada/src/worldenergydata/canada/production/cnloer_loader.py
@@ -1,427 +1,258 @@
-# ABOUTME: Canada C-NLOER (Canada-Newfoundland and Labrador Offshore Petroleum Board)
-# ABOUTME: production data loader for NL offshore fields with synthetic data profiles.
+"""Canada C-NLOER offshore per-field monthly production loader (#719).
 
-"""
-C-NLOER Offshore Production Loader.
+Parses the C-NLOER (Canada-Newfoundland and Labrador Offshore Energy Regulator,
+formerly C-NLOPB) per-field monthly production PDFs
+(https://www.cnloer.ca/information/statistics/) into the unified loader columns
+(field_name/year/month/oil_bbl/gas_mcf/water_bbl).
 
-Provides synthetic production data for the five Newfoundland & Labrador offshore
-fields regulated by C-NLOPB (Canada-Newfoundland and Labrador Offshore Petroleum
-Board, formerly C-NLOER).  Data values represent realistic annual production
-profiles based on published operator reports and regulatory filings.
+Real C-NLOER layout (codex-verified 2026-07-04): one PDF per field
+(``{h,he,n,t,w}pro.pdf``), monthly rows with oil/gas/water in BOTH metric and
+imperial. Some fields carry per-reservoir subrows that must be summed to a field
+monthly total; North Amethyst has no per-month ``Total`` row (sum reservoirs);
+Hibernia/Hebron carry explicit ``Total`` rows. ``mpro.pdf`` is the ALL-FIELD
+monthly total (not a field) and is rejected.
 
-Fields covered:
-    - Hibernia   (ExxonMobil operated, first oil 1997)
-    - Terra Nova (Suncor, first oil 2002)
-    - White Rose (Cenovus/Husky, first oil 2005)
-    - Hebron     (ExxonMobil, first oil 2017)
-    - North Amethyst (White Rose satellite, first oil 2010)
+Licence: C-NLOER PDFs are public regulator disclosures but NOT open-licensed
+(no OGL). Raw PDFs are NOT committed to the repo; the live-fetch lane caches them
+to a gitignored directory. The committed fixture is a small LABELED-SYNTHETIC
+sample (``source="cnloer_fixture_synthetic"``) so no licence-restricted data
+enters git. See ``_metadata.json`` / ``LICENCE_NOTE``.
 
-All volumetric data stored internally in sm3; converted to bbl on output via
-``OilUnits.SM3_TO_BBL`` (6.2898 bbl/sm3, API MPMS Ch. 11).
+The ``pdftotext`` I/O is a thin wrapper; the testable core is
+``parse_cnloer_production_text`` (a pure text->DataFrame transform), so it
+unit-tests without a committed binary PDF or poppler.
+
+Issue: https://github.com/vamseeachanta/worldenergydata/issues/719
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import date
-from typing import Dict, List, Optional
+import json
+import re
+from importlib.resources import files
+from pathlib import Path
+from typing import List, Optional
 
 import pandas as pd
 
-from worldenergydata.common.logging import get_logger
 from worldenergydata.common.units import GasUnits, OilUnits, WaterUnits
 
-logger = get_logger(__name__)
+# --- documented conversion constants (prefer source imperial columns) -------
+# Oil/water: metric m3 -> barrels (API MPMS Ch. 11).
+M3_TO_BBL = OilUnits.SM3_TO_BBL  # 6.2898 bbl/m3
+WATER_M3_TO_BBL = WaterUnits.M3_TO_BBL
+# Gas: C-NLOER reports 10^3 m3 (thousand m3) and MMscf. 10^3 m3 -> Mcf via
+# 1 m3 = 35.3147 scf: 1e3 m3 = 35 314.7 scf = 35.3147 Mcf.
+E3M3_TO_MCF = GasUnits.SM3_TO_SCF  # 35.3147 (1e3 m3 -> Mcf)
+MMSCF_TO_MCF = GasUnits.MMSCF_TO_MCF  # 1000.0
 
-# ---------------------------------------------------------------------------
-# Data record
-# ---------------------------------------------------------------------------
+# C-NLOER field code -> canonical field name (PDF stem ``{code}pro.pdf``).
+FIELD_CODES = {
+    "h": "Hibernia",
+    "he": "Hebron",
+    "n": "North Amethyst",
+    "t": "Terra Nova",
+    "w": "White Rose",
+}
+# ``m``pro / off_prod are ALL-FIELD totals reports, NOT a field (guard).
+_TOTALS_STEMS = {"m", "off_prod", "mpro"}
 
-
-@dataclass
-class CnloerProductionRecord:
-    """Single production record for a C-NLOER NL offshore field.
-
-    Attributes:
-        field_name: Name of the offshore field.
-        year: Calendar year of record.
-        month: Calendar month (1-12); 0 indicates annual aggregate.
-        oil_bbl: Oil production in stock-tank barrels.
-        gas_mcf: Associated gas production in thousand cubic feet (Mcf).
-        water_bbl: Produced water in barrels.
-        source: Data source identifier.
-    """
-
-    field_name: str
-    year: int
-    month: int  # 0 = annual aggregate
-    oil_bbl: float
-    gas_mcf: float
-    water_bbl: float
-    source: str = "cnloer"
-
-
-# ---------------------------------------------------------------------------
-# Internal synthetic annual data (oil_sm3, gas_msm3, water_sm3)
-# ---------------------------------------------------------------------------
-
-# Each entry: (year, oil_sm3_annual, gas_msm3_annual, water_sm3_annual)
-# Oil peaks expressed in kbopd; converted here to annual sm3 for storage.
-# 1 kbopd * 365 days * 1000 bbl/day * (1/6.2898 sm3/bbl) ≈ 58.03 ksm3/day
-
-_kbopd_to_sm3_year = 1_000 * 365 / OilUnits.SM3_TO_BBL  # ~58 030 sm3/year per kbopd
-
-
-def _bld(kbopd: float) -> float:
-    """Convert kbopd (thousands of barrels/day) to annual sm3."""
-    return kbopd * _kbopd_to_sm3_year
-
-
-def _gas_ratio_msm3(oil_sm3: float, gor: float = 100.0) -> float:
-    """Estimate gas from oil volume using gas-oil ratio (scf/bbl)."""
-    oil_bbl = oil_sm3 * OilUnits.SM3_TO_BBL
-    # gor in scf/bbl -> total scf -> MSm3
-    total_scf = oil_bbl * gor
-    return total_scf / GasUnits.SM3_TO_SCF / 1_000_000  # MSm3
-
-
-def _water_ratio(oil_sm3: float, wor: float = 0.5) -> float:
-    """Estimate water from oil volume using water-oil ratio."""
-    return oil_sm3 * wor
-
-
-# Annual production profiles as (year, oil_sm3, gas_msm3, water_sm3).
-# GOR (gas:oil ratio) approx 100 scf/bbl for Hibernia/Terra Nova/White Rose.
-# WOR starts low and rises with field maturity.
-
-
-def _build_hibernia() -> List[tuple]:
-    """
-    Hibernia: first oil 1997, peaked ~200 kbopd ~2005, gradual decline.
-    ExxonMobil operated; 33 production wells.
-    """
-    profile = [
-        (1997, 50),  # ramp-up year
-        (1998, 110),
-        (1999, 145),
-        (2000, 160),
-        (2001, 170),
-        (2002, 185),
-        (2003, 192),
-        (2004, 198),
-        (2005, 200),  # peak
-        (2006, 190),
-        (2007, 180),
-        (2008, 172),
-        (2009, 165),
-        (2010, 155),
-        (2011, 148),
-        (2012, 140),
-        (2013, 133),
-        (2014, 126),
-        (2015, 118),
-        (2016, 110),
-        (2017, 103),
-        (2018, 96),
-        (2019, 88),
-        (2020, 75),  # COVID impact
-        (2021, 82),
-        (2022, 78),
-        (2023, 72),
-    ]
-    rows = []
-    for yr, kbopd in profile:
-        maturity = (yr - 1997) / 26.0
-        wor = 0.1 + maturity * 1.5
-        oil_sm3 = _bld(kbopd)
-        gas_msm3 = _gas_ratio_msm3(oil_sm3, gor=80.0)
-        water_sm3 = _water_ratio(oil_sm3, wor=wor)
-        rows.append((yr, oil_sm3, gas_msm3, water_sm3))
-    return rows
-
-
-def _build_terra_nova() -> List[tuple]:
-    """
-    Terra Nova: first oil 2002, peaked ~130 kbopd ~2003,
-    significant unplanned shutdowns (2019 safety halt, 2022 restart).
-    Suncor operated FPSO.
-    """
-    profile = [
-        (2002, 90),
-        (2003, 130),  # peak
-        (2004, 110),
-        (2005, 100),
-        (2006, 92),
-        (2007, 85),
-        (2008, 78),
-        (2009, 73),
-        (2010, 67),
-        (2011, 63),
-        (2012, 58),
-        (2013, 55),
-        (2014, 51),
-        (2015, 48),
-        (2016, 44),
-        (2017, 41),
-        (2018, 38),
-        (2019, 10),  # safety shutdown
-        (2020, 0),  # full shutdown
-        (2021, 0),  # refurb
-        (2022, 15),  # restart
-        (2023, 30),
-    ]
-    rows = []
-    for yr, kbopd in profile:
-        maturity = (yr - 2002) / 21.0
-        wor = 0.2 + maturity * 2.0
-        oil_sm3 = _bld(kbopd)
-        gas_msm3 = _gas_ratio_msm3(oil_sm3, gor=75.0)
-        water_sm3 = _water_ratio(oil_sm3, wor=wor)
-        rows.append((yr, oil_sm3, gas_msm3, water_sm3))
-    return rows
-
-
-def _build_white_rose() -> List[tuple]:
-    """
-    White Rose: first oil 2005, peaked ~100 kbopd ~2007.
-    Cenovus/Husky FPSO.  2022 FPSO replacement in progress.
-    """
-    profile = [
-        (2005, 70),
-        (2006, 92),
-        (2007, 100),  # peak
-        (2008, 95),
-        (2009, 88),
-        (2010, 80),
-        (2011, 73),
-        (2012, 65),
-        (2013, 58),
-        (2014, 53),
-        (2015, 48),
-        (2016, 42),
-        (2017, 37),
-        (2018, 32),
-        (2019, 28),
-        (2020, 22),
-        (2021, 18),
-        (2022, 15),
-        (2023, 12),
-    ]
-    rows = []
-    for yr, kbopd in profile:
-        maturity = (yr - 2005) / 18.0
-        wor = 0.15 + maturity * 1.8
-        oil_sm3 = _bld(kbopd)
-        gas_msm3 = _gas_ratio_msm3(oil_sm3, gor=90.0)
-        water_sm3 = _water_ratio(oil_sm3, wor=wor)
-        rows.append((yr, oil_sm3, gas_msm3, water_sm3))
-    return rows
-
-
-def _build_hebron() -> List[tuple]:
-    """
-    Hebron: first oil 2017, still ramping/plateau ~150 kbopd target.
-    ExxonMobil gravity-based structure (GBS), 500 Mbbl estimated reserves.
-    """
-    profile = [
-        (2017, 30),
-        (2018, 80),
-        (2019, 115),
-        (2020, 105),  # COVID demand reduction
-        (2021, 120),
-        (2022, 135),
-        (2023, 148),
-    ]
-    rows = []
-    for yr, kbopd in profile:
-        maturity = (yr - 2017) / 6.0
-        wor = 0.05 + maturity * 0.5
-        oil_sm3 = _bld(kbopd)
-        gas_msm3 = _gas_ratio_msm3(oil_sm3, gor=70.0)
-        water_sm3 = _water_ratio(oil_sm3, wor=wor)
-        rows.append((yr, oil_sm3, gas_msm3, water_sm3))
-    return rows
-
-
-def _build_north_amethyst() -> List[tuple]:
-    """
-    North Amethyst: satellite of White Rose field, first oil 2010.
-    Tied back to White Rose FPSO; peak ~40 kbopd.
-    """
-    profile = [
-        (2010, 25),
-        (2011, 38),
-        (2012, 40),  # peak
-        (2013, 37),
-        (2014, 33),
-        (2015, 29),
-        (2016, 25),
-        (2017, 21),
-        (2018, 18),
-        (2019, 15),
-        (2020, 12),
-        (2021, 10),
-        (2022, 8),
-        (2023, 6),
-    ]
-    rows = []
-    for yr, kbopd in profile:
-        maturity = (yr - 2010) / 13.0
-        wor = 0.1 + maturity * 1.2
-        oil_sm3 = _bld(kbopd)
-        gas_msm3 = _gas_ratio_msm3(oil_sm3, gor=85.0)
-        water_sm3 = _water_ratio(oil_sm3, wor=wor)
-        rows.append((yr, oil_sm3, gas_msm3, water_sm3))
-    return rows
-
-
-# Registry mapping field name → builder function
-_FIELD_BUILDERS: Dict[str, callable] = {
-    "Hibernia": _build_hibernia,
-    "Terra Nova": _build_terra_nova,
-    "White Rose": _build_white_rose,
-    "Hebron": _build_hebron,
-    "North Amethyst": _build_north_amethyst,
+_MONTHS = {
+    "january": 1,
+    "february": 2,
+    "march": 3,
+    "april": 4,
+    "may": 5,
+    "june": 6,
+    "july": 7,
+    "august": 8,
+    "september": 9,
+    "october": 10,
+    "november": 11,
+    "december": 12,
+    "jan": 1,
+    "feb": 2,
+    "mar": 3,
+    "apr": 4,
+    "jun": 6,
+    "jul": 7,
+    "aug": 8,
+    "sep": 9,
+    "sept": 9,
+    "oct": 10,
+    "nov": 11,
+    "dec": 12,
 }
 
-_SM3_TO_MCF = GasUnits.SM3_TO_SCF / 1_000.0  # sm3 -> Mcf (1 sm3 = 0.0353147 Mcf)
-_MSM3_TO_MCF = 1_000_000 * _SM3_TO_MCF  # MSm3 -> Mcf
+_DATA_ROOT = files("worldenergydata.canada").joinpath("data/cnlopb")
+DEFAULT_FIXTURE_CSV = _DATA_ROOT.joinpath("cnlopb_offshore_sample.csv")
+DEFAULT_METADATA_JSON = _DATA_ROOT.joinpath("_metadata.json")
 
 
-def _build_records(field_name: str, rows: List[tuple]) -> List[CnloerProductionRecord]:
-    """Convert raw (year, oil_sm3, gas_msm3, water_sm3) tuples to records."""
-    records = []
-    for year, oil_sm3, gas_msm3, water_sm3 in rows:
-        oil_bbl = oil_sm3 * OilUnits.SM3_TO_BBL
-        gas_mcf = gas_msm3 * _MSM3_TO_MCF
-        water_bbl = water_sm3 * WaterUnits.M3_TO_BBL
-        records.append(
-            CnloerProductionRecord(
-                field_name=field_name,
-                year=year,
-                month=0,
-                oil_bbl=oil_bbl,
-                gas_mcf=gas_mcf,
-                water_bbl=water_bbl,
-                source="cnloer",
-            )
+class CnloerParseError(ValueError):
+    """Raised when a C-NLOER production text cannot be parsed."""
+
+
+def _month_to_int(token: str) -> Optional[int]:
+    return _MONTHS.get(str(token).strip().lower())
+
+
+def parse_cnloer_production_text(text: str, *, field_name: str) -> pd.DataFrame:
+    """Pure transform: ``pdftotext -layout`` output for one field -> long rows.
+
+    Expects whitespace-delimited monthly lines of the form::
+
+        <Month> <Year> <oil_m3> <oil_bbl> <gas_e3m3> <gas_MMscf> <water_m3> <water_bbl>
+
+    Per-reservoir subrows (same Month/Year repeated) are summed to a single
+    field monthly total. Rows with a non-parseable month or too few numeric
+    values (blank future months, headers) are dropped. Prefers the source
+    imperial columns (bbl / MMscf); converts the metric columns otherwise.
+
+    Returns ``[field_name, year, month, oil_bbl, gas_mcf, water_bbl]`` -- one row
+    per (year, month). ``condensate_bbl`` is intentionally absent (C-NLOER
+    publishes no condensate column; the adapter sets it NaN).
+    """
+    field_stem = str(field_name).strip().lower()
+    if field_stem in _TOTALS_STEMS:
+        raise CnloerParseError(
+            f"{field_name!r} is an all-field totals report (mpro), not a field"
         )
-    return records
+
+    rows: dict = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        month = _month_to_int(parts[0])
+        if month is None:
+            continue
+        nums: List[float] = []
+        for tok in parts[1:]:
+            t = tok.replace(",", "")
+            if re.fullmatch(r"-?\d+(?:\.\d+)?", t):
+                nums.append(float(t))
+        # need at least Year + oil + gas + water
+        if len(nums) < 4:
+            continue
+        year = int(nums[0])
+        if year <= 0:
+            continue
+        oil_bbl, gas_mcf, water_bbl = _extract_volumes(nums[1:])
+        acc = rows.setdefault((year, month), [0.0, 0.0, 0.0])
+        acc[0] += oil_bbl
+        acc[1] += gas_mcf
+        acc[2] += water_bbl
+
+    if not rows:
+        raise CnloerParseError(f"no monthly production rows parsed for {field_name!r}")
+
+    out = pd.DataFrame(
+        [
+            {
+                "field_name": str(field_name).strip(),
+                "year": year,
+                "month": month,
+                "oil_bbl": acc[0],
+                "gas_mcf": acc[1],
+                "water_bbl": acc[2],
+            }
+            for (year, month), acc in sorted(rows.items())
+        ]
+    )
+    return out.reset_index(drop=True)
 
 
-# ---------------------------------------------------------------------------
-# Loader
-# ---------------------------------------------------------------------------
+def _extract_volumes(vals: List[float]) -> tuple:
+    """Map a row's value columns (after Year) to (oil_bbl, gas_mcf, water_bbl).
 
-_DATAFRAME_COLUMNS = [
-    "field_name",
-    "year",
-    "month",
-    "oil_bbl",
-    "gas_mcf",
-    "water_bbl",
-    "source",
-]
+    Layout is disambiguated by COUNT, not fixed index — a full C-NLOER row
+    carries BOTH units interleaved (6 cols: oil_m3, oil_bbl, gas_e3m3,
+    gas_MMscf, water_m3, water_bbl), so the source imperial columns are used
+    directly. A metric-only row (3 cols: oil_m3, gas_e3m3, water_m3) is
+    converted. Index-based "prefer imperial" is ambiguous when the imperial
+    columns are absent, so dispatch on the column count instead.
+    """
+    n = len(vals)
+    if n >= 6:  # both units present -> use source imperial columns
+        return (vals[1], vals[3] * MMSCF_TO_MCF, vals[5])
+    if n >= 3:  # metric only -> convert
+        return (
+            vals[0] * M3_TO_BBL,
+            vals[1] * E3M3_TO_MCF,
+            vals[2] * WATER_M3_TO_BBL,
+        )
+    return (0.0, 0.0, 0.0)
 
 
-class CnloerLoader:
-    """Load C-NLOER (NL offshore) production data.
+class CnloerProductionLoader:
+    """Reads a C-NLOER field PDF (or injected text) -> long loader rows.
 
-    Data is sourced from built-in synthetic profiles that faithfully represent
-    published operator and regulatory production histories for the five NL
-    offshore fields.
-
-    Example::
-
-        loader = CnloerLoader()
-        records = loader.load_field("Hibernia", start_year=2000, end_year=2010)
-        df = loader.to_dataframe(records)
-        logger.info(df[["year", "oil_bbl"]].head())
+    Dependency-injected ``raw_text`` (pre-extracted ``pdftotext`` output) is used
+    for tests; otherwise ``path`` is read via ``pdftotext -layout``. The runtime
+    download lane (fetch + gitignored cache) is a documented #719 follow-on and
+    is NOT exercised in tests nor committed with cached PDFs (licence).
     """
 
-    def available_fields(self) -> List[str]:
-        """Return names of all NL offshore fields with built-in data.
-
-        Returns:
-            List of field name strings.
-        """
-        return list(_FIELD_BUILDERS.keys())
-
-    def load_field(
+    def __init__(
         self,
+        *,
         field_name: str,
-        start_year: int = 1997,
-        end_year: Optional[int] = None,
-    ) -> List[CnloerProductionRecord]:
-        """Load production records for a single NL offshore field.
+        path: Optional[Path] = None,
+        raw_text: Optional[str] = None,
+    ):
+        self.field_name = field_name
+        self._path = path
+        self._raw_text = raw_text
 
-        Args:
-            field_name: Name of the field (see ``available_fields()``).
-            start_year: First year to include (inclusive).
-            end_year: Last year to include (inclusive); defaults to current year.
+    def load(self) -> pd.DataFrame:
+        text = (
+            self._raw_text
+            if self._raw_text is not None
+            else self._pdftotext(self._path)
+        )
+        return parse_cnloer_production_text(text, field_name=self.field_name)
 
-        Returns:
-            List of :class:`CnloerProductionRecord` objects sorted by year.
+    @staticmethod
+    def _pdftotext(path: Optional[Path]) -> str:
+        import subprocess
 
-        Raises:
-            ValueError: If ``field_name`` is not recognised.
-        """
-        if field_name not in _FIELD_BUILDERS:
-            available = ", ".join(sorted(_FIELD_BUILDERS.keys()))
-            raise ValueError(f"Unknown field {field_name!r}. Available: {available}")
+        if path is None:
+            raise CnloerParseError("no path or raw_text provided to loader")
+        return subprocess.check_output(
+            ["pdftotext", "-layout", str(path), "-"], text=True
+        )
 
-        if end_year is None:
-            end_year = date.today().year
 
-        raw_rows = _FIELD_BUILDERS[field_name]()
-        records = _build_records(field_name, raw_rows)
-        return [r for r in records if start_year <= r.year <= end_year]
+class CnloerFixtureLoader:
+    """Loader facade over the committed labeled-synthetic offshore fixture.
 
-    def load_all_fields(
+    The fixture is SYNTHETIC (not derived real C-NLOER volumes) so nothing
+    licence-restricted enters git; it exists to make the DI-default adapter path
+    non-empty and deterministic. Real parsing is covered by
+    ``parse_cnloer_production_text`` tests over inline synthetic PDF text.
+    """
+
+    def __init__(
         self,
-        start_year: int = 1997,
-        end_year: Optional[int] = None,
-    ) -> List[CnloerProductionRecord]:
-        """Load production records for all NL offshore fields.
+        *,
+        path=DEFAULT_FIXTURE_CSV,
+        metadata_path=DEFAULT_METADATA_JSON,
+    ):
+        self._path = path
+        self._metadata_path = metadata_path
 
-        Args:
-            start_year: First year to include (inclusive).
-            end_year: Last year to include (inclusive); defaults to current year.
+    def load_all_production(self) -> pd.DataFrame:
+        return pd.read_csv(self._path)
 
-        Returns:
-            Combined list of :class:`CnloerProductionRecord` objects for all
-            five fields, sorted by field name then year.
-        """
-        all_records: List[CnloerProductionRecord] = []
-        for field_name in _FIELD_BUILDERS:
-            all_records.extend(
-                self.load_field(field_name, start_year=start_year, end_year=end_year)
-            )
-        return sorted(all_records, key=lambda r: (r.field_name, r.year))
+    def load_field_production(self, field_name: str) -> pd.DataFrame:
+        frame = self.load_all_production()
+        mask = frame["field_name"].astype(str).str.lower() == field_name.lower()
+        return frame[mask].copy()
 
-    def to_dataframe(self, records: List[CnloerProductionRecord]) -> pd.DataFrame:
-        """Convert a list of production records to a pandas DataFrame.
-
-        Args:
-            records: List of :class:`CnloerProductionRecord` objects.
-
-        Returns:
-            DataFrame with columns: field_name, year, month, oil_bbl,
-            gas_mcf, water_bbl, source.
-        """
-        if not records:
-            return pd.DataFrame(columns=_DATAFRAME_COLUMNS)
-
-        rows = [
-            {
-                "field_name": r.field_name,
-                "year": r.year,
-                "month": r.month,
-                "oil_bbl": r.oil_bbl,
-                "gas_mcf": r.gas_mcf,
-                "water_bbl": r.water_bbl,
-                "source": r.source,
-            }
-            for r in records
-        ]
-        return pd.DataFrame(rows, columns=_DATAFRAME_COLUMNS)
+    def metadata(self) -> dict:
+        with self._metadata_path.open(encoding="utf-8") as fh:
+            return json.load(fh)

--- a/packages/worldenergydata-canada/src/worldenergydata/canada/reference_chain.py
+++ b/packages/worldenergydata-canada/src/worldenergydata/canada/reference_chain.py
@@ -1,0 +1,101 @@
+"""Canada C-NLOER reference-chain runner (#719).
+
+Minimal vertical slice mirroring the merged Norway (#716) / Spain (#763) chains:
+``CanadaAdapter.fetch`` -> ``to_fdas_production`` -> ``CashflowEngine`` and
+``build_canada_field_concept`` -> ``recommend``. Economics are explicitly pre-tax
+chain plumbing, not a Canada investment NPV headline.
+
+Dev-system: the primary field Hibernia is a shallow-water (~80 m) Gravity-Based
+Structure with dry trees, so the depth classifier's ``dry`` result is accurate.
+For the FPSO+subsea fields it is a documented simplification (see
+``dev_system_source`` in the metrics + the #719 per-field-concept follow-on).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+import pandas as pd
+
+from worldenergydata.canada.field_concept import build_canada_field_concept
+from worldenergydata.fdas.adapters.contract import to_fdas_production
+from worldenergydata.fdas.adapters.field_concept_normalizer import (
+    dev_system_from_water_depth_m,
+)
+from worldenergydata.fdas.analysis.cashflow import CashflowEngine
+from worldenergydata.fdas.core.config import AssumptionsManager
+from worldenergydata.field_development.recommendation import recommend
+from worldenergydata.production.unified.query import ProductionQuery
+
+
+def run_canada_reference_chain(
+    *,
+    adapter,
+    field_meta: Dict[str, Any],
+    field_name: str,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+    oil_price_usd_bbl: float = 75.0,
+) -> Dict[str, Any]:
+    """Run the #719 one-field Canada C-NLOER chain slice."""
+    unified = adapter.fetch(
+        ProductionQuery(
+            regions=["canada"],
+            fields=[field_name],
+            start=start,
+            end=end,
+        )
+    )
+    fdas_production = to_fdas_production(unified)
+    field_concept = build_canada_field_concept(field_meta)
+    ranked_concepts = recommend(field_concept)
+
+    first_oil = _first_oil_date(fdas_production)
+    price_deck = {
+        str(year_month): oil_price_usd_bbl
+        for year_month in fdas_production.get("YEAR_MONTH", pd.Series(dtype="object"))
+    }
+    dev_system = dev_system_from_water_depth_m(field_concept.water_depth_m)
+    if dev_system == "unknown":
+        dev_system = "subsea15"
+
+    cashflows = CashflowEngine(
+        AssumptionsManager(), dev_system=dev_system
+    ).generate_monthly_cashflow(
+        fdas_production,
+        {"drilling_monthly": {}},
+        price_deck,
+        first_oil,
+    )
+
+    return {
+        "field_name": field_name,
+        "unified_production": unified,
+        "fdas_production": fdas_production,
+        "field_concept": field_concept,
+        "ranked_concepts": ranked_concepts,
+        "economics_label": "chain_plumbing_pre_tax",
+        "dev_system": dev_system,
+        "pre_tax_metrics": _pre_tax_metrics(cashflows, dev_system),
+    }
+
+
+def _first_oil_date(fdas_production: pd.DataFrame) -> datetime:
+    if fdas_production.empty:
+        return datetime(1970, 1, 1)
+    first_period = str(fdas_production["YEAR_MONTH"].min())
+    return datetime.strptime(first_period, "%Y-%m")
+
+
+def _pre_tax_metrics(cashflows, dev_system: str) -> Dict[str, Any]:
+    return {
+        "months": len(cashflows),
+        "gross_revenue_usd": float(sum(cf.oil_revenue_usd for cf in cashflows)),
+        "royalty_usd": float(sum(cf.royalty_usd for cf in cashflows)),
+        "host_capex_usd": float(sum(cf.host_capex_usd for cf in cashflows)),
+        "net_cashflow_usd": float(sum(cf.net_cashflow_usd for cf in cashflows)),
+        # dev_system from the depth classifier (see module docstring); per-field
+        # GBS-vs-FPSO/subsea concept override is a #719 follow-on.
+        "dev_system_source": "depth_classifier",
+    }

--- a/packages/worldenergydata-production/src/worldenergydata/production/unified/adapters/canada_adapter.py
+++ b/packages/worldenergydata-production/src/worldenergydata/production/unified/adapters/canada_adapter.py
@@ -1,103 +1,115 @@
-"""Canada adapter — offshore Newfoundland production data.
+"""Canada adapter — C-NLOER offshore Newfoundland production (#719).
 
-Covers the three producing offshore NL fields (Hibernia, Terra Nova,
-White Rose).  Volumes are natively in bbl / Mcf.
+DI-loader adapter (mirrors ``SodirAdapter``/``SpainCoresAdapter``): a real
+C-NLOER loader (or an injected duck-typed loader) supplies per-field monthly
+rows; the bare default loads the committed labeled-synthetic fixture. Replaces
+the previous self-contained synthetic peak-rate mock.
+
+``condensate_bbl``/``water_bbl`` defaulting: C-NLOER publishes water but no
+condensate stream → ``condensate_bbl`` is NaN.
 """
 
 from __future__ import annotations
 
 from typing import List, Tuple
 
+import numpy as np
 import pandas as pd
 
 from worldenergydata.production.unified.adapters.base import AbstractProductionAdapter
-from worldenergydata.production.unified.query import ProductionQuery
+from worldenergydata.production.unified.query import STANDARD_COLUMNS, ProductionQuery
 
 
 class CanadaAdapter(AbstractProductionAdapter):
-    """Canadian offshore Newfoundland production adapter."""
+    """Canadian offshore Newfoundland (C-NLOER) production adapter."""
 
     region: str = "canada"
 
-    # (field_name, peak_oil_bbl, peak_gas_mcf, peak_water_bbl,
-    #  peak_cond_bbl, start_year, start_month, n_months)
-    _FIELDS = [
-        ("Hibernia", 6_200_000, 2_500_000, 3_000_000, 100_000, 1997, 1, 336),
-        ("Terra Nova", 2_400_000, 900_000, 1_100_000, 40_000, 2002, 1, 276),
-        ("White Rose", 1_900_000, 700_000, 800_000, 30_000, 2005, 11, 230),
-    ]
+    def __init__(self, loader=None):
+        self.loader = loader if loader is not None else self._default_loader()
 
     def fetch(self, query: ProductionQuery) -> pd.DataFrame:
-        rows = []
-        for (
-            field_name,
-            peak_oil,
-            peak_gas,
-            peak_water,
-            peak_cond,
-            sy,
-            sm,
-            n_months,
-        ) in self._FIELDS:
-            rows.extend(
-                self._generate_field_rows(
-                    field_name,
-                    peak_oil,
-                    peak_gas,
-                    peak_water,
-                    peak_cond,
-                    sy,
-                    sm,
-                    n_months,
-                )
-            )
-
-        df = pd.DataFrame(rows)
+        df = self._loader_to_standard_columns(self._load_from_loader(query))
         df = self._filter_by_fields(df, query.fields)
         df = self._filter_by_date(df, query.start, query.end)
         return df.reset_index(drop=True)
 
     def available_fields(self) -> List[str]:
-        return [f[0] for f in self._FIELDS]
+        df = self._loader_to_standard_columns(
+            self._load_from_loader(ProductionQuery(regions=[self.region]))
+        )
+        return sorted(df["field_name"].dropna().unique().tolist())
 
     def date_range(self) -> Tuple[str, str]:
-        return ("1997-01", "2024-12")
+        df = self._loader_to_standard_columns(
+            self._load_from_loader(ProductionQuery(regions=[self.region]))
+        )
+        if df.empty:
+            return ("", "")
+        periods = df["year"].astype(int) * 100 + df["month"].astype(int)
+        start = int(periods.min())
+        end = int(periods.max())
+        return (
+            f"{start // 100:04d}-{start % 100:02d}",
+            f"{end // 100:04d}-{end % 100:02d}",
+        )
+
+    def _load_from_loader(self, query: ProductionQuery) -> pd.DataFrame:
+        if query.fields and hasattr(self.loader, "load_field_production"):
+            frames = [
+                self.loader.load_field_production(field_name)
+                for field_name in query.fields
+            ]
+            frames = [f for f in frames if f is not None and len(f) > 0]
+            if not frames:
+                return pd.DataFrame()
+            return pd.concat(frames, ignore_index=True)
+        if hasattr(self.loader, "load_all_production"):
+            return self.loader.load_all_production()
+        raise TypeError(
+            "Canada C-NLOER loader must expose load_all_production() or "
+            "load_field_production(field_name)"
+        )
+
+    def _loader_to_standard_columns(self, loader_df: pd.DataFrame) -> pd.DataFrame:
+        if loader_df is None or loader_df.empty:
+            return self._empty_frame()
+
+        out = pd.DataFrame()
+        out["field_name"] = loader_df["field_name"].astype(str).str.strip()
+        out["region"] = self.region
+        out["year"] = loader_df["year"].astype(int)
+        out["month"] = loader_df["month"].astype(int)
+        out["oil_bbl"] = _numeric_or_default(loader_df, "oil_bbl", default=0.0)
+        out["gas_mcf"] = _numeric_or_default(loader_df, "gas_mcf", default=0.0)
+        out["water_bbl"] = _numeric_or_default(loader_df, "water_bbl", default=np.nan)
+        out["condensate_bbl"] = _numeric_or_default(
+            loader_df, "condensate_bbl", default=np.nan
+        )
+        if "source" in loader_df.columns:
+            out["source"] = loader_df["source"].astype(str).values
+        else:
+            out["source"] = "cnloer"
+        return out[list(STANDARD_COLUMNS)]
 
     @staticmethod
-    def _generate_field_rows(
-        field_name: str,
-        peak_oil: float,
-        peak_gas: float,
-        peak_water: float,
-        peak_cond: float,
-        start_year: int,
-        start_month: int,
-        n_months: int,
-    ) -> list:
-        rows = []
-        year, month = start_year, start_month
-        for i in range(n_months):
-            if i < 24:
-                factor = min(1.0, (i + 1) / 24)
-            else:
-                factor = 0.87 ** ((i - 24) / 12.0)
+    def _default_loader():
+        from worldenergydata.canada.production.cnloer_loader import (
+            CnloerFixtureLoader,
+        )
 
-            rows.append(
-                {
-                    "region": "canada",
-                    "field_name": field_name,
-                    "year": year,
-                    "month": month,
-                    "oil_bbl": round(peak_oil * factor, 0),
-                    "gas_mcf": round(peak_gas * factor, 0),
-                    "water_bbl": round(peak_water * min(factor * 2.0, 4.0), 0),
-                    "condensate_bbl": round(peak_cond * factor, 0),
-                    "source": "canada_mock",
-                }
-            )
-            month += 1
-            if month > 12:
-                month = 1
-                year += 1
+        return CnloerFixtureLoader()
 
-        return rows
+
+def _numeric_or_default(
+    frame: pd.DataFrame,
+    column: str,
+    *,
+    default: float,
+) -> pd.Series:
+    if column in frame.columns:
+        values = pd.to_numeric(frame[column], errors="coerce")
+        if pd.isna(default):
+            return values
+        return values.fillna(default)
+    return pd.Series(default, index=frame.index, dtype="float64")

--- a/tests/unit/canada/production/test_cnloer_loader.py
+++ b/tests/unit/canada/production/test_cnloer_loader.py
@@ -1,292 +1,111 @@
-"""
-Tests for CnloerLoader — C-NLOER NL offshore production data module.
+"""Tests for the C-NLOER offshore production loader (#719).
 
-Coverage targets:
-- available_fields() returns all 5 NL fields
-- load_field() returns non-empty records for each field
-- Record structure and field values are correct
-- Unit conversions applied correctly (m3 -> bbl via OilUnits.SM3_TO_BBL)
-- Year filtering works
-- to_dataframe() returns DataFrame with correct schema
-- load_all_fields() covers all five fields
-- Error handling for unknown fields
+Covers the pure ``parse_cnloer_production_text`` transform (reservoir summing,
+imperial-vs-metric column preference, mpro rejection, blank/header drop,
+condensate absent) + the committed labeled-synthetic fixture loader. Fully
+self-contained (no PDFs / poppler / network).
 """
 
-import math
-
-import pandas as pd
 import pytest
 
 from worldenergydata.canada.production.cnloer_loader import (
-    _MSM3_TO_MCF,
-    CnloerLoader,
-    CnloerProductionRecord,
+    E3M3_TO_MCF,
+    M3_TO_BBL,
+    CnloerFixtureLoader,
+    CnloerParseError,
+    CnloerProductionLoader,
+    parse_cnloer_production_text,
 )
-from worldenergydata.common.units import OilUnits
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-EXPECTED_FIELDS = {"Hibernia", "Terra Nova", "White Rose", "Hebron", "North Amethyst"}
-
-
-@pytest.fixture
-def loader() -> CnloerLoader:
-    return CnloerLoader()
-
-
-# ---------------------------------------------------------------------------
-# Test: available_fields
-# ---------------------------------------------------------------------------
-
-
-class TestAvailableFields:
-    def test_available_fields_returns_list(self, loader):
-        result = loader.available_fields()
-        assert isinstance(result, list)
-
-    def test_available_fields_contains_all_five_nl_fields(self, loader):
-        result = set(loader.available_fields())
-        assert result == EXPECTED_FIELDS
-
-    def test_available_fields_has_exactly_five_entries(self, loader):
-        assert len(loader.available_fields()) == 5
-
-    def test_available_fields_contains_hibernia(self, loader):
-        assert "Hibernia" in loader.available_fields()
-
-    def test_available_fields_contains_terra_nova(self, loader):
-        assert "Terra Nova" in loader.available_fields()
-
-    def test_available_fields_contains_white_rose(self, loader):
-        assert "White Rose" in loader.available_fields()
-
-    def test_available_fields_contains_hebron(self, loader):
-        assert "Hebron" in loader.available_fields()
-
-    def test_available_fields_contains_north_amethyst(self, loader):
-        assert "North Amethyst" in loader.available_fields()
-
-
-# ---------------------------------------------------------------------------
-# Test: load_field — basic structure
-# ---------------------------------------------------------------------------
-
-
-class TestLoadFieldStructure:
-    def test_load_field_hibernia_returns_non_empty_list(self, loader):
-        records = loader.load_field("Hibernia")
-        assert len(records) > 0
-
-    def test_load_field_returns_cnloer_production_records(self, loader):
-        records = loader.load_field("Hibernia")
-        assert all(isinstance(r, CnloerProductionRecord) for r in records)
-
-    def test_load_field_record_has_field_name(self, loader):
-        records = loader.load_field("Hibernia")
-        assert all(r.field_name == "Hibernia" for r in records)
-
-    def test_load_field_record_has_year(self, loader):
-        records = loader.load_field("Hibernia")
-        assert all(isinstance(r.year, int) for r in records)
-
-    def test_load_field_record_has_month(self, loader):
-        records = loader.load_field("Hibernia")
-        assert all(isinstance(r.month, int) for r in records)
-
-    def test_load_field_record_has_oil_bbl(self, loader):
-        records = loader.load_field("Hibernia")
-        assert all(isinstance(r.oil_bbl, float) for r in records)
-
-    def test_load_field_record_has_gas_mcf(self, loader):
-        records = loader.load_field("Hibernia")
-        assert all(isinstance(r.gas_mcf, float) for r in records)
-
-    def test_load_field_record_has_water_bbl(self, loader):
-        records = loader.load_field("Hibernia")
-        assert all(isinstance(r.water_bbl, float) for r in records)
-
-    def test_load_field_record_source_is_cnloer(self, loader):
-        records = loader.load_field("Hibernia")
-        assert all(r.source == "cnloer" for r in records)
-
-    def test_load_field_all_fields_source_cnloer(self, loader):
-        for field_name in loader.available_fields():
-            records = loader.load_field(field_name)
-            assert all(
-                r.source == "cnloer" for r in records
-            ), f"field {field_name}: some records have wrong source"
-
-
-# ---------------------------------------------------------------------------
-# Test: load_field — value validity
-# ---------------------------------------------------------------------------
-
-
-class TestLoadFieldValues:
-    def test_load_field_oil_bbl_positive_for_production_years(self, loader):
-        records = loader.load_field("Hibernia")
-        assert all(r.oil_bbl >= 0 for r in records)
-        # At least one peak year should have substantial production
-        assert any(r.oil_bbl > 1_000_000 for r in records)
-
-    def test_load_field_hibernia_start_year_gte_1997(self, loader):
-        records = loader.load_field("Hibernia")
-        assert all(r.year >= 1997 for r in records)
-
-    def test_load_field_terra_nova_start_year_gte_2002(self, loader):
-        records = loader.load_field("Terra Nova")
-        assert min(r.year for r in records) >= 2002
-
-    def test_load_field_hebron_start_year_gte_2017(self, loader):
-        records = loader.load_field("Hebron")
-        assert min(r.year for r in records) >= 2017
-
-    def test_load_field_north_amethyst_start_year_gte_2010(self, loader):
-        records = loader.load_field("North Amethyst")
-        assert min(r.year for r in records) >= 2010
-
-    def test_load_field_gas_mcf_non_negative(self, loader):
-        for field_name in loader.available_fields():
-            records = loader.load_field(field_name)
-            assert all(r.gas_mcf >= 0 for r in records)
-
-    def test_load_field_water_bbl_non_negative(self, loader):
-        for field_name in loader.available_fields():
-            records = loader.load_field(field_name)
-            assert all(r.water_bbl >= 0 for r in records)
-
-
-# ---------------------------------------------------------------------------
-# Test: year filtering
-# ---------------------------------------------------------------------------
-
-
-class TestLoadFieldYearFiltering:
-    def test_start_year_filter_applied(self, loader):
-        records = loader.load_field("Hibernia", start_year=2000)
-        assert all(r.year >= 2000 for r in records)
-
-    def test_end_year_filter_applied(self, loader):
-        records = loader.load_field("Hibernia", end_year=2010)
-        assert all(r.year <= 2010 for r in records)
-
-    def test_start_and_end_year_filter(self, loader):
-        records = loader.load_field("Hibernia", start_year=2003, end_year=2007)
-        assert all(2003 <= r.year <= 2007 for r in records)
-        assert len(records) == 5
-
-    def test_unknown_field_raises_value_error(self, loader):
-        with pytest.raises(ValueError, match="Unknown field"):
-            loader.load_field("Doesnotexist")
-
-
-# ---------------------------------------------------------------------------
-# Test: unit conversion (m3 -> bbl)
-# ---------------------------------------------------------------------------
-
-
-class TestUnitConversion:
-    def test_oil_bbl_uses_sm3_to_bbl_factor(self, loader):
-        """
-        Verify that oil_bbl values reflect SM3_TO_BBL conversion.
-        For Hibernia 1997 ~50 kbopd peak, annual oil_sm3 ≈ 2.9 MSm3.
-        oil_bbl should ≈ oil_sm3 * 6.2898.
-        We verify the ratio is close to SM3_TO_BBL by back-converting.
-        """
-        records = loader.load_field("Hibernia", start_year=2005, end_year=2005)
-        assert len(records) == 1
-        rec = records[0]
-        # Back-compute sm3 from bbl
-        implied_sm3 = rec.oil_bbl / OilUnits.SM3_TO_BBL
-        # For 200 kbopd * 365 days * 1000 = 73,000,000 bbl/year -> sm3 = 11,606,700
-        # Accept within 1% of expected range for 200 kbopd
-        expected_bbl_approx = 200 * 1000 * 365  # 73 million bbl
-        assert math.isclose(
-            rec.oil_bbl, expected_bbl_approx, rel_tol=0.02
-        ), f"Hibernia 2005 oil_bbl {rec.oil_bbl:.0f} not close to {expected_bbl_approx}"
-
-
-# ---------------------------------------------------------------------------
-# Test: to_dataframe
-# ---------------------------------------------------------------------------
-
-
-class TestToDataframe:
-    def test_to_dataframe_returns_dataframe(self, loader):
-        records = loader.load_field("Hibernia")
-        df = loader.to_dataframe(records)
-        assert isinstance(df, pd.DataFrame)
-
-    def test_to_dataframe_has_field_name_column(self, loader):
-        records = loader.load_field("Hibernia")
-        df = loader.to_dataframe(records)
-        assert "field_name" in df.columns
-
-    def test_to_dataframe_has_year_column(self, loader):
-        records = loader.load_field("Hibernia")
-        df = loader.to_dataframe(records)
-        assert "year" in df.columns
-
-    def test_to_dataframe_has_oil_bbl_column(self, loader):
-        records = loader.load_field("Hibernia")
-        df = loader.to_dataframe(records)
-        assert "oil_bbl" in df.columns
-
-    def test_to_dataframe_has_gas_mcf_column(self, loader):
-        records = loader.load_field("Hibernia")
-        df = loader.to_dataframe(records)
-        assert "gas_mcf" in df.columns
-
-    def test_to_dataframe_has_water_bbl_column(self, loader):
-        records = loader.load_field("Hibernia")
-        df = loader.to_dataframe(records)
-        assert "water_bbl" in df.columns
-
-    def test_to_dataframe_has_source_column(self, loader):
-        records = loader.load_field("Hibernia")
-        df = loader.to_dataframe(records)
-        assert "source" in df.columns
-
-    def test_to_dataframe_row_count_matches_records(self, loader):
-        records = loader.load_field("Hibernia")
-        df = loader.to_dataframe(records)
-        assert len(df) == len(records)
-
-    def test_to_dataframe_empty_records_returns_empty_df(self, loader):
-        df = loader.to_dataframe([])
-        assert isinstance(df, pd.DataFrame)
-        assert len(df) == 0
-        assert "oil_bbl" in df.columns
-
-
-# ---------------------------------------------------------------------------
-# Test: load_all_fields
-# ---------------------------------------------------------------------------
-
-
-class TestLoadAllFields:
-    def test_load_all_fields_returns_list(self, loader):
-        records = loader.load_all_fields()
-        assert isinstance(records, list)
-
-    def test_load_all_fields_non_empty(self, loader):
-        records = loader.load_all_fields()
-        assert len(records) > 0
-
-    def test_load_all_fields_covers_all_five_fields(self, loader):
-        records = loader.load_all_fields()
-        found_fields = {r.field_name for r in records}
-        assert found_fields == EXPECTED_FIELDS
-
-    def test_load_all_fields_all_source_cnloer(self, loader):
-        records = loader.load_all_fields()
-        assert all(r.source == "cnloer" for r in records)
-
-    def test_load_all_fields_year_filter_respected(self, loader):
-        records = loader.load_all_fields(start_year=2017, end_year=2017)
-        # Hibernia, Terra Nova, White Rose, Hebron should all have 2017 data
-        # (North Amethyst may not; Hebron starts 2017)
-        years = {r.year for r in records}
-        assert years == {2017}
+# Synthetic pdftotext-style text: Month Year oil_m3 oil_bbl gas_e3m3 gas_MMscf
+# water_m3 water_bbl. Header + a blank future month are interleaved and dropped.
+_HIBERNIA_TEXT = """
+Hibernia Monthly Production
+Month Year Oil(m3) Oil(bbl) Gas(e3m3) Gas(MMscf) Water(m3) Water(bbl)
+January 2024 10000 62898 5000 176.6 8000 50318
+February 2024 9500 59753 4800 169.5 8200 51576
+March 2024
+"""
+
+# North Amethyst has NO per-month Total row — two reservoir subrows per month
+# must be summed to the field monthly total.
+_NORTH_AMETHYST_TEXT = """
+Month Year Oil(m3) Oil(bbl) Gas(e3m3) Gas(MMscf) Water(m3) Water(bbl)
+January 2023 1000 6290 500 17.7 400 2516
+January 2023 2000 12580 500 17.7 600 3774
+"""
+
+# Metric-only row (no imperial columns) → converted via factors.
+_METRIC_ONLY_TEXT = """
+Month Year Oil(m3) Gas(e3m3) Water(m3)
+January 2022 100 10 50
+"""
+
+
+def test_parse_prefers_imperial_columns_and_drops_header_and_blank_month():
+    out = parse_cnloer_production_text(_HIBERNIA_TEXT, field_name="Hibernia")
+
+    assert list(out.columns) == [
+        "field_name",
+        "year",
+        "month",
+        "oil_bbl",
+        "gas_mcf",
+        "water_bbl",
+    ]
+    # header ("Month Year …") + blank "March 2024" row dropped
+    assert set(out["month"]) == {1, 2}
+    jan = out[out["month"] == 1].iloc[0]
+    assert jan["oil_bbl"] == pytest.approx(62898.0)  # imperial bbl column
+    assert jan["gas_mcf"] == pytest.approx(176.6 * 1000)  # MMscf × 1000
+    assert jan["water_bbl"] == pytest.approx(50318.0)
+    # condensate intentionally absent (C-NLOER has no condensate column)
+    assert "condensate_bbl" not in out.columns
+
+
+def test_parse_sums_reservoir_subrows_per_month():
+    out = parse_cnloer_production_text(
+        _NORTH_AMETHYST_TEXT, field_name="North Amethyst"
+    )
+    assert len(out) == 1
+    row = out.iloc[0]
+    assert row["oil_bbl"] == pytest.approx(6290.0 + 12580.0)
+    assert row["water_bbl"] == pytest.approx(2516.0 + 3774.0)
+
+
+def test_parse_falls_back_to_metric_columns():
+    out = parse_cnloer_production_text(_METRIC_ONLY_TEXT, field_name="Hibernia")
+    row = out.iloc[0]
+    assert row["oil_bbl"] == pytest.approx(100 * M3_TO_BBL)
+    assert row["gas_mcf"] == pytest.approx(10 * E3M3_TO_MCF)
+
+
+def test_parse_rejects_all_field_totals_report():
+    with pytest.raises(CnloerParseError, match="totals"):
+        parse_cnloer_production_text(_HIBERNIA_TEXT, field_name="mpro")
+
+
+def test_parse_raises_when_no_rows():
+    with pytest.raises(CnloerParseError, match="no monthly"):
+        parse_cnloer_production_text("just a header line\n", field_name="Hibernia")
+
+
+def test_production_loader_uses_injected_raw_text():
+    loader = CnloerProductionLoader(field_name="Hibernia", raw_text=_HIBERNIA_TEXT)
+    out = loader.load()
+    assert set(out["field_name"]) == {"Hibernia"}
+    assert out["oil_bbl"].gt(0).all()
+
+
+def test_fixture_loader_is_labeled_synthetic_with_licence_provenance():
+    loader = CnloerFixtureLoader()
+
+    metadata = loader.metadata()
+    frame = loader.load_field_production("Hibernia")
+
+    assert "LICENCE_NOTE" in metadata
+    assert "SYNTHETIC" in metadata["fixture_nature"].upper()
+    assert metadata["statistics_page"].startswith("https://www.cnloer.ca")
+    assert set(frame["field_name"]) == {"Hibernia"}
+    assert (frame["source"] == "cnloer_fixture_synthetic").all()
+    assert frame["oil_bbl"].gt(0).any()

--- a/tests/unit/canada/test_reference_chain.py
+++ b/tests/unit/canada/test_reference_chain.py
@@ -1,0 +1,84 @@
+"""Canada C-NLOER reference-chain tests (#719)."""
+
+import math
+
+import pandas as pd
+
+from worldenergydata.canada.field_concept import build_canada_field_concept
+from worldenergydata.canada.reference_chain import run_canada_reference_chain
+from worldenergydata.fdas.adapters.contract import FDAS_PRODUCTION_COLUMNS
+from worldenergydata.production.unified.adapters.canada_adapter import CanadaAdapter
+
+
+class FixtureCnloerLoader:
+    def load_field_production(self, field_name):
+        return pd.DataFrame(
+            [
+                {
+                    "field_name": field_name,
+                    "year": 2024,
+                    "month": 1,
+                    "oil_bbl": 3_800_000.0,
+                    "gas_mcf": 1_500_000.0,
+                    "water_bbl": 4_200_000.0,
+                    "source": "cnloer",
+                },
+                {
+                    "field_name": field_name,
+                    "year": 2024,
+                    "month": 2,
+                    "oil_bbl": 3_550_000.0,
+                    "gas_mcf": 1_420_000.0,
+                    "water_bbl": 4_300_000.0,
+                    "source": "cnloer",
+                },
+            ]
+        )
+
+
+def _field_meta():
+    return {"field_name": "Hibernia", "operator": "ExxonMobil", "source": "cnloer"}
+
+
+def test_field_concept_uses_representative_water_depth():
+    concept = build_canada_field_concept(_field_meta())
+    assert concept.name == "Hibernia"
+    assert concept.region == "canada"
+    assert concept.water_depth_m == 80.0  # Hibernia GBS, shallow
+
+
+def test_reference_chain_hibernia_is_dry_gbs_and_revenue_positive():
+    result = run_canada_reference_chain(
+        adapter=CanadaAdapter(loader=FixtureCnloerLoader()),
+        field_meta=_field_meta(),
+        field_name="Hibernia",
+        start="2024-01",
+        end="2024-02",
+        oil_price_usd_bbl=75.0,
+    )
+
+    assert result["economics_label"] == "chain_plumbing_pre_tax"
+    # Hibernia is a shallow-water GBS dry-tree field → depth classifier "dry"
+    assert result["dev_system"] == "dry"
+    assert result["pre_tax_metrics"]["dev_system_source"] == "depth_classifier"
+    assert list(result["fdas_production"].columns) == list(FDAS_PRODUCTION_COLUMNS)
+    assert list(result["fdas_production"]["YEAR_MONTH"]) == ["2024-01", "2024-02"]
+    assert result["pre_tax_metrics"]["gross_revenue_usd"] > 0.0
+    assert math.isfinite(result["pre_tax_metrics"]["net_cashflow_usd"])
+
+
+def test_reference_chain_is_deterministic():
+    first = run_canada_reference_chain(
+        adapter=CanadaAdapter(loader=FixtureCnloerLoader()),
+        field_meta=_field_meta(),
+        field_name="Hibernia",
+    )
+    second = run_canada_reference_chain(
+        adapter=CanadaAdapter(loader=FixtureCnloerLoader()),
+        field_meta=_field_meta(),
+        field_name="Hibernia",
+    )
+    assert first["field_concept"] == build_canada_field_concept(_field_meta())
+    assert [r.concept_type for r in first["ranked_concepts"]] == [
+        r.concept_type for r in second["ranked_concepts"]
+    ]

--- a/tests/unit/production/unified/test_canada_cnloer_adapter_loader.py
+++ b/tests/unit/production/unified/test_canada_cnloer_adapter_loader.py
@@ -1,0 +1,122 @@
+"""Canada C-NLOER adapter DI-loader + fixture contract tests (#719)."""
+
+import pandas as pd
+import pytest
+
+from worldenergydata.fdas.adapters.contract import to_fdas_production
+from worldenergydata.production.unified.adapters.canada_adapter import CanadaAdapter
+from worldenergydata.production.unified.query import STANDARD_COLUMNS, ProductionQuery
+
+
+class FixtureCnloerLoader:
+    """Duck-typed C-NLOER loader returning normalized per-field monthly rows."""
+
+    def __init__(self):
+        self.calls = []
+
+    def _frame(self):
+        return pd.DataFrame(
+            [
+                {
+                    "field_name": "Hibernia",
+                    "year": 2024,
+                    "month": 1,
+                    "oil_bbl": 3_800_000.0,
+                    "gas_mcf": 1_500_000.0,
+                    "water_bbl": 4_200_000.0,
+                    "source": "cnloer",
+                },
+                {
+                    "field_name": "Hibernia",
+                    "year": 2024,
+                    "month": 2,
+                    "oil_bbl": 3_550_000.0,
+                    "gas_mcf": 1_420_000.0,
+                    "water_bbl": 4_300_000.0,
+                    "source": "cnloer",
+                },
+                {
+                    "field_name": "Terra Nova",
+                    "year": 2024,
+                    "month": 1,
+                    "oil_bbl": 1_200_000.0,
+                    "gas_mcf": 450_000.0,
+                    "water_bbl": 2_100_000.0,
+                    "source": "cnloer",
+                },
+            ]
+        )
+
+    def load_all_production(self):
+        self.calls.append(("all", None))
+        return self._frame()
+
+    def load_field_production(self, field_name):
+        self.calls.append(("field", field_name))
+        frame = self._frame()
+        return frame[frame["field_name"] == field_name].copy()
+
+
+def test_fetch_transforms_loader_output_to_standard_columns():
+    loader = FixtureCnloerLoader()
+    adapter = CanadaAdapter(loader=loader)
+
+    out = adapter.fetch(
+        ProductionQuery(
+            regions=["canada"], fields=["Hibernia"], start="2024-02", end="2024-02"
+        )
+    )
+
+    assert loader.calls == [("field", "Hibernia")]
+    assert list(out.columns) == list(STANDARD_COLUMNS)
+    assert len(out) == 1
+    row = out.iloc[0]
+    assert row["region"] == "canada"
+    assert row["field_name"] == "Hibernia"
+    assert row["oil_bbl"] == pytest.approx(3_550_000.0)
+    assert row["source"] == "cnloer"
+    # C-NLOER has no condensate stream
+    assert pd.isna(row["condensate_bbl"])
+    # water IS published
+    assert row["water_bbl"] == pytest.approx(4_300_000.0)
+
+
+def test_fetch_output_is_accepted_by_fdas_production_contract():
+    adapter = CanadaAdapter(loader=FixtureCnloerLoader())
+
+    unified = adapter.fetch(ProductionQuery(regions=["canada"], fields=["Hibernia"]))
+    fdas = to_fdas_production(unified)
+
+    assert list(fdas["DEV_NAME"].unique()) == ["Hibernia"]
+    assert list(fdas["YEAR_MONTH"]) == ["2024-01", "2024-02"]
+    assert fdas["MONTHLY_WATER_BBL"].notna().all()
+
+
+def test_fetch_all_uses_loader_all_path_when_no_field_filter():
+    loader = FixtureCnloerLoader()
+    adapter = CanadaAdapter(loader=loader)
+
+    out = adapter.fetch(ProductionQuery(regions=["canada"]))
+
+    assert loader.calls == [("all", None)]
+    assert set(out["field_name"]) == {"Hibernia", "Terra Nova"}
+    assert out["condensate_bbl"].isna().all()
+
+
+def test_default_adapter_loads_committed_synthetic_fixture():
+    adapter = CanadaAdapter()
+
+    out = adapter.fetch(ProductionQuery(regions=["canada"], fields=["Hibernia"]))
+
+    assert not out.empty
+    assert set(out["field_name"]) == {"Hibernia"}
+    assert (out["source"] == "cnloer_fixture_synthetic").all()
+    assert out["oil_bbl"].gt(0).any()
+
+
+def test_default_adapter_available_fields_and_date_range_non_empty():
+    adapter = CanadaAdapter()
+    fields = adapter.available_fields()
+    assert {"Hibernia", "Terra Nova", "White Rose"}.issubset(set(fields))
+    start, end = adapter.date_range()
+    assert "-" in start and "-" in end


### PR DESCRIPTION
## Summary

Replaces the fully-synthetic Canada offshore path with a **real C-NLOER loader** and runs the F2 field-development chain, mirroring the merged Norway (#716) / Spain (#763) chains. Epic #713. **Consolidates** the two prior *disconnected* synthetic sources (`canada_adapter` peak-rate mock + `cnloer_loader` `_build_*` profiles) into one DI-loader.

Closes #719.

### Ingest (719a)
- `parse_cnloer_production_text` — pure `pdftotext`→long transform: reservoir-subrow summing, **count-based imperial/metric column dispatch**, `mpro` all-field-totals rejection, blank/header-row drop. Units: oil/water m³→bbl (×6.2898), gas 10³m³→Mcf (×35.3147) / MMscf→Mcf (×1000); `condensate_bbl` absent (C-NLOER publishes none).
- `CnloerProductionLoader` (DI `raw_text=`/`path=`) + `CnloerFixtureLoader` over a committed **labeled-synthetic** fixture.
- Removed synthetic `CnloerLoader`/`CnloerProductionRecord` (their `month=0` annual rows violated the FDAS contract's `month∈[1,12]` guard); both `__init__` exports updated.

### Chain (719b)
- `CanadaAdapter` refactored self-synthetic → **DI-loader** (region=canada, source from loader, `water_bbl` kept, `condensate_bbl`=NaN; non-empty fixture default). Already registered — no router/registration changes.
- `canada/field_concept.py` + `reference_chain.py`: **Hibernia** primary. Grand Banks fields are shallow (262–394 ft) → depth classifier returns `dry`, which is *accurate* for the Hibernia GBS dry-tree platform; `dev_system_source: depth_classifier` marks the seam for the per-field-concept follow-on. No onshore-mismatch flag (offshore).

### ⚠️ Licence posture
C-NLOER/CNSOER PDFs are public regulator disclosures but **NOT OGL-licensed**. So: **no raw PDFs committed**, the fixture is synthetic, and public exposure is gated on an owner legal read (`_metadata.json` `LICENCE_NOTE`).

### Verification
- **154 tests pass** (`--noconftest` path): loader transform, adapter DI/contract, reference chain, conformance, router, registry.
- black / isort / flake8 clean; `legal-sanity-scan` PASS; **`uv.lock` unchanged** (no new dependency).

### Follow-ons filed (epic #713)
#814 live download+refresh · #815 per-field dev-concept override · #816 CNSOER gas ingest+revenue · #817 Hibernia HTML-modal backfill · #818 ArcGIS water-depth enrichment · #819 owner legal-read gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)