### PR TITLE
feat(fdas): KC deepwater ingest — Buckskin recovered via raw WAR .bin (#842)

### DIFF
--- a/docs/modules/bsee/analysis/production/FDAS_V30/extract_drilling_completion_days.py
+++ b/docs/modules/bsee/analysis/production/FDAS_V30/extract_drilling_completion_days.py
@@ -102,7 +102,13 @@ def load_leases(path):
     return out
 
 def load_war_main(path):
-    df = pd.read_csv(path, encoding="ISO-8859-1", on_bad_lines="skip", low_memory=False)
+    # Raw BSEE WAR is distributed as pickled DataFrames (.bin) on the data share and
+    # as delimited text (.txt) in exports; both carry the same raw columns, so read
+    # either and let the column-mapping below normalise. One canonical extractor.
+    if str(path).lower().endswith(".bin"):
+        df = pd.read_pickle(path)
+    else:
+        df = pd.read_csv(path, encoding="ISO-8859-1", on_bad_lines="skip", low_memory=False)
     C = {c.upper(): c for c in df.columns}
 
     api   = C.get("API_WELL_NUMBER") or C.get("API_NUMBER") or C.get("API")
@@ -127,7 +133,10 @@ def load_war_main(path):
     return out
 
 def load_boreholes(path):
-    df = pd.read_csv(path, encoding="ISO-8859-1", on_bad_lines="skip", low_memory=False)
+    if str(path).lower().endswith(".bin"):
+        df = pd.read_pickle(path)
+    else:
+        df = pd.read_csv(path, encoding="ISO-8859-1", on_bad_lines="skip", low_memory=False)
     C = {c.upper(): c for c in df.columns}
 
     api = C.get("API_WELL_NUMBER") or C.get("API")
@@ -159,11 +168,17 @@ def load_boreholes(path):
     return out
 
 def load_remarks(path):
-    df = pd.read_csv(
-        path, encoding="ISO-8859-1",
-        header=None, names=["SN_WAR","TEXT_REMARK"],
-        on_bad_lines="skip", low_memory=False
-    )
+    if str(path).lower().endswith(".bin"):
+        df = pd.read_pickle(path)
+        cols = {c.upper(): c for c in df.columns}
+        df = df.rename(columns={cols.get("SN_WAR", "SN_WAR"): "SN_WAR",
+                                cols.get("TEXT_REMARK", "TEXT_REMARK"): "TEXT_REMARK"})
+    else:
+        df = pd.read_csv(
+            path, encoding="ISO-8859-1",
+            header=None, names=["SN_WAR","TEXT_REMARK"],
+            on_bad_lines="skip", low_memory=False
+        )
     df = df[df["SN_WAR"].astype(str).str.upper()!="SN_WAR"].copy()
     df["SN_WAR"] = pd.to_numeric(df["SN_WAR"], errors="coerce")
     df = df.dropna(subset=["SN_WAR"])

--- a/docs/modules/bsee/analysis/production/FDAS_V30/leases_v21_kc.csv
+++ b/docs/modules/bsee/analysis/production/FDAS_V30/leases_v21_kc.csv
@@ -1,0 +1,27 @@
+LEASE_NUM,Lease_Numeric,LEASE_NAME,DEV_NAME,WATER_DEPTH,DEV_SYSTEM
+G17001,17001,Stones,Stones,9525,subsea15
+G16965,16965,Cascade,Cascade Chinook,8200,subsea15
+G16997,16997,Chinook,Cascade Chinook,8900,subsea15
+G20351,20351,Julia,Julia,7335,tieback15
+G31752,31752,Anchor,Anchor,5080,subsea20
+G31751,31751,Anchor,Anchor,5080,subsea20
+G21245,21245,Jack,Jack St Malo,7240,subsea15
+G18753,18753,St Malo,Jack St Malo,6820,subsea15
+G18745,18745,St Malo,Jack St Malo,6820,subsea15
+G17015,17015,St Malo,Jack St Malo,6820,subsea15
+G17016,17016,St Malo,Jack St Malo,6820,subsea15
+G20394,20394,St Malo,Jack St Malo,6820,subsea15
+g25792,25792,Kaskida,Kaskida,5860,subsea20
+g19555,19555,Kaskida,Kaskida,5860,subsea20
+G25782,25782,Tiber,Tiber,4130,subsea20
+G31938,31938,Shenandoah,Shenandoah,5800,subsea20
+G25232,25232,Shenandoah,Shenandoah,5840,subsea20
+G30876,30876,North Platte,North Platte,5840,subsea20
+G32460,32460,North Platte,North Platte,4230,subsea20
+G16942,16942,Big Foot,Big Foot,5190,dry
+G25806,25806,Buckskin,Buckskin,6800,tieback20
+G25813,25813,Buckskin,Buckskin,6800,tieback20
+G25814,25814,Buckskin,Buckskin,6800,tieback20
+G25815,25815,Buckskin,Buckskin,6800,tieback20
+G25823,25823,Buckskin,Buckskin,6800,tieback20
+G32650,32650,Buckskin,Buckskin,6800,tieback20

--- a/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/buckskin/buckskin_config.py
+++ b/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/buckskin/buckskin_config.py
@@ -22,25 +22,29 @@ class BuckskinConfig:
     host_facility: str = "Lucius Spar"
 
     # BOEM OCS lease numbers (from BOEM serial register)
-    # KC 871 and KC 872 share the same lease number OCS-G 25823
+    # WAR data (mv_war_main) shows KC 871 under OCS-G 32650 and KC 872 under
+    # OCS-G 25823 — they do NOT share a lease
     boem_leases: Dict[str, str] = field(
         default_factory=lambda: {
             "OCS-G 25806": "KC 785",
             "OCS-G 25813": "KC 828",
             "OCS-G 25814": "KC 829",
             "OCS-G 25815": "KC 830",
-            "OCS-G 25823": "KC 871 / KC 872",
+            "OCS-G 25823": "KC 872",
+            "OCS-G 32650": "KC 871",
         }
     )
 
     # Lease numbers as found in BSEE data (without "OCS-" prefix)
     # The data may use trimmed format like "G25806" or with space "G 25806"
+    # All six carry WAR activity (buckskin_war_activity.csv)
     lease_numbers: Tuple[str, ...] = (
         "G25806",
         "G25813",
         "G25814",
         "G25815",
         "G25823",
+        "G32650",
     )
 
     # Additional leases discovered in BSEE LAB data (8 total)

--- a/tests/integration/test_kc_ingest_fidelity.py
+++ b/tests/integration/test_kc_ingest_fidelity.py
@@ -1,0 +1,110 @@
+"""KC-deepwater ingest fidelity (#842).
+
+The canonical FDAS extractor (``docs/modules/bsee/analysis/production/FDAS_V30/
+extract_drilling_completion_days.py``) now reads the raw BSEE WAR ``.bin``
+pickles on the data share directly, and the lease list gained Buckskin's six
+Keathley Canyon leases (``leases_v21_kc.csv``).
+
+Two fidelity anchors pin that ingest:
+
+* **Anchor** must reproduce the frozen V30 workbook exactly (821 drilling /
+  1,004 completion days) — proving the ``.bin`` code path is bit-for-bit
+  faithful to the canonical extraction on an already-matched field.
+* **Buckskin** must land at 25 bores / 2,056 D&C days — the recovered field
+  the shelf-only extract dropped (World Oil April 2026 article: 24 / 2,004).
+
+Runs the real extractor against the real share; skipped when /mnt/ace is not
+mounted (e.g., CI).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+FDAS_DIR = (
+    REPO_ROOT / "docs" / "modules" / "bsee" / "analysis" / "production" / "FDAS_V30"
+)
+SCRIPT = FDAS_DIR / "extract_drilling_completion_days.py"
+LEASES = FDAS_DIR / "leases_v21_kc.csv"
+
+WAR_BIN_DIR = Path("/mnt/ace/worldenergydata/data/modules/bsee/bin/war")
+WAR_MAIN = WAR_BIN_DIR / "mv_war_main.bin"
+WAR_BOREHOLES = WAR_BIN_DIR / "mv_war_boreholes_view.bin"
+WAR_REMARKS = WAR_BIN_DIR / "mv_war_main_prop_remark.bin"
+
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        not WAR_MAIN.exists(),
+        reason="raw WAR .bin share not mounted at /mnt/ace",
+    ),
+]
+
+BUCKSKIN_LEASES = {"G25806", "G25813", "G25814", "G25815", "G25823", "G32650"}
+
+
+@pytest.fixture(scope="module")
+def extract(tmp_path_factory):
+    """Run the canonical extractor once against the raw .bin share."""
+    out = tmp_path_factory.mktemp("kc_ingest") / "dc_days_candidate.xlsx"
+    subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--leases",
+            str(LEASES),
+            "--war-main",
+            str(WAR_MAIN),
+            "--war-boreholes",
+            str(WAR_BOREHOLES),
+            "--war-remarks",
+            str(WAR_REMARKS),
+            "--out",
+            str(out),
+        ],
+        check=True,
+        capture_output=True,
+        cwd=FDAS_DIR,
+    )
+    df = pd.read_excel(out, sheet_name="Sheet1")
+    leases = pd.read_csv(LEASES)
+    leases["_KEY"] = leases["LEASE_NUM"].str.upper()
+    df["_KEY"] = df["SURF_LEASE_NUM"].str.upper()
+    return df.merge(leases[["_KEY", "DEV_NAME"]], on="_KEY", how="left")
+
+
+def _dev(df, name):
+    return df[df["DEV_NAME"] == name]
+
+
+def test_leases_file_is_v20_plus_buckskin():
+    leases = pd.read_csv(LEASES)
+    assert len(leases) == 26
+    assert (
+        set(leases.loc[leases["DEV_NAME"] == "Buckskin", "LEASE_NUM"])
+        == BUCKSKIN_LEASES
+    )
+
+
+def test_anchor_reproduces_frozen_v30_exactly(extract):
+    anchor = _dev(extract, "Anchor")
+    assert int(anchor["DRILLING_DAYS"].sum()) == 821
+    assert int(anchor["COMPLETION_DAYS"].sum()) == 1004
+
+
+def test_buckskin_recovered(extract):
+    buckskin = _dev(extract, "Buckskin")
+    assert buckskin["API_WELL_NUMBER"].nunique() == 25
+    dc = int(buckskin["DRILLING_DAYS"].sum() + buckskin["COMPLETION_DAYS"].sum())
+    assert dc == 2056  # World Oil April 2026 article: 24 bores / 2,004 D&C
+
+
+def test_all_wells_map_to_a_development(extract):
+    assert extract["DEV_NAME"].notna().all()
+    assert len(extract) == 253

--- a/tests/integration/test_kc_ingest_fidelity.py
+++ b/tests/integration/test_kc_ingest_fidelity.py
@@ -38,13 +38,14 @@ WAR_MAIN = WAR_BIN_DIR / "mv_war_main.bin"
 WAR_BOREHOLES = WAR_BIN_DIR / "mv_war_boreholes_view.bin"
 WAR_REMARKS = WAR_BIN_DIR / "mv_war_main_prop_remark.bin"
 
-pytestmark = [
-    pytest.mark.slow,
-    pytest.mark.skipif(
-        not WAR_MAIN.exists(),
-        reason="raw WAR .bin share not mounted at /mnt/ace",
-    ),
-]
+pytestmark = pytest.mark.slow
+
+# Only the extraction tests need the share; the leases-CSV integrity test
+# must keep running in CI where /mnt/ace is absent.
+requires_share = pytest.mark.skipif(
+    not WAR_MAIN.exists(),
+    reason="raw WAR .bin share not mounted at /mnt/ace",
+)
 
 BUCKSKIN_LEASES = {"G25806", "G25813", "G25814", "G25815", "G25823", "G32650"}
 
@@ -53,7 +54,7 @@ BUCKSKIN_LEASES = {"G25806", "G25813", "G25814", "G25815", "G25823", "G32650"}
 def extract(tmp_path_factory):
     """Run the canonical extractor once against the raw .bin share."""
     out = tmp_path_factory.mktemp("kc_ingest") / "dc_days_candidate.xlsx"
-    subprocess.run(
+    proc = subprocess.run(
         [
             sys.executable,
             str(SCRIPT),
@@ -68,10 +69,10 @@ def extract(tmp_path_factory):
             "--out",
             str(out),
         ],
-        check=True,
         capture_output=True,
         cwd=FDAS_DIR,
     )
+    assert proc.returncode == 0, proc.stderr.decode()
     df = pd.read_excel(out, sheet_name="Sheet1")
     leases = pd.read_csv(LEASES)
     leases["_KEY"] = leases["LEASE_NUM"].str.upper()
@@ -92,12 +93,14 @@ def test_leases_file_is_v20_plus_buckskin():
     )
 
 
+@requires_share
 def test_anchor_reproduces_frozen_v30_exactly(extract):
     anchor = _dev(extract, "Anchor")
     assert int(anchor["DRILLING_DAYS"].sum()) == 821
     assert int(anchor["COMPLETION_DAYS"].sum()) == 1004
 
 
+@requires_share
 def test_buckskin_recovered(extract):
     buckskin = _dev(extract, "Buckskin")
     assert buckskin["API_WELL_NUMBER"].nunique() == 25
@@ -105,6 +108,7 @@ def test_buckskin_recovered(extract):
     assert dc == 2056  # World Oil April 2026 article: 24 bores / 2,004 D&C
 
 
+@requires_share
 def test_all_wells_map_to_a_development(extract):
     assert extract["DEV_NAME"].notna().all()
     assert len(extract) == 253


### PR DESCRIPTION
## What

Closes the Buckskin gap in the Lower Tertiary D&C reconciliation (#842) by wiring the canonical FDAS extractor to the raw BSEE WAR data instead of the shelf-only text extract:

1. **`extract_drilling_completion_days.py`** — the three loaders (`load_war_main`, `load_boreholes`, `load_remarks`) now read the raw `.bin` pickled DataFrames on the data share (`/mnt/ace/worldenergydata/data/modules/bsee/bin/war/`) directly, falling through to the same column-normalization as the legacy `.txt` path. One canonical extractor, two input formats.
2. **`leases_v21_kc.csv`** — leases_v20 (20 leases) + Buckskin's 6 WAR-active Keathley Canyon leases: G25806 (KC785), G25813 (KC828), G25814 (KC829), G25815 (KC830), G25823 (KC872, discovery), G32650 (KC871). Additive; `leases.xlsx` and the frozen V30 workbook are untouched.
3. **`buckskin_config.py`** — fixes the lease mapping: WAR shows KC871 under **G32650** and KC872 under **G25823** (they do not share a lease, contrary to the old comment); adds G32650 to `lease_numbers`.
4. **`tests/integration/test_kc_ingest_fidelity.py`** — 4 tests, `slow`-marked, skip when `/mnt/ace` is not mounted.

## Fidelity (verified, tests pin these)

| Check | Result | Reference |
|---|---|---|
| Anchor drilling / completion | **821 / 1,004** | frozen V30 workbook — **exact** |
| Buckskin | **25 bores / 2,056 D&C days** | World Oil April 2026 article: 24 / 2,004 (Δ +1 bore, +2.6%) |
| Total (26 leases, 11 devs) | 253 wells / 25,404 D&C days | candidate for V30 supersede |

## Scope notes

- Does **NOT** regenerate the frozen `drilling_and_completion_days.xlsx` or touch its consumers (`v30_reproducer`, `financial/config_loader`). Per the owner decision on #842, the full-raw extraction becomes canonical (supersede V30) only after Roy confirms the validation — that migration is a follow-on.
- Known deferred bug: JSM candidate overshoots (7,047 vs WO 6,928) — tracked in #846, unaffected by this PR.

Refs #842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)