### PR TITLE
feat(dev): pin format pre-commit hooks to CI's uv toolchain (#822)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,34 +24,46 @@ repos:
       - id: no-commit-to-branch
         args: [--branch, main]
 
-  # Python code formatting
-  - repo: https://github.com/psf/black
-    rev: 24.10.0
+  # Python formatting + lint — MUST stay byte-for-byte in step with the CI
+  # "Lint" job in .github/workflows/ci.yml, which runs:
+  #     uv run black  --check --diff src/ tests/
+  #     uv run isort  --check-only --diff src/ tests/
+  #     uv run flake8 src/ --max-line-length=100 --extend-ignore=E203,W503 ...
+  # These are LOCAL hooks that shell out to the repo's own uv env, so the tool
+  # VERSIONS come straight from uv.lock (black 25.9.0, isort 8.0.1, flake8
+  # 7.3.0) — identical to CI, and they can never silently drift from it. That
+  # drift is the exact bug this fixes: the old pinned mirror ran black 24.10.0
+  # locally while CI ran 25.9.0, so PR #821 was merge-refused twice on
+  # formatting that "passed" at commit time. `--extra dev` pulls the pinned dev
+  # toolchain (uv sync --all-extras in CI). Config is read from the same files
+  # CI uses: [tool.black]/[tool.isort] in pyproject.toml and [flake8] in
+  # .flake8 (incl. per-file-ignores). Hooks run in fix mode (no --check) so a
+  # bad file is reformatted in place and the commit fails until re-staged. (#822)
+  - repo: local
     hooks:
       - id: black
-        language_version: python3.11
-        args: [--line-length=88]
-
-  # Import sorting
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
+        name: black (uv run — matches CI Lint job)
+        entry: uv run --extra dev black
+        language: system
+        types: [python]
+        files: ^(src|tests)/.*\.py$
+        require_serial: true
       - id: isort
-        args: [--profile=black]
-
-  # Linting
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
-    hooks:
+        name: isort (uv run — matches CI Lint job)
+        entry: uv run --extra dev isort
+        language: system
+        types: [python]
+        files: ^(src|tests)/.*\.py$
+        require_serial: true
+      # CI lints src/ only with flake8; .flake8 supplies max-line-length=100,
+      # extend-ignore=E203,W503 and per-file-ignores (__init__.py:F401).
       - id: flake8
-        args:
-          - --max-line-length=100
-          - --extend-ignore=E203,W503
-          - --exclude=__pycache__,*.egg-info,.git,.venv,docs/_legacy
-        additional_dependencies:
-          - flake8-bugbear
-          - flake8-comprehensions
-          - flake8-simplify
+        name: flake8 (uv run — matches CI Lint job)
+        entry: uv run --extra dev flake8
+        language: system
+        types: [python]
+        files: ^src/.*\.py$
+        require_serial: true
 
   # Security checks
   - repo: https://github.com/PyCQA/bandit

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ git clone https://github.com/username/worldenergydata.git
 cd worldenergydata
 uv sync
 
+# Install git hooks (black/isort/flake8 run at commit, matching CI)
+uv run pre-commit install
+
 # Populate BSEE data (not stored in git, ~300 MB download)
 make data
 # or: python3 scripts/refresh_bsee_all.py
@@ -298,11 +301,12 @@ uv add --dev pytest-cov   # Development dependency
 ## Contributing
 
 1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/new-feature`)
-3. Write tests first (TDD)
-4. Implement your changes
-5. Run quality checks (`uv run pytest && uv run ruff check .`)
-6. Submit a pull request
+2. Install the pre-commit hooks once (`uv run pre-commit install`) so black/isort/flake8 run at `git commit` with the same versions as CI
+3. Create a feature branch (`git checkout -b feature/new-feature`)
+4. Write tests first (TDD)
+5. Implement your changes
+6. Run quality checks (`uv run pytest && uv run ruff check .`)
+7. Submit a pull request
 
 ## License
 


### PR DESCRIPTION
Closes #822. Refs #821 (the incident), #526 (CI hygiene).

## Problem
The repo's `.pre-commit-config.yaml` pinned the formatter hooks to **mirror repos at versions that had drifted from CI**: `psf/black@24.10.0` (with `--line-length=88`) while the CI `Lint` job runs `uv run black` = **25.9.0** (from `uv.lock`). So a contributor *with hooks installed* still got formatting CI rejects. PR #821 was merge-refused twice on exactly this drift.

## Fix
Convert the three formatter hooks (black/isort/flake8) to **local `uv run --extra dev …` hooks**. Their versions now come from `uv.lock` (black 25.9.0, isort 8.0.1, flake8 7.3.0) — identical to the CI Lint job by construction, and they read config from the same `pyproject`/`.flake8` CI uses. They can never silently drift from CI again. README documents `uv run pre-commit install`.

## Why correct-by-construction
The hook invocation is now byte-for-byte the CI invocation (`uv run <tool>`, same lockfile), so a local pass ⇒ a CI pass. No manually-synced version to rot.

## Scope
Only the 3 formatter hooks changed (see diff); the pre-existing bandit/mypy/gitleaks/legal-scan hooks are untouched. No repo-wide reformat. No `.py` changes, so this PR's own Lint check is unaffected.

## Follow-on
Ecosystem rollout of this pattern to the other Python repos is tracked in workspace-hub#3382.
