### PR TITLE
feat(spain): harden CORES density audit gates

### DIFF
--- a/config/scheduler/scheduler_config.yml
+++ b/config/scheduler/scheduler_config.yml
@@ -71,7 +71,7 @@ jobs:
     force_refresh: false
     refresh_fixture: true
     fixture_output_dir: packages/worldenergydata-spain/src/worldenergydata/spain/data/cores
-    oil_density_registry_path: packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
+    density_registry_path: packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
     allow_default_density: false
 
 monitoring:

--- a/config/scheduler/scheduler_config.yml
+++ b/config/scheduler/scheduler_config.yml
@@ -71,6 +71,8 @@ jobs:
     force_refresh: false
     refresh_fixture: true
     fixture_output_dir: packages/worldenergydata-spain/src/worldenergydata/spain/data/cores
+    oil_density_registry_path: packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
+    allow_default_density: false
 
 monitoring:
   log_dir: logs/scheduler/

--- a/docs/plans/2026-07-06-issue-807-spain-cores-crude-density-api-table.md
+++ b/docs/plans/2026-07-06-issue-807-spain-cores-crude-density-api-table.md
@@ -1,0 +1,800 @@
+# Plan: Issue [#807](https://github.com/vamseeachanta/worldenergydata/issues/807) - Spain CORES crude density/API table
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/807
+**Status:** plan-review
+**Tier:** T2 (parser, live-refresh metadata, report provenance)
+**Client:** N/A
+**Project:** worldenergydata Spain CORES production lifecycle
+**Lane:** codex
+
+## Resource Intelligence Summary
+
+### Execution mode
+
+Implementation will use a serialized TDD lane because the parser, live loader,
+committed fixture metadata, and report caveat all depend on the same conversion
+contract. Read-only research and adversarial review can run in parallel, but
+file writes will stay serialized to avoid inconsistent conversion metadata.
+
+Implementation will not begin until this plan is reviewed, pushed, moved to
+`status:plan-review`, and explicitly approved by the user as
+`status:plan-approved`.
+
+### Issue and dependency status
+
+| Issue | State | Role for this plan |
+|---|---|---|
+| [#713](https://github.com/vamseeachanta/worldenergydata/issues/713) | open, `status:needs-plan` | International source-to-field-development epic |
+| [#763](https://github.com/vamseeachanta/worldenergydata/issues/763) | closed, `status:done` | Spain CORES parser, fixture, adapter, and reference chain |
+| [#806](https://github.com/vamseeachanta/worldenergydata/issues/806) | closed, `status:done` | Direct-source live CORES XLSX download and normalized CSV lane |
+| [#807](https://github.com/vamseeachanta/worldenergydata/issues/807) | open | This crude-density/API conversion slice |
+| [#808](https://github.com/vamseeachanta/worldenergydata/issues/808) | open | Gas revenue modeling, outside this slice |
+| [#809](https://github.com/vamseeachanta/worldenergydata/issues/809) | closed, `status:done` | Scheduler job that refreshes the live CORES cache |
+| [#810](https://github.com/vamseeachanta/worldenergydata/issues/810) | closed, `status:done` | Spain CORES field-development report |
+
+Parallel work check:
+
+- [PR #840](https://github.com/vamseeachanta/worldenergydata/pull/840) is open
+  for GTM re-land work and does not touch the Spain CORES parser path.
+- [PR #841](https://github.com/vamseeachanta/worldenergydata/pull/841) is open
+  for completion reconciliation/report work and does not touch this plan's
+  Spain CORES, scheduler, or production-adapter paths.
+
+### Current code surfaces
+
+- `packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_loader.py`
+  defines `TONNES_TO_BBL = 7.33`, `GWH_TO_MCF`, `parse_cores_frame(...)`,
+  `CoresProductionLoader`, and `CoresFixtureProductionLoader`.
+- `parse_cores_frame(raw, *, product)` currently accepts only `product`; for
+  oil it applies the single `TONNES_TO_BBL` value to every field.
+- `packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_live.py`
+  calls `CoresProductionLoader(...).load()` and writes normalized CSVs under
+  the configured cache root.
+- `refresh_ayoluengo_fixture(...)` currently writes fixture metadata with
+  `"oil_bbl = tonnes * 7.33"` and `oil_tonnes_to_bbl: 7.33`.
+- `packages/worldenergydata-production/src/worldenergydata/production/unified/adapters/spain_cores_adapter.py`
+  passes through `oil_bbl`; it should not contain density conversion logic.
+- `packages/worldenergydata-spain/src/worldenergydata/spain/reports/cores_field_development.py`
+  currently surfaces the limitation
+  `oil_tonnes_to_bbl_conversion_deferred_to_issue_807`; this slice will replace
+  that caveat with explicit conversion provenance only when strict conversion
+  coverage is actually available.
+
+### Live CORES oil-field scope
+
+The current operational cache under `/mnt/ace/worldenergydata/data/spain/cores`
+contains these oil-producing CORES field names in
+`normalized/cores_oil_production.csv`:
+
+```text
+Albatros
+Amposta
+Ayoluengo
+Boquerón
+Casablanca
+Dorada
+Gaviota
+Montanazo-Lubina
+Rodaballo
+Salmonete
+Tarraco
+Viura (1)
+```
+
+Implementation will treat this as the current source-coverage set. This issue
+will close only if every oil-producing CORES field in the parsed oil workbook is
+backed by a validated cited factor accepted for conversion. If source work cannot
+support every current oil field, implementation will stop at a named source-gap
+closeout and [#807](https://github.com/vamseeachanta/worldenergydata/issues/807)
+will remain incomplete rather than shipping a partial "real per-field" table.
+
+### Source evidence boundary
+
+CORES provides production volumes in metric tonnes for crude oil but does not
+publish per-field API gravity or density in the production workbook. This slice
+will therefore keep CORES as the production source and add a separate cited
+conversion registry for density/API values.
+
+Candidate density/API sources identified during planning:
+
+- CORES statistics page and oil workbook:
+  `https://www.cores.es/en/estadisticas`,
+  `https://www.cores.es/sites/default/files/archivos/estadisticas/crude-oil-production.xlsx`
+- AAPG Explorer, "Spain's Oldest and Only Onshore Oilfield":
+  `https://www.aapg.org/news-and-media/explorer/spains-oldest-and-only-onshore-oilfield/`
+  - The discovery well flowed 36-degree API oil.
+  - Ayoluengo oils vary by well/sand, with gravities ranging from 20 to 39
+    degrees API.
+- EIA API gravity definition:
+  `https://www.eia.gov/dnav/pet/TblDefs/pet_crd_api_tbldef2.asp`
+  - Defines API gravity as `141.5 / specific_gravity - 131.5`.
+- Chevron Marine Products fuel conversion chart:
+  `https://www.chevronmarineproducts.com/content/dam/chevron-marine/fuels-conversion-chart/Fuels%20Conversion%20Charts.pdf`
+  - Provides density/API/barrels-per-metric-ton conversion reference values.
+- Additional candidate source leads will be verified during implementation for
+  offshore Mediterranean fields. Planning source scouting found useful but not
+  yet accepted secondary evidence for Ayoluengo, Boquerón, Casablanca,
+  Rodaballo, Amposta, and Tarraco.
+
+Planning source scouting did not find reliable density/API evidence for
+`Albatros`, `Dorada`, `Gaviota`, `Montanazo-Lubina`, `Salmonete`, or
+`Viura (1)`. Implementation will treat these as source gaps unless further
+source work finds cited factors.
+
+The implementation will not scrape third-party mirrors or uncited copies into
+the repository. Numeric factors that affect `oil_bbl` will be accepted only from
+regulator records, operator records, securities filings, crude assay data, or
+technical literature with an explicit field-applicable measurement basis. A
+secondary article, industry news article, or summary article can support an
+evidence note or source lead, but it will not drive `bbl_per_tonne`. If a source
+contains enough measurement detail to drive conversion, the registry must
+classify it as one of the conversion-eligible source classes and record the
+explicit representative produced stream, sales crude, blend, field average, or
+other field-applicable conversion basis.
+Each registry entry will carry `accepted_for_conversion`; entries with
+`accepted_for_conversion: false` will be excluded from strict conversion.
+
+### Boundary decisions
+
+- Production data will remain direct CORES data; the density registry will only
+  convert CORES metric tonnes to barrels.
+- Durable live outputs will stay under `/mnt/ace`; repository changes will be
+  code, tests, committed fixtures, and small cited metadata only.
+- The parser will stay pure and fixture-testable. It will receive an optional
+  `CoresOilConversionAudit` built from validated cited factors and will not
+  perform network access. Raw float mappings will not be accepted at the public
+  parser/live-loader boundary because they strip citation provenance.
+- Citation/provenance validation will live outside the pure parser in a small
+  registry loader module.
+- The unified production adapter and FDAS cashflow code will remain unchanged
+  unless tests prove they drop conversion metadata needed by the report.
+- Missing density coverage will not silently masquerade as real per-field
+  conversion. Strict conversion will raise on missing cited factors. Legacy
+  default conversion will require an explicit `allow_default_density=True` opt-in
+  and will always return/report exact defaulted fields.
+- The implementation will not present Ayoluengo's 20-39 API range as a single
+  accepted conversion factor. A single Ayoluengo factor will require a specific
+  cited value for a representative produced stream, sales crude, blend, field
+  average, or explicit current conversion basis; otherwise Ayoluengo will remain
+  missing/defaulted and [#807](https://github.com/vamseeachanta/worldenergydata/issues/807)
+  will not close.
+
+## Artifact Map
+
+| Artifact | Path |
+|---|---|
+| Plan | `docs/plans/2026-07-06-issue-807-spain-cores-crude-density-api-table.md` |
+| Plan index row | `docs/plans/README.md` |
+| Plan review artifacts | `scripts/review/results/2026-07-06-plan-807-*.md` |
+| Parser | `packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_loader.py` |
+| Density registry module | `packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_density.py` |
+| Density registry data | `packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json` |
+| Live loader metadata | `packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_live.py` |
+| Scheduler job wiring | `packages/worldenergydata-scheduler/src/worldenergydata/scheduler/jobs/spain_cores_refresh.py` |
+| Scheduler config | `config/scheduler/scheduler_config.yml` |
+| Committed fixture metadata | `packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/_metadata.json` |
+| Committed fixture sample | `packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/ayoluengo_oil_sample.csv` |
+| Production adapter fallback | `packages/worldenergydata-production/src/worldenergydata/production/unified/adapters/spain_cores_adapter.py` |
+| Spain report builder | `packages/worldenergydata-spain/src/worldenergydata/spain/reports/cores_field_development.py` |
+| Parser tests | `tests/unit/spain/test_cores_loader.py` |
+| Density registry tests | `tests/unit/spain/test_cores_density.py` |
+| Live loader tests | `tests/unit/spain/test_cores_live.py` |
+| Scheduler tests | `tests/unit/scheduler/test_spain_cores_refresh.py` |
+| Scheduler config tests | `tests/unit/scheduler/test_config.py` |
+| Adapter tests | `tests/unit/production/unified/test_spain_cores_adapter_loader.py` |
+| Report tests | `tests/unit/spain/test_cores_field_development_report.py` |
+
+## Deliverable
+
+The implementation will add a cited Spain CORES crude density/API registry and
+will wire it through the CORES oil parser so oil `tonnes` become `oil_bbl`
+using field-specific conversion factors only where cited factors exist.
+
+The registry will expose deterministic conversion metadata. Evidence that does
+not support a representative field-level conversion factor will be retained only
+as non-converting evidence, for example:
+
+```json
+{
+  "field_name": "Ayoluengo",
+  "aliases": ["ayoluengo"],
+  "api_gravity_deg": null,
+  "api_gravity_min_deg": 20.0,
+  "api_gravity_max_deg": 39.0,
+  "bbl_per_tonne": null,
+  "source_title": "Spain's Oldest and Only Onshore Oilfield",
+  "source_url": "https://www.aapg.org/news-and-media/explorer/spains-oldest-and-only-onshore-oilfield/",
+  "source_class": "industry_technical_article",
+  "measurement_basis": "non-representative discovery-test and field-range evidence only",
+  "evidence_note": "Discovery-well oil tested at 36-degree API; field oil range also reported as 20-39 API by well/sand.",
+  "confidence": "medium",
+  "accepted_for_conversion": false
+}
+```
+
+Final implementation will use a conversion factor for Ayoluengo only if source
+research verifies a representative field-level API gravity, density, or
+bbl/tonne basis. Any such value will be traceable in the registry and tests.
+
+## Proposed Design
+
+### Density registry API
+
+`cores_density.py` will provide:
+
+```python
+@dataclass(frozen=True)
+class CoresCrudeDensityFactor:
+    field_name: str
+    aliases: tuple[str, ...]
+    api_gravity_deg: float | None
+    api_gravity_min_deg: float | None
+    api_gravity_max_deg: float | None
+    bbl_per_tonne: float | None
+    measurement_basis: str
+    source_title: str
+    source_url: str
+    source_class: str
+    evidence_note: str
+    confidence: str
+    accepted_for_conversion: bool
+
+    def __post_init__(self) -> None:
+        """Validate citation, source class, representative basis, and math."""
+
+
+@dataclass(frozen=True)
+class CoresOilConversionAudit:
+    used_factors: tuple[CoresCrudeDensityFactor, ...]
+    defaulted_fields: tuple[str, ...]
+    missing_fields: tuple[str, ...]
+    _accepted_entries: tuple[tuple[str, CoresCrudeDensityFactor], ...]
+    _defaulted_field_keys: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        """Revalidate factors and immutable conversion entries."""
+
+    def bbl_per_tonne_for_field(self, field_name: str) -> float:
+        """Return cited/default factor for a parsed CORES field."""
+
+
+def bbl_per_tonne_from_api(api_gravity_deg: float) -> float:
+    specific_gravity = 141.5 / (api_gravity_deg + 131.5)
+    return 1.0 / (specific_gravity * 0.158987294928)
+
+
+def load_crude_density_factors(path: Path | None = None) -> dict[str, CoresCrudeDensityFactor]:
+    """Load, normalize, and validate cited crude density factors."""
+
+
+def validate_crude_density_factor(factor: CoresCrudeDensityFactor) -> None:
+    """Validate one cited density factor regardless of construction path."""
+
+
+def build_oil_conversion_audit(
+    field_names: Iterable[str],
+    factors: Mapping[str, CoresCrudeDensityFactor],
+    *,
+    allow_default_density: bool = False,
+) -> CoresOilConversionAudit:
+    """Resolve cited factors and exact missing/defaulted field lists."""
+
+
+class CoresDensityCoverageError(ValueError):
+    """Raised when strict oil conversion lacks accepted density coverage."""
+```
+
+The shared factor validator and registry loader will validate:
+
+- `field_name` and each alias are non-empty strings.
+- Accepted conversion entries have a positive `bbl_per_tonne` within a
+  conservative crude-oil range.
+- Evidence-only entries may carry `api_gravity_min_deg`/`api_gravity_max_deg`
+  and `bbl_per_tonne: null`, but must have `accepted_for_conversion: false`.
+- `measurement_basis`, `source_url`, `source_title`, `source_class`,
+  `evidence_note`, `confidence`, and `accepted_for_conversion` are present for
+  every factor.
+- `source_class` is one of `regulator_record`, `operator_record`,
+  `securities_filing`, `crude_assay`, `technical_literature`,
+  `industry_technical_article`, or `secondary_article`.
+- Only `regulator_record`, `operator_record`, `securities_filing`,
+  `crude_assay`, and `technical_literature` may have
+  `accepted_for_conversion: true`. `industry_technical_article` and
+  `secondary_article` are evidence-only unless replaced by an underlying
+  conversion-eligible source.
+- If `api_gravity_deg` is present, `bbl_per_tonne` matches
+  `bbl_per_tonne_from_api(...)` within a small tolerance.
+- Ranged, discovery-test-only, or non-representative evidence can be stored only
+  with `accepted_for_conversion: false`.
+- Duplicate normalized names/aliases fail closed.
+- `CoresCrudeDensityFactor.__post_init__` will call the same
+  `validate_crude_density_factor(...)` helper used by the registry loader, so
+  direct dataclass construction cannot bypass citation, source-class,
+  representative-basis, range, or API-math validation.
+- `build_oil_conversion_audit(...)` is the single helper used by the parser
+  caller and sidecar writer so conversion math and provenance cannot drift.
+- `CoresOilConversionAudit` will not expose a public mutable conversion map and
+  will not accept raw numeric conversion maps. It will store immutable
+  `_accepted_entries` tuples plus `_defaulted_field_keys`, and
+  `__post_init__` will call `validate_crude_density_factor(...)` for every
+  `used_factors` and `_accepted_entries` factor. It will then fail closed if any
+  accepted entry is not backed by an `accepted_for_conversion: true`
+  `CoresCrudeDensityFactor` in `used_factors`, if any accepted factor lacks
+  `bbl_per_tonne`, if keys are duplicated, or if a default key is not
+  represented in `defaulted_fields`.
+- `build_oil_conversion_audit(...)` will be the normal construction path, but a
+  direct `CoresOilConversionAudit(...)` call will still validate the invariant
+  at runtime so tests cannot bypass provenance by constructing the dataclass
+  manually.
+
+### Parser API
+
+`parse_cores_frame(...)` will become:
+
+```python
+def parse_cores_frame(
+    raw: pd.DataFrame,
+    *,
+    product: str,
+    oil_conversion_audit: CoresOilConversionAudit | None = None,
+) -> pd.DataFrame:
+    """Parse CORES production rows with optional audited oil conversion factors."""
+```
+
+For `product == "oil"`:
+
+- field names will be normalized for lookup with case/space/punctuation
+  tolerance but output field names will preserve CORES display spelling.
+- fields resolved by `oil_conversion_audit.bbl_per_tonne_for_field(...)` will
+  use cited values from accepted `CoresCrudeDensityFactor` objects or explicit
+  audited defaults. The parser will not inspect public conversion maps or
+  caller-supplied floats.
+- fields defaulted by `build_oil_conversion_audit(..., allow_default_density=True)`
+  will use `TONNES_TO_BBL` and will remain visible in the audit sidecar/report.
+- fields missing from the audit will raise `CoresParseError`.
+- the live/default code path will build the audit from validated
+  `CoresCrudeDensityFactor` objects. Any raw float mapping will be limited to a
+  private helper or test fixture derived from `CoresOilConversionAudit`, not a
+  public parser or live-loader API.
+
+For `product == "gas"`:
+
+- `oil_conversion_audit` will have no effect.
+- GWh to Mcf conversion will stay unchanged.
+
+### Live loader and metadata
+
+`CoresProductionLoader` will accept the parser's new `oil_conversion_audit`
+argument and pass it through unchanged.
+
+`CoresLiveProductionLoader` will accept a density registry path and an
+`allow_default_density` flag. The default live refresh path will fail closed
+when source gaps remain. Operators may set `allow_default_density=True` only for
+legacy/diagnostic refreshes, and those refreshes will mark defaulted fields
+explicitly.
+
+The live loader will write a small normalized metadata sidecar under the
+configured cache root, for example:
+
+```text
+normalized/cores_oil_density_factors.json
+```
+
+The sidecar will include cited factors, defaulted fields if any, and explicit
+registry version/date fields. It will not add columns to the normalized
+production CSV schemas.
+
+Exact sidecar schema:
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-06T00:00:00+00:00",
+  "registry_version": "2026-07-06",
+  "registry_date": "2026-07-06",
+  "conversion_basis": "cited_field_density_factors",
+  "coverage_status": "complete",
+  "oil_field_count": 1,
+  "used_fields": ["Example CORES Field"],
+  "defaulted_fields": [],
+  "missing_fields": [],
+  "factors": [
+    {
+      "field_name": "Example CORES Field",
+      "aliases": ["example cores field"],
+      "api_gravity_deg": 30.0,
+      "api_gravity_min_deg": null,
+      "api_gravity_max_deg": null,
+      "bbl_per_tonne": 7.17883,
+      "measurement_basis": "representative produced stream",
+      "source_title": "source title",
+      "source_url": "https://example.test/source",
+      "source_class": "technical_literature",
+      "evidence_note": "why this value is field-applicable",
+      "confidence": "medium",
+      "accepted_for_conversion": true
+    }
+  ]
+}
+```
+
+`coverage_status` will be `complete`, `defaulted`, or `missing`. A `complete`
+sidecar will require every current oil field to be represented in `factors` with
+`accepted_for_conversion: true`; otherwise [#807](https://github.com/vamseeachanta/worldenergydata/issues/807)
+will remain incomplete.
+
+`refresh_ayoluengo_fixture(...)` will include the relevant conversion factor and
+citation metadata in the committed `_metadata.json` fixture. The sample CSV will
+continue to contain normalized `oil_bbl` values and will not grow source
+provenance columns.
+
+### Scheduler wiring
+
+`SpainCoresRefreshJob.run(...)` will pass optional scheduler config keys into
+`CoresLiveProductionLoader`:
+
+```yaml
+spain_cores_refresh:
+  output_dir: data/spain/cores
+  density_registry_path: packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
+  allow_default_density: false
+```
+
+If strict density coverage fails, the scheduler job will classify the error as a
+deterministic source/coverage failure, not a retryable network failure. The
+strict live-loader path will raise the exported `CoresDensityCoverageError` for
+missing accepted density factors; the scheduler will treat that exception as
+non-retryable alongside the existing `CoresSourceError` contract. The scheduler
+test will raise the real exported `CoresDensityCoverageError`, not an arbitrary
+fake exception, so the live-loader gap cannot remain retryable by accident.
+The job will still preserve the existing direct-source network/source failure
+behavior from [#809](https://github.com/vamseeachanta/worldenergydata/issues/809).
+
+`density_registry_path` will use the same `_scheduler_repo_root` resolution
+contract as `output_dir` and `fixture_output_dir`: absolute paths pass through,
+and relative paths from `config/scheduler/scheduler_config.yml` resolve against
+the scheduler repo root before construction of `CoresLiveProductionLoader`.
+
+`_metadata.json` will keep `format: "csv"` for the primary normalized
+production tables. The implementation will add separate metadata fields such as
+`data_files` and `sidecar_files` so JSON conversion sidecars are not misreported
+as primary CSV outputs.
+
+### Report provenance
+
+The Spain CORES report builder will load and validate the normalized density
+sidecar when it exists. It will include conversion provenance in the JSON/HTML
+summary and will remove the issue-807 limitation only when the sidecar is
+`coverage_status: "complete"` and has no defaulted or missing fields.
+
+The report will emit:
+
+- `oil_tonnes_to_bbl_uses_cited_field_density_factors`, when all oil fields
+  have cited factors; or
+- `oil_tonnes_to_bbl_has_defaulted_fields`, when any fields remain on the
+  documented default; or
+- `oil_tonnes_to_bbl_has_missing_fields`, when a density sidecar exists but any
+  oil fields are missing accepted/defaulted conversion factors; or
+- `oil_tonnes_to_bbl_conversion_deferred_to_issue_807`, when no density sidecar
+  is available.
+
+## Files to Change
+
+### `packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_density.py`
+
+This new module will own registry parsing, API-to-bbl/tonne math, alias
+normalization, and validation.
+
+### `packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json`
+
+This new data file will store the cited per-field conversion registry. Each
+entry will include the field name, aliases, value, source URL, source title,
+source class, evidence note, and confidence.
+
+### `packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_loader.py`
+
+The parser and `CoresProductionLoader` constructor will accept
+`CoresOilConversionAudit` for oil conversion. Oil conversion will use a per-row
+factor derived from the melted field name and
+`oil_conversion_audit.bbl_per_tonne_for_field(...)`. Gas conversion will remain
+unchanged.
+
+### `packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_live.py`
+
+The live loader will load/validate the density registry, build the oil
+conversion audit, pass that audit into oil parsing, write the conversion
+sidecar, and update fixture metadata conversion fields.
+
+### `packages/worldenergydata-scheduler/src/worldenergydata/scheduler/jobs/spain_cores_refresh.py`
+
+The scheduler job will pass `density_registry_path` and `allow_default_density`
+config values into `CoresLiveProductionLoader`. It will classify deterministic
+density coverage errors as non-retryable.
+
+### `config/scheduler/scheduler_config.yml`
+
+The Spain CORES scheduler config will document the density registry path and
+default strict behavior.
+
+### `packages/worldenergydata-production/src/worldenergydata/production/unified/adapters/spain_cores_adapter.py`
+
+The production adapter fallback will be updated to avoid stale 7.33-based
+Ayoluengo barrels. The preferred implementation will derive default data from
+the committed Spain fixture; if an embedded fallback must remain, it will carry
+updated values and explicit conversion provenance.
+
+### `packages/worldenergydata-spain/src/worldenergydata/spain/reports/cores_field_development.py`
+
+The report builder will read the conversion sidecar when present and surface
+conversion provenance/limitations in the report summary.
+
+### Tests
+
+The implementation will update existing parser/live/report tests and add a
+focused density-registry test file.
+
+## TDD Test List
+
+1. `tests/unit/spain/test_cores_density.py::test_bbl_per_tonne_from_api_matches_reference_formula`
+   - Assert API 36.0 converts to approximately `7.44554` bbl/tonne.
+   - Assert API 20.0 converts to approximately `6.73432` bbl/tonne.
+
+2. `tests/unit/spain/test_cores_density.py::test_density_registry_requires_citation_fields`
+   - Build a temporary JSON entry missing `source_url`.
+   - Expect the registry loader to raise `CoresParseError` or a density-specific
+     `ValueError`.
+
+3. `tests/unit/spain/test_cores_density.py::test_density_registry_rejects_duplicate_aliases`
+   - Build two entries with aliases that normalize to the same key.
+   - Expect validation failure before parser use.
+
+4. `tests/unit/spain/test_cores_density.py::test_density_registry_rejects_non_representative_range_as_conversion_factor`
+   - Build an entry with `api_gravity_min`, `api_gravity_max`, and no
+     representative conversion basis.
+   - Expect the entry to be retained only as evidence or rejected for
+     `accepted_for_conversion`.
+
+5. `tests/unit/spain/test_cores_density.py::test_density_registry_normalizes_accents_and_punctuation`
+   - Include aliases for `Boquerón` and `Viura (1)`.
+   - Expect lookup keys to resolve without losing display names.
+
+6. `tests/unit/spain/test_cores_density.py::test_density_registry_rejects_invalid_source_class_and_confidence`
+   - Use unsupported `source_class` and `confidence` values.
+   - Expect validation failure.
+
+7. `tests/unit/spain/test_cores_density.py::test_crude_density_factor_rejects_secondary_article_conversion_directly`
+   - Directly construct `CoresCrudeDensityFactor` with
+     `source_class="secondary_article"` and `accepted_for_conversion=True`.
+   - Expect validation failure even if the factor contains a numeric API value.
+   - Repeat with a direct accepted factor that contains only
+     `api_gravity_min_deg`/`api_gravity_max_deg` non-representative range
+     evidence and no representative `api_gravity_deg`/`bbl_per_tonne`.
+   - Repeat through the JSON registry loader to prove both paths share the same
+     validator.
+
+8. `tests/unit/spain/test_cores_density.py::test_oil_conversion_audit_rejects_unbacked_conversion_entries`
+   - Attempt to directly construct an audit with an accepted secondary-source
+     factor, non-representative ranged factor, factor missing `bbl_per_tonne`,
+     duplicate keys, or a default key not listed in `defaulted_fields`.
+   - Expect validation failure before parser use.
+
+9. `tests/unit/spain/test_cores_loader.py::test_parse_oil_frame_uses_conversion_audit_factor`
+   - Parse a two-field oil frame with a `CoresOilConversionAudit` built by
+     `build_oil_conversion_audit(...)` from an accepted Ayoluengo factor whose
+     `bbl_per_tonne` is `6.95`.
+   - Expect Ayoluengo to use `6.95`.
+
+10. `tests/unit/spain/test_cores_loader.py::test_parse_oil_frame_requires_explicit_default_opt_in`
+   - Build an audit for Ayoluengo and Casablanca while only Ayoluengo has an
+     accepted factor and `allow_default_density=False`.
+   - Parse a frame with that audit.
+   - Expect `CoresParseError` naming Casablanca.
+
+11. `tests/unit/spain/test_cores_loader.py::test_parse_oil_frame_allows_legacy_default_when_explicit`
+   - Build an audit for Ayoluengo and Casablanca while only Ayoluengo has an
+     accepted factor and `allow_default_density=True`.
+   - Parse a frame with that audit.
+   - Expect Casablanca to use `TONNES_TO_BBL`.
+
+12. `tests/unit/spain/test_cores_density.py::test_oil_conversion_audit_names_defaulted_fields`
+    - Build an audit for Ayoluengo and Casablanca while only Ayoluengo has an
+      accepted factor and `allow_default_density=True`.
+    - Expect Casablanca in `defaulted_fields`.
+
+13. `tests/unit/spain/test_cores_loader.py::test_parse_gas_frame_ignores_oil_conversion_audit`
+   - Parse a gas frame with a bogus oil conversion audit.
+   - Expect GWh-to-Mcf behavior to match the current test exactly.
+
+14. `tests/unit/spain/test_cores_loader.py::test_loader_passes_conversion_audit_to_parser`
+   - Write a small XLSX and construct `CoresProductionLoader(product="oil",
+     oil_conversion_audit=...)`.
+   - Expect the parsed `oil_bbl` to use the override.
+
+15. `tests/unit/spain/test_cores_live.py::test_live_loader_writes_oil_density_sidecar`
+   - Run `CoresLiveProductionLoader` against fake oil/gas workbooks.
+   - Expect `normalized/cores_oil_density_factors.json` to exist and include
+     used/defaulted field lists.
+
+16. `tests/unit/spain/test_cores_live.py::test_live_loader_strict_density_fails_on_source_gaps`
+   - Run the live loader against fake oil workbooks containing one unmapped oil
+     field and `allow_default_density=False`.
+   - Expect `CoresDensityCoverageError` naming the missing field.
+
+17. `tests/unit/spain/test_cores_live.py::test_refresh_ayoluengo_fixture_records_density_provenance`
+    - Refresh the Ayoluengo fixture from a fake oil frame and metadata.
+    - Expect `_metadata.json` to include the selected Ayoluengo
+      `bbl_per_tonne`, `source_url`, and evidence note.
+
+18. `tests/unit/scheduler/test_spain_cores_refresh.py::test_spain_cores_refresh_passes_density_config_to_loader`
+    - Run the scheduler job with `density_registry_path` and
+      `allow_default_density`.
+    - Expect the fake loader constructor to receive both values, with a
+      repo-relative `density_registry_path` resolved against
+      `_scheduler_repo_root`.
+
+19. `tests/unit/scheduler/test_spain_cores_refresh.py::test_spain_cores_density_coverage_failure_is_non_retryable`
+    - Make the fake loader raise the real exported
+      `CoresDensityCoverageError`.
+    - Expect job status `failure` and `retryable is False`.
+
+20. `tests/unit/scheduler/test_spain_cores_refresh.py::test_spain_cores_refresh_metadata_lists_sidecars_separately`
+    - Run a fake successful refresh with a conversion sidecar.
+    - Expect `_metadata.json` to keep `format: "csv"` and list the sidecar under
+      `sidecar_files`.
+
+21. `tests/unit/scheduler/test_config.py::test_repo_scheduler_config_includes_spain_density_options`
+    - Load `config/scheduler/scheduler_config.yml` through the real scheduler
+      config loader.
+    - Expect `spain_cores_refresh` to expose `density_registry_path` and
+      `allow_default_density: false`.
+
+22. `tests/unit/production/unified/test_spain_cores_adapter_loader.py::test_adapter_accepts_live_cores_loader`
+    - Update expected oil barrels if the default live loader applies a cited
+      Ayoluengo factor.
+
+23. `tests/unit/production/unified/test_spain_cores_adapter_loader.py::test_default_adapter_uses_density_adjusted_fixture_or_marked_fallback`
+    - Construct `SpainCoresAdapter()` without injecting a loader.
+    - Expect default Ayoluengo data to match the committed fixture or an
+      explicitly updated fallback with conversion provenance.
+
+24. `tests/unit/production/unified/test_spain_cores_adapter_loader.py::test_embedded_adapter_fallback_does_not_use_stale_733_barrels`
+    - Force the production adapter onto `_EmbeddedCoresFixtureLoader` by
+      monkeypatching the Spain fixture import path to raise `ModuleNotFoundError`
+      or by removing the embedded fallback entirely.
+    - Expect embedded fallback oil barrels to match the density-adjusted fixture
+      or expect the fallback-removal path to raise a clear missing-fixture error.
+
+25. `tests/unit/spain/test_cores_field_development_report.py::test_build_report_includes_density_conversion_provenance`
+    - Write a report cache with the density sidecar.
+    - Expect the summary to include the factor source and no longer include
+      `oil_tonnes_to_bbl_conversion_deferred_to_issue_807` only when coverage is
+      complete.
+
+26. `tests/unit/spain/test_cores_field_development_report.py::test_report_preserves_defaulted_density_limitations`
+    - Write a report cache whose sidecar lists a defaulted field.
+    - Expect the summary and HTML to include
+      `oil_tonnes_to_bbl_has_defaulted_fields`.
+
+27. `tests/unit/spain/test_cores_field_development_report.py::test_report_preserves_missing_density_limitations`
+    - Write a report cache whose sidecar has `coverage_status: "missing"` and a
+      non-empty `missing_fields` list.
+    - Expect the summary and HTML to include
+      `oil_tonnes_to_bbl_has_missing_fields` and the exact missing field names.
+
+28. `tests/unit/spain/test_cores_field_development_report.py::test_report_rejects_malformed_density_sidecar`
+    - Write a sidecar missing `coverage_status` or `factors`.
+    - Expect `CoresReportError`.
+
+29. `tests/unit/spain/test_cores_field_development_report.py::test_render_html_keeps_density_provenance_self_contained`
+    - Render HTML with complete density provenance.
+    - Expect no `/mnt/ace`, no `src=`, strict JSON, and visible conversion
+      source metadata.
+
+## Acceptance Criteria
+
+- `parse_cores_frame(..., product="oil", oil_conversion_audit=...)` will support
+  per-field oil conversion while preserving current output columns and keeping
+  conversion provenance attached at the parser boundary.
+- `parse_cores_frame(..., product="gas")` will remain unchanged.
+- A cited crude density/API registry will live in the Spain package data tree.
+- Registry entries will fail validation if they lack citation/provenance fields.
+- Registry entries will fail validation as conversion factors when they are
+  based only on ranges, discovery-test-only values, or non-representative notes.
+- Registry entries will fail validation as conversion factors when they use
+  `industry_technical_article` or `secondary_article` source classes.
+- Direct `CoresCrudeDensityFactor(...)` construction will run the same
+  validation as registry loading, so tests cannot bypass provenance by manually
+  creating accepted invalid factors.
+- Conversion audits will fail validation if a parsed field conversion value is
+  not backed by an accepted cited factor or an explicit defaulted-field entry.
+- Strict oil conversion will fail closed when any oil field lacks an accepted
+  cited factor.
+- Legacy/default oil conversion will remain possible only through explicit
+  `allow_default_density=True` opt-in and will identify defaulted fields in
+  conversion metadata.
+- [#807](https://github.com/vamseeachanta/worldenergydata/issues/807) will be
+  closed only when every current CORES oil field has an accepted cited factor.
+  If source gaps remain, the implementation will stop with a source-gap comment
+  and leave the issue open.
+- Live CORES refresh will write normalized production CSVs plus a density
+  conversion sidecar under the configured cache root.
+- Scheduler config will pass density registry options to the live loader and
+  classify strict density coverage gaps as non-retryable deterministic failures.
+- Scheduler wiring will resolve repo-relative `density_registry_path` values
+  through `_scheduler_repo_root` before passing them to the live loader.
+- Scheduler retry classification will use the real exported
+  `CoresDensityCoverageError` for strict density gaps.
+- The committed Ayoluengo fixture metadata will record the oil conversion factor
+  and citation used to produce its `oil_bbl` values.
+- The Spain CORES report will surface conversion provenance and will not remove
+  the [#807](https://github.com/vamseeachanta/worldenergydata/issues/807)
+  caveat unless the density sidecar is complete and has no
+  defaulted or missing fields.
+- Missing density coverage will be visible in metadata/report limitations and
+  will not be described as real per-field conversion.
+- Present sidecars with `coverage_status: "missing"` will surface
+  `oil_tonnes_to_bbl_has_missing_fields` and exact missing field names in the
+  report.
+- The production adapter fallback will not retain stale 7.33-based embedded
+  Ayoluengo barrels.
+- The embedded production adapter fallback path will be directly exercised or
+  removed, so production-only installs cannot keep stale 7.33-based rows hidden
+  behind the package fixture loader path.
+- Targeted tests will pass:
+
+```bash
+uv run python -m pytest \
+  tests/unit/spain/test_cores_density.py \
+  tests/unit/spain/test_cores_loader.py \
+  tests/unit/spain/test_cores_live.py \
+  tests/unit/scheduler/test_spain_cores_refresh.py \
+  tests/unit/scheduler/test_config.py \
+  tests/unit/production/unified/test_spain_cores_adapter_loader.py \
+  tests/unit/spain/test_cores_field_development_report.py \
+  -q
+```
+
+- Formatting and scan gates will pass:
+
+```bash
+uv run black --check packages/worldenergydata-spain packages/worldenergydata-scheduler/src packages/worldenergydata-production/src tests/unit/spain tests/unit/scheduler tests/unit/production/unified
+uv run isort --check-only packages/worldenergydata-spain packages/worldenergydata-scheduler/src packages/worldenergydata-production/src tests/unit/spain tests/unit/scheduler tests/unit/production/unified
+scripts/legal/legal-sanity-scan.sh
+uv run pre-commit run check-yaml --files config/scheduler/scheduler_config.yml
+uv run pre-commit run yamllint --files config/scheduler/scheduler_config.yml
+```
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| CORES does not publish density/API in the production workbook. | Keep CORES as production source and require separate cited density sources with explicit source class/confidence. |
+| A field-level source gives a range rather than a single representative factor. | Store range/evidence note and use a single factor only when the source supports one; otherwise mark the field defaulted/missing. |
+| Parser defaults could hide missing density coverage. | Require explicit `allow_default_density=True` tests and conversion sidecar/report limitations for defaulted fields. |
+| Updating normalized CSV schemas could break downstream adapters. | Keep production CSV columns unchanged; put conversion provenance in a sidecar and report metadata. |
+| Ayoluengo API evidence conflicts across sources. | Prefer conversion-eligible sources in order: regulator/operator/filing records, crude assays, then peer-reviewed or technical literature; keep industry articles and surveys as evidence-only leads unless backed by an underlying conversion-eligible source. |
+| Generated fixture values may change when the density factor changes. | Update fixture metadata and tests in the same TDD cycle as parser wiring. |
+| Scheduler config may not propagate density settings. | Add scheduler config keys, resolve repo-relative `density_registry_path` through `_scheduler_repo_root`, pass the resolved path into `CoresLiveProductionLoader`, and test the fake loader constructor receives it. |
+| `_metadata.json` may misclassify JSON sidecars as CSV outputs. | Keep `format: "csv"` for production tables and list conversion sidecars separately in metadata. |
+| Parser conversion and sidecar provenance may drift. | Use one conversion-audit helper for parser inputs and sidecar generation. |
+| Production adapter fallback may keep stale embedded barrels. | Directly force the embedded fallback path in tests, or remove it and test the clear missing-fixture error. |
+
+## Review Plan
+
+Plan-stage adversarial review will inspect this plan for:
+
+- source-evidence overclaiming;
+- silent fallback to the global default;
+- downstream breakage from metadata/schema changes;
+- missing tests for strict density coverage; and
+- failure to update the [#810](https://github.com/vamseeachanta/worldenergydata/issues/810)
+  report caveat.
+
+Review artifacts will be written under:
+
+```text
+scripts/review/results/2026-07-06-plan-807-*.md
+```
+
+The issue will stay unapproved until the review findings are addressed and the
+user explicitly approves implementation.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -92,6 +92,7 @@ This directory contains issue-plan artifacts created during the issue-planning-m
 | [#749](https://github.com/vamseeachanta/worldenergydata/issues/749) | [colorado-ecmc-pressure-source-discovery](2026-07-04-issue-749-colorado-ecmc-pressure-source-discovery.md) | implemented | 2026-07-04 |
 | [#751](https://github.com/vamseeachanta/worldenergydata/issues/751) | [colorado-ecmc-form5a-ingest](2026-07-04-issue-751-colorado-ecmc-form5a-ingest.md) | plan-approved | 2026-07-04 |
 | [#806](https://github.com/vamseeachanta/worldenergydata/issues/806) | [spain-live-cores-xlsx](2026-07-04-issue-806-spain-live-cores-xlsx.md) | implemented | 2026-07-04 |
+| [#807](https://github.com/vamseeachanta/worldenergydata/issues/807) | [spain-cores-crude-density-api-table](2026-07-06-issue-807-spain-cores-crude-density-api-table.md) | plan-review | 2026-07-06 |
 | [#809](https://github.com/vamseeachanta/worldenergydata/issues/809) | [spain-cores-refresh-job](2026-07-05-issue-809-spain-cores-refresh-job.md) | plan-review | 2026-07-05 |
 | [#810](https://github.com/vamseeachanta/worldenergydata/issues/810) | [spain-cores-field-development-report](2026-07-05-issue-810-spain-cores-field-development-report.md) | plan-approved | 2026-07-05 |
 

--- a/packages/worldenergydata-production/src/worldenergydata/production/unified/adapters/spain_cores_adapter.py
+++ b/packages/worldenergydata-production/src/worldenergydata/production/unified/adapters/spain_cores_adapter.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
 import numpy as np
 import pandas as pd
@@ -16,7 +16,7 @@ class SpainCoresAdapter(AbstractProductionAdapter):
 
     region: str = "spain"
 
-    def __init__(self, loader=None):
+    def __init__(self, loader: Any | None = None) -> None:
         self.loader = loader if loader is not None else self._default_loader()
 
     def fetch(self, query: ProductionQuery) -> pd.DataFrame:
@@ -103,7 +103,7 @@ class SpainCoresAdapter(AbstractProductionAdapter):
         return out[list(STANDARD_COLUMNS)]
 
     @staticmethod
-    def _default_loader():
+    def _default_loader() -> Any:
         try:
             from worldenergydata.spain.production.cores_loader import (
                 CoresFixtureProductionLoader,
@@ -131,6 +131,8 @@ def _numeric_or_default(
 class _EmbeddedCoresFixtureLoader:
     """Direct-source Ayoluengo sample fallback for production-only installs."""
 
+    _DEFAULT_BBL_PER_TONNE = 7.33
+    _GAS_GWH_TO_MCF = 3290.0
     _ROWS = [
         {"field_name": "Ayoluengo", "year": 1968, "month": 1, "oil_bbl": 69356.46},
         {"field_name": "Ayoluengo", "year": 1968, "month": 2, "oil_bbl": 92160.09},
@@ -149,3 +151,34 @@ class _EmbeddedCoresFixtureLoader:
         frame = self.load_all_production()
         mask = frame["field_name"].astype(str).str.lower() == field_name.lower()
         return frame[mask].copy()
+
+    def metadata(self) -> dict:
+        return {
+            "source_name": "CORES Indigenous Crude Oil Production",
+            "source_url": (
+                "https://www.cores.es/sites/default/files/archivos/estadisticas/"
+                "crude-oil-production.xlsx"
+            ),
+            "statistics_page": "https://www.cores.es/en/estadisticas",
+            "source_unit": "tonnes",
+            "normalized_unit": "bbl",
+            "conversion": "oil_bbl = tonnes * cited_field_density_factors",
+            "conversion_factors": {
+                "gas_gwh_to_mcf": self._GAS_GWH_TO_MCF,
+                "oil_tonnes_to_bbl_default": self._DEFAULT_BBL_PER_TONNE,
+            },
+            "oil_conversion_audit": {
+                "schema_version": 1,
+                "generated_at": "2026-07-04T00:00:00Z",
+                "registry_version": "fixture-default-density",
+                "registry_date": "2026-07-04",
+                "conversion_basis": "cited_field_density_factors",
+                "coverage_status": "defaulted",
+                "oil_field_count": 1,
+                "used_fields": [],
+                "defaulted_fields": ["Ayoluengo"],
+                "missing_fields": [],
+                "default_bbl_per_tonne": self._DEFAULT_BBL_PER_TONNE,
+                "factors": [],
+            },
+        }

--- a/packages/worldenergydata-scheduler/src/worldenergydata/scheduler/jobs/spain_cores_refresh.py
+++ b/packages/worldenergydata-scheduler/src/worldenergydata/scheduler/jobs/spain_cores_refresh.py
@@ -23,6 +23,10 @@ _DEFAULT_FIXTURE_OUTPUT_DIR = Path(
 )
 
 
+class SpainCoresConfigError(ValueError):
+    """Raised for deterministic Spain CORES scheduler configuration errors."""
+
+
 class SpainCoresRefreshJob(AbstractJob):
     """Refresh official Spain CORES monthly oil/gas production workbooks."""
 
@@ -43,6 +47,8 @@ class SpainCoresRefreshJob(AbstractJob):
 
     def _is_retryable_exception(self, exc: Exception) -> bool:
         """Classify deterministic CORES source-contract failures."""
+        if isinstance(exc, SpainCoresConfigError):
+            return False
         deterministic_errors: list[type[Exception]] = []
         try:
             from worldenergydata.spain.production import CoresSourceError
@@ -113,17 +119,28 @@ class SpainCoresRefreshJob(AbstractJob):
     ) -> dict[str, Any]:
         repo_root = config.get("_scheduler_repo_root")
         kwargs: dict[str, Any] = {"cache_root": output_dir}
-        if config.get("oil_density_registry_path") is not None:
+        registry_path = self._density_registry_path(config)
+        if registry_path is not None:
             kwargs["oil_density_registry_path"] = self._resolve_path(
-                config["oil_density_registry_path"],
+                registry_path,
                 repo_root,
             )
         if "allow_default_density" in config:
             allow_default_density = config["allow_default_density"]
             if not isinstance(allow_default_density, bool):
-                raise ValueError("allow_default_density must be boolean")
+                raise SpainCoresConfigError("allow_default_density must be boolean")
             kwargs["allow_default_density"] = allow_default_density
         return kwargs
+
+    @staticmethod
+    def _density_registry_path(config: dict[str, Any]) -> Any:
+        primary = config.get("density_registry_path")
+        legacy = config.get("oil_density_registry_path")
+        if primary is not None and legacy is not None and str(primary) != str(legacy):
+            raise SpainCoresConfigError(
+                "density_registry_path conflicts with oil_density_registry_path"
+            )
+        return primary if primary is not None else legacy
 
     def _refresh_fixture(
         self,

--- a/packages/worldenergydata-scheduler/src/worldenergydata/scheduler/jobs/spain_cores_refresh.py
+++ b/packages/worldenergydata-scheduler/src/worldenergydata/scheduler/jobs/spain_cores_refresh.py
@@ -11,7 +11,7 @@ import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 from worldenergydata.scheduler.jobs.base import AbstractJob, JobResult
 
@@ -29,25 +29,38 @@ class SpainCoresRefreshJob(AbstractJob):
     name = "spain_cores_refresh"
     default_output_dir = _DEFAULT_OUTPUT_DIR
 
-    def _loader_class(self):
+    def _loader_class(self) -> type[Any]:
         """Return the live CORES loader class (overridden in tests)."""
         from worldenergydata.spain.production import CoresLiveProductionLoader
 
-        return CoresLiveProductionLoader
+        return cast(type[Any], CoresLiveProductionLoader)
 
     def _fixture_refresher(self) -> Callable[..., Any]:
         """Return the Ayoluengo fixture refresher (overridden in tests)."""
         from worldenergydata.spain.production import refresh_ayoluengo_fixture
 
-        return refresh_ayoluengo_fixture
+        return cast(Callable[..., Any], refresh_ayoluengo_fixture)
 
     def _is_retryable_exception(self, exc: Exception) -> bool:
         """Classify deterministic CORES source-contract failures."""
+        deterministic_errors: list[type[Exception]] = []
         try:
             from worldenergydata.spain.production import CoresSourceError
+
+            deterministic_errors.append(CoresSourceError)
         except Exception:
+            pass
+        try:
+            from worldenergydata.spain.production.cores_density import (
+                CoresDensityCoverageError,
+            )
+
+            deterministic_errors.append(CoresDensityCoverageError)
+        except Exception:
+            pass
+        if not deterministic_errors:
             return True
-        return not isinstance(exc, CoresSourceError)
+        return not isinstance(exc, tuple(deterministic_errors))
 
     @staticmethod
     def _resolve_path(value: str | Path, repo_root: str | Path | None) -> Path:
@@ -56,24 +69,17 @@ class SpainCoresRefreshJob(AbstractJob):
             return path
         return Path(repo_root) / path
 
-    def run(self, config: dict) -> JobResult:
+    def run(self, config: dict[str, Any]) -> JobResult:
         start = datetime.now()
         if "output_dir" not in config:
-            return JobResult(
-                job_name=self.name,
-                start_time=start,
-                end_time=datetime.now(),
-                status="skipped",
-                records_updated=0,
-                error_msg="Spain CORES refresh requires an explicit output_dir",
-            )
+            return self._skipped_result(start)
 
         repo_root = config.get("_scheduler_repo_root")
         output_dir = self._resolve_path(config["output_dir"], repo_root)
         force_refresh = bool(config.get("force_refresh", False))
 
         try:
-            loader = self._loader_class()(cache_root=output_dir)
+            loader = self._loader_class()(**self._loader_kwargs(config, output_dir))
             loader.refresh(force_refresh=force_refresh)
             production = loader.load_all_production()
             records_updated = len(production)
@@ -81,36 +87,16 @@ class SpainCoresRefreshJob(AbstractJob):
             if records_updated <= 0:
                 error_msg = "CORES refresh produced 0 rows (download incomplete)"
                 logger.error(error_msg)
-                return JobResult(
-                    job_name=self.name,
-                    start_time=start,
-                    end_time=datetime.now(),
-                    status="failure",
-                    records_updated=0,
-                    error_msg=error_msg,
-                    retryable=True,
-                )
+                return self._failure_result(start, error_msg, retryable=True)
 
             if config.get("refresh_fixture", False):
-                fixture_output_dir = self._resolve_path(
-                    config.get("fixture_output_dir", _DEFAULT_FIXTURE_OUTPUT_DIR),
-                    repo_root,
-                )
-                self._fixture_refresher()(
-                    oil_frame=loader.load_oil_production(),
-                    metadata=loader.metadata(),
-                    output_dir=fixture_output_dir,
-                )
+                self._refresh_fixture(loader, config, repo_root)
         except Exception as exc:
             error_msg = f"CORES refresh failed: {exc}"
             logger.error(error_msg)
-            return JobResult(
-                job_name=self.name,
-                start_time=start,
-                end_time=datetime.now(),
-                status="failure",
-                records_updated=0,
-                error_msg=error_msg,
+            return self._failure_result(
+                start,
+                error_msg,
                 retryable=self._is_retryable_exception(exc),
             )
 
@@ -120,6 +106,56 @@ class SpainCoresRefreshJob(AbstractJob):
             records_updated,
             output_dir,
         )
+        return self._success_result(start, records_updated)
+
+    def _loader_kwargs(
+        self, config: dict[str, Any], output_dir: Path
+    ) -> dict[str, Any]:
+        repo_root = config.get("_scheduler_repo_root")
+        kwargs: dict[str, Any] = {"cache_root": output_dir}
+        if config.get("oil_density_registry_path") is not None:
+            kwargs["oil_density_registry_path"] = self._resolve_path(
+                config["oil_density_registry_path"],
+                repo_root,
+            )
+        if "allow_default_density" in config:
+            allow_default_density = config["allow_default_density"]
+            if not isinstance(allow_default_density, bool):
+                raise ValueError("allow_default_density must be boolean")
+            kwargs["allow_default_density"] = allow_default_density
+        return kwargs
+
+    def _refresh_fixture(
+        self,
+        loader: Any,
+        config: dict[str, Any],
+        repo_root: str | Path | None,
+    ) -> None:
+        fixture_output_dir = self._resolve_path(
+            config.get("fixture_output_dir", _DEFAULT_FIXTURE_OUTPUT_DIR),
+            repo_root,
+        )
+        fixture_kwargs = {
+            "oil_frame": loader.load_oil_production(),
+            "metadata": loader.metadata(),
+            "output_dir": fixture_output_dir,
+        }
+        oil_conversion_audit = getattr(loader, "oil_conversion_audit", None)
+        if oil_conversion_audit is not None:
+            fixture_kwargs["oil_conversion_audit"] = oil_conversion_audit
+        self._fixture_refresher()(**fixture_kwargs)
+
+    def _skipped_result(self, start: datetime) -> JobResult:
+        return JobResult(
+            job_name=self.name,
+            start_time=start,
+            end_time=datetime.now(),
+            status="skipped",
+            records_updated=0,
+            error_msg="Spain CORES refresh requires an explicit output_dir",
+        )
+
+    def _success_result(self, start: datetime, records_updated: int) -> JobResult:
         return JobResult(
             job_name=self.name,
             start_time=start,
@@ -129,24 +165,52 @@ class SpainCoresRefreshJob(AbstractJob):
             error_msg=None,
         )
 
+    def _failure_result(
+        self,
+        start: datetime,
+        error_msg: str,
+        *,
+        retryable: bool,
+    ) -> JobResult:
+        return JobResult(
+            job_name=self.name,
+            start_time=start,
+            end_time=datetime.now(),
+            status="failure",
+            records_updated=0,
+            error_msg=error_msg,
+            retryable=retryable,
+        )
+
     @staticmethod
     def _write_refresh_metadata(output_dir: Path, records_updated: int) -> None:
         """Write Spain CORES freshness metadata with the correct CSV format."""
         output_dir.mkdir(parents=True, exist_ok=True)
-        files = sorted(
+        csv_files = sorted(
             p
             for p in output_dir.rglob("*")
-            if p.is_file() and p.name not in {"_metadata.json", "manifest.json"}
+            if p.is_file() and p.suffix.lower() == ".csv"
+        )
+        sidecar_files = sorted(
+            p
+            for p in output_dir.rglob("*")
+            if p.is_file()
+            and p.suffix.lower() == ".json"
+            and p.name not in {"_metadata.json", "manifest.json"}
         )
         metadata = {
             "module": "spain_cores",
             "last_refresh": datetime.now(tz=timezone.utc).isoformat(),
             "record_count": records_updated,
-            "file_count": len(files),
-            "total_size_bytes": sum(p.stat().st_size for p in files),
+            "file_count": len(csv_files),
+            "sidecar_file_count": len(sidecar_files),
+            "total_size_bytes": sum(
+                p.stat().st_size for p in [*csv_files, *sidecar_files]
+            ),
             "source_url": "https://www.cores.es/en/estadisticas",
             "format": "csv",
-            "files": [str(p.relative_to(output_dir)) for p in files],
+            "files": [str(p.relative_to(output_dir)) for p in csv_files],
+            "sidecar_files": [str(p.relative_to(output_dir)) for p in sidecar_files],
         }
         (output_dir / "_metadata.json").write_text(
             json.dumps(metadata, indent=2) + "\n",

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/_metadata.json
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/_metadata.json
@@ -1,11 +1,27 @@
 {
-  "conversion": "oil_bbl = tonnes * 7.33",
+  "conversion": "oil_bbl = tonnes * cited_field_density_factors",
   "conversion_factors": {
     "gas_gwh_to_mcf": 3290.0,
-    "oil_tonnes_to_bbl": 7.33
+    "oil_tonnes_to_bbl_default": 7.33
   },
   "license_note": "CORES attribution required; cite source URL and latest-update date.",
   "normalized_unit": "bbl",
+  "oil_conversion_audit": {
+    "conversion_basis": "cited_field_density_factors",
+    "coverage_status": "defaulted",
+    "default_bbl_per_tonne": 7.33,
+    "defaulted_fields": [
+      "Ayoluengo"
+    ],
+    "factors": [],
+    "generated_at": "2026-07-04T00:00:00Z",
+    "missing_fields": [],
+    "oil_field_count": 1,
+    "registry_date": "2026-07-04",
+    "registry_version": "fixture-default-density",
+    "schema_version": 1,
+    "used_fields": []
+  },
   "sample_extracted_date": "2026-07-04",
   "sample_field": "Ayoluengo",
   "sample_row_count": 6,

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
@@ -1,0 +1,21 @@
+{
+  "registry_version": "2026-07-06-source-gap",
+  "registry_date": "2026-07-06",
+  "coverage_status": "missing",
+  "coverage_note": "No CORES oil field currently has an accepted field-applicable crude density/API conversion factor in this registry. Strict refreshes fail closed until accepted cited factors are added.",
+  "source_gap_fields": [
+    "Albatros",
+    "Amposta",
+    "Ayoluengo",
+    "Boquer\u00f3n",
+    "Casablanca",
+    "Dorada",
+    "Gaviota",
+    "Montanazo-Lubina",
+    "Rodaballo",
+    "Salmonete",
+    "Tarraco",
+    "Viura (1)"
+  ],
+  "factors": []
+}

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/production/__init__.py
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/production/__init__.py
@@ -1,22 +1,43 @@
 """Spain production loaders."""
 
+from typing import Any
+
 __all__ = [
     "DEFAULT_WORKBOOKS",
     "STATISTICS_PAGE_URL",
     "CoresFixtureProductionLoader",
+    "CoresCrudeDensityFactor",
+    "CoresDensityCoverageError",
     "CoresHttpResponse",
     "CoresLiveProductionLoader",
+    "CoresOilConversionAudit",
     "CoresProductionLoader",
     "CoresSourceError",
     "CoresWorkbook",
     "CoresWorkbookSource",
     "FixtureRefreshResult",
+    "bbl_per_tonne_from_api",
+    "build_oil_conversion_audit",
+    "load_crude_density_factors",
     "parse_cores_frame",
     "refresh_ayoluengo_fixture",
+    "validate_crude_density_factor",
 ]
 
 
-def __getattr__(name):
+def __getattr__(name: str) -> Any:
+    if name in {
+        "CoresCrudeDensityFactor",
+        "CoresDensityCoverageError",
+        "CoresOilConversionAudit",
+        "bbl_per_tonne_from_api",
+        "build_oil_conversion_audit",
+        "load_crude_density_factors",
+        "validate_crude_density_factor",
+    }:
+        from worldenergydata.spain.production import cores_density
+
+        return getattr(cores_density, name)
     if name in {
         "CoresFixtureProductionLoader",
         "CoresProductionLoader",

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_density.py
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_density.py
@@ -121,6 +121,14 @@ class CoresOilConversionAudit:
             return DEFAULT_OIL_BBL_PER_TONNE
         raise CoresDensityCoverageError(f"missing density factor for {field_name}")
 
+    @property
+    def used_field_names(self) -> tuple[str, ...]:
+        """Parsed CORES display field names resolved to accepted factors."""
+        names: dict[str, None] = {}
+        for field_name, _factor in self._accepted_entries:
+            names[str(field_name)] = None
+        return tuple(names)
+
 
 def validate_crude_density_factor(factor: CoresCrudeDensityFactor) -> None:
     """Validate one cited density factor regardless of construction path."""
@@ -181,10 +189,12 @@ def load_crude_density_factors(
         path = _default_registry_path()
     with Path(path).open(encoding="utf-8") as fh:
         payload = json.load(fh)
-    if isinstance(payload, list):
-        entries = payload
-    else:
-        entries = payload.get("factors", [])
+    if not isinstance(payload, dict):
+        raise ValueError("registry_version is required")
+    _validate_registry_metadata(payload)
+    entries = payload.get("factors", [])
+    if not isinstance(entries, list):
+        raise ValueError("factors must be a list")
     factors: dict[str, CoresCrudeDensityFactor] = {}
     for entry in entries:
         if "accepted_for_conversion" not in entry:
@@ -236,7 +246,7 @@ def build_oil_conversion_audit(
         factor = normalized_factors.get(key)
         if factor is not None and factor.accepted_for_conversion:
             used.append(factor)
-            entries.append((key, factor))
+            entries.append((str(field_name), factor))
         elif allow_default_density:
             defaulted.append(str(field_name))
         else:
@@ -253,6 +263,13 @@ def build_oil_conversion_audit(
         _accepted_entries=tuple(entries),
         _defaulted_field_keys=tuple(normalize_field_key(name) for name in defaulted),
     )
+
+
+def _validate_registry_metadata(payload: Mapping[str, object]) -> None:
+    for key in ("registry_version", "registry_date"):
+        value = payload.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"{key} is required")
 
 
 def _default_registry_path() -> Path:

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_density.py
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_density.py
@@ -1,0 +1,264 @@
+"""Spain CORES crude density/API conversion registry (#807)."""
+
+from __future__ import annotations
+
+import json
+import re
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping
+
+DEFAULT_OIL_BBL_PER_TONNE = 7.33
+
+_ALLOWED_SOURCE_CLASSES = {
+    "regulator_record",
+    "operator_record",
+    "securities_filing",
+    "crude_assay",
+    "technical_literature",
+    "industry_technical_article",
+    "secondary_article",
+}
+_CONVERSION_SOURCE_CLASSES = {
+    "regulator_record",
+    "operator_record",
+    "securities_filing",
+    "crude_assay",
+    "technical_literature",
+}
+_ALLOWED_CONFIDENCE = {"low", "medium", "high"}
+
+
+class CoresDensityCoverageError(ValueError):
+    """Raised when strict oil conversion lacks accepted density coverage."""
+
+
+def normalize_field_key(value: str) -> str:
+    """Normalize CORES field names for density lookups."""
+    text = unicodedata.normalize("NFKD", str(value))
+    text = "".join(ch for ch in text if not unicodedata.combining(ch))
+    return re.sub(r"[^a-z0-9]+", "", text.lower())
+
+
+def bbl_per_tonne_from_api(api_gravity_deg: float) -> float:
+    """Convert API gravity to barrels per metric tonne."""
+    specific_gravity = 141.5 / (float(api_gravity_deg) + 131.5)
+    return 1.0 / (specific_gravity * 0.158987294928)
+
+
+@dataclass(frozen=True)
+class CoresCrudeDensityFactor:
+    """Cited crude density/API factor for one CORES oil field."""
+
+    field_name: str
+    aliases: tuple[str, ...]
+    api_gravity_deg: float | None
+    api_gravity_min_deg: float | None
+    api_gravity_max_deg: float | None
+    bbl_per_tonne: float | None
+    measurement_basis: str
+    source_title: str
+    source_url: str
+    source_class: str
+    evidence_note: str
+    confidence: str
+    accepted_for_conversion: bool
+
+    def __post_init__(self) -> None:
+        validate_crude_density_factor(self)
+
+
+@dataclass(frozen=True)
+class CoresOilConversionAudit:
+    """Resolved oil conversion factors for a parsed CORES frame."""
+
+    used_factors: tuple[CoresCrudeDensityFactor, ...]
+    defaulted_fields: tuple[str, ...]
+    missing_fields: tuple[str, ...]
+    _accepted_entries: tuple[tuple[str, CoresCrudeDensityFactor], ...]
+    _defaulted_field_keys: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        for factor in [*self.used_factors, *(f for _, f in self._accepted_entries)]:
+            validate_crude_density_factor(factor)
+
+        for factor in self.used_factors:
+            if factor.bbl_per_tonne is None:
+                raise ValueError(f"{factor.field_name} missing bbl_per_tonne")
+            if not factor.accepted_for_conversion:
+                raise ValueError(f"{factor.field_name} is not accepted for conversion")
+
+        accepted = {id(factor) for factor in self.used_factors}
+        seen: set[str] = set()
+        for key, factor in self._accepted_entries:
+            if normalize_field_key(key) in seen:
+                raise ValueError(f"duplicate density key: {key}")
+            seen.add(normalize_field_key(key))
+            if not factor.accepted_for_conversion:
+                raise ValueError(f"{factor.field_name} is not accepted for conversion")
+            if id(factor) not in accepted:
+                raise ValueError(f"{factor.field_name} is not present in used_factors")
+            if factor.bbl_per_tonne is None:
+                raise ValueError(f"{factor.field_name} missing bbl_per_tonne")
+
+        defaulted_keys = {normalize_field_key(name) for name in self.defaulted_fields}
+        for key in self._defaulted_field_keys:
+            if normalize_field_key(key) not in defaulted_keys:
+                raise ValueError(
+                    f"default key {key!r} not represented in defaulted_fields"
+                )
+
+    def bbl_per_tonne_for_field(self, field_name: str) -> float:
+        """Return cited/default factor for a parsed CORES field."""
+        key = normalize_field_key(field_name)
+        for entry_key, factor in self._accepted_entries:
+            if normalize_field_key(entry_key) == key:
+                if factor.bbl_per_tonne is None:
+                    raise ValueError(f"{factor.field_name} missing bbl_per_tonne")
+                return factor.bbl_per_tonne
+        if key in {normalize_field_key(name) for name in self.defaulted_fields}:
+            return DEFAULT_OIL_BBL_PER_TONNE
+        raise CoresDensityCoverageError(f"missing density factor for {field_name}")
+
+
+def validate_crude_density_factor(factor: CoresCrudeDensityFactor) -> None:
+    """Validate one cited density factor regardless of construction path."""
+    required = {
+        "field_name": factor.field_name,
+        "measurement_basis": factor.measurement_basis,
+        "source_title": factor.source_title,
+        "source_url": factor.source_url,
+        "source_class": factor.source_class,
+        "evidence_note": factor.evidence_note,
+        "confidence": factor.confidence,
+    }
+    for name, value in required.items():
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"{name} is required")
+    if not factor.aliases:
+        raise ValueError("aliases are required")
+    for alias in factor.aliases:
+        if not isinstance(alias, str) or not alias.strip():
+            raise ValueError("aliases must be non-empty strings")
+    if not isinstance(factor.accepted_for_conversion, bool):
+        raise ValueError("accepted_for_conversion must be boolean")
+    if factor.source_class not in _ALLOWED_SOURCE_CLASSES:
+        raise ValueError(f"unsupported source_class: {factor.source_class}")
+    if factor.confidence not in _ALLOWED_CONFIDENCE:
+        raise ValueError(f"unsupported confidence: {factor.confidence}")
+
+    has_range = (
+        factor.api_gravity_min_deg is not None or factor.api_gravity_max_deg is not None
+    )
+    if factor.accepted_for_conversion:
+        if factor.source_class not in _CONVERSION_SOURCE_CLASSES:
+            raise ValueError(
+                f"source_class {factor.source_class} cannot drive conversion"
+            )
+        if has_range and factor.api_gravity_deg is None:
+            raise ValueError(
+                "representative API gravity is required for range evidence"
+            )
+        if factor.bbl_per_tonne is None or factor.bbl_per_tonne <= 0:
+            raise ValueError("bbl_per_tonne must be positive for accepted factors")
+        if not 5.0 <= factor.bbl_per_tonne <= 9.5:
+            raise ValueError("bbl_per_tonne outside conservative crude-oil range")
+    elif has_range and factor.bbl_per_tonne is not None:
+        raise ValueError("evidence-only range entries must not carry bbl_per_tonne")
+
+    if factor.api_gravity_deg is not None and factor.bbl_per_tonne is not None:
+        expected = bbl_per_tonne_from_api(factor.api_gravity_deg)
+        if abs(factor.bbl_per_tonne - expected) > 0.01:
+            raise ValueError("bbl_per_tonne does not match API gravity")
+
+
+def load_crude_density_factors(
+    path: Path | None = None,
+) -> dict[str, CoresCrudeDensityFactor]:
+    """Load, normalize, and validate cited crude density factors."""
+    if path is None:
+        path = _default_registry_path()
+    with Path(path).open(encoding="utf-8") as fh:
+        payload = json.load(fh)
+    if isinstance(payload, list):
+        entries = payload
+    else:
+        entries = payload.get("factors", [])
+    factors: dict[str, CoresCrudeDensityFactor] = {}
+    for entry in entries:
+        if "accepted_for_conversion" not in entry:
+            raise ValueError("accepted_for_conversion is required")
+        factor = CoresCrudeDensityFactor(
+            field_name=entry.get("field_name"),
+            aliases=tuple(entry.get("aliases", ())),
+            api_gravity_deg=entry.get("api_gravity_deg"),
+            api_gravity_min_deg=entry.get("api_gravity_min_deg"),
+            api_gravity_max_deg=entry.get("api_gravity_max_deg"),
+            bbl_per_tonne=entry.get("bbl_per_tonne"),
+            measurement_basis=entry.get("measurement_basis"),
+            source_title=entry.get("source_title"),
+            source_url=entry.get("source_url"),
+            source_class=entry.get("source_class"),
+            evidence_note=entry.get("evidence_note"),
+            confidence=entry.get("confidence"),
+            accepted_for_conversion=entry.get("accepted_for_conversion", False),
+        )
+        factor_keys: set[str] = set()
+        for key in (factor.field_name, *factor.aliases):
+            normalized = normalize_field_key(key)
+            if normalized in factor_keys:
+                continue
+            factor_keys.add(normalized)
+            if normalized in factors:
+                raise ValueError(f"duplicate density alias: {key}")
+            factors[normalized] = factor
+    return factors
+
+
+def build_oil_conversion_audit(
+    field_names: Iterable[str],
+    factors: Mapping[str, CoresCrudeDensityFactor],
+    *,
+    allow_default_density: bool = False,
+) -> CoresOilConversionAudit:
+    """Resolve cited factors and exact missing/defaulted field lists."""
+    if not isinstance(allow_default_density, bool):
+        raise ValueError("allow_default_density must be boolean")
+    normalized_factors = {normalize_field_key(k): v for k, v in factors.items()}
+    used: list[CoresCrudeDensityFactor] = []
+    entries: list[tuple[str, CoresCrudeDensityFactor]] = []
+    defaulted: list[str] = []
+    missing: list[str] = []
+
+    for field_name in field_names:
+        key = normalize_field_key(field_name)
+        factor = normalized_factors.get(key)
+        if factor is not None and factor.accepted_for_conversion:
+            used.append(factor)
+            entries.append((key, factor))
+        elif allow_default_density:
+            defaulted.append(str(field_name))
+        else:
+            missing.append(str(field_name))
+
+    if missing:
+        names = ", ".join(missing)
+        raise CoresDensityCoverageError(f"missing density factors for: {names}")
+
+    return CoresOilConversionAudit(
+        used_factors=tuple(used),
+        defaulted_fields=tuple(defaulted),
+        missing_fields=tuple(missing),
+        _accepted_entries=tuple(entries),
+        _defaulted_field_keys=tuple(normalize_field_key(name) for name in defaulted),
+    )
+
+
+def _default_registry_path() -> Path:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "data"
+        / "cores"
+        / "crude_density_factors.json"
+    )

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_live.py
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_live.py
@@ -10,17 +10,18 @@ from typing import Any, Iterable, Mapping, Optional, cast
 
 import pandas as pd
 
+from worldenergydata.spain.production.cores_density import (
+    DEFAULT_OIL_BBL_PER_TONNE,
+    CoresCrudeDensityFactor,
+    CoresOilConversionAudit,
+    build_oil_conversion_audit,
+    load_crude_density_factors,
+)
 from worldenergydata.spain.production.cores_loader import (
     GWH_TO_MCF,
     TONNES_TO_BBL,
     CoresProductionLoader,
-)
-from worldenergydata.spain.production.cores_density import (
-    CoresCrudeDensityFactor,
-    CoresOilConversionAudit,
-    DEFAULT_OIL_BBL_PER_TONNE,
-    build_oil_conversion_audit,
-    load_crude_density_factors,
+    extract_cores_field_names,
 )
 from worldenergydata.spain.production.cores_source import (
     DEFAULT_WORKBOOKS,
@@ -139,8 +140,7 @@ class CoresLiveProductionLoader:
         self,
         raw: pd.DataFrame,
     ) -> CoresOilConversionAudit:
-        legacy_frame = CoresProductionLoader(product="oil", raw_frame=raw).load()
-        field_names = sorted(legacy_frame["field_name"].dropna().astype(str).unique())
+        field_names = extract_cores_field_names(raw)
         factors = load_crude_density_factors(self.oil_density_registry_path)
         return build_oil_conversion_audit(
             field_names,
@@ -170,8 +170,10 @@ class CoresLiveProductionLoader:
             "registry_date": metadata.get("registry_date"),
             "conversion_basis": "cited_field_density_factors",
             "coverage_status": _coverage_status(audit),
-            "oil_field_count": len(audit.used_factors) + len(audit.defaulted_fields),
-            "used_fields": _unique_factor_names(audit.used_factors),
+            "oil_field_count": len(audit.used_field_names)
+            + len(audit.defaulted_fields)
+            + len(audit.missing_fields),
+            "used_fields": list(audit.used_field_names),
             "defaulted_fields": list(audit.defaulted_fields),
             "missing_fields": list(audit.missing_fields),
             "default_bbl_per_tonne": _default_bbl_per_tonne(audit),
@@ -265,11 +267,16 @@ def _fixture_metadata(
         "workbooks": workbooks,
     }
     if oil_conversion_audit is not None:
-        metadata.update(_fixture_density_metadata(oil_conversion_audit))
+        metadata.update(_fixture_density_metadata(oil_conversion_audit, refreshed))
+    else:
+        metadata.update(_fixture_default_density_metadata(refreshed))
     return metadata
 
 
-def _fixture_density_metadata(audit: CoresOilConversionAudit) -> dict[str, Any]:
+def _fixture_density_metadata(
+    audit: CoresOilConversionAudit,
+    generated_at: str,
+) -> dict[str, Any]:
     conversion_factors = {
         "gas_gwh_to_mcf": GWH_TO_MCF,
         "oil_tonnes_to_bbl_by_field": _factor_map(audit.used_factors),
@@ -281,12 +288,44 @@ def _fixture_density_metadata(audit: CoresOilConversionAudit) -> dict[str, Any]:
         "conversion": "oil_bbl = tonnes * cited_field_density_factors",
         "conversion_factors": conversion_factors,
         "oil_conversion_audit": {
+            "schema_version": 1,
+            "generated_at": generated_at,
+            "registry_version": "fixture-refresh-density-audit",
+            "registry_date": generated_at[:10],
+            "conversion_basis": "cited_field_density_factors",
             "coverage_status": _coverage_status(audit),
-            "used_fields": _unique_factor_names(audit.used_factors),
+            "oil_field_count": len(audit.used_field_names)
+            + len(audit.defaulted_fields)
+            + len(audit.missing_fields),
+            "used_fields": list(audit.used_field_names),
             "defaulted_fields": list(audit.defaulted_fields),
             "missing_fields": list(audit.missing_fields),
             "default_bbl_per_tonne": default_bbl_per_tonne,
             "factors": [asdict(factor) for factor in audit.used_factors],
+        },
+    }
+
+
+def _fixture_default_density_metadata(generated_at: str) -> dict[str, Any]:
+    return {
+        "conversion": "oil_bbl = tonnes * cited_field_density_factors",
+        "conversion_factors": {
+            "gas_gwh_to_mcf": GWH_TO_MCF,
+            "oil_tonnes_to_bbl_default": TONNES_TO_BBL,
+        },
+        "oil_conversion_audit": {
+            "schema_version": 1,
+            "generated_at": generated_at,
+            "registry_version": "fixture-default-density",
+            "registry_date": generated_at[:10],
+            "conversion_basis": "cited_field_density_factors",
+            "coverage_status": "defaulted",
+            "oil_field_count": 1,
+            "used_fields": [],
+            "defaulted_fields": ["Ayoluengo"],
+            "missing_fields": [],
+            "default_bbl_per_tonne": TONNES_TO_BBL,
+            "factors": [],
         },
     }
 
@@ -333,13 +372,6 @@ def _default_bbl_per_tonne(audit: CoresOilConversionAudit) -> float | None:
     if audit.defaulted_fields:
         return float(DEFAULT_OIL_BBL_PER_TONNE)
     return None
-
-
-def _unique_factor_names(factors: Iterable[CoresCrudeDensityFactor]) -> list[str]:
-    names: dict[str, None] = {}
-    for factor in factors:
-        names[factor.field_name] = None
-    return list(names)
 
 
 def _optional_str(value: Any) -> str | None:

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_live.py
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_live.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from email.utils import parsedate_to_datetime
 from pathlib import Path
-from typing import Any, Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional, cast
 
 import pandas as pd
 
@@ -14,6 +14,13 @@ from worldenergydata.spain.production.cores_loader import (
     GWH_TO_MCF,
     TONNES_TO_BBL,
     CoresProductionLoader,
+)
+from worldenergydata.spain.production.cores_density import (
+    CoresCrudeDensityFactor,
+    CoresOilConversionAudit,
+    DEFAULT_OIL_BBL_PER_TONNE,
+    build_oil_conversion_audit,
+    load_crude_density_factors,
 )
 from worldenergydata.spain.production.cores_source import (
     DEFAULT_WORKBOOKS,
@@ -56,6 +63,8 @@ class CoresLiveProductionLoader:
         source: Optional[CoresWorkbookSource] = None,
         header_row: int = 5,
         sheet_name: str = "Production",
+        oil_density_registry_path: Optional[Path] = None,
+        allow_default_density: bool = False,
     ):
         self.cache_root = Path(cache_root)
         self.source = source or CoresWorkbookSource(cache_root=self.cache_root)
@@ -63,6 +72,15 @@ class CoresLiveProductionLoader:
         self.normalized_dir = self.cache_root / "normalized"
         self.header_row = header_row
         self.sheet_name = sheet_name
+        self.oil_density_registry_path = (
+            Path(oil_density_registry_path)
+            if oil_density_registry_path is not None
+            else _default_density_registry_path()
+        )
+        if not isinstance(allow_default_density, bool):
+            raise ValueError("allow_default_density must be boolean")
+        self.allow_default_density = allow_default_density
+        self.oil_conversion_audit: CoresOilConversionAudit | None = None
 
     def refresh(self, *, force_refresh: bool = False) -> dict[str, Any]:
         self.source.download_all(force_refresh=force_refresh, validate_links=True)
@@ -88,20 +106,83 @@ class CoresLiveProductionLoader:
         return frame[mask].copy()
 
     def metadata(self) -> dict[str, Any]:
-        return self.source.metadata()
+        return cast(dict[str, Any], self.source.metadata())
 
     def _load_product(self, product: str) -> pd.DataFrame:
         workbook = DEFAULT_WORKBOOKS[product]
         path = self.raw_dir / workbook.filename
         if not path.exists():
             path = self.source.download(product)
+        raw = self._read_workbook(path)
+        audit = self._oil_conversion_audit(raw) if product == "oil" else None
+        if product == "oil":
+            self.oil_conversion_audit = audit
         frame = CoresProductionLoader(
             product=product,
-            path=path,
+            raw_frame=raw,
             header_row=self.header_row,
             sheet_name=self.sheet_name,
+            oil_conversion_audit=audit,
         ).load()
+        if audit is not None:
+            self._write_oil_density_sidecar(audit)
         return self._write_normalized(product, frame)
+
+    def _read_workbook(self, path: Path) -> pd.DataFrame:
+        return pd.read_excel(
+            path,
+            sheet_name=self.sheet_name,
+            header=self.header_row,
+        )
+
+    def _oil_conversion_audit(
+        self,
+        raw: pd.DataFrame,
+    ) -> CoresOilConversionAudit:
+        legacy_frame = CoresProductionLoader(product="oil", raw_frame=raw).load()
+        field_names = sorted(legacy_frame["field_name"].dropna().astype(str).unique())
+        factors = load_crude_density_factors(self.oil_density_registry_path)
+        return build_oil_conversion_audit(
+            field_names,
+            factors,
+            allow_default_density=self.allow_default_density,
+        )
+
+    def _write_oil_density_sidecar(self, audit: CoresOilConversionAudit) -> None:
+        self.normalized_dir.mkdir(parents=True, exist_ok=True)
+        path = self.normalized_dir / "cores_oil_density_factors.json"
+        path.write_text(
+            json.dumps(
+                self._oil_density_sidecar_payload(audit),
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    def _oil_density_sidecar_payload(self, audit: CoresOilConversionAudit) -> dict:
+        metadata = self._density_registry_metadata()
+        return {
+            "schema_version": 1,
+            "generated_at": utc_now_iso(),
+            "registry_version": metadata.get("registry_version"),
+            "registry_date": metadata.get("registry_date"),
+            "conversion_basis": "cited_field_density_factors",
+            "coverage_status": _coverage_status(audit),
+            "oil_field_count": len(audit.used_factors) + len(audit.defaulted_fields),
+            "used_fields": _unique_factor_names(audit.used_factors),
+            "defaulted_fields": list(audit.defaulted_fields),
+            "missing_fields": list(audit.missing_fields),
+            "default_bbl_per_tonne": _default_bbl_per_tonne(audit),
+            "factors": [asdict(factor) for factor in audit.used_factors],
+        }
+
+    def _density_registry_metadata(self) -> dict[str, Any]:
+        if self.oil_density_registry_path is None:
+            return {}
+        with self.oil_density_registry_path.open(encoding="utf-8") as fh:
+            return cast(dict[str, Any], json.load(fh))
 
     def _write_normalized(self, name: str, frame: pd.DataFrame) -> pd.DataFrame:
         self.normalized_dir.mkdir(parents=True, exist_ok=True)
@@ -117,6 +198,7 @@ def refresh_ayoluengo_fixture(
     output_dir: Optional[Path] = None,
     refreshed_at_utc: Optional[str] = None,
     sample_rows: int = 6,
+    oil_conversion_audit: CoresOilConversionAudit | None = None,
 ) -> FixtureRefreshResult:
     """Refresh the small committed Ayoluengo fixture from live oil output."""
 
@@ -128,7 +210,12 @@ def refresh_ayoluengo_fixture(
     sample.to_csv(sample_path, index=False)
     metadata_path.write_text(
         json.dumps(
-            _fixture_metadata(metadata, len(sample), refreshed_at_utc),
+            _fixture_metadata(
+                metadata,
+                len(sample),
+                refreshed_at_utc,
+                oil_conversion_audit,
+            ),
             indent=2,
             sort_keys=True,
         )
@@ -152,11 +239,12 @@ def _fixture_metadata(
     source_metadata: Mapping[str, Any],
     sample_row_count: int,
     refreshed_at_utc: Optional[str],
+    oil_conversion_audit: CoresOilConversionAudit | None = None,
 ) -> dict[str, Any]:
     workbooks = dict(source_metadata.get("workbooks", {}))
     oil = dict(workbooks.get("oil", {}))
     refreshed = refreshed_at_utc or utc_now_iso()
-    return {
+    metadata = {
         "source_name": DEFAULT_WORKBOOKS["oil"].dataset_name,
         "source_url": oil.get("source_url", DEFAULT_WORKBOOKS["oil"].source_url),
         "statistics_page": source_metadata.get("statistics_page", STATISTICS_PAGE_URL),
@@ -176,16 +264,49 @@ def _fixture_metadata(
         ),
         "workbooks": workbooks,
     }
+    if oil_conversion_audit is not None:
+        metadata.update(_fixture_density_metadata(oil_conversion_audit))
+    return metadata
+
+
+def _fixture_density_metadata(audit: CoresOilConversionAudit) -> dict[str, Any]:
+    conversion_factors = {
+        "gas_gwh_to_mcf": GWH_TO_MCF,
+        "oil_tonnes_to_bbl_by_field": _factor_map(audit.used_factors),
+    }
+    default_bbl_per_tonne = _default_bbl_per_tonne(audit)
+    if default_bbl_per_tonne is not None:
+        conversion_factors["oil_tonnes_to_bbl_default"] = default_bbl_per_tonne
+    return {
+        "conversion": "oil_bbl = tonnes * cited_field_density_factors",
+        "conversion_factors": conversion_factors,
+        "oil_conversion_audit": {
+            "coverage_status": _coverage_status(audit),
+            "used_fields": _unique_factor_names(audit.used_factors),
+            "defaulted_fields": list(audit.defaulted_fields),
+            "missing_fields": list(audit.missing_fields),
+            "default_bbl_per_tonne": default_bbl_per_tonne,
+            "factors": [asdict(factor) for factor in audit.used_factors],
+        },
+    }
+
+
+def _factor_map(factors: Iterable[CoresCrudeDensityFactor]) -> dict[str, float]:
+    values: dict[str, float] = {}
+    for factor in factors:
+        if factor.bbl_per_tonne is not None:
+            values[factor.field_name] = factor.bbl_per_tonne
+    return values
 
 
 def _source_updated_date(oil_metadata: Mapping[str, Any]) -> Optional[str]:
     last_modified = oil_metadata.get("last_modified")
     if not last_modified:
-        return oil_metadata.get("source_updated_date")
+        return _optional_str(oil_metadata.get("source_updated_date"))
     try:
-        return parsedate_to_datetime(last_modified).date().isoformat()
+        return parsedate_to_datetime(str(last_modified)).date().isoformat()
     except (TypeError, ValueError):
-        return oil_metadata.get("source_updated_date")
+        return _optional_str(oil_metadata.get("source_updated_date"))
 
 
 def _sort_production(frame: pd.DataFrame) -> pd.DataFrame:
@@ -194,3 +315,32 @@ def _sort_production(frame: pd.DataFrame) -> pd.DataFrame:
 
 def _package_cores_data_dir() -> Path:
     return Path(__file__).resolve().parents[1] / "data" / "cores"
+
+
+def _default_density_registry_path() -> Path:
+    return _package_cores_data_dir() / "crude_density_factors.json"
+
+
+def _coverage_status(audit: CoresOilConversionAudit) -> str:
+    if audit.missing_fields:
+        return "missing"
+    if audit.defaulted_fields:
+        return "defaulted"
+    return "complete"
+
+
+def _default_bbl_per_tonne(audit: CoresOilConversionAudit) -> float | None:
+    if audit.defaulted_fields:
+        return DEFAULT_OIL_BBL_PER_TONNE
+    return None
+
+
+def _unique_factor_names(factors: Iterable[CoresCrudeDensityFactor]) -> list[str]:
+    names: dict[str, None] = {}
+    for factor in factors:
+        names[factor.field_name] = None
+    return list(names)
+
+
+def _optional_str(value: Any) -> str | None:
+    return None if value is None else str(value)

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_live.py
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_live.py
@@ -331,7 +331,7 @@ def _coverage_status(audit: CoresOilConversionAudit) -> str:
 
 def _default_bbl_per_tonne(audit: CoresOilConversionAudit) -> float | None:
     if audit.defaulted_fields:
-        return DEFAULT_OIL_BBL_PER_TONNE
+        return float(DEFAULT_OIL_BBL_PER_TONNE)
     return None
 
 

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_loader.py
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_loader.py
@@ -113,6 +113,17 @@ def parse_cores_frame(
     return _parsed_output(long, product, oil_conversion_audit)
 
 
+def extract_cores_field_names(raw: pd.DataFrame) -> list[str]:
+    """Return parsed CORES field display names without unit conversion."""
+    year_col, month_col, field_cols = _frame_columns(raw)
+    monthly = _monthly_rows(raw, year_col, month_col)
+    long = _melt_field_values(monthly, field_cols)
+    names: dict[str, None] = {}
+    for value in long["field_name"].dropna():
+        names[str(value).strip()] = None
+    return sorted(names)
+
+
 def _frame_columns(raw: pd.DataFrame) -> tuple[Any, Any, list[Any]]:
     cols = {str(c).strip().lower(): c for c in raw.columns}
     year_col = next((cols[c] for c in _YEAR_COLS if c in cols), None)
@@ -180,7 +191,7 @@ def _conversion_factor(
     if product == "gas":
         return GWH_TO_MCF
     if oil_conversion_audit is None:
-        return TONNES_TO_BBL
+        raise CoresParseError("oil_conversion_audit is required for oil conversion")
     try:
         return long["field_name"].map(oil_conversion_audit.bbl_per_tonne_for_field)
     except CoresDensityCoverageError as exc:

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_loader.py
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_loader.py
@@ -20,9 +20,14 @@ from __future__ import annotations
 import json
 from importlib.resources import files
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional, cast
 
 import pandas as pd
+
+from worldenergydata.spain.production.cores_density import (
+    CoresDensityCoverageError,
+    CoresOilConversionAudit,
+)
 
 # --- documented conversion constants (review B1) ---------------------------
 # Oil: metric tonnes of crude → barrels. Default ~34° API light crude
@@ -75,11 +80,16 @@ class CoresParseError(ValueError):
     """Raised when a CORES frame cannot be parsed."""
 
 
-def _month_to_int(m) -> Optional[int]:
+def _month_to_int(m: object) -> Optional[int]:
     return _MONTHS.get(str(m).strip().lower())
 
 
-def parse_cores_frame(raw: pd.DataFrame, *, product: str) -> pd.DataFrame:
+def parse_cores_frame(
+    raw: pd.DataFrame,
+    *,
+    product: str,
+    oil_conversion_audit: CoresOilConversionAudit | None = None,
+) -> pd.DataFrame:
     """Pure transform: wide CORES frame → long loader rows.
 
     Args:
@@ -87,6 +97,7 @@ def parse_cores_frame(raw: pd.DataFrame, *, product: str) -> pd.DataFrame:
             per-field value columns, and a grand-total column.
         product: ``"oil"`` (tonnes→bbl → ``oil_bbl``) or ``"gas"`` (GWh→Mcf →
             ``gas_mcf``).
+        oil_conversion_audit: optional cited/defaulted oil conversion audit.
 
     Returns:
         DataFrame ``[field_name, year, month, <oil_bbl|gas_mcf>]`` — only real
@@ -96,27 +107,37 @@ def parse_cores_frame(raw: pd.DataFrame, *, product: str) -> pd.DataFrame:
     if product not in ("oil", "gas"):
         raise CoresParseError(f"product must be 'oil'|'gas', got {product!r}")
 
+    year_col, month_col, field_cols = _frame_columns(raw)
+    monthly = _monthly_rows(raw, year_col, month_col)
+    long = _melt_field_values(monthly, field_cols)
+    return _parsed_output(long, product, oil_conversion_audit)
+
+
+def _frame_columns(raw: pd.DataFrame) -> tuple[Any, Any, list[Any]]:
     cols = {str(c).strip().lower(): c for c in raw.columns}
     year_col = next((cols[c] for c in _YEAR_COLS if c in cols), None)
     month_col = next((cols[c] for c in _MONTH_COLS if c in cols), None)
     if year_col is None or month_col is None:
         raise CoresParseError(f"missing Year/Month columns; have {list(raw.columns)}")
-    field_cols = [
-        c
-        for c in raw.columns
-        if str(c).strip().lower() not in (_YEAR_COLS | _MONTH_COLS | _TOTAL_COLS)
-    ]
+    field_cols = [c for c in raw.columns if _is_field_column(c)]
     if not field_cols:
         raise CoresParseError("no field columns found")
+    return year_col, month_col, field_cols
 
+
+def _is_field_column(column: object) -> bool:
+    return str(column).strip().lower() not in (_YEAR_COLS | _MONTH_COLS | _TOTAL_COLS)
+
+
+def _monthly_rows(raw: pd.DataFrame, year_col: Any, month_col: Any) -> pd.DataFrame:
     df = raw.copy()
-    # positive-int year filter (drops no-year tail rows)
     df["_year"] = pd.to_numeric(df[year_col], errors="coerce")
     df = df[df["_year"].notna() & (df["_year"] > 0)]
-    # month → int (drops 'Total'/'total' annual rows: they map to None)
     df["_month"] = df[month_col].map(_month_to_int)
-    df = df[df["_month"].notna()]
+    return df[df["_month"].notna()]
 
+
+def _melt_field_values(df: pd.DataFrame, field_cols: list[Any]) -> pd.DataFrame:
     long = df.melt(
         id_vars=["_year", "_month"],
         value_vars=field_cols,
@@ -124,19 +145,46 @@ def parse_cores_frame(raw: pd.DataFrame, *, product: str) -> pd.DataFrame:
         value_name="_val",
     )
     long["_val"] = pd.to_numeric(long["_val"], errors="coerce")
-    long = long[long["_val"].notna()]
+    return long[long["_val"].notna()]
 
-    value_col = "oil_bbl" if product == "oil" else "gas_mcf"
-    factor = TONNES_TO_BBL if product == "oil" else GWH_TO_MCF
+
+def _parsed_output(
+    long: pd.DataFrame,
+    product: str,
+    oil_conversion_audit: CoresOilConversionAudit | None,
+) -> pd.DataFrame:
     out = pd.DataFrame(
         {
             "field_name": long["field_name"].astype(str).str.strip().values,
             "year": long["_year"].astype(int).values,
             "month": long["_month"].astype(int).values,
-            value_col: (long["_val"] * factor).astype(float).values,
+            _value_column(product): (
+                long["_val"] * _conversion_factor(long, product, oil_conversion_audit)
+            )
+            .astype(float)
+            .values,
         }
     )
     return out.reset_index(drop=True)
+
+
+def _value_column(product: str) -> str:
+    return "oil_bbl" if product == "oil" else "gas_mcf"
+
+
+def _conversion_factor(
+    long: pd.DataFrame,
+    product: str,
+    oil_conversion_audit: CoresOilConversionAudit | None,
+) -> float | pd.Series:
+    if product == "gas":
+        return GWH_TO_MCF
+    if oil_conversion_audit is None:
+        return TONNES_TO_BBL
+    try:
+        return long["field_name"].map(oil_conversion_audit.bbl_per_tonne_for_field)
+    except CoresDensityCoverageError as exc:
+        raise CoresParseError(str(exc)) from exc
 
 
 class CoresProductionLoader:
@@ -154,13 +202,15 @@ class CoresProductionLoader:
         path: Optional[Path] = None,
         raw_frame: Optional[pd.DataFrame] = None,
         header_row: int = 5,
-        sheet_name=0,
-    ):
+        sheet_name: Any = 0,
+        oil_conversion_audit: CoresOilConversionAudit | None = None,
+    ) -> None:
         self.product = product
         self._path = path
         self._raw = raw_frame
         self._header_row = header_row
         self._sheet_name = sheet_name
+        self._oil_conversion_audit = oil_conversion_audit
 
     def load(self) -> pd.DataFrame:
         raw = (
@@ -172,7 +222,11 @@ class CoresProductionLoader:
                 header=self._header_row,
             )
         )
-        return parse_cores_frame(raw, product=self.product)
+        return parse_cores_frame(
+            raw,
+            product=self.product,
+            oil_conversion_audit=self._oil_conversion_audit,
+        )
 
 
 class CoresFixtureProductionLoader:
@@ -181,9 +235,9 @@ class CoresFixtureProductionLoader:
     def __init__(
         self,
         *,
-        path=DEFAULT_FIXTURE_CSV,
-        metadata_path=DEFAULT_METADATA_JSON,
-    ):
+        path: Any = DEFAULT_FIXTURE_CSV,
+        metadata_path: Any = DEFAULT_METADATA_JSON,
+    ) -> None:
         self._path = path
         self._metadata_path = metadata_path
 
@@ -195,6 +249,6 @@ class CoresFixtureProductionLoader:
         mask = frame["field_name"].astype(str).str.lower() == field_name.lower()
         return frame[mask].copy()
 
-    def metadata(self) -> dict:
+    def metadata(self) -> dict[str, Any]:
         with self._metadata_path.open(encoding="utf-8") as fh:
-            return json.load(fh)
+            return cast(dict[str, Any], json.load(fh))

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/reports/cores_density_audit.py
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/reports/cores_density_audit.py
@@ -1,0 +1,343 @@
+"""CORES oil density audit validation for report inputs (#807)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+from urllib.parse import urlparse
+
+import pandas as pd
+
+from worldenergydata.spain.production.cores_density import CoresCrudeDensityFactor
+
+
+class CoresDensityAuditError(RuntimeError):
+    """Raised when a normalized CORES density audit is not report-ready."""
+
+
+def load_oil_conversion_audit(
+    root: Path,
+    metadata: dict[str, Any],
+    oil_production: pd.DataFrame,
+) -> dict[str, Any] | None:
+    """Load and validate the density audit sidecar or metadata fallback."""
+    sidecar_path = root / "normalized" / "cores_oil_density_factors.json"
+    if sidecar_path.exists():
+        audit = _validated_oil_conversion_audit(
+            _read_json(sidecar_path),
+            sidecar_path.name,
+        )
+        _validate_oil_conversion_coverage(audit, oil_production, sidecar_path.name)
+        return audit
+    metadata_audit = metadata.get("oil_conversion_audit")
+    if metadata_audit is None:
+        return None
+    return _load_metadata_audit(metadata_audit, oil_production)
+
+
+def oil_conversion_limitations(audit: dict[str, Any] | None) -> list[str]:
+    """Return summary limitations for the loaded oil conversion audit."""
+    if audit is None:
+        return ["oil_tonnes_to_bbl_conversion_deferred_to_issue_807"]
+    coverage_status = audit["coverage_status"]
+    defaulted_fields = list(audit["defaulted_fields"])
+    missing_fields = list(audit["missing_fields"])
+    if coverage_status == "missing" or missing_fields:
+        return [
+            "oil_tonnes_to_bbl_conversion_deferred_to_issue_807",
+            _field_list_limitation(
+                "oil_tonnes_to_bbl_has_missing_fields", missing_fields
+            ),
+        ]
+    if coverage_status == "defaulted" or defaulted_fields:
+        return [
+            "oil_tonnes_to_bbl_conversion_deferred_to_issue_807",
+            _field_list_limitation(
+                "oil_tonnes_to_bbl_has_defaulted_fields",
+                defaulted_fields,
+            ),
+        ]
+    if coverage_status == "complete" and not defaulted_fields and not missing_fields:
+        return ["oil_tonnes_to_bbl_uses_cited_field_density_factors"]
+    return ["oil_tonnes_to_bbl_conversion_deferred_to_issue_807"]
+
+
+def _load_metadata_audit(
+    metadata_audit: Any,
+    oil_production: pd.DataFrame,
+) -> dict[str, Any]:
+    source_name = "_metadata.json oil_conversion_audit"
+    audit = _validated_oil_conversion_audit(metadata_audit, source_name)
+    _validate_oil_conversion_coverage(audit, oil_production, source_name)
+    return audit
+
+
+def _field_list_limitation(marker: str, fields: list[str]) -> str:
+    if not fields:
+        return marker
+    return f"{marker}: {', '.join(str(field) for field in fields)}"
+
+
+def _validated_oil_conversion_audit(audit: Any, source_name: str) -> dict[str, Any]:
+    if not isinstance(audit, dict):
+        raise CoresDensityAuditError(f"{source_name} must be an object")
+    if audit.get("coverage_status") not in {"complete", "defaulted", "missing"}:
+        raise CoresDensityAuditError(f"{source_name} missing valid coverage_status")
+    _validate_oil_conversion_audit_provenance(audit, source_name)
+    _validate_oil_conversion_factors(audit, source_name)
+    _validate_oil_conversion_field_lists(audit, source_name)
+    _validate_oil_conversion_status_fields(audit, source_name)
+    _validate_oil_conversion_factor_links(audit, source_name)
+    return audit
+
+
+def _validate_oil_conversion_audit_provenance(
+    audit: dict[str, Any],
+    source_name: str,
+) -> None:
+    for key in ("generated_at", "registry_version", "registry_date"):
+        if not isinstance(audit.get(key), str) or not audit[key].strip():
+            raise CoresDensityAuditError(f"{source_name} missing {key}")
+    if audit.get("conversion_basis") != "cited_field_density_factors":
+        raise CoresDensityAuditError(f"{source_name} missing conversion_basis")
+    for key in ("schema_version", "oil_field_count"):
+        value = audit.get(key)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise CoresDensityAuditError(f"{source_name} missing {key}")
+
+
+def _validate_oil_conversion_factors(
+    audit: dict[str, Any],
+    source_name: str,
+) -> None:
+    factors = audit.get("factors")
+    if not isinstance(factors, list):
+        raise CoresDensityAuditError(f"{source_name} missing factors")
+    for index, factor in enumerate(factors):
+        _validate_oil_conversion_factor(factor, source_name, index)
+
+
+def _validate_oil_conversion_field_lists(
+    audit: dict[str, Any],
+    source_name: str,
+) -> None:
+    for key in ("used_fields", "defaulted_fields", "missing_fields"):
+        if key not in audit:
+            raise CoresDensityAuditError(f"{source_name} missing {key}")
+        if not isinstance(audit[key], list):
+            raise CoresDensityAuditError(f"{source_name} {key} must be a list")
+        _validate_field_list(audit[key], source_name, key)
+
+
+def _validate_field_list(values: list[Any], source_name: str, key: str) -> None:
+    for index, value in enumerate(values):
+        if not isinstance(value, str) or not value.strip():
+            raise CoresDensityAuditError(f"{source_name} {key}[{index}] must be text")
+
+
+def _validate_oil_conversion_status_fields(
+    audit: dict[str, Any],
+    source_name: str,
+) -> None:
+    if audit["coverage_status"] == "complete":
+        if audit["defaulted_fields"] or audit["missing_fields"]:
+            raise CoresDensityAuditError(f"{source_name} complete coverage has gaps")
+    if audit["coverage_status"] == "defaulted" and not audit["defaulted_fields"]:
+        raise CoresDensityAuditError(f"{source_name} missing defaulted_fields")
+    if audit["coverage_status"] == "missing" and not audit["missing_fields"]:
+        raise CoresDensityAuditError(f"{source_name} missing missing_fields")
+    _validate_oil_field_count(audit, source_name)
+
+
+def _validate_oil_field_count(audit: dict[str, Any], source_name: str) -> None:
+    field_count = sum(
+        len(audit[key]) for key in ("used_fields", "defaulted_fields", "missing_fields")
+    )
+    if audit["oil_field_count"] != field_count:
+        raise CoresDensityAuditError(f"{source_name} oil_field_count mismatch")
+
+
+def _validate_oil_conversion_factor_links(
+    audit: dict[str, Any],
+    source_name: str,
+) -> None:
+    factor_fields = [str(factor["field_name"]) for factor in audit["factors"]]
+    if len(set(factor_fields)) != len(factor_fields):
+        raise CoresDensityAuditError(f"{source_name} duplicate density factor field")
+    used_fields = [str(field) for field in audit["used_fields"]]
+    _validate_matching_factors(used_fields, factor_fields, source_name)
+
+
+def _validate_matching_factors(
+    used_fields: list[str],
+    factor_fields: list[str],
+    source_name: str,
+) -> None:
+    missing_factors = [field for field in used_fields if field not in factor_fields]
+    extra_factors = [field for field in factor_fields if field not in used_fields]
+    if missing_factors:
+        names = ", ".join(missing_factors)
+        raise CoresDensityAuditError(
+            f"{source_name} missing accepted oil density factors for: {names}"
+        )
+    if extra_factors:
+        names = ", ".join(extra_factors)
+        raise CoresDensityAuditError(
+            f"{source_name} has unreferenced oil density factors for: {names}"
+        )
+
+
+def _validate_oil_conversion_coverage(
+    audit: dict[str, Any],
+    oil_production: pd.DataFrame,
+    source_name: str,
+) -> None:
+    oil_fields = _production_fields(oil_production)
+    covered = {
+        str(field)
+        for key in ("used_fields", "defaulted_fields", "missing_fields")
+        for field in audit[key]
+    }
+    missing = [field for field in oil_fields if field not in covered]
+    if missing:
+        names = ", ".join(missing)
+        raise CoresDensityAuditError(
+            f"{source_name} missing oil density coverage for: {names}"
+        )
+    extra = [field for field in sorted(covered) if field not in oil_fields]
+    if extra:
+        names = ", ".join(extra)
+        raise CoresDensityAuditError(
+            f"{source_name} has oil density coverage outside CSV fields for: {names}"
+        )
+    if audit["coverage_status"] == "complete":
+        _validate_complete_oil_coverage(audit, oil_fields, source_name)
+
+
+def _validate_complete_oil_coverage(
+    audit: dict[str, Any],
+    oil_fields: list[str],
+    source_name: str,
+) -> None:
+    used_fields = {str(field) for field in audit["used_fields"]}
+    missing = [field for field in oil_fields if field not in used_fields]
+    if missing:
+        names = ", ".join(missing)
+        raise CoresDensityAuditError(
+            f"{source_name} missing accepted oil density factors for: {names}"
+        )
+
+
+def _production_fields(frame: pd.DataFrame) -> list[str]:
+    return sorted(frame["field_name"].dropna().astype(str).unique())
+
+
+def _validate_oil_conversion_factor(
+    factor: Any,
+    source_name: str,
+    index: int,
+) -> None:
+    if not isinstance(factor, dict):
+        raise CoresDensityAuditError(
+            f"{source_name} factors[{index}] must be an object"
+        )
+    _validate_factor_keys(factor, source_name, index)
+    _validate_factor_scalar_fields(factor, source_name, index)
+    _validate_factor_with_registry_rules(factor, source_name, index)
+
+
+def _validate_factor_keys(factor: dict[str, Any], source_name: str, index: int) -> None:
+    for key in _FACTOR_KEYS:
+        if key not in factor:
+            raise CoresDensityAuditError(
+                f"{source_name} factors[{index}] missing {key}"
+            )
+
+
+def _validate_factor_scalar_fields(
+    factor: dict[str, Any],
+    source_name: str,
+    index: int,
+) -> None:
+    for key in _REQUIRED_TEXT_KEYS:
+        if not isinstance(factor[key], str) or not factor[key].strip():
+            raise CoresDensityAuditError(
+                f"{source_name} factors[{index}] missing {key}"
+            )
+    _validate_http_url(factor["source_url"], source_name, index)
+    if not isinstance(factor["aliases"], list):
+        raise CoresDensityAuditError(
+            f"{source_name} factors[{index}] aliases must be a list"
+        )
+    if not isinstance(factor["accepted_for_conversion"], bool):
+        raise CoresDensityAuditError(
+            f"{source_name} factors[{index}] accepted_for_conversion must be boolean"
+        )
+    if not factor["accepted_for_conversion"]:
+        raise CoresDensityAuditError(
+            f"{source_name} factors[{index}] accepted_for_conversion must be true"
+        )
+
+
+def _validate_factor_with_registry_rules(
+    factor: dict[str, Any],
+    source_name: str,
+    index: int,
+) -> None:
+    try:
+        CoresCrudeDensityFactor(
+            field_name=factor["field_name"],
+            aliases=tuple(factor["aliases"]),
+            api_gravity_deg=factor["api_gravity_deg"],
+            api_gravity_min_deg=factor["api_gravity_min_deg"],
+            api_gravity_max_deg=factor["api_gravity_max_deg"],
+            bbl_per_tonne=factor["bbl_per_tonne"],
+            measurement_basis=factor["measurement_basis"],
+            source_title=factor["source_title"],
+            source_url=factor["source_url"],
+            source_class=factor["source_class"],
+            evidence_note=factor["evidence_note"],
+            confidence=factor["confidence"],
+            accepted_for_conversion=factor["accepted_for_conversion"],
+        )
+    except (TypeError, ValueError) as exc:
+        raise CoresDensityAuditError(f"{source_name} factors[{index}] {exc}") from exc
+
+
+def _validate_http_url(value: str, source_name: str, index: int) -> None:
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise CoresDensityAuditError(
+            f"{source_name} factors[{index}] invalid source_url"
+        )
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
+
+
+_FACTOR_KEYS = (
+    "field_name",
+    "aliases",
+    "api_gravity_deg",
+    "api_gravity_min_deg",
+    "api_gravity_max_deg",
+    "bbl_per_tonne",
+    "measurement_basis",
+    "source_title",
+    "source_url",
+    "source_class",
+    "evidence_note",
+    "confidence",
+    "accepted_for_conversion",
+)
+_REQUIRED_TEXT_KEYS = (
+    "field_name",
+    "measurement_basis",
+    "source_title",
+    "source_url",
+    "source_class",
+    "evidence_note",
+    "confidence",
+)

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/reports/cores_density_audit.py
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/reports/cores_density_audit.py
@@ -9,7 +9,10 @@ from urllib.parse import urlparse
 
 import pandas as pd
 
-from worldenergydata.spain.production.cores_density import CoresCrudeDensityFactor
+from worldenergydata.spain.production.cores_density import (
+    CoresCrudeDensityFactor,
+    normalize_field_key,
+)
 
 
 class CoresDensityAuditError(RuntimeError):
@@ -147,7 +150,19 @@ def _validate_oil_conversion_status_fields(
         raise CoresDensityAuditError(f"{source_name} missing defaulted_fields")
     if audit["coverage_status"] == "missing" and not audit["missing_fields"]:
         raise CoresDensityAuditError(f"{source_name} missing missing_fields")
+    _validate_default_bbl_per_tonne(audit, source_name)
     _validate_oil_field_count(audit, source_name)
+
+
+def _validate_default_bbl_per_tonne(
+    audit: dict[str, Any],
+    source_name: str,
+) -> None:
+    if not audit["defaulted_fields"]:
+        return
+    value = audit.get("default_bbl_per_tonne")
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+        raise CoresDensityAuditError(f"{source_name} missing default_bbl_per_tonne")
 
 
 def _validate_oil_field_count(audit: dict[str, Any], source_name: str) -> None:
@@ -162,20 +177,30 @@ def _validate_oil_conversion_factor_links(
     audit: dict[str, Any],
     source_name: str,
 ) -> None:
-    factor_fields = [str(factor["field_name"]) for factor in audit["factors"]]
+    factors = cast(list[dict[str, Any]], audit["factors"])
+    factor_fields = [str(factor["field_name"]) for factor in factors]
     if len(set(factor_fields)) != len(factor_fields):
         raise CoresDensityAuditError(f"{source_name} duplicate density factor field")
     used_fields = [str(field) for field in audit["used_fields"]]
-    _validate_matching_factors(used_fields, factor_fields, source_name)
+    _validate_matching_factors(used_fields, factors, source_name)
 
 
 def _validate_matching_factors(
     used_fields: list[str],
-    factor_fields: list[str],
+    factors: list[dict[str, Any]],
     source_name: str,
 ) -> None:
-    missing_factors = [field for field in used_fields if field not in factor_fields]
-    extra_factors = [field for field in factor_fields if field not in used_fields]
+    used_keys = {normalize_field_key(field) for field in used_fields}
+    missing_factors = [
+        field
+        for field in used_fields
+        if normalize_field_key(field) not in _accepted_factor_keys(factors)
+    ]
+    extra_factors = [
+        str(factor["field_name"])
+        for factor in factors
+        if not _factor_matches_any_used_field(factor, used_keys)
+    ]
     if missing_factors:
         names = ", ".join(missing_factors)
         raise CoresDensityAuditError(
@@ -188,6 +213,24 @@ def _validate_matching_factors(
         )
 
 
+def _accepted_factor_keys(factors: list[dict[str, Any]]) -> set[str]:
+    keys: set[str] = set()
+    for factor in factors:
+        for value in (factor["field_name"], *factor["aliases"]):
+            keys.add(normalize_field_key(str(value)))
+    return keys
+
+
+def _factor_matches_any_used_field(
+    factor: dict[str, Any],
+    used_keys: set[str],
+) -> bool:
+    return any(
+        normalize_field_key(str(value)) in used_keys
+        for value in (factor["field_name"], *factor["aliases"])
+    )
+
+
 def _validate_oil_conversion_coverage(
     audit: dict[str, Any],
     oil_production: pd.DataFrame,
@@ -195,17 +238,22 @@ def _validate_oil_conversion_coverage(
 ) -> None:
     oil_fields = _production_fields(oil_production)
     covered = {
-        str(field)
+        normalize_field_key(str(field)): str(field)
         for key in ("used_fields", "defaulted_fields", "missing_fields")
         for field in audit[key]
     }
-    missing = [field for field in oil_fields if field not in covered]
+    oil_field_keys = {normalize_field_key(field) for field in oil_fields}
+    missing = [
+        field for field in oil_fields if normalize_field_key(field) not in covered
+    ]
     if missing:
         names = ", ".join(missing)
         raise CoresDensityAuditError(
             f"{source_name} missing oil density coverage for: {names}"
         )
-    extra = [field for field in sorted(covered) if field not in oil_fields]
+    extra = [
+        field for key, field in sorted(covered.items()) if key not in oil_field_keys
+    ]
     if extra:
         names = ", ".join(extra)
         raise CoresDensityAuditError(
@@ -220,8 +268,10 @@ def _validate_complete_oil_coverage(
     oil_fields: list[str],
     source_name: str,
 ) -> None:
-    used_fields = {str(field) for field in audit["used_fields"]}
-    missing = [field for field in oil_fields if field not in used_fields]
+    used_fields = {normalize_field_key(str(field)) for field in audit["used_fields"]}
+    missing = [
+        field for field in oil_fields if normalize_field_key(field) not in used_fields
+    ]
     if missing:
         names = ", ".join(missing)
         raise CoresDensityAuditError(

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/reports/cores_field_development.py
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/reports/cores_field_development.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pandas as pd
 
@@ -14,6 +14,11 @@ from worldenergydata.production.unified.adapters.spain_cores_adapter import (
 )
 from worldenergydata.production.unified.query import ProductionQuery
 from worldenergydata.spain.reference_chain import run_spain_reference_chain
+from worldenergydata.spain.reports.cores_density_audit import (
+    CoresDensityAuditError,
+    load_oil_conversion_audit,
+    oil_conversion_limitations,
+)
 from worldenergydata.spain.reports.cores_html import render_spain_cores_html
 
 FIELD_METADATA = {
@@ -39,6 +44,7 @@ class CoresReportSource:
     metadata: dict[str, Any]
     manifest: dict[str, Any]
     workbook_metadata: dict[str, Any]
+    oil_conversion_audit: dict[str, Any] | None = None
 
 
 class NormalizedCoresReportLoader:
@@ -72,6 +78,14 @@ def load_cores_report_source(cache_root: str | Path) -> CoresReportSource:
     metadata = _read_json(root / "_metadata.json")
     manifest = _read_json(root / "manifest.json")
     workbook_metadata = _read_json(root / "metadata" / "cores_refresh_metadata.json")
+    try:
+        oil_conversion_audit = load_oil_conversion_audit(
+            root,
+            metadata,
+            oil_production,
+        )
+    except CoresDensityAuditError as exc:
+        raise CoresReportError(str(exc)) from exc
     _validate_metadata(metadata, manifest, workbook_metadata, len(all_production))
     return CoresReportSource(
         all_production=all_production,
@@ -80,6 +94,7 @@ def load_cores_report_source(cache_root: str | Path) -> CoresReportSource:
         metadata=metadata,
         manifest=manifest,
         workbook_metadata=workbook_metadata,
+        oil_conversion_audit=oil_conversion_audit,
     )
 
 
@@ -107,7 +122,7 @@ def _summary(
     fields: list[dict[str, Any]],
     economics: dict[str, Any],
 ) -> dict[str, Any]:
-    return {
+    summary = {
         "source": {
             "format": source.metadata["format"],
             "last_refresh": source.metadata["last_refresh"],
@@ -124,10 +139,13 @@ def _summary(
         "limitations": [
             "Only fields with explicit field metadata and oil production run economics.",
             "Gas-only revenue is deferred to issue #808.",
-            "oil_tonnes_to_bbl_conversion_deferred_to_issue_807",
+            *oil_conversion_limitations(source.oil_conversion_audit),
             "Ayoluengo uses offshore FDAS plumbing as a wiring check; mismatch is flagged.",
         ],
     }
+    if source.oil_conversion_audit is not None:
+        summary["oil_conversion_audit"] = source.oil_conversion_audit
+    return summary
 
 
 def _economics_summary(
@@ -279,7 +297,11 @@ def _to_unified(frame: pd.DataFrame) -> pd.DataFrame:
     )
 
 
-def _filter_period(frame: pd.DataFrame, start: str | None, end: str | None):
+def _filter_period(
+    frame: pd.DataFrame,
+    start: str | None,
+    end: str | None,
+) -> pd.DataFrame:
     if start is None and end is None:
         return frame
     period = _period_series(frame)
@@ -339,7 +361,7 @@ def _rounded_number(value: Any) -> float:
 def _read_json(path: Path) -> dict[str, Any]:
     if not path.exists():
         raise CoresReportError(f"missing {path.name}")
-    return json.loads(path.read_text(encoding="utf-8"))
+    return cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
 
 
 def _read_csv(path: Path) -> pd.DataFrame:

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/reports/cores_html.py
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/reports/cores_html.py
@@ -8,35 +8,69 @@ from typing import Any
 
 
 def render_spain_cores_html(summary: dict[str, Any]) -> str:
-    payload = _json_payload(summary)
-    fields = summary["fields"]
-    source = summary["source"]
-    economics = summary["economics"]
-    manifest = summary["scheduler_manifest"]
+    return _document_html(summary, _json_payload(summary))
+
+
+def _document_html(summary: dict[str, Any], payload: str) -> str:
     return f"""<!doctype html>
 <html lang="en">
-<head>
+{_head_html()}
+{_body_html(summary, payload)}
+</html>
+"""
+
+
+def _head_html() -> str:
+    return f"""<head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Spain CORES Field Development</title>
 <style>{_STYLE}</style>
-</head>
-<body>
-<header>
+</head>"""
+
+
+def _body_html(summary: dict[str, Any], payload: str) -> str:
+    return f"""<body>
+{_header_html()}
+<main>
+  {_metrics_html(summary)}
+  {_source_provenance_html(summary)}
+  {_density_provenance_html(summary)}
+  {_caveats_html(summary)}
+  {_production_layout_html()}
+  {_economics_html()}
+</main>
+<script type="application/json" id="cores-data">{payload}</script>
+<script>{_SCRIPT}</script>
+</body>"""
+
+
+def _header_html() -> str:
+    return """<header>
   <a class="home" href="../index.html">worldenergydata</a>
   <div>
     <h1>Spain CORES Field Development</h1>
     <p>Normalized CORES production, scheduler provenance, and reference-chain field-development screening.</p>
   </div>
-</header>
-<main>
-  <section class="metrics">
+</header>"""
+
+
+def _metrics_html(summary: dict[str, Any]) -> str:
+    fields = summary["fields"]
+    source = summary["source"]
+    economics = summary["economics"]
+    return f"""<section class="metrics">
     <div><strong>{fields["field_count"]}</strong><span>fields</span></div>
     <div><strong>{source["record_count"]:,}</strong><span>normalized rows</span></div>
     <div><strong>{len(economics["evaluated_fields"])}</strong><span>economics runs</span></div>
     <div><strong>{html.escape(source["format"])}</strong><span>format</span></div>
-  </section>
-  <section class="panel provenance">
+  </section>"""
+
+
+def _source_provenance_html(summary: dict[str, Any]) -> str:
+    source = summary["source"]
+    manifest = summary["scheduler_manifest"]
+    return f"""<section class="panel provenance">
     <h2>Source Provenance</h2>
     <p><strong>Source URL:</strong> {html.escape(source["source_url"])}</p>
     <p><strong>Refresh timestamp:</strong> {html.escape(source["last_refresh"])}</p>
@@ -44,12 +78,18 @@ def render_spain_cores_html(summary: dict[str, Any]) -> str:
     <p><strong>Scheduler job:</strong> {html.escape(str(manifest["job_name"]))}</p>
     <p><strong>Scheduler records:</strong> {html.escape(str(manifest["records_updated"]))}</p>
     {_workbook_table(summary)}
-  </section>
-  <section class="panel warning">
+  </section>"""
+
+
+def _caveats_html(summary: dict[str, Any]) -> str:
+    return f"""<section class="panel warning">
     <h2>Caveats</h2>
     {_limitations_html(summary)}
-  </section>
-  <section class="layout">
+  </section>"""
+
+
+def _production_layout_html() -> str:
+    return """<section class="layout">
     <aside class="panel">
       <h2>Fields</h2>
       <label for="field-select">Field</label>
@@ -64,17 +104,14 @@ def render_spain_cores_html(summary: dict[str, Any]) -> str:
         <span><i class="gas"></i> gas mcf</span>
       </div>
     </section>
-  </section>
-  <section class="panel">
+  </section>"""
+
+
+def _economics_html() -> str:
+    return """<section class="panel">
     <h2>Economics And Limits</h2>
     <div id="economics"></div>
-  </section>
-</main>
-<script type="application/json" id="cores-data">{payload}</script>
-<script>{_SCRIPT}</script>
-</body>
-</html>
-"""
+  </section>"""
 
 
 def _json_payload(summary: dict[str, Any]) -> str:
@@ -104,6 +141,71 @@ def _workbook_table(summary: dict[str, Any]) -> str:
         "<th>product</th><th>status_code</th><th>byte_count</th>"
         "<th>last_modified</th><th>sha256</th><th>source_url</th>"
         "</tr></thead><tbody>" + "".join(rows) + "</tbody></table></div>"
+    )
+
+
+def _density_provenance_html(summary: dict[str, Any]) -> str:
+    audit = summary.get("oil_conversion_audit")
+    if not isinstance(audit, dict):
+        return ""
+    return (
+        '<section class="panel provenance">'
+        "<h2>Density Provenance</h2>"
+        f"<p><strong>Coverage status:</strong> "
+        f"{html.escape(str(audit['coverage_status']))}</p>"
+        f"<p><strong>Registry version:</strong> "
+        f"{html.escape(str(audit.get('registry_version', 'unknown')))}</p>"
+        f"<p><strong>Registry date:</strong> "
+        f"{html.escape(str(audit.get('registry_date', 'unknown')))}</p>"
+        f"{_density_field_summary(audit)}"
+        f"{_density_factor_table(audit)}"
+        "</section>"
+    )
+
+
+def _density_field_summary(audit: dict[str, Any]) -> str:
+    items = []
+    for label, key in (
+        ("Accepted fields", "used_fields"),
+        ("Defaulted fields", "defaulted_fields"),
+        ("Missing fields", "missing_fields"),
+    ):
+        values = ", ".join(str(value) for value in audit.get(key, [])) or "None"
+        items.append(f"<p><strong>{label}:</strong> {html.escape(values)}</p>")
+    return "".join(items)
+
+
+def _density_factor_table(audit: dict[str, Any]) -> str:
+    rows = [_density_factor_row(factor) for factor in audit.get("factors", [])]
+    if not rows:
+        rows.append(
+            '<tr><td colspan="7">No accepted field density factors are recorded.</td></tr>'
+        )
+    return (
+        "<div class='table-wrap'><table><thead><tr>"
+        "<th>field</th><th>bbl_per_tonne</th><th>source_title</th>"
+        "<th>source_url</th><th>source_class</th><th>confidence</th>"
+        "<th>accepted</th></tr></thead><tbody>"
+        + "".join(rows)
+        + "</tbody></table></div>"
+    )
+
+
+def _density_factor_row(factor: dict[str, Any]) -> str:
+    source_url = str(factor.get("source_url", ""))
+    source_link = (
+        f'<a href="{html.escape(source_url, quote=True)}">{html.escape(source_url)}</a>'
+    )
+    return (
+        "<tr>"
+        f"<td>{html.escape(str(factor.get('field_name', '')))}</td>"
+        f"<td>{html.escape(str(factor.get('bbl_per_tonne', '')))}</td>"
+        f"<td>{html.escape(str(factor.get('source_title', '')))}</td>"
+        f"<td>{source_link}</td>"
+        f"<td>{html.escape(str(factor.get('source_class', '')))}</td>"
+        f"<td>{html.escape(str(factor.get('confidence', '')))}</td>"
+        f"<td>{html.escape(str(factor.get('accepted_for_conversion', '')))}</td>"
+        "</tr>"
     )
 
 

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/reports/cores_html.py
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/reports/cores_html.py
@@ -172,6 +172,12 @@ def _density_field_summary(audit: dict[str, Any]) -> str:
     ):
         values = ", ".join(str(value) for value in audit.get(key, [])) or "None"
         items.append(f"<p><strong>{label}:</strong> {html.escape(values)}</p>")
+    if audit.get("defaulted_fields"):
+        default_factor = audit.get("default_bbl_per_tonne")
+        items.append(
+            f"<p><strong>Default bbl/tonne:</strong> "
+            f"{html.escape(str(default_factor))}</p>"
+        )
     return "".join(items)
 
 

--- a/scripts/review/results/2026-07-06-plan-807-implementation-review-r1.md
+++ b/scripts/review/results/2026-07-06-plan-807-implementation-review-r1.md
@@ -1,0 +1,56 @@
+# Plan Review: Issue [#807](https://github.com/vamseeachanta/worldenergydata/issues/807) Implementation/Downstream - r1
+
+**Plan:** `docs/plans/2026-07-06-issue-807-spain-cores-crude-density-api-table.md`
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/807
+**Reviewer:** parallel Codex explorer
+**Verdict:** MAJOR
+
+## Findings
+
+1. **MAJOR - Scheduler/live loader behavior was not planned end-to-end.**
+
+   The draft added live-loader density options but the scheduler job currently
+   constructs `CoresLiveProductionLoader(cache_root=output_dir)` only. No
+   scheduler config keys or scheduler tests were planned. Strict density gaps
+   could also be treated as retryable generic failures. Required change: plan
+   scheduler config propagation, sidecar creation under scheduler run, fixture
+   refresh provenance, and non-retryable deterministic density failures.
+
+2. **MAJOR - Density sidecar/report contract was underspecified and conflicted with existing cache metadata.**
+
+   The draft proposed `normalized/cores_oil_density_factors.json` without an
+   exact schema. `_metadata.json` still declares `format: csv`, while its file
+   list could include JSON sidecars. Report loading did not define absent or
+   malformed sidecar handling. Required change: define sidecar schema and
+   validation, update metadata semantics, add `CoresReportSource` support, and
+   test absent, malformed, all-cited, and defaulted cases.
+
+3. **MAJOR - Parser API did not define how conversion provenance is produced.**
+
+   The parser would still return only a DataFrame, while the live sidecar needs
+   used/defaulted/missing field metadata generated with the same normalization
+   and lookup logic. Tests also missed accented/punctuated names such as
+   `Boquerón` and `Viura (1)`. Required change: define and test a shared
+   field-normalization helper and conversion audit object/helper.
+
+4. **MAJOR - Adapter/FDAS fallback divergence was not addressed.**
+
+   The production adapter has hardcoded embedded Ayoluengo oil values for
+   production-only installs. If committed fixture values change but fallback does
+   not, downstream users get stale 7.33-based barrels. Required change: update
+   or explicitly deprecate the embedded fallback and add default
+   adapter/fallback tests after density conversion changes.
+
+5. **MINOR - TDD list needed more exact negative coverage.**
+
+   Required tests include default package registry loading, invalid/out-of-range
+   API and bbl/tonne values, unsupported source class/confidence, accent and
+   punctuation alias normalization, malformed report sidecar, and preservation of
+   no-`/mnt/ace` HTML output.
+
+## Patch Response
+
+The plan was patched to add scheduler config/job/test scope, exact sidecar
+schema, parser conversion audit design, adapter fallback scope, report sidecar
+validation tests, accent/punctuation tests, malformed sidecar tests, and
+metadata sidecar categorization.

--- a/scripts/review/results/2026-07-06-plan-807-implementation-review-r2.md
+++ b/scripts/review/results/2026-07-06-plan-807-implementation-review-r2.md
@@ -1,0 +1,47 @@
+# Plan Review r2: Issue [#807](https://github.com/vamseeachanta/worldenergydata/issues/807) Implementation/Downstream
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/807
+**Plan:** `docs/plans/2026-07-06-issue-807-spain-cores-crude-density-api-table.md`
+**Reviewer:** Codex subagent Averroes
+**Verdict:** MAJOR
+
+## Findings
+
+1. **MAJOR - Verification gates still did not cover all planned touched
+   surfaces.**
+
+   The plan changed scheduler code/config and production adapter fallback, but
+   the format gates only covered Spain package files and selected tests. The
+   plan also placed scheduler tests under a package-local path that does not
+   match this repository's test layout.
+
+   Required patch: use `tests/unit/scheduler/test_spain_cores_refresh.py` and
+   include scheduler and production adapter source paths in the Black/isort
+   gates.
+
+2. **MINOR - Sidecar schema promised registry version/date without defining
+   fields for it.**
+
+   The prose said the sidecar would include registry version/date, but the exact
+   schema had only `schema_version` and `generated_at`.
+
+   Required patch: add explicit `registry_version` and `registry_date`, or
+   remove the claim.
+
+## Passed Checks
+
+- All-or-blocked source coverage was planned.
+- Ayoluengo non-representative evidence handling was planned.
+- Parser conversion audit and sidecar/report caveat semantics were planned.
+- Adapter fallback scope, scheduler non-retryable coverage semantics, legal
+  scan, and user approval gate were present.
+
+## Patch Response
+
+- Scheduler tests now point to `tests/unit/scheduler/test_spain_cores_refresh.py`
+  in the artifact map, TDD list, and pytest command.
+- Formatting checks now include `packages/worldenergydata-scheduler/src`,
+  `packages/worldenergydata-production/src`, `tests/unit/scheduler`, and
+  `tests/unit/production/unified`.
+- The sidecar schema now includes explicit `registry_version` and
+  `registry_date` fields.

--- a/scripts/review/results/2026-07-06-plan-807-implementation-review-r3.md
+++ b/scripts/review/results/2026-07-06-plan-807-implementation-review-r3.md
@@ -1,0 +1,35 @@
+# Plan Review r3: Issue [#807](https://github.com/vamseeachanta/worldenergydata/issues/807) Implementation/Downstream
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/807
+**Plan:** `docs/plans/2026-07-06-issue-807-spain-cores-crude-density-api-table.md`
+**Reviewer:** Codex subagent Wegener
+**Verdict:** MAJOR
+
+## Findings
+
+1. **MAJOR - The verification gate still missed the committed scheduler config
+   surface.**
+
+   The plan listed `config/scheduler/scheduler_config.yml` as a touched artifact
+   and planned change, but the targeted pytest command omitted the existing
+   `tests/unit/scheduler/test_config.py` file that loads the real repository
+   scheduler config.
+
+   Required patch: add or extend a config test for `density_registry_path` and
+   `allow_default_density`, and include `tests/unit/scheduler/test_config.py` in
+   the targeted pytest command.
+
+## r2 Implementation Finding Status
+
+- Scheduler job test path was fixed.
+- Black/isort gates were widened to cover scheduler and production adapter
+  source paths.
+- Sidecar `registry_version` and `registry_date` were added.
+- The remaining blocker was the scheduler config test coverage gap.
+
+## Patch Response
+
+- The artifact map now includes `tests/unit/scheduler/test_config.py`.
+- The TDD list now includes
+  `test_repo_scheduler_config_includes_spain_density_options`.
+- The targeted pytest command now includes `tests/unit/scheduler/test_config.py`.

--- a/scripts/review/results/2026-07-06-plan-807-implementation-review-r4.md
+++ b/scripts/review/results/2026-07-06-plan-807-implementation-review-r4.md
@@ -1,0 +1,57 @@
+# Plan Review r4: Issue [#807](https://github.com/vamseeachanta/worldenergydata/issues/807) Implementation/Downstream
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/807
+**Plan:** `docs/plans/2026-07-06-issue-807-spain-cores-crude-density-api-table.md`
+**Reviewer:** Codex subagent Mendel
+**Verdict:** MAJOR
+
+## Findings
+
+1. **MAJOR - Repo-relative `density_registry_path` lacked repo-root
+   resolution.**
+
+   The plan added a relative path in scheduler config and said the job would
+   pass it into the loader. Existing scheduler code already resolves
+   `output_dir` and `fixture_output_dir` through `_scheduler_repo_root`; the
+   density registry path needed the same contract so scheduled runs from a
+   non-repo cwd can find the registry.
+
+2. **MAJOR - Non-retryable density coverage error contract was
+   under-specified.**
+
+   Existing retry classification treats `CoresSourceError` as non-retryable.
+   The plan expected `CoresParseError` in the live-loader test and a generic
+   deterministic error in the scheduler test, which could false-green with a
+   fake exception while real density gaps stayed retryable.
+
+3. **MAJOR - Production adapter fallback test did not force the embedded
+   fallback path.**
+
+   `SpainCoresAdapter()` normally uses `CoresFixtureProductionLoader` in this
+   repo, so embedded fallback rows could remain stale unless the plan directly
+   forces `_EmbeddedCoresFixtureLoader` or removes the fallback.
+
+4. **MINOR - YAML scheduler config was not included in verification gates.**
+
+   The plan covered Python format gates but did not run `check-yaml` or
+   `yamllint` against `config/scheduler/scheduler_config.yml`.
+
+## r3 Implementation Finding Status
+
+- Scheduler config test coverage was fixed before r4.
+- The remaining blockers were repo-root path resolution, real exception
+  classification, embedded fallback path coverage, and YAML validation.
+
+## Patch Response
+
+- Scheduler wiring now resolves repo-relative `density_registry_path` through
+  `_scheduler_repo_root` before constructing `CoresLiveProductionLoader`.
+- The live-loader strict gap path now raises exported
+  `CoresDensityCoverageError`; scheduler retry classification will treat that
+  real exception as non-retryable alongside `CoresSourceError`.
+- Scheduler tests now require the fake loader to receive the resolved registry
+  path and the real `CoresDensityCoverageError`.
+- Adapter tests now force `_EmbeddedCoresFixtureLoader` or require removal of
+  the embedded fallback with a clear missing-fixture error.
+- Verification gates now include `check-yaml` and `yamllint` for
+  `config/scheduler/scheduler_config.yml`.

--- a/scripts/review/results/2026-07-06-plan-807-implementation-review-r5.md
+++ b/scripts/review/results/2026-07-06-plan-807-implementation-review-r5.md
@@ -1,0 +1,22 @@
+# Plan Review r5: Issue [#807](https://github.com/vamseeachanta/worldenergydata/issues/807) Implementation/Downstream
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/807
+**Plan:** `docs/plans/2026-07-06-issue-807-spain-cores-crude-density-api-table.md`
+**Reviewer:** Codex subagent Kepler
+**Verdict:** APPROVE
+
+## Findings
+
+None blocking in the focused r5 implementation/downstream scope.
+
+## r4 Implementation Finding Status
+
+- Repo-relative `density_registry_path` resolution through `_scheduler_repo_root`
+  was fixed and covered by scheduler tests.
+- Strict density coverage now names the exported `CoresDensityCoverageError` in
+  live-loader and scheduler retry-classification tests.
+- Embedded production adapter fallback is directly forced or removed, so stale
+  7.33 rows cannot hide behind the default fixture path.
+- YAML gates are included for `config/scheduler/scheduler_config.yml`.
+- Targeted tests/gates cover Spain parser/live/report, scheduler job/config,
+  production adapter, and legal/security scan.

--- a/scripts/review/results/2026-07-06-plan-807-implementation-review-r6.md
+++ b/scripts/review/results/2026-07-06-plan-807-implementation-review-r6.md
@@ -1,0 +1,16 @@
+# Plan Review r6: Issue [#807](https://github.com/vamseeachanta/worldenergydata/issues/807) Implementation/Downstream
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/807
+**Plan:** `docs/plans/2026-07-06-issue-807-spain-cores-crude-density-api-table.md`
+**Reviewer:** Codex subagent Raman
+**Verdict:** APPROVE
+
+## Findings
+
+None.
+
+## Status
+
+Implementation remains approved after the source validation patch. The new
+surfaces are covered by `cores_density.py`, `test_cores_density.py`, the TDD
+list, the targeted pytest command, and the format/legal/YAML gates.

--- a/scripts/review/results/2026-07-06-plan-807-r1-synthesis.md
+++ b/scripts/review/results/2026-07-06-plan-807-r1-synthesis.md
@@ -1,0 +1,37 @@
+# Plan Review Synthesis: Issue [#807](https://github.com/vamseeachanta/worldenergydata/issues/807) - r1
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/807
+**Plan:** `docs/plans/2026-07-06-issue-807-spain-cores-crude-density-api-table.md`
+**Round:** r1
+**Consensus Verdict:** MAJOR
+
+## Consensus
+
+Both parallel reviewers found the original draft directionally sound but not
+approvable. The common defect class was that the plan allowed partial/defaulted
+conversion to look operationally complete, while [#807](https://github.com/vamseeachanta/worldenergydata/issues/807)
+asks for real per-field cited conversion factors.
+
+## Required Patches Applied
+
+- Defined [#807](https://github.com/vamseeachanta/worldenergydata/issues/807)
+  closeout as all-or-blocked: every current CORES oil field needs
+  an accepted cited factor, or the issue remains open with named source gaps.
+- Added hard source acceptance rules and `accepted_for_conversion`.
+- Rejected ranged/non-representative evidence as conversion-factor input.
+- Replaced implicit fallback with explicit `allow_default_density=True`.
+- Added a conversion audit helper so parser factor resolution and sidecar
+  provenance share normalization and lookup behavior.
+- Added exact sidecar schema and report validation rules.
+- Added scheduler config propagation and non-retryable deterministic density
+  failure handling.
+- Added adapter fallback scope so stale 7.33-based embedded Ayoluengo values do
+  not survive.
+- Expanded tests for source validation, accents/punctuation, malformed sidecars,
+  scheduler propagation, adapter fallback, and HTML provenance invariants.
+
+## Next Gate
+
+Run r2 adversarial review against the patched plan. Do not move to
+`status:plan-review` or request implementation approval while unresolved MAJOR
+findings remain.

--- a/scripts/review/results/2026-07-06-plan-807-r2-synthesis.md
+++ b/scripts/review/results/2026-07-06-plan-807-r2-synthesis.md
@@ -1,0 +1,38 @@
+# Plan Review r2 Synthesis: Issue [#807](https://github.com/vamseeachanta/worldenergydata/issues/807)
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/807
+**Plan:** `docs/plans/2026-07-06-issue-807-spain-cores-crude-density-api-table.md`
+**Round:** r2
+**Result before patch:** MAJOR
+**Result after patch:** Ready for focused r3 review
+
+## Blocking Findings
+
+- Source/provenance review found that raw float mappings at the parser boundary
+  still stripped citation provenance.
+- Source/provenance review found that the plan still showed rejected Ayoluengo
+  discovery/range evidence as the concrete accepted registry example.
+- Implementation/downstream review found scheduler test paths and format gates
+  did not cover all planned touched surfaces.
+- Implementation/downstream review found a sidecar schema/prose mismatch for
+  registry version/date.
+
+## Applied Changes
+
+- Replaced the public `density_by_field` parser/live-loader plan with
+  `CoresOilConversionAudit`.
+- Converted the Ayoluengo example into non-converting evidence with
+  `accepted_for_conversion: false`.
+- Corrected scheduler test paths to `tests/unit/scheduler/test_spain_cores_refresh.py`.
+- Expanded targeted formatting gates to include Spain, scheduler, production
+  adapter, and corresponding test paths.
+- Added `registry_version` and `registry_date` to the exact sidecar schema.
+
+## Next Review Focus
+
+r3 should verify that:
+
+- no public parser/live-loader contract still accepts raw conversion floats;
+- Ayoluengo discovery/range evidence is never accepted for conversion;
+- scheduler tests and format gates match repository layout; and
+- sidecar schema/prose are internally consistent.

--- a/scripts/review/results/2026-07-06-plan-807-r3-synthesis.md
+++ b/scripts/review/results/2026-07-06-plan-807-r3-synthesis.md
@@ -1,0 +1,38 @@
+# Plan Review r3 Synthesis: Issue [#807](https://github.com/vamseeachanta/worldenergydata/issues/807)
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/807
+**Plan:** `docs/plans/2026-07-06-issue-807-spain-cores-crude-density-api-table.md`
+**Round:** r3
+**Result before patch:** MAJOR
+**Result after patch:** Ready for focused r4 review
+
+## Blocking Findings
+
+- Source/provenance review found the audit wrapper still exposed raw conversion
+  floats without a provenance invariant.
+- Source/provenance review found the report did not explicitly surface
+  present-sidecar missing fields.
+- Source/provenance review found source-class rules left a secondary-source
+  loophole.
+- Implementation/downstream review found the scheduler config file was in scope
+  but the real config-loading test was omitted from targeted pytest gates.
+
+## Applied Changes
+
+- Replaced audit float maps with backed `CoresCrudeDensityFactor` entries and a
+  `bbl_per_tonne_for_field(...)` accessor.
+- Added audit validation and TDD coverage for unbacked conversion entries.
+- Added missing-fields report limitation and TDD coverage.
+- Enumerated source classes and made secondary/industry articles evidence-only.
+- Added scheduler config test coverage and included it in targeted pytest.
+
+## Next Review Focus
+
+r4 should verify that:
+
+- conversion factors cannot be injected as raw floats at public parser or audit
+  boundaries;
+- source classes cannot promote secondary/industry articles into conversion
+  factors;
+- present sidecars with missing fields are visible in report limitations; and
+- targeted tests/gates cover scheduler config as well as scheduler job wiring.

--- a/scripts/review/results/2026-07-06-plan-807-r4-synthesis.md
+++ b/scripts/review/results/2026-07-06-plan-807-r4-synthesis.md
@@ -1,0 +1,45 @@
+# Plan Review r4 Synthesis: Issue [#807](https://github.com/vamseeachanta/worldenergydata/issues/807)
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/807
+**Plan:** `docs/plans/2026-07-06-issue-807-spain-cores-crude-density-api-table.md`
+**Round:** r4
+**Result before patch:** MAJOR
+**Result after patch:** Ready for focused r5 review
+
+## Blocking Findings
+
+- Source/provenance review found the audit still exposed a mutable public
+  conversion map.
+- Source/provenance review found ambiguous source hierarchy wording in the risk
+  section.
+- Implementation/downstream review found repo-relative `density_registry_path`
+  resolution was not specified.
+- Implementation/downstream review found retry classification used an
+  underspecified fake density error rather than the real live-loader gap
+  exception.
+- Implementation/downstream review found the embedded adapter fallback path was
+  not directly tested.
+- Implementation/downstream review found the scheduler YAML config lacked YAML
+  validation gates.
+
+## Applied Changes
+
+- Replaced public conversion maps with immutable private audit entries and
+  construction-time validation.
+- Removed the ambiguous “industry annual survey” source hierarchy language.
+- Added repo-root resolution for `density_registry_path`.
+- Added exported `CoresDensityCoverageError` and real-exception scheduler
+  classification tests.
+- Added embedded fallback path coverage/removal test.
+- Added `check-yaml` and `yamllint` gates for scheduler config.
+
+## Next Review Focus
+
+r5 should verify that:
+
+- no mutable public conversion map or direct raw-float path remains;
+- source-class and risk wording agree;
+- scheduler config path resolution is explicit and tested;
+- strict density coverage uses the real exported exception in live loader and
+  scheduler retry classification; and
+- embedded adapter fallback and YAML config validation are covered.

--- a/scripts/review/results/2026-07-06-plan-807-r5-synthesis.md
+++ b/scripts/review/results/2026-07-06-plan-807-r5-synthesis.md
@@ -1,0 +1,26 @@
+# Plan Review r5 Synthesis: Issue [#807](https://github.com/vamseeachanta/worldenergydata/issues/807)
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/807
+**Plan:** `docs/plans/2026-07-06-issue-807-spain-cores-crude-density-api-table.md`
+**Round:** r5
+**Result before patch:** Source MAJOR, Implementation APPROVE
+**Result after patch:** Ready for focused r6 source review
+
+## Blocking Finding
+
+- Source/provenance review found direct factor/audit construction could still
+  bypass registry-loader validation.
+
+## Applied Changes
+
+- Added shared `validate_crude_density_factor(...)`.
+- Added `CoresCrudeDensityFactor.__post_init__` validation.
+- Added `CoresOilConversionAudit.__post_init__` revalidation of all used and
+  accepted factors.
+- Added direct-construction TDD coverage for accepted invalid secondary-source
+  and non-representative ranged factors.
+
+## Next Review Focus
+
+r6 should verify only whether direct construction can still bypass source,
+citation, representative-basis, range, or API-math validation.

--- a/scripts/review/results/2026-07-06-plan-807-r6-synthesis.md
+++ b/scripts/review/results/2026-07-06-plan-807-r6-synthesis.md
@@ -1,0 +1,24 @@
+# Plan Review r6 Synthesis: Issue [#807](https://github.com/vamseeachanta/worldenergydata/issues/807)
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/807
+**Plan:** `docs/plans/2026-07-06-issue-807-spain-cores-crude-density-api-table.md`
+**Round:** r6
+**Result before patch:** Source MINOR, Implementation APPROVE
+**Result after patch:** Plan-stage review complete
+
+## Findings
+
+- Source/provenance review found one MINOR test wording gap for direct
+  construction of non-representative ranged factors.
+- Implementation/downstream review remained APPROVE.
+
+## Applied Changes
+
+- Test 7 now explicitly covers direct `CoresCrudeDensityFactor(...)` rejection
+  for accepted non-representative ranged factors.
+
+## Gate Status
+
+No unresolved MAJOR findings remain. The plan can move to `status:plan-review`
+for user approval. It must not be moved to `status:plan-approved` without user
+approval.

--- a/scripts/review/results/2026-07-06-plan-807-source-review-r1.md
+++ b/scripts/review/results/2026-07-06-plan-807-source-review-r1.md
@@ -1,0 +1,66 @@
+# Plan Review: Issue [#807](https://github.com/vamseeachanta/worldenergydata/issues/807) Source/Provenance - r1
+
+**Plan:** `docs/plans/2026-07-06-issue-807-spain-cores-crude-density-api-table.md`
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/807
+**Reviewer:** parallel Codex explorer
+**Verdict:** MAJOR
+
+## Findings
+
+1. **MAJOR - Partial/defaulted conversion could satisfy the draft despite [#807](https://github.com/vamseeachanta/worldenergydata/issues/807) asking for each field's real cited factor.**
+
+   The draft permitted field-specific factors only where cited values existed and
+   allowed default conversion when strict mode was off. That was source-safe only
+   if treated as incomplete. Required change: closeout must be all-or-blocked.
+   Every current CORES oil field must have a validated cited factor, or
+   [#807](https://github.com/vamseeachanta/worldenergydata/issues/807) must
+   remain open with named source gaps.
+
+2. **MAJOR - Ayoluengo example used non-representative/conflicted evidence.**
+
+   The draft example used 36 API from an AAPG discovery well while the same
+   source reports Ayoluengo oils vary from 20 to 39 API by well/sand. Required
+   change: Ayoluengo must remain missing/defaulted unless a source identifies a
+   representative produced stream, sales crude, blend, field-average density, or
+   explicit current conversion basis. Ranged/non-representative evidence must not
+   populate `bbl_per_tonne`.
+
+3. **MAJOR - Secondary-source policy was too permissive for values that change production volumes.**
+
+   The draft allowed non-official/operator/regulator sources if labeled with
+   `source_class` and `confidence`. Required change: numeric factors affecting
+   `oil_bbl` must come from regulator/operator/filing/crude assay/technical
+   literature with explicit measurement basis. Secondary articles may support
+   notes only unless they provide representative field-applicable values.
+
+4. **MAJOR - Provenance was stripped before parsing.**
+
+   The draft exposed `crude_density_mapping() -> dict[str, float]` and
+   `parse_cores_frame(..., density_by_field=...)`, allowing uncited floats and
+   silent fallback. Required change: live/default path must consume validated
+   factor objects or emit conversion metadata from the parser boundary. Fallback
+   must require explicit opt-in and report exact defaulted fields.
+
+5. **MINOR - Report caveat removal was keyed to sidecar existence, not full cited coverage.**
+
+   Required change: remove the issue-807 caveat only when sidecar coverage is
+   complete and no fields are defaulted; otherwise retain a limitation naming
+   defaulted/missing fields.
+
+## Sources Checked
+
+- CORES statistics page and crude workbook confirm production unit is tonnes and
+  do not provide density/API:
+  `https://www.cores.es/en/estadisticas`,
+  `https://www.cores.es/sites/default/files/archivos/estadisticas/crude-oil-production.xlsx`
+- EIA supports the API gravity formula:
+  `https://www.eia.gov/dnav/pet/TblDefs/pet_crd_api_tbldef2.asp`
+- AAPG supports Ayoluengo conflict/range:
+  `https://www.aapg.org/news-and-media/explorer/spains-oldest-and-only-onshore-oilfield/`
+
+## Patch Response
+
+The plan was patched to require all-or-blocked closeout, reject
+non-representative/ranged evidence as conversion factors, add
+`accepted_for_conversion`, require explicit `allow_default_density=True`, and
+gate report caveat removal on complete sidecar coverage.

--- a/scripts/review/results/2026-07-06-plan-807-source-review-r2.md
+++ b/scripts/review/results/2026-07-06-plan-807-source-review-r2.md
@@ -1,0 +1,53 @@
+# Plan Review r2: Issue [#807](https://github.com/vamseeachanta/worldenergydata/issues/807) Source/Provenance
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/807
+**Plan:** `docs/plans/2026-07-06-issue-807-spain-cores-crude-density-api-table.md`
+**Reviewer:** Codex subagent Pasteur
+**Verdict:** MAJOR
+
+## Findings
+
+1. **MAJOR - Provenance was still stripped at the parser/loader boundary.**
+
+   The plan introduced `CoresOilConversionAudit`, but the parser API still
+   accepted raw `density_by_field: Mapping[str, float]` and returned only a
+   `DataFrame`. The TDD list also passed ad hoc floats directly. That did not
+   satisfy the r1 requirement that the live/default path consume validated
+   factor objects or keep conversion metadata at the parser boundary.
+
+   Required patch: make the parser/loader consume an audit/factor object or
+   return `DataFrame + audit`, with raw float mappings restricted to an internal
+   artifact derived from validated factors.
+
+2. **MAJOR - Rejected Ayoluengo evidence remained as the concrete accepted
+   registry example.**
+
+   The plan correctly stated that Ayoluengo's 20-39 API range and
+   discovery-test value must not become a conversion factor without a
+   representative basis. However, the deliverable example still used Ayoluengo,
+   `api_gravity_deg: 36.0`, AAPG as the source title, and the discovery-well
+   note as though it were a conversion factor.
+
+   Required patch: replace the example with either a neutral placeholder or an
+   `accepted_for_conversion: false` evidence-only example.
+
+## Passed Checks
+
+- The all-or-blocked closeout rule was explicit: every current oil field needs
+  an accepted cited factor or issue [#807](https://github.com/vamseeachanta/worldenergydata/issues/807)
+  stays open.
+- The live cache coverage set was empirically verified as 12 oil fields.
+- The secondary-source policy was materially tighter than r1.
+- Report caveat removal was gated on complete sidecar coverage with no
+  defaulted or missing fields.
+
+## Patch Response
+
+- The plan now requires `parse_cores_frame(..., oil_conversion_audit=...)` and
+  `CoresProductionLoader(..., oil_conversion_audit=...)`; raw float mappings are
+  excluded from the public parser/live-loader boundary.
+- The Ayoluengo example is now explicitly evidence-only with
+  `accepted_for_conversion: false`, `api_gravity_min_deg`, `api_gravity_max_deg`,
+  and `bbl_per_tonne: null`.
+- The TDD list now builds and passes `CoresOilConversionAudit` objects instead
+  of ad hoc public `density_by_field` floats.

--- a/scripts/review/results/2026-07-06-plan-807-source-review-r3.md
+++ b/scripts/review/results/2026-07-06-plan-807-source-review-r3.md
@@ -1,0 +1,56 @@
+# Plan Review r3: Issue [#807](https://github.com/vamseeachanta/worldenergydata/issues/807) Source/Provenance
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/807
+**Plan:** `docs/plans/2026-07-06-issue-807-spain-cores-crude-density-api-table.md`
+**Reviewer:** Codex subagent Feynman
+**Verdict:** MAJOR
+
+## Findings
+
+1. **MAJOR - Provenance could still be bypassed through
+   `CoresOilConversionAudit.factors_by_field`.**
+
+   The public `density_by_field` API was removed, but the proposed audit
+   dataclass still exposed `factors_by_field: dict[str, float]`. The parser
+   used that float map directly, and a planned parser test constructed an audit
+   whose float map contained `{"ayoluengo": 6.95}`. The plan needed an explicit
+   invariant/test that every field conversion entry is derived from an accepted
+   `CoresCrudeDensityFactor` in `used_factors`.
+
+2. **MAJOR - Report handling did not explicitly surface `missing_fields` when a
+   sidecar exists.**
+
+   The sidecar schema supported `coverage_status: "missing"` and
+   `missing_fields`, but report limitations only enumerated all-cited,
+   defaulted, or no-sidecar states. The plan needed a visible
+   `oil_tonnes_to_bbl_has_missing_fields` limitation and a test for a
+   present-but-missing sidecar.
+
+3. **MINOR - Secondary-source acceptance remained slightly ambiguous.**
+
+   The prose restricted conversion-driving factors to regulator/operator/
+   filing/assay/technical literature, but still left a possible secondary-source
+   loophole. The registry needed explicit allowed `source_class` values and a
+   rule that secondary/industry articles are evidence-only unless replaced by an
+   underlying conversion-eligible source.
+
+## r2 Source Finding Status
+
+- Ayoluengo evidence handling was fixed before r3.
+- Public `density_by_field` was removed before r3, but the audit wrapper still
+  needed a provenance invariant.
+
+## Patch Response
+
+- `CoresOilConversionAudit.factors_by_field` now maps to
+  `CoresCrudeDensityFactor` objects instead of raw floats.
+- The plan now requires `CoresOilConversionAudit` to be built only by
+  `build_oil_conversion_audit(...)`, with every conversion factor backed by an
+  accepted cited factor or an explicit defaulted-field entry.
+- The parser now uses `oil_conversion_audit.bbl_per_tonne_for_field(...)`
+  instead of reading a float map directly.
+- The TDD list now includes a test rejecting unbacked audit conversion entries.
+- Report states now include `oil_tonnes_to_bbl_has_missing_fields`, with a
+  present-sidecar missing-fields test.
+- Source-class validation now enumerates allowed source classes and makes
+  `industry_technical_article` and `secondary_article` evidence-only.

--- a/scripts/review/results/2026-07-06-plan-807-source-review-r4.md
+++ b/scripts/review/results/2026-07-06-plan-807-source-review-r4.md
@@ -1,0 +1,47 @@
+# Plan Review r4: Issue [#807](https://github.com/vamseeachanta/worldenergydata/issues/807) Source/Provenance
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/807
+**Plan:** `docs/plans/2026-07-06-issue-807-spain-cores-crude-density-api-table.md`
+**Reviewer:** Codex subagent Euclid
+**Verdict:** MAJOR
+
+## Findings
+
+1. **MAJOR - Audit provenance could still be bypassed through a public mutable
+   map.**
+
+   The plan exposed `CoresOilConversionAudit.factors_by_field:
+   dict[str, CoresCrudeDensityFactor]` in a public frozen dataclass. A frozen
+   dataclass does not freeze a nested `dict`, and the public constructor
+   remained available. That left a public audit-boundary bypass: mutate or
+   directly construct `factors_by_field` with a raw/unaccepted value and let the
+   parser key off that map.
+
+2. **MINOR - The risk section reintroduced ambiguous source hierarchy language.**
+
+   The validation section made `industry_technical_article` and
+   `secondary_article` evidence-only, but the risk mitigation still mentioned
+   “industry annual survey” after technical literature without mapping it to an
+   allowed conversion-eligible class.
+
+## r3 Source Finding Status
+
+- Present sidecars with `missing_fields` were fixed.
+- Secondary/industry source-class rules were mostly fixed but needed risk text
+  cleanup.
+- Ayoluengo range/discovery evidence and all-or-blocked closeout were fixed.
+- The raw-float/public audit bypass remained unresolved before this patch.
+
+## Patch Response
+
+- `CoresOilConversionAudit` now stores immutable private tuples
+  `_accepted_entries` and `_defaulted_field_keys` instead of a public conversion
+  map.
+- `CoresOilConversionAudit.__post_init__` now validates direct construction
+  attempts as well as builder-created audits.
+- The parser now uses only `bbl_per_tonne_for_field(...)` and does not inspect a
+  public conversion map.
+- The audit-bypass test now covers unaccepted factors, missing `bbl_per_tonne`,
+  duplicate keys, and default keys not represented in `defaulted_fields`.
+- The “industry annual survey” risk wording was replaced with an evidence-only
+  source-lead rule unless backed by a conversion-eligible source.

--- a/scripts/review/results/2026-07-06-plan-807-source-review-r5.md
+++ b/scripts/review/results/2026-07-06-plan-807-source-review-r5.md
@@ -1,0 +1,42 @@
+# Plan Review r5: Issue [#807](https://github.com/vamseeachanta/worldenergydata/issues/807) Source/Provenance
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/807
+**Plan:** `docs/plans/2026-07-06-issue-807-spain-cores-crude-density-api-table.md`
+**Reviewer:** Codex subagent Curie
+**Verdict:** MAJOR
+
+## Findings
+
+1. **MAJOR - Direct `CoresOilConversionAudit(...)` construction could still
+   bypass source/provenance validation.**
+
+   The plan moved source-class, citation, API math, and representative-basis
+   checks into the registry loader, while `CoresCrudeDensityFactor` remained a
+   plain frozen dataclass and `CoresOilConversionAudit.__post_init__` only
+   checked accepted membership, non-null `bbl_per_tonne`, duplicate keys, and
+   default-key consistency. A caller could manually construct an
+   `accepted_for_conversion=True` factor with `source_class="secondary_article"`
+   or an arbitrary `bbl_per_tonne`, then pass it through `_accepted_entries`.
+
+## r4 Source Finding Status
+
+- Public mutable conversion map was fixed.
+- Source-class/risk wording was fixed.
+- Present sidecars with `missing_fields` were fixed.
+- Ayoluengo evidence-only handling was fixed.
+- All-or-blocked closeout was fixed.
+- Raw-float injection was not fully fixed because direct audit construction
+  could still carry unvalidated accepted factors.
+
+## Patch Response
+
+- `CoresCrudeDensityFactor.__post_init__` now calls shared
+  `validate_crude_density_factor(...)`.
+- The registry loader now uses the same validation helper as direct dataclass
+  construction.
+- `CoresOilConversionAudit.__post_init__` now revalidates every factor in
+  `used_factors` and `_accepted_entries`.
+- The TDD list now includes direct construction rejection for
+  `source_class="secondary_article"` with `accepted_for_conversion=True`, and
+  audit rejection for accepted secondary-source/non-representative ranged
+  factors.

--- a/scripts/review/results/2026-07-06-plan-807-source-review-r6.md
+++ b/scripts/review/results/2026-07-06-plan-807-source-review-r6.md
@@ -1,0 +1,34 @@
+# Plan Review r6: Issue [#807](https://github.com/vamseeachanta/worldenergydata/issues/807) Source/Provenance
+
+**Issue:** https://github.com/vamseeachanta/worldenergydata/issues/807
+**Plan:** `docs/plans/2026-07-06-issue-807-spain-cores-crude-density-api-table.md`
+**Reviewer:** Codex subagent Avicenna
+**Verdict:** MINOR
+
+## Findings
+
+1. **MINOR - TDD list did not explicitly cover direct
+   `CoresCrudeDensityFactor(...)` rejection for non-representative ranged
+   factors.**
+
+   The plan tested direct factor construction rejection for accepted
+   `secondary_article` factors, and it tested non-representative ranged factors
+   through registry loading and direct audit construction. It did not explicitly
+   say that direct `CoresCrudeDensityFactor(...)` construction itself rejects an
+   accepted ranged/non-representative factor.
+
+## r5 Source Finding Status
+
+- Fixed for the plan design. Direct factor construction now routes through
+  `validate_crude_density_factor(...)`, and direct audit construction revalidates
+  every used/accepted factor.
+- Previous safe properties remain intact: no public mutable conversion map,
+  secondary/industry sources evidence-only, Ayoluengo range evidence-only,
+  missing-fields sidecar/report visibility, and all-or-blocked closeout.
+
+## Patch Response
+
+- Test 7 now explicitly repeats direct `CoresCrudeDensityFactor(...)`
+  construction with accepted non-representative
+  `api_gravity_min_deg`/`api_gravity_max_deg` range evidence and no
+  representative `api_gravity_deg`/`bbl_per_tonne`.

--- a/tests/unit/production/unified/test_spain_cores_adapter_loader.py
+++ b/tests/unit/production/unified/test_spain_cores_adapter_loader.py
@@ -8,6 +8,7 @@ import pytest
 from worldenergydata.fdas.adapters.contract import to_fdas_production
 from worldenergydata.production.unified.adapters.spain_cores_adapter import (
     SpainCoresAdapter,
+    _EmbeddedCoresFixtureLoader,
 )
 from worldenergydata.production.unified.query import STANDARD_COLUMNS, ProductionQuery
 from worldenergydata.spain.production.cores_live import (
@@ -165,11 +166,27 @@ def test_default_adapter_loads_committed_ayoluengo_fixture():
     adapter = SpainCoresAdapter()
 
     out = adapter.fetch(ProductionQuery(regions=["spain"], fields=["Ayoluengo"]))
+    metadata = adapter.loader.metadata()
 
     assert not out.empty
     assert set(out["field_name"]) == {"Ayoluengo"}
     assert set(out["source"]) == {"cores"}
     assert out["oil_bbl"].gt(0).any()
+    audit = metadata["oil_conversion_audit"]
+    assert audit["coverage_status"] == "defaulted"
+    assert audit["defaulted_fields"] == ["Ayoluengo"]
+    assert audit["default_bbl_per_tonne"] == TONNES_TO_BBL
+
+
+def test_embedded_fixture_loader_exposes_default_density_metadata():
+    loader = _EmbeddedCoresFixtureLoader()
+
+    metadata = loader.metadata()
+
+    audit = metadata["oil_conversion_audit"]
+    assert audit["coverage_status"] == "defaulted"
+    assert audit["defaulted_fields"] == ["Ayoluengo"]
+    assert audit["default_bbl_per_tonne"] == TONNES_TO_BBL
 
 
 def test_adapter_accepts_live_cores_loader(tmp_path):

--- a/tests/unit/production/unified/test_spain_cores_adapter_loader.py
+++ b/tests/unit/production/unified/test_spain_cores_adapter_loader.py
@@ -1,5 +1,7 @@
 """Spain CORES adapter fixture-backed contract tests (#763b)."""
 
+import json
+
 import pandas as pd
 import pytest
 
@@ -200,7 +202,12 @@ def test_adapter_accepts_live_cores_loader(tmp_path):
         ),
     )
 
-    adapter = SpainCoresAdapter(loader=CoresLiveProductionLoader(cache_root=tmp_path))
+    adapter = SpainCoresAdapter(
+        loader=CoresLiveProductionLoader(
+            cache_root=tmp_path,
+            allow_default_density=True,
+        )
+    )
     out = adapter.fetch(
         ProductionQuery(regions=["spain"], fields=["Ayoluengo"], start="2026-06")
     )
@@ -208,6 +215,52 @@ def test_adapter_accepts_live_cores_loader(tmp_path):
     assert list(out.columns) == list(STANDARD_COLUMNS)
     assert len(out) == 1
     assert out.iloc[0]["oil_bbl"] == pytest.approx(2.0 * TONNES_TO_BBL)
+    assert out.iloc[0]["gas_mcf"] == pytest.approx(3.0 * GWH_TO_MCF)
+    assert out.iloc[0]["source"] == "cores"
+
+
+def test_adapter_accepts_live_loader_with_density_audit_conversion(tmp_path):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    _write_cores_xlsx(
+        raw_dir / DEFAULT_WORKBOOKS["oil"].filename,
+        pd.DataFrame(
+            [
+                {
+                    "Year": 2026,
+                    "Month": "June",
+                    "Ayoluengo": 2.0,
+                    "Grand total": 2.0,
+                }
+            ]
+        ),
+    )
+    _write_cores_xlsx(
+        raw_dir / DEFAULT_WORKBOOKS["gas"].filename,
+        pd.DataFrame(
+            [
+                {
+                    "Year": 2026,
+                    "Month": "June",
+                    "Ayoluengo": 3.0,
+                    "Grand total": 3.0,
+                }
+            ]
+        ),
+    )
+    registry_path = _write_density_registry(tmp_path)
+    loader = CoresLiveProductionLoader(
+        cache_root=tmp_path,
+        oil_density_registry_path=registry_path,
+    )
+
+    adapter = SpainCoresAdapter(loader=loader)
+    out = adapter.fetch(
+        ProductionQuery(regions=["spain"], fields=["Ayoluengo"], start="2026-06")
+    )
+
+    assert len(out) == 1
+    assert out.iloc[0]["oil_bbl"] == pytest.approx(2.0 * 6.95)
     assert out.iloc[0]["gas_mcf"] == pytest.approx(3.0 * GWH_TO_MCF)
     assert out.iloc[0]["source"] == "cores"
 
@@ -220,3 +273,34 @@ def _write_cores_xlsx(path, frame):
             index=False,
         )
         frame.to_excel(writer, sheet_name="Production", index=False, startrow=5)
+
+
+def _write_density_registry(tmp_path):
+    path = tmp_path / "density.json"
+    path.write_text(
+        json.dumps(
+            {
+                "registry_version": "test-2026-07-06",
+                "registry_date": "2026-07-06",
+                "factors": [
+                    {
+                        "field_name": "Ayoluengo",
+                        "aliases": ["ayoluengo"],
+                        "api_gravity_deg": None,
+                        "api_gravity_min_deg": None,
+                        "api_gravity_max_deg": None,
+                        "bbl_per_tonne": 6.95,
+                        "measurement_basis": "representative produced stream",
+                        "source_title": "Example operator assay",
+                        "source_url": "https://example.test/ayoluengo",
+                        "source_class": "operator_record",
+                        "evidence_note": "Accepted field-specific conversion factor.",
+                        "confidence": "high",
+                        "accepted_for_conversion": True,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path

--- a/tests/unit/scheduler/test_config.py
+++ b/tests/unit/scheduler/test_config.py
@@ -137,7 +137,7 @@ class TestLoadConfig:
             == "packages/worldenergydata-spain/src/worldenergydata/spain/data/cores"
         )
         assert (
-            spain["oil_density_registry_path"]
+            spain["density_registry_path"]
             == "packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json"
         )
         assert spain["allow_default_density"] is False

--- a/tests/unit/scheduler/test_config.py
+++ b/tests/unit/scheduler/test_config.py
@@ -136,6 +136,11 @@ class TestLoadConfig:
             spain["fixture_output_dir"]
             == "packages/worldenergydata-spain/src/worldenergydata/spain/data/cores"
         )
+        assert (
+            spain["oil_density_registry_path"]
+            == "packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json"
+        )
+        assert spain["allow_default_density"] is False
 
     def test_load_valid_config(self):
         path = _write_temp_yaml(VALID_YAML)

--- a/tests/unit/scheduler/test_spain_cores_refresh.py
+++ b/tests/unit/scheduler/test_spain_cores_refresh.py
@@ -215,7 +215,7 @@ def test_density_options_pass_to_loader_and_registry_path_resolves_from_repo_roo
     result = _job().run(
         {
             "output_dir": str(tmp_path / "out"),
-            "oil_density_registry_path": registry_path,
+            "density_registry_path": registry_path,
             "allow_default_density": False,
             "_scheduler_repo_root": str(repo_root),
         }
@@ -237,6 +237,7 @@ def test_density_default_opt_in_must_be_boolean(tmp_path):
 
     assert result.status == "failure"
     assert "allow_default_density" in result.error_msg
+    assert result.retryable is False
 
 
 def test_refresh_fixture_false_disables_fixture_refresh(tmp_path):

--- a/tests/unit/scheduler/test_spain_cores_refresh.py
+++ b/tests/unit/scheduler/test_spain_cores_refresh.py
@@ -16,8 +16,20 @@ class _FakeLoader:
     instances: list["_FakeLoader"] = []
     row_count = 3
 
-    def __init__(self, *, cache_root):
+    def __init__(
+        self,
+        *,
+        cache_root,
+        oil_density_registry_path=None,
+        allow_default_density=True,
+    ):
         self.cache_root = Path(cache_root)
+        self.oil_density_registry_path = (
+            Path(oil_density_registry_path)
+            if oil_density_registry_path is not None
+            else None
+        )
+        self.allow_default_density = allow_default_density
         self.force_refresh = None
         self.refreshed = False
         _FakeLoader.instances.append(self)
@@ -52,6 +64,32 @@ class _SourceErrorLoader(_FakeLoader):
         raise CoresSourceError("statistics page missing workbook link")
 
 
+class _DensityCoverageErrorLoader(_FakeLoader):
+    def refresh(self, *, force_refresh=False):
+        from worldenergydata.spain.production.cores_density import (
+            CoresDensityCoverageError,
+        )
+
+        raise CoresDensityCoverageError("missing density factor for Casablanca")
+
+
+class _AuditLoader(_FakeLoader):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.oil_conversion_audit = {"coverage_status": "complete"}
+
+
+class _SidecarFileLoader(_FakeLoader):
+    def load_all_production(self):
+        normalized = self.cache_root / "normalized"
+        normalized.mkdir(parents=True, exist_ok=True)
+        (normalized / "cores_all_production.csv").write_text("field_name\nAyoluengo\n")
+        (normalized / "cores_oil_density_factors.json").write_text(
+            '{"coverage_status":"defaulted"}\n'
+        )
+        return super().load_all_production()
+
+
 def _job(loader_cls=_FakeLoader, fixture_refresher=None):
     job = SpainCoresRefreshJob()
     job._loader_class = lambda: loader_cls
@@ -84,6 +122,17 @@ def test_success_refreshes_cores_and_writes_metadata(tmp_path):
     assert metadata["module"] == "spain_cores"
     assert metadata["record_count"] == 3
     assert metadata["format"] == "csv"
+
+
+def test_refresh_metadata_separates_csv_files_from_sidecars(tmp_path):
+    result = _job(loader_cls=_SidecarFileLoader).run({"output_dir": str(tmp_path)})
+
+    assert result.status == "success"
+    metadata = json.loads((tmp_path / "_metadata.json").read_text())
+    assert metadata["files"] == ["normalized/cores_all_production.csv"]
+    assert metadata["sidecar_files"] == ["normalized/cores_oil_density_factors.json"]
+    assert metadata["file_count"] == 1
+    assert metadata["sidecar_file_count"] == 1
 
 
 def test_fixture_refresh_writes_to_configured_fixture_output(tmp_path):
@@ -154,6 +203,42 @@ def test_relative_fixture_output_resolves_from_scheduler_repo_root(tmp_path):
     ]
 
 
+def test_density_options_pass_to_loader_and_registry_path_resolves_from_repo_root(
+    tmp_path,
+):
+    repo_root = tmp_path / "repo"
+    registry_path = (
+        "packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/"
+        "crude_density_factors.json"
+    )
+
+    result = _job().run(
+        {
+            "output_dir": str(tmp_path / "out"),
+            "oil_density_registry_path": registry_path,
+            "allow_default_density": False,
+            "_scheduler_repo_root": str(repo_root),
+        }
+    )
+
+    assert result.status == "success"
+    loader = _FakeLoader.instances[0]
+    assert loader.oil_density_registry_path == repo_root / registry_path
+    assert loader.allow_default_density is False
+
+
+def test_density_default_opt_in_must_be_boolean(tmp_path):
+    result = _job().run(
+        {
+            "output_dir": str(tmp_path / "out"),
+            "allow_default_density": "false",
+        }
+    )
+
+    assert result.status == "failure"
+    assert "allow_default_density" in result.error_msg
+
+
 def test_refresh_fixture_false_disables_fixture_refresh(tmp_path):
     calls = []
 
@@ -171,6 +256,31 @@ def test_refresh_fixture_false_disables_fixture_refresh(tmp_path):
 
     assert result.status == "success"
     assert calls == []
+
+
+def test_fixture_refresh_receives_loader_oil_conversion_audit(tmp_path):
+    calls = []
+
+    def fixture_refresher(
+        *, oil_frame, metadata, output_dir, oil_conversion_audit=None
+    ):
+        calls.append(oil_conversion_audit)
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        return object()
+
+    result = _job(
+        loader_cls=_AuditLoader,
+        fixture_refresher=fixture_refresher,
+    ).run(
+        {
+            "output_dir": str(tmp_path / "out"),
+            "refresh_fixture": True,
+            "fixture_output_dir": str(tmp_path / "fixtures"),
+        }
+    )
+
+    assert result.status == "success"
+    assert calls == [{"coverage_status": "complete"}]
 
 
 def test_fixture_refresh_failure_is_reported_as_retryable_failure(tmp_path):
@@ -207,6 +317,17 @@ def test_source_validation_failure_is_not_retryable(tmp_path):
     assert result.records_updated == 0
     assert result.retryable is False
     assert "statistics page missing workbook link" in result.error_msg
+
+
+def test_density_coverage_failure_is_not_retryable(tmp_path):
+    result = _job(loader_cls=_DensityCoverageErrorLoader).run(
+        {"output_dir": str(tmp_path)}
+    )
+
+    assert result.status == "failure"
+    assert result.records_updated == 0
+    assert result.retryable is False
+    assert "missing density factor for Casablanca" in result.error_msg
 
 
 def test_zero_rows_is_failure(tmp_path):

--- a/tests/unit/spain/test_cores_density.py
+++ b/tests/unit/spain/test_cores_density.py
@@ -1,6 +1,7 @@
 """Spain CORES crude density/API conversion registry tests (#807)."""
 
 import json
+from importlib.resources import files
 
 import pytest
 
@@ -35,7 +36,15 @@ def _factor(**overrides):
 
 
 def _write_registry(path, entries):
-    path.write_text(json.dumps({"registry_version": "test", "factors": entries}))
+    path.write_text(
+        json.dumps(
+            {
+                "registry_version": "test",
+                "registry_date": "2026-07-06",
+                "factors": entries,
+            }
+        )
+    )
 
 
 def test_bbl_per_tonne_from_api_matches_reference_formula():
@@ -53,13 +62,27 @@ def test_density_registry_requires_citation_fields(tmp_path):
         load_crude_density_factors(path)
 
 
-def test_density_registry_accepts_legacy_list_payload(tmp_path):
+def test_density_registry_rejects_legacy_list_payload(tmp_path):
     path = tmp_path / "density.json"
     path.write_text(json.dumps([_factor().__dict__]), encoding="utf-8")
 
-    factors = load_crude_density_factors(path)
+    with pytest.raises(ValueError, match="registry_version"):
+        load_crude_density_factors(path)
 
-    assert factors["ayoluengo"].field_name == "Ayoluengo"
+
+def test_density_registry_requires_root_metadata(tmp_path):
+    path = tmp_path / "density.json"
+    path.write_text(json.dumps({"factors": [_factor().__dict__]}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="registry_version"):
+        load_crude_density_factors(path)
+
+    path.write_text(
+        json.dumps({"registry_version": "test", "factors": [_factor().__dict__]}),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="registry_date"):
+        load_crude_density_factors(path)
 
 
 def test_density_registry_rejects_duplicate_aliases(tmp_path):
@@ -145,12 +168,21 @@ def test_default_density_registry_file_loads_from_package_data():
 
 
 def test_default_density_registry_keeps_current_fields_missing():
-    with pytest.raises(CoresDensityCoverageError, match="Ayoluengo"):
+    registry_path = files("worldenergydata.spain").joinpath(
+        "data/cores/crude_density_factors.json"
+    )
+    payload = json.loads(registry_path.read_text())
+    expected_fields = payload["source_gap_fields"]
+
+    with pytest.raises(CoresDensityCoverageError) as exc_info:
         build_oil_conversion_audit(
-            ["Ayoluengo", "Casablanca"],
+            expected_fields,
             load_crude_density_factors(),
             allow_default_density=False,
         )
+    message = str(exc_info.value)
+    for field_name in expected_fields:
+        assert field_name in message
 
 
 def test_crude_density_factor_rejects_secondary_article_conversion_directly(tmp_path):

--- a/tests/unit/spain/test_cores_density.py
+++ b/tests/unit/spain/test_cores_density.py
@@ -1,0 +1,242 @@
+"""Spain CORES crude density/API conversion registry tests (#807)."""
+
+import json
+
+import pytest
+
+from worldenergydata.spain.production.cores_density import (
+    CoresCrudeDensityFactor,
+    CoresDensityCoverageError,
+    CoresOilConversionAudit,
+    bbl_per_tonne_from_api,
+    build_oil_conversion_audit,
+    load_crude_density_factors,
+)
+
+
+def _factor(**overrides):
+    values = {
+        "field_name": "Ayoluengo",
+        "aliases": ("ayoluengo",),
+        "api_gravity_deg": 30.0,
+        "api_gravity_min_deg": None,
+        "api_gravity_max_deg": None,
+        "bbl_per_tonne": bbl_per_tonne_from_api(30.0),
+        "measurement_basis": "representative produced stream",
+        "source_title": "Example technical literature",
+        "source_url": "https://example.test/ayoluengo-assay",
+        "source_class": "technical_literature",
+        "evidence_note": "Representative field-applicable conversion basis.",
+        "confidence": "medium",
+        "accepted_for_conversion": True,
+    }
+    values.update(overrides)
+    return CoresCrudeDensityFactor(**values)
+
+
+def _write_registry(path, entries):
+    path.write_text(json.dumps({"registry_version": "test", "factors": entries}))
+
+
+def test_bbl_per_tonne_from_api_matches_reference_formula():
+    assert bbl_per_tonne_from_api(36.0) == pytest.approx(7.44554, rel=1e-5)
+    assert bbl_per_tonne_from_api(20.0) == pytest.approx(6.73432, rel=1e-5)
+
+
+def test_density_registry_requires_citation_fields(tmp_path):
+    path = tmp_path / "density.json"
+    entry = _factor().__dict__
+    entry.pop("source_url")
+    _write_registry(path, [entry])
+
+    with pytest.raises(ValueError, match="source_url"):
+        load_crude_density_factors(path)
+
+
+def test_density_registry_accepts_legacy_list_payload(tmp_path):
+    path = tmp_path / "density.json"
+    path.write_text(json.dumps([_factor().__dict__]), encoding="utf-8")
+
+    factors = load_crude_density_factors(path)
+
+    assert factors["ayoluengo"].field_name == "Ayoluengo"
+
+
+def test_density_registry_rejects_duplicate_aliases(tmp_path):
+    path = tmp_path / "density.json"
+    _write_registry(
+        path,
+        [
+            _factor(field_name="Ayoluengo", aliases=("ayoluengo",)).__dict__,
+            _factor(field_name="AYOLUENGO", aliases=("Ayo luengo",)).__dict__,
+        ],
+    )
+
+    with pytest.raises(ValueError, match="duplicate"):
+        load_crude_density_factors(path)
+
+
+def test_density_registry_rejects_non_representative_range_as_conversion_factor():
+    with pytest.raises(ValueError, match="representative"):
+        _factor(
+            api_gravity_deg=None,
+            api_gravity_min_deg=20.0,
+            api_gravity_max_deg=39.0,
+            bbl_per_tonne=7.1,
+            measurement_basis="non-representative discovery-test range",
+        )
+
+
+def test_density_registry_normalizes_accents_and_punctuation(tmp_path):
+    path = tmp_path / "density.json"
+    _write_registry(
+        path,
+        [
+            _factor(
+                field_name="Boquerón",
+                aliases=("boqueron", "Boquerón"),
+            ).__dict__,
+            _factor(
+                field_name="Viura (1)",
+                aliases=("viura 1", "Viura-1"),
+            ).__dict__,
+        ],
+    )
+
+    factors = load_crude_density_factors(path)
+
+    assert factors["boqueron"].field_name == "Boquerón"
+    assert factors["viura1"].field_name == "Viura (1)"
+
+
+def test_density_registry_rejects_invalid_source_class_and_confidence():
+    with pytest.raises(ValueError, match="source_class"):
+        _factor(source_class="blog")
+    with pytest.raises(ValueError, match="confidence"):
+        _factor(confidence="certain")
+    with pytest.raises(ValueError, match="accepted_for_conversion"):
+        _factor(accepted_for_conversion="false")
+
+
+def test_density_registry_rejects_string_boolean_flags(tmp_path):
+    path = tmp_path / "density.json"
+    entry = _factor().__dict__
+    entry["accepted_for_conversion"] = "false"
+    _write_registry(path, [entry])
+
+    with pytest.raises(ValueError, match="accepted_for_conversion"):
+        load_crude_density_factors(path)
+
+
+def test_density_registry_requires_boolean_flag(tmp_path):
+    path = tmp_path / "density.json"
+    entry = _factor().__dict__
+    del entry["accepted_for_conversion"]
+    _write_registry(path, [entry])
+
+    with pytest.raises(ValueError, match="accepted_for_conversion"):
+        load_crude_density_factors(path)
+
+
+def test_default_density_registry_file_loads_from_package_data():
+    factors = load_crude_density_factors()
+
+    assert isinstance(factors, dict)
+
+
+def test_default_density_registry_keeps_current_fields_missing():
+    with pytest.raises(CoresDensityCoverageError, match="Ayoluengo"):
+        build_oil_conversion_audit(
+            ["Ayoluengo", "Casablanca"],
+            load_crude_density_factors(),
+            allow_default_density=False,
+        )
+
+
+def test_crude_density_factor_rejects_secondary_article_conversion_directly(tmp_path):
+    with pytest.raises(ValueError, match="source_class"):
+        _factor(source_class="secondary_article", accepted_for_conversion=True)
+    with pytest.raises(ValueError, match="representative"):
+        _factor(
+            api_gravity_deg=None,
+            api_gravity_min_deg=20.0,
+            api_gravity_max_deg=39.0,
+            bbl_per_tonne=None,
+            measurement_basis="non-representative field range only",
+            accepted_for_conversion=True,
+        )
+
+    path = tmp_path / "density.json"
+    entry = _factor().__dict__
+    entry["source_class"] = "secondary_article"
+    _write_registry(path, [entry])
+    with pytest.raises(ValueError, match="source_class"):
+        load_crude_density_factors(path)
+
+
+def test_oil_conversion_audit_rejects_unbacked_conversion_entries():
+    good = _factor()
+    unaccepted = _factor(accepted_for_conversion=False, bbl_per_tonne=None)
+
+    with pytest.raises(ValueError, match="accepted"):
+        CoresOilConversionAudit(
+            used_factors=(good,),
+            defaulted_fields=(),
+            missing_fields=(),
+            _accepted_entries=(("ayoluengo", unaccepted),),
+            _defaulted_field_keys=(),
+        )
+    with pytest.raises(ValueError, match="bbl_per_tonne"):
+        CoresOilConversionAudit(
+            used_factors=(_factor(bbl_per_tonne=None, accepted_for_conversion=False),),
+            defaulted_fields=(),
+            missing_fields=(),
+            _accepted_entries=(),
+            _defaulted_field_keys=(),
+        )
+    with pytest.raises(ValueError, match="duplicate"):
+        CoresOilConversionAudit(
+            used_factors=(good,),
+            defaulted_fields=(),
+            missing_fields=(),
+            _accepted_entries=(("ayoluengo", good), ("ayoluengo", good)),
+            _defaulted_field_keys=(),
+        )
+    with pytest.raises(ValueError, match="default"):
+        CoresOilConversionAudit(
+            used_factors=(good,),
+            defaulted_fields=(),
+            missing_fields=(),
+            _accepted_entries=(("ayoluengo", good),),
+            _defaulted_field_keys=("casablanca",),
+        )
+
+
+def test_oil_conversion_audit_names_defaulted_fields():
+    audit = build_oil_conversion_audit(
+        ["Ayoluengo", "Casablanca"],
+        {"ayoluengo": _factor()},
+        allow_default_density=True,
+    )
+
+    assert audit.defaulted_fields == ("Casablanca",)
+    assert audit.missing_fields == ()
+    assert audit.bbl_per_tonne_for_field("Casablanca") == pytest.approx(7.33)
+
+
+def test_oil_conversion_audit_strict_mode_names_missing_fields():
+    with pytest.raises(CoresDensityCoverageError, match="Casablanca"):
+        build_oil_conversion_audit(
+            ["Ayoluengo", "Casablanca"],
+            {"ayoluengo": _factor()},
+            allow_default_density=False,
+        )
+
+
+def test_oil_conversion_audit_rejects_non_boolean_default_opt_in():
+    with pytest.raises(ValueError, match="allow_default_density"):
+        build_oil_conversion_audit(
+            ["Casablanca"],
+            {},
+            allow_default_density="false",
+        )

--- a/tests/unit/spain/test_cores_field_development_density.py
+++ b/tests/unit/spain/test_cores_field_development_density.py
@@ -45,6 +45,7 @@ def test_report_preserves_defaulted_density_limitations(tmp_path):
 
     summary = build_report(tmp_path)
     html = render_spain_cores_html(summary)
+    visible_html = html.split('<script type="application/json"', 1)[0]
 
     assert "oil_tonnes_to_bbl_conversion_deferred_to_issue_807" in html
     assert (
@@ -55,6 +56,7 @@ def test_report_preserves_defaulted_density_limitations(tmp_path):
         for item in summary["limitations"]
     )
     assert "oil_tonnes_to_bbl_has_defaulted_fields: Casablanca" in html
+    assert "7.33" in visible_html
 
 
 def test_report_preserves_missing_density_limitations(tmp_path):
@@ -102,6 +104,23 @@ def test_report_rejects_defaulted_sidecar_without_defaulted_field_names(tmp_path
     _mutate_density_sidecar(tmp_path, lambda sidecar: sidecar.pop("defaulted_fields"))
 
     with pytest.raises(CoresReportError, match="defaulted_fields"):
+        build_report(tmp_path)
+
+
+def test_report_rejects_defaulted_sidecar_without_default_bbl_per_tonne(tmp_path):
+    _write_cache(tmp_path, extra_rows=[_cache_row("Casablanca", 2025, 1, 5.0, pd.NA)])
+    _write_density_sidecar(
+        tmp_path,
+        coverage_status="defaulted",
+        used_fields=["Ayoluengo"],
+        defaulted_fields=["Casablanca"],
+    )
+    _mutate_density_sidecar(
+        tmp_path,
+        lambda sidecar: sidecar.pop("default_bbl_per_tonne"),
+    )
+
+    with pytest.raises(CoresReportError, match="default_bbl_per_tonne"):
         build_report(tmp_path)
 
 
@@ -205,6 +224,22 @@ def test_render_html_shows_density_provenance_fields(tmp_path):
     assert "7.17883" in visible_html
 
 
+def test_report_accepts_sidecar_used_fields_matching_factor_aliases(tmp_path):
+    _write_cache(tmp_path)
+    _rewrite_field_name(tmp_path, "Ayoluengo", "Ayo luengo")
+    _write_density_sidecar(tmp_path, used_fields=["Ayo luengo"])
+    _mutate_density_sidecar(
+        tmp_path,
+        lambda sidecar: sidecar["factors"][0].update({"aliases": ["Ayo luengo"]}),
+    )
+
+    summary = build_report(tmp_path)
+
+    audit = summary["oil_conversion_audit"]
+    assert audit["used_fields"] == ["Ayo luengo"]
+    assert audit["factors"][0]["field_name"] == "Ayoluengo"
+
+
 def _write_cache(root: Path, *, extra_rows: list[dict] | None = None) -> None:
     normalized = root / "normalized"
     metadata = root / "metadata"
@@ -298,6 +333,13 @@ def _mutate_density_sidecar(root: Path, mutator) -> None:
     path.write_text(_json_text(sidecar), encoding="utf-8")
 
 
+def _rewrite_field_name(root: Path, old: str, new: str) -> None:
+    for path in (root / "normalized").glob("cores_*_production.csv"):
+        frame = pd.read_csv(path)
+        frame["field_name"] = frame["field_name"].replace(old, new)
+        frame.to_csv(path, index=False)
+
+
 def _write_density_sidecar(
     root: Path,
     *,
@@ -327,7 +369,7 @@ def _density_sidecar_payload(
     defaulted_fields: list[str],
     missing_fields: list[str],
 ) -> dict:
-    return {
+    payload = {
         "schema_version": 1,
         "generated_at": "2026-07-05T18:37:12.102722+00:00",
         "registry_version": "test-2026-07-06",
@@ -342,6 +384,9 @@ def _density_sidecar_payload(
         "missing_fields": missing_fields,
         "factors": [_density_factor()],
     }
+    if defaulted_fields:
+        payload["default_bbl_per_tonne"] = 7.33
+    return payload
 
 
 def _density_factor() -> dict:

--- a/tests/unit/spain/test_cores_field_development_density.py
+++ b/tests/unit/spain/test_cores_field_development_density.py
@@ -1,0 +1,362 @@
+"""Spain CORES field-development density provenance tests (#807)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from worldenergydata.spain.reports.cores_field_development import (
+    CoresReportError,
+    build_report,
+    render_spain_cores_html,
+)
+
+
+def test_build_report_replaces_deferred_caveat_with_density_provenance(tmp_path):
+    _write_cache(tmp_path)
+    _write_density_sidecar(tmp_path)
+
+    summary = build_report(tmp_path)
+
+    assert (
+        "oil_tonnes_to_bbl_conversion_deferred_to_issue_807"
+        not in summary["limitations"]
+    )
+    assert (
+        "oil_tonnes_to_bbl_uses_cited_field_density_factors" in summary["limitations"]
+    )
+    assert summary["oil_conversion_audit"]["coverage_status"] == "complete"
+    assert summary["oil_conversion_audit"]["factors"][0]["source_url"] == (
+        "https://example.test/ayoluengo-density"
+    )
+
+
+def test_report_preserves_defaulted_density_limitations(tmp_path):
+    _write_cache(tmp_path, extra_rows=[_cache_row("Casablanca", 2025, 1, 5.0, pd.NA)])
+    _write_density_sidecar(
+        tmp_path,
+        coverage_status="defaulted",
+        used_fields=["Ayoluengo"],
+        defaulted_fields=["Casablanca"],
+    )
+
+    summary = build_report(tmp_path)
+    html = render_spain_cores_html(summary)
+
+    assert "oil_tonnes_to_bbl_conversion_deferred_to_issue_807" in html
+    assert (
+        "oil_tonnes_to_bbl_conversion_deferred_to_issue_807" in summary["limitations"]
+    )
+    assert any(
+        item == "oil_tonnes_to_bbl_has_defaulted_fields: Casablanca"
+        for item in summary["limitations"]
+    )
+    assert "oil_tonnes_to_bbl_has_defaulted_fields: Casablanca" in html
+
+
+def test_report_preserves_missing_density_limitations(tmp_path):
+    _write_cache(tmp_path, extra_rows=[_cache_row("Gaviota", 2025, 1, 5.0, pd.NA)])
+    _write_density_sidecar(
+        tmp_path,
+        coverage_status="missing",
+        used_fields=["Ayoluengo"],
+        missing_fields=["Gaviota"],
+    )
+
+    summary = build_report(tmp_path)
+    html = render_spain_cores_html(summary)
+
+    assert "oil_tonnes_to_bbl_conversion_deferred_to_issue_807" in html
+    assert (
+        "oil_tonnes_to_bbl_conversion_deferred_to_issue_807" in summary["limitations"]
+    )
+    assert any(
+        item == "oil_tonnes_to_bbl_has_missing_fields: Gaviota"
+        for item in summary["limitations"]
+    )
+    assert "oil_tonnes_to_bbl_has_missing_fields: Gaviota" in html
+
+
+def test_report_rejects_malformed_density_sidecar(tmp_path):
+    _write_cache(tmp_path)
+    _write_density_sidecar(tmp_path)
+    sidecar_path = tmp_path / "normalized" / "cores_oil_density_factors.json"
+    sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
+    del sidecar["factors"][0]["source_url"]
+    sidecar_path.write_text(_json_text(sidecar), encoding="utf-8")
+
+    with pytest.raises(CoresReportError, match="source_url"):
+        build_report(tmp_path)
+
+
+def test_report_rejects_defaulted_sidecar_without_defaulted_field_names(tmp_path):
+    _write_cache(tmp_path)
+    _write_density_sidecar(
+        tmp_path,
+        coverage_status="defaulted",
+        defaulted_fields=["Casablanca"],
+    )
+    _mutate_density_sidecar(tmp_path, lambda sidecar: sidecar.pop("defaulted_fields"))
+
+    with pytest.raises(CoresReportError, match="defaulted_fields"):
+        build_report(tmp_path)
+
+
+def test_report_rejects_complete_sidecar_that_omits_oil_fields(tmp_path):
+    _write_cache(tmp_path)
+    _write_density_sidecar(tmp_path, used_fields=[])
+
+    with pytest.raises(CoresReportError, match="Ayoluengo"):
+        build_report(tmp_path)
+
+
+def test_report_rejects_complete_sidecar_without_matching_factor(tmp_path):
+    _write_cache(tmp_path)
+    _write_density_sidecar(tmp_path)
+    _mutate_density_sidecar(tmp_path, lambda sidecar: sidecar.update({"factors": []}))
+
+    with pytest.raises(CoresReportError, match="Ayoluengo"):
+        build_report(tmp_path)
+
+
+def test_report_rejects_complete_sidecar_with_extra_accepted_factor(tmp_path):
+    _write_cache(tmp_path)
+    _write_density_sidecar(tmp_path)
+
+    def mutate(sidecar: dict) -> None:
+        extra_factor = dict(sidecar["factors"][0])
+        extra_factor.update(
+            {
+                "field_name": "Casablanca",
+                "aliases": ["Casablanca"],
+                "api_gravity_deg": None,
+                "bbl_per_tonne": 6.95,
+                "source_title": "Casablanca density reference",
+            }
+        )
+        sidecar["used_fields"].append("Casablanca")
+        sidecar["factors"].append(extra_factor)
+        sidecar["oil_field_count"] = 2
+
+    _mutate_density_sidecar(tmp_path, mutate)
+
+    with pytest.raises(CoresReportError, match="Casablanca"):
+        build_report(tmp_path)
+
+
+def test_report_rejects_used_field_without_matching_factor_for_all_oil_fields(tmp_path):
+    extra_rows = [_cache_row("Casablanca", 2025, 1, 5.0, pd.NA)]
+    _write_cache(tmp_path, extra_rows=extra_rows)
+    _write_density_sidecar(tmp_path, used_fields=["Ayoluengo", "Casablanca"])
+
+    with pytest.raises(CoresReportError, match="Casablanca"):
+        build_report(tmp_path)
+
+
+def test_report_rejects_density_sidecar_missing_registry_version(tmp_path):
+    _write_cache(tmp_path)
+    _write_density_sidecar(tmp_path)
+    _mutate_density_sidecar(tmp_path, lambda sidecar: sidecar.pop("registry_version"))
+
+    with pytest.raises(CoresReportError, match="registry_version"):
+        build_report(tmp_path)
+
+
+def test_report_rejects_density_sidecar_with_invalid_numeric_factor(tmp_path):
+    _write_cache(tmp_path)
+    _write_density_sidecar(tmp_path)
+    _mutate_density_sidecar(
+        tmp_path,
+        lambda sidecar: sidecar["factors"][0].update({"bbl_per_tonne": -7.1}),
+    )
+
+    with pytest.raises(CoresReportError, match="bbl_per_tonne"):
+        build_report(tmp_path)
+
+
+def test_report_rejects_density_sidecar_with_non_http_source_url(tmp_path):
+    _write_cache(tmp_path)
+    _write_density_sidecar(tmp_path)
+    _mutate_density_sidecar(
+        tmp_path,
+        lambda sidecar: sidecar["factors"][0].update(
+            {"source_url": "javascript:alert(1)"}
+        ),
+    )
+
+    with pytest.raises(CoresReportError, match="source_url"):
+        build_report(tmp_path)
+
+
+def test_render_html_shows_density_provenance_fields(tmp_path):
+    _write_cache(tmp_path)
+    _write_density_sidecar(tmp_path)
+
+    html = render_spain_cores_html(build_report(tmp_path))
+    visible_html = html.split('<script type="application/json"', 1)[0]
+
+    assert "Density Provenance" in visible_html
+    assert "Ayoluengo density reference" in visible_html
+    assert "https://example.test/ayoluengo-density" in visible_html
+    assert "operator_record" in visible_html
+    assert "7.17883" in visible_html
+
+
+def _write_cache(root: Path, *, extra_rows: list[dict] | None = None) -> None:
+    normalized = root / "normalized"
+    metadata = root / "metadata"
+    normalized.mkdir(parents=True)
+    metadata.mkdir(parents=True)
+    all_rows = _cache_rows(extra_rows)
+    all_rows.to_csv(normalized / "cores_all_production.csv", index=False)
+    all_rows[all_rows["oil_bbl"] > 0].to_csv(
+        normalized / "cores_oil_production.csv", index=False
+    )
+    all_rows[all_rows["gas_mcf"] > 0].to_csv(
+        normalized / "cores_gas_production.csv", index=False
+    )
+    record_count = len(all_rows)
+    (root / "_metadata.json").write_text(_json_text(_cache_metadata(record_count)))
+    (root / "manifest.json").write_text(_json_text(_cache_manifest(record_count)))
+    (metadata / "cores_refresh_metadata.json").write_text(
+        _json_text(_workbook_metadata())
+    )
+
+
+def _cache_rows(extra_rows: list[dict] | None = None) -> pd.DataFrame:
+    rows = [
+        _cache_row("Ayoluengo", 2025, 1, 10.0, pd.NA),
+        _cache_row("Ayoluengo", 2025, 2, 20.0, pd.NA),
+        _cache_row("Gaviota", 2025, 1, pd.NA, 100.0),
+        _cache_row("Gaviota", 2025, 2, pd.NA, 150.0),
+    ]
+    if extra_rows is not None:
+        rows.extend(extra_rows)
+    return pd.DataFrame(rows)
+
+
+def _cache_row(field_name, year, month, oil_bbl, gas_mcf) -> dict:
+    return {
+        "field_name": field_name,
+        "year": year,
+        "month": month,
+        "oil_bbl": oil_bbl,
+        "gas_mcf": gas_mcf,
+    }
+
+
+def _cache_metadata(record_count: int) -> dict:
+    return {
+        "format": "csv",
+        "last_refresh": "2026-07-05T18:37:12.102722+00:00",
+        "record_count": record_count,
+        "source_url": "https://www.cores.es/en/estadisticas",
+    }
+
+
+def _cache_manifest(record_count: int) -> dict:
+    return {
+        "job_name": "spain_cores_refresh",
+        "records_updated": record_count,
+        "status": "success",
+        "updated_at": "2026-07-05T18:37:12.102722+00:00",
+    }
+
+
+def _workbook_metadata() -> dict:
+    return {
+        "refreshed_at_utc": "2026-07-05T18:37:12.102722+00:00",
+        "statistics_page": "https://www.cores.es/en/estadisticas",
+        "workbooks": {
+            "oil": _workbook("https://www.cores.es/oil.xlsx", "0" * 64),
+            "gas": _workbook("https://www.cores.es/gas.xlsx", "1" * 64),
+        },
+    }
+
+
+def _workbook(source_url: str, sha256: str) -> dict:
+    return {
+        "byte_count": 12345,
+        "last_modified": "Fri, 12 Jun 2026 07:51:41 GMT",
+        "sha256": sha256,
+        "source_url": source_url,
+        "status_code": 200,
+    }
+
+
+def _json_text(payload: dict) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _mutate_density_sidecar(root: Path, mutator) -> None:
+    path = root / "normalized" / "cores_oil_density_factors.json"
+    sidecar = json.loads(path.read_text(encoding="utf-8"))
+    mutator(sidecar)
+    path.write_text(_json_text(sidecar), encoding="utf-8")
+
+
+def _write_density_sidecar(
+    root: Path,
+    *,
+    coverage_status: str = "complete",
+    used_fields: list[str] | None = None,
+    defaulted_fields: list[str] | None = None,
+    missing_fields: list[str] | None = None,
+) -> None:
+    used_fields = ["Ayoluengo"] if used_fields is None else used_fields
+    defaulted_fields = [] if defaulted_fields is None else defaulted_fields
+    missing_fields = [] if missing_fields is None else missing_fields
+    payload = _density_sidecar_payload(
+        coverage_status,
+        used_fields,
+        defaulted_fields,
+        missing_fields,
+    )
+    (root / "normalized" / "cores_oil_density_factors.json").write_text(
+        _json_text(payload),
+        encoding="utf-8",
+    )
+
+
+def _density_sidecar_payload(
+    coverage_status: str,
+    used_fields: list[str],
+    defaulted_fields: list[str],
+    missing_fields: list[str],
+) -> dict:
+    return {
+        "schema_version": 1,
+        "generated_at": "2026-07-05T18:37:12.102722+00:00",
+        "registry_version": "test-2026-07-06",
+        "registry_date": "2026-07-06",
+        "conversion_basis": "cited_field_density_factors",
+        "coverage_status": coverage_status,
+        "oil_field_count": (
+            len(used_fields) + len(defaulted_fields) + len(missing_fields)
+        ),
+        "used_fields": used_fields,
+        "defaulted_fields": defaulted_fields,
+        "missing_fields": missing_fields,
+        "factors": [_density_factor()],
+    }
+
+
+def _density_factor() -> dict:
+    return {
+        "field_name": "Ayoluengo",
+        "aliases": ["Ayoluengo"],
+        "api_gravity_deg": 30.0,
+        "api_gravity_min_deg": None,
+        "api_gravity_max_deg": None,
+        "bbl_per_tonne": 7.17883,
+        "measurement_basis": "representative_api_gravity",
+        "source_title": "Ayoluengo density reference",
+        "source_url": "https://example.test/ayoluengo-density",
+        "source_class": "operator_record",
+        "evidence_note": "Synthetic test citation",
+        "confidence": "high",
+        "accepted_for_conversion": True,
+    }

--- a/tests/unit/spain/test_cores_field_development_report.py
+++ b/tests/unit/spain/test_cores_field_development_report.py
@@ -266,43 +266,14 @@ def _write_cache(
     source_url: str = "https://www.cores.es/en/estadisticas",
     manifest_status: str = "success",
     include_oil_status: bool = True,
+    extra_rows: list[dict] | None = None,
 ) -> None:
     normalized = root / "normalized"
     metadata = root / "metadata"
     normalized.mkdir(parents=True)
     metadata.mkdir(parents=True)
-    all_rows = pd.DataFrame(
-        [
-            {
-                "field_name": "Ayoluengo",
-                "year": 2025,
-                "month": 1,
-                "oil_bbl": 10.0,
-                "gas_mcf": pd.NA,
-            },
-            {
-                "field_name": "Ayoluengo",
-                "year": 2025,
-                "month": 2,
-                "oil_bbl": 20.0,
-                "gas_mcf": pd.NA,
-            },
-            {
-                "field_name": "Gaviota",
-                "year": 2025,
-                "month": 1,
-                "oil_bbl": pd.NA,
-                "gas_mcf": 100.0,
-            },
-            {
-                "field_name": "Gaviota",
-                "year": 2025,
-                "month": 2,
-                "oil_bbl": pd.NA,
-                "gas_mcf": 150.0,
-            },
-        ]
-    )
+    all_rows = _cache_rows(extra_rows)
+    record_count = len(all_rows) if extra_rows is not None else record_count
     all_rows.to_csv(normalized / "cores_all_production.csv", index=False)
     all_rows[all_rows["oil_bbl"] > 0].to_csv(
         normalized / "cores_oil_production.csv", index=False
@@ -311,33 +282,60 @@ def _write_cache(
         normalized / "cores_gas_production.csv", index=False
     )
     (root / "_metadata.json").write_text(
-        json.dumps(
-            {
-                "format": "csv",
-                "last_refresh": "2026-07-05T18:37:12.102722+00:00",
-                "record_count": record_count,
-                "source_url": source_url,
-            },
-            indent=2,
-            sort_keys=True,
-        )
-        + "\n",
+        _json_text(_cache_metadata(record_count, source_url)),
         encoding="utf-8",
     )
     (root / "manifest.json").write_text(
-        json.dumps(
-            {
-                "job_name": "spain_cores_refresh",
-                "records_updated": record_count,
-                "status": manifest_status,
-                "updated_at": "2026-07-05T18:37:12.102722+00:00",
-            },
-            indent=2,
-            sort_keys=True,
-        )
-        + "\n",
+        _json_text(_cache_manifest(record_count, manifest_status)),
         encoding="utf-8",
     )
+    (metadata / "cores_refresh_metadata.json").write_text(
+        _json_text(_workbook_metadata(source_url, include_oil_status)),
+        encoding="utf-8",
+    )
+
+
+def _cache_rows(extra_rows: list[dict] | None = None) -> pd.DataFrame:
+    rows = [
+        _cache_row("Ayoluengo", 2025, 1, 10.0, pd.NA),
+        _cache_row("Ayoluengo", 2025, 2, 20.0, pd.NA),
+        _cache_row("Gaviota", 2025, 1, pd.NA, 100.0),
+        _cache_row("Gaviota", 2025, 2, pd.NA, 150.0),
+    ]
+    if extra_rows is not None:
+        rows.extend(extra_rows)
+    return pd.DataFrame(rows)
+
+
+def _cache_row(field_name, year, month, oil_bbl, gas_mcf) -> dict:
+    return {
+        "field_name": field_name,
+        "year": year,
+        "month": month,
+        "oil_bbl": oil_bbl,
+        "gas_mcf": gas_mcf,
+    }
+
+
+def _cache_metadata(record_count: int, source_url: str) -> dict:
+    return {
+        "format": "csv",
+        "last_refresh": "2026-07-05T18:37:12.102722+00:00",
+        "record_count": record_count,
+        "source_url": source_url,
+    }
+
+
+def _cache_manifest(record_count: int, manifest_status: str) -> dict:
+    return {
+        "job_name": "spain_cores_refresh",
+        "records_updated": record_count,
+        "status": manifest_status,
+        "updated_at": "2026-07-05T18:37:12.102722+00:00",
+    }
+
+
+def _workbook_metadata(source_url: str, include_oil_status: bool) -> dict:
     oil_workbook = {
         "byte_count": 12345,
         "last_modified": "Fri, 12 Jun 2026 07:51:41 GMT",
@@ -346,25 +344,25 @@ def _write_cache(
     }
     if include_oil_status:
         oil_workbook["status_code"] = 200
-    (metadata / "cores_refresh_metadata.json").write_text(
-        json.dumps(
-            {
-                "refreshed_at_utc": "2026-07-05T18:37:12.102722+00:00",
-                "statistics_page": source_url,
-                "workbooks": {
-                    "oil": oil_workbook,
-                    "gas": {
-                        "byte_count": 23456,
-                        "last_modified": "Fri, 12 Jun 2026 07:52:01 GMT",
-                        "sha256": "1" * 64,
-                        "source_url": "https://www.cores.es/gas.xlsx",
-                        "status_code": 200,
-                    },
-                },
-            },
-            indent=2,
-            sort_keys=True,
-        )
-        + "\n",
-        encoding="utf-8",
-    )
+    return {
+        "refreshed_at_utc": "2026-07-05T18:37:12.102722+00:00",
+        "statistics_page": source_url,
+        "workbooks": {
+            "oil": oil_workbook,
+            "gas": _gas_workbook_metadata(),
+        },
+    }
+
+
+def _gas_workbook_metadata() -> dict:
+    return {
+        "byte_count": 23456,
+        "last_modified": "Fri, 12 Jun 2026 07:52:01 GMT",
+        "sha256": "1" * 64,
+        "source_url": "https://www.cores.es/gas.xlsx",
+        "status_code": 200,
+    }
+
+
+def _json_text(payload: dict) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"

--- a/tests/unit/spain/test_cores_live.py
+++ b/tests/unit/spain/test_cores_live.py
@@ -139,12 +139,13 @@ def test_refresh_ayoluengo_fixture_writes_stable_sample_and_metadata(tmp_path):
 
 
 def _fake_workbook_responses(oil_bytes, gas_bytes):
-    return {
-        STATISTICS_PAGE_URL: CoresHttpResponse(
-            content=f"""
+    statistics_page = f"""
             <a href="{DEFAULT_WORKBOOKS["oil"].source_url}">oil</a>
             <a href="{DEFAULT_WORKBOOKS["gas"].source_url}">gas</a>
-            """.encode("utf-8"),
+            """
+    return {
+        STATISTICS_PAGE_URL: CoresHttpResponse(
+            content=statistics_page.encode("utf-8"),
             headers={"Content-Type": "text/html"},
         ),
         DEFAULT_WORKBOOKS["oil"].source_url: _fake_xlsx_response(

--- a/tests/unit/spain/test_cores_live.py
+++ b/tests/unit/spain/test_cores_live.py
@@ -134,7 +134,14 @@ def test_refresh_ayoluengo_fixture_writes_stable_sample_and_metadata(tmp_path):
     assert written_metadata["source_url"] == DEFAULT_WORKBOOKS["oil"].source_url
     assert written_metadata["statistics_page"] == STATISTICS_PAGE_URL
     assert written_metadata["sample_row_count"] == 2
-    assert written_metadata["conversion_factors"]["oil_tonnes_to_bbl"] == TONNES_TO_BBL
+    assert "oil_tonnes_to_bbl" not in written_metadata["conversion_factors"]
+    assert written_metadata["conversion_factors"]["oil_tonnes_to_bbl_default"] == (
+        TONNES_TO_BBL
+    )
+    audit = written_metadata["oil_conversion_audit"]
+    assert audit["coverage_status"] == "defaulted"
+    assert audit["defaulted_fields"] == ["Ayoluengo"]
+    assert audit["default_bbl_per_tonne"] == TONNES_TO_BBL
     assert written_metadata["workbooks"]["oil"]["sha256"] == "abc123"
 
 

--- a/tests/unit/spain/test_cores_live.py
+++ b/tests/unit/spain/test_cores_live.py
@@ -10,15 +10,11 @@ from worldenergydata.spain.production.cores_live import (
     DEFAULT_WORKBOOKS,
     STATISTICS_PAGE_URL,
     CoresHttpResponse,
-    CoresLiveProductionLoader,
     CoresSourceError,
     CoresWorkbookSource,
     refresh_ayoluengo_fixture,
 )
-from worldenergydata.spain.production.cores_loader import (
-    GWH_TO_MCF,
-    TONNES_TO_BBL,
-)
+from worldenergydata.spain.production.cores_loader import TONNES_TO_BBL
 
 
 def test_discover_resolves_official_workbook_links_from_statistics_page_html(tmp_path):
@@ -58,35 +54,7 @@ def test_discover_fails_closed_when_a_workbook_link_is_missing(tmp_path):
 def test_download_all_writes_raw_files_atomically_and_records_metadata(tmp_path):
     oil_bytes = b"oil workbook bytes"
     gas_bytes = b"gas workbook bytes"
-    responses = {
-        STATISTICS_PAGE_URL: CoresHttpResponse(
-            content=f"""
-            <a href="{DEFAULT_WORKBOOKS["oil"].source_url}">oil</a>
-            <a href="{DEFAULT_WORKBOOKS["gas"].source_url}">gas</a>
-            """.encode(
-                "utf-8"
-            ),
-            headers={"Content-Type": "text/html"},
-        ),
-        DEFAULT_WORKBOOKS["oil"].source_url: CoresHttpResponse(
-            content=oil_bytes,
-            headers={
-                "Content-Type": (
-                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-                ),
-                "Last-Modified": "Fri, 12 Jun 2026 07:51:41 GMT",
-            },
-        ),
-        DEFAULT_WORKBOOKS["gas"].source_url: CoresHttpResponse(
-            content=gas_bytes,
-            headers={
-                "Content-Type": (
-                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-                ),
-                "Last-Modified": "Fri, 12 Jun 2026 07:52:01 GMT",
-            },
-        ),
-    }
+    responses = _fake_workbook_responses(oil_bytes, gas_bytes)
 
     def fake_http_get(url, *, method="GET"):
         assert method == "GET"
@@ -116,51 +84,6 @@ def test_download_all_writes_raw_files_atomically_and_records_metadata(tmp_path)
     assert (
         metadata["workbooks"]["oil"]["last_modified"] == "Fri, 12 Jun 2026 07:51:41 GMT"
     )
-
-
-def test_live_loader_parses_production_sheets_and_writes_normalized_outputs(tmp_path):
-    raw_dir = tmp_path / "raw"
-    raw_dir.mkdir()
-    _write_cores_xlsx(
-        raw_dir / DEFAULT_WORKBOOKS["oil"].filename,
-        pd.DataFrame(
-            [
-                {
-                    "Year": 2026,
-                    "Month": "June",
-                    "Ayoluengo": 2.0,
-                    "Grand total": 2.0,
-                }
-            ]
-        ),
-    )
-    _write_cores_xlsx(
-        raw_dir / DEFAULT_WORKBOOKS["gas"].filename,
-        pd.DataFrame(
-            [
-                {
-                    "Year": 2026,
-                    "Month": "June",
-                    "Ayoluengo": 3.0,
-                    "Grand total": 3.0,
-                }
-            ]
-        ),
-    )
-
-    loader = CoresLiveProductionLoader(cache_root=tmp_path)
-
-    oil = loader.load_oil_production()
-    gas = loader.load_gas_production()
-    all_products = loader.load_all_production()
-
-    assert oil.iloc[0]["oil_bbl"] == pytest.approx(2.0 * TONNES_TO_BBL)
-    assert gas.iloc[0]["gas_mcf"] == pytest.approx(3.0 * GWH_TO_MCF)
-    assert all_products.iloc[0]["oil_bbl"] == pytest.approx(2.0 * TONNES_TO_BBL)
-    assert all_products.iloc[0]["gas_mcf"] == pytest.approx(3.0 * GWH_TO_MCF)
-    assert (tmp_path / "normalized" / "cores_oil_production.csv").exists()
-    assert (tmp_path / "normalized" / "cores_gas_production.csv").exists()
-    assert (tmp_path / "normalized" / "cores_all_production.csv").exists()
 
 
 def test_refresh_ayoluengo_fixture_writes_stable_sample_and_metadata(tmp_path):
@@ -215,11 +138,33 @@ def test_refresh_ayoluengo_fixture_writes_stable_sample_and_metadata(tmp_path):
     assert written_metadata["workbooks"]["oil"]["sha256"] == "abc123"
 
 
-def _write_cores_xlsx(path, frame):
-    with pd.ExcelWriter(path) as writer:
-        pd.DataFrame({"note": ["landing sheet"]}).to_excel(
-            writer,
-            sheet_name="Start",
-            index=False,
-        )
-        frame.to_excel(writer, sheet_name="Production", index=False, startrow=5)
+def _fake_workbook_responses(oil_bytes, gas_bytes):
+    return {
+        STATISTICS_PAGE_URL: CoresHttpResponse(
+            content=f"""
+            <a href="{DEFAULT_WORKBOOKS["oil"].source_url}">oil</a>
+            <a href="{DEFAULT_WORKBOOKS["gas"].source_url}">gas</a>
+            """.encode("utf-8"),
+            headers={"Content-Type": "text/html"},
+        ),
+        DEFAULT_WORKBOOKS["oil"].source_url: _fake_xlsx_response(
+            oil_bytes,
+            "Fri, 12 Jun 2026 07:51:41 GMT",
+        ),
+        DEFAULT_WORKBOOKS["gas"].source_url: _fake_xlsx_response(
+            gas_bytes,
+            "Fri, 12 Jun 2026 07:52:01 GMT",
+        ),
+    }
+
+
+def _fake_xlsx_response(content, last_modified):
+    return CoresHttpResponse(
+        content=content,
+        headers={
+            "Content-Type": (
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+            "Last-Modified": last_modified,
+        },
+    )

--- a/tests/unit/spain/test_cores_live_density.py
+++ b/tests/unit/spain/test_cores_live_density.py
@@ -1,0 +1,275 @@
+"""Spain CORES live-loader density audit tests (#807)."""
+
+import json
+
+import pandas as pd
+import pytest
+
+from worldenergydata.spain.production.cores_density import (
+    CoresCrudeDensityFactor,
+    CoresDensityCoverageError,
+    CoresOilConversionAudit,
+)
+from worldenergydata.spain.production.cores_live import (
+    DEFAULT_WORKBOOKS,
+    STATISTICS_PAGE_URL,
+    CoresLiveProductionLoader,
+    refresh_ayoluengo_fixture,
+)
+from worldenergydata.spain.production.cores_loader import GWH_TO_MCF, TONNES_TO_BBL
+
+
+def test_live_loader_allows_legacy_default_only_when_explicit(tmp_path):
+    _write_live_workbooks(
+        tmp_path,
+        pd.DataFrame([_workbook_row("Ayoluengo", 2.0)]),
+        pd.DataFrame([_workbook_row("Ayoluengo", 3.0)]),
+    )
+
+    loader = CoresLiveProductionLoader(
+        cache_root=tmp_path,
+        allow_default_density=True,
+    )
+
+    oil = loader.load_oil_production()
+    gas = loader.load_gas_production()
+    all_products = loader.load_all_production()
+
+    assert oil.iloc[0]["oil_bbl"] == pytest.approx(2.0 * TONNES_TO_BBL)
+    assert gas.iloc[0]["gas_mcf"] == pytest.approx(3.0 * GWH_TO_MCF)
+    assert all_products.iloc[0]["oil_bbl"] == pytest.approx(2.0 * TONNES_TO_BBL)
+    assert all_products.iloc[0]["gas_mcf"] == pytest.approx(3.0 * GWH_TO_MCF)
+    assert loader.oil_conversion_audit is not None
+    assert loader.oil_conversion_audit.defaulted_fields == ("Ayoluengo",)
+    sidecar = _read_density_sidecar(tmp_path)
+    assert sidecar["coverage_status"] == "defaulted"
+    assert sidecar["defaulted_fields"] == ["Ayoluengo"]
+    assert sidecar["default_bbl_per_tonne"] == TONNES_TO_BBL
+    assert (tmp_path / "normalized" / "cores_oil_production.csv").exists()
+    assert (tmp_path / "normalized" / "cores_gas_production.csv").exists()
+    assert (tmp_path / "normalized" / "cores_all_production.csv").exists()
+
+
+def test_live_loader_rejects_non_boolean_default_opt_in(tmp_path):
+    with pytest.raises(ValueError, match="allow_default_density"):
+        CoresLiveProductionLoader(
+            cache_root=tmp_path,
+            allow_default_density="false",
+        )
+
+
+def test_live_loader_default_registry_fails_closed_on_source_gaps(tmp_path):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    _write_cores_xlsx(
+        raw_dir / DEFAULT_WORKBOOKS["oil"].filename,
+        pd.DataFrame([_workbook_row("Ayoluengo", 2.0)]),
+    )
+
+    loader = CoresLiveProductionLoader(cache_root=tmp_path)
+
+    with pytest.raises(CoresDensityCoverageError, match="Ayoluengo"):
+        loader.load_oil_production()
+
+
+def test_live_loader_applies_density_registry_and_writes_oil_conversion_audit(tmp_path):
+    _write_live_workbooks(
+        tmp_path,
+        pd.DataFrame([_workbook_row("Ayoluengo", 2.0)]),
+        pd.DataFrame([_workbook_row("Ayoluengo", 3.0)]),
+    )
+    registry_path = _write_density_registry(tmp_path, [_density_entry()])
+
+    loader = CoresLiveProductionLoader(
+        cache_root=tmp_path,
+        oil_density_registry_path=registry_path,
+    )
+
+    all_products = loader.load_all_production()
+
+    assert all_products.iloc[0]["oil_bbl"] == pytest.approx(2.0 * 6.95)
+    assert all_products.iloc[0]["gas_mcf"] == pytest.approx(3.0 * GWH_TO_MCF)
+    sidecar = _read_density_sidecar(tmp_path)
+    assert sidecar["registry_version"] == "test-2026-07-06"
+    assert sidecar["registry_date"] == "2026-07-06"
+    assert sidecar["coverage_status"] == "complete"
+    assert sidecar["oil_field_count"] == 1
+    assert sidecar["used_fields"] == ["Ayoluengo"]
+    assert sidecar["defaulted_fields"] == []
+    assert sidecar["missing_fields"] == []
+    assert sidecar["factors"][0]["field_name"] == "Ayoluengo"
+    assert sidecar["factors"][0]["bbl_per_tonne"] == 6.95
+    assert sidecar["factors"][0]["source_url"] == "https://example.test/ayoluengo"
+
+
+def test_live_loader_missing_density_is_fail_closed_without_default(tmp_path):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    _write_cores_xlsx(
+        raw_dir / DEFAULT_WORKBOOKS["oil"].filename,
+        pd.DataFrame(
+            [
+                {
+                    "Year": 2026,
+                    "Month": "June",
+                    "Ayoluengo": 2.0,
+                    "Casablanca": 1.0,
+                    "Grand total": 3.0,
+                }
+            ]
+        ),
+    )
+    registry_path = _write_density_registry(tmp_path, [_density_entry()])
+    loader = CoresLiveProductionLoader(
+        cache_root=tmp_path,
+        oil_density_registry_path=registry_path,
+        allow_default_density=False,
+    )
+
+    with pytest.raises(CoresDensityCoverageError, match="Casablanca"):
+        loader.load_oil_production()
+    assert not (tmp_path / "normalized" / "cores_oil_density_factors.json").exists()
+
+
+def test_refresh_ayoluengo_fixture_records_density_provenance(tmp_path):
+    oil = pd.DataFrame(
+        [
+            {"field_name": "Ayoluengo", "year": 2026, "month": 1, "oil_bbl": 13.9},
+        ]
+    )
+    source_metadata = {
+        "statistics_page": STATISTICS_PAGE_URL,
+        "workbooks": {
+            "oil": {
+                "source_url": DEFAULT_WORKBOOKS["oil"].source_url,
+                "last_modified": "Fri, 12 Jun 2026 07:51:41 GMT",
+            }
+        },
+    }
+
+    result = refresh_ayoluengo_fixture(
+        oil_frame=oil,
+        metadata=source_metadata,
+        output_dir=tmp_path,
+        refreshed_at_utc="2026-07-04T00:00:00Z",
+        oil_conversion_audit=_single_field_audit(),
+    )
+
+    written_metadata = json.loads(result.metadata_path.read_text())
+    assert written_metadata["conversion"] == (
+        "oil_bbl = tonnes * cited_field_density_factors"
+    )
+    assert written_metadata["conversion_factors"]["oil_tonnes_to_bbl_by_field"] == {
+        "Ayoluengo": 6.95
+    }
+    audit = written_metadata["oil_conversion_audit"]
+    assert audit["coverage_status"] == "complete"
+    assert audit["used_fields"] == ["Ayoluengo"]
+    assert audit["factors"][0]["source_url"] == "https://example.test/ayoluengo"
+
+
+def test_refresh_ayoluengo_fixture_records_default_density_factor(tmp_path):
+    oil = pd.DataFrame(
+        [
+            {"field_name": "Ayoluengo", "year": 2026, "month": 1, "oil_bbl": 13.9},
+        ]
+    )
+    result = refresh_ayoluengo_fixture(
+        oil_frame=oil,
+        metadata={"workbooks": {"oil": {}}},
+        output_dir=tmp_path,
+        refreshed_at_utc="2026-07-04T00:00:00Z",
+        oil_conversion_audit=_defaulted_audit(),
+    )
+
+    written_metadata = json.loads(result.metadata_path.read_text())
+    assert written_metadata["conversion_factors"]["oil_tonnes_to_bbl_default"] == (
+        TONNES_TO_BBL
+    )
+    assert written_metadata["oil_conversion_audit"]["default_bbl_per_tonne"] == (
+        TONNES_TO_BBL
+    )
+
+
+def _workbook_row(field_name: str, value: float) -> dict:
+    return {"Year": 2026, "Month": "June", field_name: value, "Grand total": value}
+
+
+def _write_cores_xlsx(path, frame):
+    with pd.ExcelWriter(path) as writer:
+        pd.DataFrame({"note": ["landing sheet"]}).to_excel(
+            writer,
+            sheet_name="Start",
+            index=False,
+        )
+        frame.to_excel(writer, sheet_name="Production", index=False, startrow=5)
+
+
+def _write_live_workbooks(tmp_path, oil_frame, gas_frame=None):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    _write_cores_xlsx(raw_dir / DEFAULT_WORKBOOKS["oil"].filename, oil_frame)
+    if gas_frame is not None:
+        _write_cores_xlsx(raw_dir / DEFAULT_WORKBOOKS["gas"].filename, gas_frame)
+
+
+def _density_entry(**overrides):
+    entry = {
+        "field_name": "Ayoluengo",
+        "aliases": ["ayoluengo"],
+        "api_gravity_deg": None,
+        "api_gravity_min_deg": None,
+        "api_gravity_max_deg": None,
+        "bbl_per_tonne": 6.95,
+        "measurement_basis": "representative produced stream",
+        "source_title": "Example operator assay",
+        "source_url": "https://example.test/ayoluengo",
+        "source_class": "operator_record",
+        "evidence_note": "Accepted field-specific conversion factor.",
+        "confidence": "high",
+        "accepted_for_conversion": True,
+    }
+    entry.update(overrides)
+    return entry
+
+
+def _write_density_registry(tmp_path, factors):
+    path = tmp_path / "density.json"
+    path.write_text(
+        json.dumps(
+            {
+                "registry_version": "test-2026-07-06",
+                "registry_date": "2026-07-06",
+                "factors": factors,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _single_field_audit():
+    factor = CoresCrudeDensityFactor(**_density_entry())
+    return CoresOilConversionAudit(
+        used_factors=(factor,),
+        defaulted_fields=(),
+        missing_fields=(),
+        _accepted_entries=(("ayoluengo", factor),),
+        _defaulted_field_keys=(),
+    )
+
+
+def _defaulted_audit():
+    return CoresOilConversionAudit(
+        used_factors=(),
+        defaulted_fields=("Ayoluengo",),
+        missing_fields=(),
+        _accepted_entries=(),
+        _defaulted_field_keys=("ayoluengo",),
+    )
+
+
+def _read_density_sidecar(tmp_path) -> dict:
+    return json.loads(
+        (tmp_path / "normalized" / "cores_oil_density_factors.json").read_text()
+    )

--- a/tests/unit/spain/test_cores_live_density.py
+++ b/tests/unit/spain/test_cores_live_density.py
@@ -102,6 +102,30 @@ def test_live_loader_applies_density_registry_and_writes_oil_conversion_audit(tm
     assert sidecar["factors"][0]["source_url"] == "https://example.test/ayoluengo"
 
 
+def test_live_loader_writes_sidecar_used_fields_from_cores_display_alias(tmp_path):
+    _write_live_workbooks(
+        tmp_path,
+        pd.DataFrame([_workbook_row("Ayo luengo", 2.0)]),
+    )
+    registry_path = _write_density_registry(
+        tmp_path,
+        [_density_entry(aliases=["Ayo luengo", "ayoluengo"])],
+    )
+
+    loader = CoresLiveProductionLoader(
+        cache_root=tmp_path,
+        oil_density_registry_path=registry_path,
+    )
+
+    oil = loader.load_oil_production()
+
+    assert oil.iloc[0]["field_name"] == "Ayo luengo"
+    assert oil.iloc[0]["oil_bbl"] == pytest.approx(2.0 * 6.95)
+    sidecar = _read_density_sidecar(tmp_path)
+    assert sidecar["used_fields"] == ["Ayo luengo"]
+    assert sidecar["factors"][0]["field_name"] == "Ayoluengo"
+
+
 def test_live_loader_missing_density_is_fail_closed_without_default(tmp_path):
     raw_dir = tmp_path / "raw"
     raw_dir.mkdir()
@@ -254,7 +278,7 @@ def _single_field_audit():
         used_factors=(factor,),
         defaulted_fields=(),
         missing_fields=(),
-        _accepted_entries=(("ayoluengo", factor),),
+        _accepted_entries=(("Ayoluengo", factor),),
         _defaulted_field_keys=(),
     )
 

--- a/tests/unit/spain/test_cores_loader.py
+++ b/tests/unit/spain/test_cores_loader.py
@@ -42,9 +42,20 @@ def _single_field_audit(factor=None):
         used_factors=(factor,),
         defaulted_fields=(),
         missing_fields=(),
-        _accepted_entries=(("ayoluengo", factor),),
+        _accepted_entries=(("Ayoluengo", factor),),
         _defaulted_field_keys=(),
     )
+
+
+def _audit_for_fields(*field_names):
+    factors = {}
+    for field_name in field_names:
+        factors[field_name] = _density_factor(
+            field_name=field_name,
+            aliases=(field_name,),
+            factor=TONNES_TO_BBL,
+        )
+    return build_oil_conversion_audit(field_names, factors)
 
 
 def test_parse_oil_frame_drops_total_rows_and_converts_tonnes_to_bbl():
@@ -81,7 +92,11 @@ def test_parse_oil_frame_drops_total_rows_and_converts_tonnes_to_bbl():
         ]
     )
 
-    out = parse_cores_frame(raw, product="oil")
+    out = parse_cores_frame(
+        raw,
+        product="oil",
+        oil_conversion_audit=_audit_for_fields("Ayoluengo", "Casablanca"),
+    )
 
     assert list(out.columns) == ["field_name", "year", "month", "oil_bbl"]
     assert set(out["field_name"]) == {"Ayoluengo", "Casablanca"}
@@ -93,6 +108,22 @@ def test_parse_oil_frame_drops_total_rows_and_converts_tonnes_to_bbl():
     casablanca = out[out["field_name"] == "Casablanca"]
     assert len(casablanca) == 1
     assert casablanca.iloc[0]["oil_bbl"] == pytest.approx(1.5 * TONNES_TO_BBL)
+
+
+def test_parse_oil_frame_requires_conversion_audit():
+    raw = pd.DataFrame(
+        [
+            {
+                "Year": 2024,
+                "Month": "January",
+                "Ayoluengo": 10.0,
+                "Grand total": 10.0,
+            }
+        ]
+    )
+
+    with pytest.raises(CoresParseError, match="oil_conversion_audit"):
+        parse_cores_frame(raw, product="oil")
 
 
 def test_parse_gas_frame_accepts_spanish_months_and_converts_gwh_to_mcf():
@@ -241,7 +272,12 @@ def test_loader_reads_xlsx_with_cores_header_row(tmp_path):
     )
     raw.to_excel(path, index=False, startrow=5)
 
-    out = CoresProductionLoader(product="oil", path=path, header_row=5).load()
+    out = CoresProductionLoader(
+        product="oil",
+        path=path,
+        header_row=5,
+        oil_conversion_audit=_single_field_audit(_density_factor(factor=TONNES_TO_BBL)),
+    ).load()
 
     assert out.to_dict("records") == [
         {
@@ -309,6 +345,7 @@ def test_loader_can_select_real_cores_production_sheet(tmp_path):
         path=path,
         header_row=5,
         sheet_name="Production",
+        oil_conversion_audit=_single_field_audit(_density_factor(factor=TONNES_TO_BBL)),
     ).load()
 
     assert out.to_dict("records") == [

--- a/tests/unit/spain/test_cores_loader.py
+++ b/tests/unit/spain/test_cores_loader.py
@@ -11,6 +11,40 @@ from worldenergydata.spain.production.cores_loader import (
     CoresProductionLoader,
     parse_cores_frame,
 )
+from worldenergydata.spain.production.cores_density import (
+    CoresCrudeDensityFactor,
+    CoresOilConversionAudit,
+    build_oil_conversion_audit,
+)
+
+
+def _density_factor(field_name="Ayoluengo", aliases=("ayoluengo",), factor=6.95):
+    return CoresCrudeDensityFactor(
+        field_name=field_name,
+        aliases=aliases,
+        api_gravity_deg=None,
+        api_gravity_min_deg=None,
+        api_gravity_max_deg=None,
+        bbl_per_tonne=factor,
+        measurement_basis="representative produced stream",
+        source_title="Example operator assay",
+        source_url="https://example.test/spain-crude-assay",
+        source_class="operator_record",
+        evidence_note="Accepted field-specific conversion factor.",
+        confidence="high",
+        accepted_for_conversion=True,
+    )
+
+
+def _single_field_audit(factor=None):
+    factor = factor or _density_factor()
+    return CoresOilConversionAudit(
+        used_factors=(factor,),
+        defaulted_fields=(),
+        missing_fields=(),
+        _accepted_entries=(("ayoluengo", factor),),
+        _defaulted_field_keys=(),
+    )
 
 
 def test_parse_oil_frame_drops_total_rows_and_converts_tonnes_to_bbl():
@@ -91,6 +125,108 @@ def test_parse_gas_frame_accepts_spanish_months_and_converts_gwh_to_mcf():
     )
 
 
+def test_parse_oil_frame_uses_conversion_audit_factor():
+    raw = pd.DataFrame(
+        [
+            {
+                "Year": 2024,
+                "Month": "January",
+                "Ayoluengo": 10.0,
+                "Grand total": 10.0,
+            }
+        ]
+    )
+
+    out = parse_cores_frame(
+        raw,
+        product="oil",
+        oil_conversion_audit=_single_field_audit(),
+    )
+
+    assert out.to_dict("records") == [
+        {
+            "field_name": "Ayoluengo",
+            "year": 2024,
+            "month": 1,
+            "oil_bbl": pytest.approx(10.0 * 6.95),
+        }
+    ]
+
+
+def test_parse_oil_frame_requires_explicit_default_opt_in():
+    raw = pd.DataFrame(
+        [
+            {
+                "Year": 2024,
+                "Month": "January",
+                "Ayoluengo": 10.0,
+                "Casablanca": 2.0,
+                "Grand total": 12.0,
+            }
+        ]
+    )
+
+    with pytest.raises(CoresParseError, match="Casablanca"):
+        parse_cores_frame(
+            raw,
+            product="oil",
+            oil_conversion_audit=_single_field_audit(),
+        )
+
+
+def test_parse_oil_frame_allows_legacy_default_when_explicit():
+    raw = pd.DataFrame(
+        [
+            {
+                "Year": 2024,
+                "Month": "January",
+                "Ayoluengo": 10.0,
+                "Casablanca": 2.0,
+                "Grand total": 12.0,
+            }
+        ]
+    )
+    audit = build_oil_conversion_audit(
+        ["Ayoluengo", "Casablanca"],
+        {"ayoluengo": _density_factor()},
+        allow_default_density=True,
+    )
+
+    out = parse_cores_frame(raw, product="oil", oil_conversion_audit=audit)
+
+    values = {row["field_name"]: row["oil_bbl"] for row in out.to_dict("records")}
+    assert values["Ayoluengo"] == pytest.approx(10.0 * 6.95)
+    assert values["Casablanca"] == pytest.approx(2.0 * TONNES_TO_BBL)
+
+
+def test_parse_gas_frame_ignores_oil_conversion_audit():
+    raw = pd.DataFrame(
+        [
+            {
+                "Year": 2024,
+                "Month": "January",
+                "Gaviota": 3.0,
+                "Grand total": 3.0,
+            }
+        ]
+    )
+
+    out = parse_cores_frame(
+        raw,
+        product="gas",
+        oil_conversion_audit=_single_field_audit(),
+    )
+
+    assert out.to_dict("records") == [
+        {
+            "field_name": "Gaviota",
+            "year": 2024,
+            "month": 1,
+            "gas_mcf": pytest.approx(3.0 * GWH_TO_MCF),
+        }
+    ]
+
+
 def test_loader_reads_xlsx_with_cores_header_row(tmp_path):
     path = tmp_path / "cores_oil.xlsx"
     raw = pd.DataFrame(
@@ -113,6 +249,37 @@ def test_loader_reads_xlsx_with_cores_header_row(tmp_path):
             "year": 2026,
             "month": 6,
             "oil_bbl": pytest.approx(2.0 * TONNES_TO_BBL),
+        }
+    ]
+
+
+def test_loader_passes_conversion_audit_to_parser(tmp_path):
+    path = tmp_path / "cores_oil.xlsx"
+    raw = pd.DataFrame(
+        [
+            {
+                "Year": 2026,
+                "Month": "June",
+                "Ayoluengo": 2.0,
+                "Grand total": 2.0,
+            }
+        ]
+    )
+    raw.to_excel(path, index=False, startrow=5)
+
+    out = CoresProductionLoader(
+        product="oil",
+        path=path,
+        header_row=5,
+        oil_conversion_audit=_single_field_audit(),
+    ).load()
+
+    assert out.to_dict("records") == [
+        {
+            "field_name": "Ayoluengo",
+            "year": 2026,
+            "month": 6,
+            "oil_bbl": pytest.approx(2.0 * 6.95),
         }
     ]
 

--- a/tests/unit/spain/test_cores_loader.py
+++ b/tests/unit/spain/test_cores_loader.py
@@ -3,6 +3,11 @@
 import pandas as pd
 import pytest
 
+from worldenergydata.spain.production.cores_density import (
+    CoresCrudeDensityFactor,
+    CoresOilConversionAudit,
+    build_oil_conversion_audit,
+)
 from worldenergydata.spain.production.cores_loader import (
     GWH_TO_MCF,
     TONNES_TO_BBL,
@@ -10,11 +15,6 @@ from worldenergydata.spain.production.cores_loader import (
     CoresParseError,
     CoresProductionLoader,
     parse_cores_frame,
-)
-from worldenergydata.spain.production.cores_density import (
-    CoresCrudeDensityFactor,
-    CoresOilConversionAudit,
-    build_oil_conversion_audit,
 )
 
 


### PR DESCRIPTION
## Summary

Implements the approved [#807](https://github.com/vamseeachanta/worldenergydata/issues/807) CORES crude density/API infrastructure slice without fabricating missing field-density evidence.

Changes include:
- Adds a provenance-bearing CORES crude density registry loader and conversion audit model.
- Adds a package source-gap registry at `packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json`; it intentionally contains no accepted conversion factors yet.
- Makes the live CORES loader use the package registry by default and fail closed on missing density coverage unless `allow_default_density: true` is explicitly boolean.
- Requires an explicit oil conversion audit for oil parsing instead of silently falling back to `7.33`.
- Requires root `registry_version` and `registry_date` metadata in density registries.
- Writes density audit sidecars that preserve actual CORES display field names while linking accepted canonical factors by alias.
- Validates and renders `default_bbl_per_tonne` whenever fields use default density conversion.
- Updates scheduler wiring to use public `density_registry_path`, preserve internal loader compatibility, and mark deterministic config errors non-retryable.
- Updates committed and embedded Ayoluengo fixture metadata with explicit defaulted-density provenance instead of bare `oil_bbl = tonnes * 7.33` metadata.
- Hardens report ingestion to validate density sidecars, accepted factor rows, actual oil CSV field coverage, alias matching, and visible HTML density provenance.

## Important Status

Do not close [#807](https://github.com/vamseeachanta/worldenergydata/issues/807) from this PR alone. The implementation is source-gap honest: strict live refresh should fail with named missing fields until accepted field-applicable density/API evidence exists for all current CORES oil fields.

This does not redo [#809](https://github.com/vamseeachanta/worldenergydata/issues/809); it builds on the already-merged scheduler work.

## Review / Traceability

- Plan and implementation issue: [#807](https://github.com/vamseeachanta/worldenergydata/issues/807)
- Review-fix commit: `257cdeb5` (`fix: tighten Spain CORES density provenance`)
- Issue trace comment: https://github.com/vamseeachanta/worldenergydata/issues/807#issuecomment-4892065583
- Code-stage adversarial review findings were addressed before moving this PR out of draft.

## Verification

Local:
- `.venv/bin/python -m pytest tests/unit/spain/test_cores_live.py::test_refresh_ayoluengo_fixture_writes_stable_sample_and_metadata tests/unit/spain/test_cores_density.py tests/unit/spain/test_cores_loader.py tests/unit/scheduler/test_spain_cores_refresh.py tests/unit/scheduler/test_config.py::TestLoadConfig::test_repo_scheduler_config_includes_lng_spain_and_expected_output_dirs tests/unit/spain/test_cores_field_development_density.py tests/unit/spain/test_cores_live_density.py tests/unit/production/unified/test_spain_cores_adapter_loader.py --no-cov -q` -> 77 passed
- `.venv/bin/python -m pytest tests/unit/spain/test_cores_live.py::test_refresh_ayoluengo_fixture_writes_stable_sample_and_metadata tests/unit/spain/test_cores_live_density.py tests/unit/spain/test_cores_field_development_density.py --no-cov -q` -> 24 passed
- `scripts/legal/legal-sanity-scan.sh` -> PASS
- touched-surface `black --check`, `isort --check-only`, and `git diff --check` -> PASS
- touched-file `bandit -ll -ii` -> no medium/high issues
- `uv build --all-packages` -> PASS

GitHub PR checks at `257cdeb5`:
- Lint, Type Check, Security Scan, Build Package -> pass
- domain-tests `_always`, `unit-bsee`, `unit-production`, `unit-scheduler`, `unit-spain`, aggregate PR gate -> pass
- PR validation and GitGuardian -> pass
