### PR TITLE
fix(benchmark): exclude Canada from _REAL_SOURCES per licence gate (#819)

### DIFF
--- a/packages/worldenergydata-production/src/worldenergydata/production/unified/benchmark_report.py
+++ b/packages/worldenergydata-production/src/worldenergydata/production/unified/benchmark_report.py
@@ -46,6 +46,12 @@ _CONCEPT_BUCKETS = ("dry", "subsea15", "subsea20", "unknown")
 # a ``*_mock`` tag, a blank/NaN source, or any unrecognised string — is "seed"
 # by construction, so unknown provenance can never be upgraded to real by
 # naming luck (#723 review Finding 1). Compared case-insensitively.
+# Entries are the SOURCE tags adapters emit (not region names). Canada is
+# deliberately EXCLUDED: C-NLOER production data is NOT open-licensed and its
+# derived per-field figures must not publish as "real" on any public surface
+# (capabilities page / reports) until an owner legal read clears it (#819).
+# The Canada adapter emits "cnloer"/"cnloer_fixture_synthetic" (never "canada"),
+# so it correctly badges "seed"; do NOT add "cnloer" here before #819 is closed.
 _REAL_SOURCES = frozenset(
     {
         "bsee",
@@ -56,7 +62,6 @@ _REAL_SOURCES = frozenset(
         "eia_us",
         "mexico_cnh",
         "texas_rrc",
-        "canada",
     }
 )
 


### PR DESCRIPTION
## Summary
The cross-country benchmark (#723) provenance allowlist `_REAL_SOURCES` in `benchmark_report.py` contained `"canada"`. **C-NLOER production data is NOT open-licensed**, and **#819** gates its derived per-field figures from any public surface (capabilities page / reports) pending an owner legal read.

`"canada"` was also a latent footgun: every other allowlist entry is a real adapter **source tag** (`bsee`/`sodir`/`cores`/…), but the Canada adapter emits `"cnloer"`/`"cnloer_fixture_synthetic"` (never `"canada"`), so the entry matched nothing and Canada already badged `"seed"` — but it read as *"Canada real data is allowed"*, one edit away from publishing restricted figures. Removed it (and deliberately did **not** substitute `"cnloer"`) with a comment tying the exclusion to #819.

**No behaviour change today** (Canada stays `seed`); **12 benchmark tests pass**. Refs #819, #723.

🤖 Generated with [Claude Code](https://claude.com/claude-code)