### PR TITLE
chore(completion): rename benchmark to "World Oil April 2026 article"

### DIFF
--- a/reports/completion/index.html
+++ b/reports/completion/index.html
@@ -63,7 +63,7 @@
   <div class="stats"><div class="stat"><div class="v">217</div><div class="k">deepwater wells (WAR records)</div></div><div class="stat"><div class="v">12</div><div class="k">lease names (10 developments)</div></div><div class="stat"><div class="v">19</div><div class="k">federal surface leases</div></div><div class="stat"><div class="v">2000&ndash;2024</div><div class="k">spud-year span</div></div><div class="stat"><div class="v">38 d</div><div class="k">median drilling time</div></div><div class="stat"><div class="v">24 d</div><div class="k">median completion time</div></div><div class="stat"><div class="v">4,130&ndash;9,525 ft</div><div class="k">water-depth range</div></div><div class="stat"><div class="v">37,743 ft</div><div class="k">deepest well (measured depth)</div></div></div>
 
   <div class="verify">
-    <strong>Verification &middot; reconciled against the WO Article, end of 2025.</strong>
+    <strong>Verification &middot; reconciled against the World Oil April 2026 article.</strong>
     On the 9 developments both sources cover, WED totals
     <b>19,445</b> D&amp;C days vs the World Oil article's
     <b>19,940</b> &mdash; -495 days
@@ -83,7 +83,7 @@
   (robust to the sidetracks and recompletions whose WAR milestones coincide on a
   single day); means are shown alongside. <b>Total D&amp;C</b> is the summed drilling +
   completion days per lease; rolled up to developments (Cascade+Chinook, Jack+St&nbsp;Malo)
-  it reconciles to the <a href="verification.html">WO Article, end of 2025</a> benchmark
+  it reconciles to the <a href="verification.html">World Oil April 2026 article</a> benchmark
   on the matched developments. The deepest borehole in the set is North Platte well <code>608074032001</code> at 37,743 ft measured / 35,115 ft TVD.</p>
   <div class="table-wrap"><table>
     <thead><tr>

--- a/reports/completion/verification.html
+++ b/reports/completion/verification.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>worldenergydata — D&amp;C Days Reconciliation vs WO Article, end of 2025</title>
+<title>worldenergydata — D&amp;C Days Reconciliation vs World Oil April 2026 article</title>
 <style>
   :root{--bg:#0d1117;--panel:#161b22;--line:#30363d;--ink:#e6edf3;--mut:#8b949e;
         --accent:#3b82f6;--ok:#3fb950;--warn:#d29922}
@@ -51,7 +51,7 @@
 <header><div class="wrap">
   <h1>Drilling &amp; Completion Days &mdash; Verification</h1>
   <div class="sub">Field- and well-level reconciliation of the live worldenergydata
-  (WED) BSEE extract against the frozen <b>WO Article, end of 2025</b> benchmark
+  (WED) BSEE extract against the frozen <b>World Oil April 2026 article</b> benchmark
   (World Oil Lower-Tertiary series, Table&nbsp;1 &mdash; &ldquo;Project and well
   metrics, BSEE data derived summary through 2025&rdquo;). A living QA/QC surface:
   flagged rows stay open until each difference is resolved.</div>
@@ -76,7 +76,7 @@
   latest-OGOR rerun &mdash; V50 extends only the production window (economics), not
   these day counts. So this reconciliation is version-independent.</p>
 
-  <h2>Field-level reconciliation (WED vs WO Article, end of 2025)</h2>
+  <h2>Field-level reconciliation (WED vs World Oil April 2026 article)</h2>
   <div class="table-wrap"><table>
     <thead><tr>
       <th>Development</th><th>First oil</th>
@@ -111,7 +111,7 @@
   <h2>Provenance</h2>
   <p class="note">WED figures are computed deterministically from the frozen workbook
   <a href="https://github.com/vamseeachanta/worldenergydata/blob/main/docs/modules/bsee/analysis/production/FDAS_V30/drilling_and_completion_days.xlsx"><code>drilling_and_completion_days.xlsx</code></a>
-  (BSEE Well Activity Reports, V30 methodology). WO-Article figures are transcribed
+  (BSEE Well Activity Reports, V30 methodology). World Oil April 2026 article figures are transcribed
   verbatim from World Oil Lower-Tertiary Table&nbsp;1 (BSEE-derived summary thru
   Nov&nbsp;2025) and are held fixed as an external benchmark.</p>
 

--- a/scripts/completion/build_completion_report.py
+++ b/scripts/completion/build_completion_report.py
@@ -38,7 +38,7 @@ _OUT = _REPO / "reports" / "completion" / "index.html"
 _OUT_VERIFY = _REPO / "reports" / "completion" / "verification.html"
 
 # ---------------------------------------------------------------------------
-# "WO Article, end of 2025" benchmark — World Oil Lower-Tertiary series, Table 1
+# "World Oil April 2026 article" benchmark — World Oil Lower-Tertiary series, Table 1
 # ("Project and well metrics — BSEE data derived summary through 2025", the
 # Nov-2025 cut). This is a FROZEN external reference we reconcile the live
 # worldenergydata (WED) extract against; the numbers are transcribed verbatim
@@ -47,7 +47,7 @@ _OUT_VERIFY = _REPO / "reports" / "completion" / "verification.html"
 #   d_and_c = "Total drilling and completion days" (drilling + completion)
 # Big Foot intentionally has NO row: the article excluded it from its comparison
 # set, so it surfaces in the reconciliation as a WED-only development.
-WO_ARTICLE_END_2025: dict[str, dict] = {
+WO_APRIL_2026_ARTICLE: dict[str, dict] = {
     "Anchor": {"fo": "8/1/24", "prod": 3, "bores": 17, "d_and_c": 1825},
     "Buckskin": {"fo": "6/1/19", "prod": 4, "bores": 24, "d_and_c": 2004},
     "Cascade Chinook": {"fo": "9/1/12", "prod": 3, "bores": 14, "d_and_c": 2467},
@@ -179,7 +179,7 @@ def compute(data: list[dict]) -> dict:
 
 
 def compute_reconciliation(data: list[dict]) -> dict:
-    """Reconcile the live WED extract against the frozen WO-Article benchmark.
+    """Reconcile the live WED extract against the frozen World Oil April 2026 article benchmark.
 
     Rolls the per-lease workbook records up to WO *development* granularity
     (Cascade+Chinook, Jack+St Malo) and pairs each development with its WO row.
@@ -201,12 +201,12 @@ def compute_reconciliation(data: list[dict]) -> dict:
             b["comp"] += d["COMPLETION_DAYS"]
 
     # WO developments in article order, then any WED-only development alphabetically.
-    order = list(WO_ARTICLE_END_2025) + sorted(set(by_dev) - set(WO_ARTICLE_END_2025))
+    order = list(WO_APRIL_2026_ARTICLE) + sorted(set(by_dev) - set(WO_APRIL_2026_ARTICLE))
 
     rows = []
     for dev in order:
         wed = by_dev.get(dev)
-        wo = WO_ARTICLE_END_2025.get(dev)
+        wo = WO_APRIL_2026_ARTICLE.get(dev)
         wed_bores = wed["bores"] if wed else None
         wed_drill = int(round(wed["drill"])) if wed else None
         wed_comp = int(round(wed["comp"])) if wed else None
@@ -249,8 +249,8 @@ def compute_reconciliation(data: list[dict]) -> dict:
     }
     wed_total["dc"] = wed_total["drill"] + wed_total["comp"]
     wo_total = {
-        "bores": sum(v["bores"] for v in WO_ARTICLE_END_2025.values()),
-        "dc": sum(v["d_and_c"] for v in WO_ARTICLE_END_2025.values()),
+        "bores": sum(v["bores"] for v in WO_APRIL_2026_ARTICLE.values()),
+        "dc": sum(v["d_and_c"] for v in WO_APRIL_2026_ARTICLE.values()),
     }
     # Like-for-like: only developments BOTH sides carry (drop WED-only Big Foot and
     # WO-only Buckskin). This is the honest apples-to-apples reconciliation; the raw
@@ -397,7 +397,7 @@ def render(c: dict, recon: dict) -> str:
   <div class="stats">{stats}</div>
 
   <div class="verify">
-    <strong>Verification &middot; reconciled against the WO Article, end of 2025.</strong>
+    <strong>Verification &middot; reconciled against the World Oil April 2026 article.</strong>
     On the {recon['common_n']} developments both sources cover, WED totals
     <b>{recon['wed_common']['dc']:,}</b> D&amp;C days vs the World Oil article's
     <b>{recon['wo_common']['dc']:,}</b> &mdash; {recon['common_delta_dc']:+,} days
@@ -417,7 +417,7 @@ def render(c: dict, recon: dict) -> str:
   (robust to the sidetracks and recompletions whose WAR milestones coincide on a
   single day); means are shown alongside. <b>Total D&amp;C</b> is the summed drilling +
   completion days per lease; rolled up to developments (Cascade+Chinook, Jack+St&nbsp;Malo)
-  it reconciles to the <a href="verification.html">WO Article, end of 2025</a> benchmark
+  it reconciles to the <a href="verification.html">World Oil April 2026 article</a> benchmark
   on the matched developments.{deepest_txt}</p>
   <div class="table-wrap"><table>
     <thead><tr>
@@ -601,14 +601,14 @@ def render_verification(recon: dict, data: list[dict]) -> str:
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>worldenergydata — D&amp;C Days Reconciliation vs WO Article, end of 2025</title>
+<title>worldenergydata — D&amp;C Days Reconciliation vs World Oil April 2026 article</title>
 <style>{_STYLE}</style>
 </head>
 <body>
 <header><div class="wrap">
   <h1>Drilling &amp; Completion Days &mdash; Verification</h1>
   <div class="sub">Field- and well-level reconciliation of the live worldenergydata
-  (WED) BSEE extract against the frozen <b>WO Article, end of 2025</b> benchmark
+  (WED) BSEE extract against the frozen <b>World Oil April 2026 article</b> benchmark
   (World Oil Lower-Tertiary series, Table&nbsp;1 &mdash; &ldquo;Project and well
   metrics, BSEE data derived summary through 2025&rdquo;). A living QA/QC surface:
   flagged rows stay open until each difference is resolved.</div>
@@ -633,7 +633,7 @@ def render_verification(recon: dict, data: list[dict]) -> str:
   latest-OGOR rerun &mdash; V50 extends only the production window (economics), not
   these day counts. So this reconciliation is version-independent.</p>
 
-  <h2>Field-level reconciliation (WED vs WO Article, end of 2025)</h2>
+  <h2>Field-level reconciliation (WED vs World Oil April 2026 article)</h2>
   <div class="table-wrap"><table>
     <thead><tr>
       <th>Development</th><th>First oil</th>
@@ -668,7 +668,7 @@ def render_verification(recon: dict, data: list[dict]) -> str:
   <h2>Provenance</h2>
   <p class="note">WED figures are computed deterministically from the frozen workbook
   <a href="https://github.com/vamseeachanta/worldenergydata/blob/main/docs/modules/bsee/analysis/production/FDAS_V30/drilling_and_completion_days.xlsx"><code>drilling_and_completion_days.xlsx</code></a>
-  (BSEE Well Activity Reports, V30 methodology). WO-Article figures are transcribed
+  (BSEE Well Activity Reports, V30 methodology). World Oil April 2026 article figures are transcribed
   verbatim from World Oil Lower-Tertiary Table&nbsp;1 (BSEE-derived summary thru
   Nov&nbsp;2025) and are held fixed as an external benchmark.</p>
 

--- a/tests/test_completion_reconciliation.py
+++ b/tests/test_completion_reconciliation.py
@@ -1,9 +1,9 @@
-"""Tests for the WO-Article reconciliation in the completion-days report.
+"""Tests for the World Oil April 2026 article reconciliation in the completion-days report.
 
 The completion report (``scripts/completion/build_completion_report.py``)
 publishes, alongside the observational drilling/completion-days table, a
 verification surface that reconciles the live worldenergydata (WED) extract
-against the frozen "WO Article, end of 2025" benchmark (World Oil Lower-Tertiary
+against the frozen "World Oil April 2026 article" benchmark (World Oil Lower-Tertiary
 series, Table 1 — BSEE-derived summary thru Nov 2025).
 
 These tests pin the reconciliation arithmetic to the frozen reference workbook
@@ -60,7 +60,7 @@ _WED_DC = {
 
 
 def test_wo_reference_shape(gen):
-    wo = gen.WO_ARTICLE_END_2025
+    wo = gen.WO_APRIL_2026_ARTICLE
     assert len(wo) == 10
     assert "Buckskin" in wo  # in WO, absent from WED
     assert "Big Foot" not in wo  # in WED, excluded from WO comparison set
@@ -146,7 +146,7 @@ def test_bore_deltas_flagged_days_match_not_full_match(recon):
 def test_verification_html_renders(gen, recon):
     data = gen._load()
     html_out = gen.render_verification(recon, data)
-    assert "WO Article, end of 2025" in html_out
+    assert "World Oil April 2026 article" in html_out
     assert "Shenandoah" in html_out
     assert "<table" in html_out
     # like-for-like framing must be present, not just the raw grand total


### PR DESCRIPTION
Naming-only change, no numeric drift.

- `WO_ARTICLE_END_2025` → `WO_APRIL_2026_ARTICLE` in `scripts/completion/build_completion_report.py` (+ test references)
- Display strings "WO Article, end of 2025" / "WO-Article" → **"World Oil April 2026 article"** (the benchmark's canonical name — the earlier label used the data-thru date, not the publication issue)
- `reports/completion/{index,verification}.html` regenerated: 12 changed lines, all benchmark-name text; totals unchanged (217 wells; WED D&C 22,478 vs WO 21,944)
- `tests/test_completion_reconciliation.py`: 20 pass; black/isort clean via the repo's `uv run` toolchain

🤖 Generated with [Claude Code](https://claude.com/claude-code)