### PR TITLE
docs: add #809 Spain CORES scheduler exit handoff

### DIFF
--- a/docs/session-handoffs/2026-07-05-spain-cores-scheduler-809-exit.md
+++ b/docs/session-handoffs/2026-07-05-spain-cores-scheduler-809-exit.md
@@ -1,0 +1,78 @@
+# worldenergydata #809 Exit Handoff
+
+Date: 2026-07-05
+
+## Current State
+
+- Issue: https://github.com/vamseeachanta/worldenergydata/issues/809 is CLOSED with `status:done`.
+- PR: https://github.com/vamseeachanta/worldenergydata/pull/835 is MERGED to `main`.
+- Merge commit: `8619df236d45680eaec2a517863a795c1d792a1f`.
+- Issue summary comment: https://github.com/vamseeachanta/worldenergydata/issues/809#issuecomment-4886028295.
+
+## What Landed
+
+The Spain CORES scheduler refresh job was added and wired into scheduler config, CLI discovery, package dependencies, docs, and tests. The job refreshes Spain CORES production data, writes normalized CSV output plus `_metadata.json`, supports fixture refresh, resolves scheduler-relative paths, and classifies deterministic CORES source failures as non-retryable.
+
+Primary changed areas:
+
+- `packages/worldenergydata-scheduler/src/worldenergydata/scheduler/jobs/spain_cores_refresh.py`
+- `packages/worldenergydata-scheduler/src/worldenergydata/scheduler/cli.py`
+- `packages/worldenergydata-scheduler/src/worldenergydata/scheduler/jobs/__init__.py`
+- `packages/worldenergydata-scheduler/config/scheduler/scheduler_config.yml`
+- `packages/worldenergydata-scheduler/README.md`
+- `packages/worldenergydata-scheduler/tests/unit/scheduler/test_spain_cores_refresh.py`
+
+## Verification Evidence
+
+Local targeted checks passed before merge:
+
+- Spain CORES scheduler unit tests: 10 passed.
+- Scheduler startup tests: 2 passed.
+- CLI run-job and actual-adapter scheduler integration tests: 2 passed.
+- Spain CORES live-loader unit tests: 5 passed.
+- Issue-specific config/CLI/scheduler tests: 3 passed.
+- Direct lazy registry/interface assertion: `direct-interface-ok`.
+- Black, isort, flake8 on touched Python files passed.
+- Path-limited legal sanity scan over changed files passed.
+
+PR checks were green and the PR merge state was clean before squash merge.
+
+## Review Record
+
+Adversarial review findings were addressed before merge:
+
+- Fixture refresh exceptions now return `JobResult(status="failure")` instead of escaping the job contract.
+- Metadata format now records `csv`, not `parquet`.
+- `CoresSourceError` is non-retryable.
+- Scheduler coverage now exercises the actual Spain job adapter through `DataScheduler.run_once`.
+- `cmd_run_job` default lazy registry execution is covered.
+- Tests use DataFrame-shaped loader results.
+- README documents the operator `/mnt/ace/worldenergydata/data/spain/cores` output path.
+
+## Cleanup State
+
+Task scratch/workspaces were removed:
+
+- `/mnt/local-analysis/wed-809-spain-scheduler-work`
+- `/mnt/local-analysis/wed-809-spain-scheduler-archive`
+- `/mnt/local-analysis/wed-809-spain-scheduler-impl`
+- `/tmp/wed-809-*`
+
+Expected unrelated residue left untouched:
+
+- Existing stash in `/mnt/local-analysis/worldenergydata`: `stash@{0}: On main: wed stale pre-reorg dirty tree (recoverable) 2026-06-26`.
+- Existing cleanup trash: `/mnt/local-analysis/.cleanup-trash/20260616-095709`.
+
+## Known Limitation
+
+A broad local scheduler collection in the archive workspace stalled during filesystem/path discovery. Targeted local checks and GitHub PR checks passed; no blocking issue remains for #809.
+
+## Recommended Next Step
+
+Run the live Spain CORES refresh against the direct source and write the operational dataset to `/mnt/ace/worldenergydata/data/spain/cores`. Verify the actual network workbook refresh, `_metadata.json`, normalized CSV shape, and scheduler `manifest.json`. After that, promote Spain production data into the next production/field-development analysis slice.
+
+## Suggested Skills
+
+- `handoff`
+- `github:gh-fix-ci` only if the next live-refresh PR develops failing checks.
+- `superpowers:verification-before-completion` before closing the next implementation slice.


### PR DESCRIPTION
## Summary
- add exit handoff for #809 / PR #835 Spain CORES scheduler work
- capture verification, review closure, cleanup state, and recommended next step

## Validation
- handoff content generated from verified GitHub issue/PR state
- no code changes