### PR TITLE
feat(econ): per-well economics card — rig-days to cost, revenue, coverage

### DIFF
--- a/config/well_economics.yml
+++ b/config/well_economics.yml
@@ -1,0 +1,26 @@
+# ABOUTME: Per-well economics configuration (issue #849) — display policy and
+# ABOUTME: per-field flags. Rates live ONLY in config/analysis/cost_data/day_rates.yml.
+
+region: gom
+
+# HPHT premium is config-opt-in per field (never inferred from mud weight).
+# Big Foot: no public equipment-rating basis -> false (see #805 honesty rule).
+hpht_fields:
+  big_foot: false
+
+# revenue_flag values treated as clean (benchmark emits "" when unflagged)
+clean_revenue_flags: [""]
+
+producing_statuses: [producing]
+
+sources:
+  benchmark_csv: reports/lower_tertiary/lt_well_benchmark_lower_tertiary_2010_latest.csv
+  rates_dir: config/analysis/cost_data
+  facts_json: reports/lower_tertiary/lifecycle/_facts.json
+  norms_json: reports/lower_tertiary/lifecycle/_norms.json
+
+display:
+  cost_label: "Construction cost (proxy)"
+  cost_qualifier: "proxy · medium confidence · excl. mob/demob & services"
+  revenue_label: "Revenue to date"
+  coverage_label: "Gross-revenue coverage (indicative)"

--- a/reports/lower_tertiary/lifecycle/wells/big_foot_A001_well.html
+++ b/reports/lower_tertiary/lifecycle/wells/big_foot_A001_well.html
@@ -72,6 +72,8 @@
   .card .big{font-family:var(--mono);font-size:19px;font-weight:700;font-variant-numeric:tabular-nums}
   .card ul{margin:6px 0 0;padding-left:15px} .card li{font-size:12.5px;color:var(--muted);margin-bottom:2px}
   .foot{border-top:1px solid var(--line);padding:16px clamp(18px,2.4vw,30px);display:flex;flex-wrap:wrap;gap:6px 18px;justify-content:space-between;font-size:11px;color:var(--muted);font-family:var(--mono)}
+  .econ-note{font-size:11px;line-height:1.5;color:#5a6b7b;margin:10px 2px 0;max-width:900px}
+  @media (prefers-color-scheme:dark){.econ-note{color:#8fa3b5}}
 </style>
 
 <div class="wrap"><div class="sheet">
@@ -92,6 +94,11 @@
     <section><p class="lane-label">Well construction · rig-day scale</p><div class="scrollx"><div class="tl" id="tlc"></div></div></section>
     <section><p class="lane-label">Production life · calendar years</p><div class="scrollx"><div class="tl" id="tlp"></div></div></section>
     <section><p class="lane-label">Stage detail</p><div class="cards" id="cards"></div></section>
+    <section id="econ-section" hidden>
+      <p class="lane-label">Economics (proxy) · rig-days × day-rate vs gross revenue</p>
+      <div class="cards" id="econ"></div>
+      <p class="econ-note" id="econ-note"></p>
+    </section>
   </div>
   <footer class="foot">
     <span>Data: BSEE WAR (spud/complete/workover milestones) + V30 drilling workbook (native rig-days, TD, mud wt) + OGOR-A (first oil, cum, uptime). Draft tracer — refs #758/#754.</span>
@@ -313,7 +320,61 @@ const WELL = {
         "no P&A"
       ]
     }
-  ]
+  ],
+  "economics": {
+    "schema_version": "1.0",
+    "drill_cost_mm_usd": 47.88,
+    "completion_cost_mm_usd": 37.1,
+    "construction_cost_mm_usd": 84.98,
+    "rate_cells": [
+      {
+        "activity": "drilling",
+        "band": "deep",
+        "year_requested": 2012,
+        "year_used": 2020,
+        "usd_per_day": 380000.0,
+        "rate_status": "clamped",
+        "vintage_fallback": "spud_year",
+        "hpht_applied": false
+      },
+      {
+        "activity": "completion",
+        "band": "deep",
+        "year_requested": 2018,
+        "year_used": 2020,
+        "usd_per_day": 140000.0,
+        "rate_status": "clamped",
+        "vintage_fallback": "first_oil_year",
+        "hpht_applied": false
+      }
+    ],
+    "revenue_mm_usd": 910.3,
+    "revenue_flag": "",
+    "revenue_source": "gross · BSEE monthly production × EIA WTI monthly (benchmark)",
+    "coverage_ratio": 10.7,
+    "coverage_status": "degraded",
+    "coverage_reason": "clamped-rate proxy (vintage outside rate DB range)",
+    "status": "producing",
+    "notes": [
+      "Nominal-USD proxy: day rates are nominal per-vintage-year; revenue is nominal realized; the coverage ratio mixes vintages and excludes royalty (~18.75%), working interest, services, mob/demob, opex, facilities, P&A and discounting — an indicative upper bound only."
+    ],
+    "field_id": "big_foot",
+    "norms": {
+      "state": "ok",
+      "field_median": 36.5,
+      "field_n": 24,
+      "well_vs_field_pct": 245.2,
+      "play_median": 47.0,
+      "play_n": 160,
+      "well_vs_play_pct": 168.1
+    },
+    "display": {
+      "cost_label": "Construction cost (proxy)",
+      "cost_qualifier": "proxy · medium confidence · excl. mob/demob & services",
+      "revenue_label": "Revenue to date",
+      "coverage_label": "Gross-revenue coverage (indicative)"
+    }
+  }
 };
 const $=id=>document.getElementById(id);
 document.title = WELL.title + " — Well Life-Cycle";
@@ -342,4 +403,51 @@ function renderTL(el,axis,gates,spans){
 renderTL($("tlc"),WELL.cAxis,WELL.cGates,WELL.cSpans);
 renderTL($("tlp"),WELL.pAxis,WELL.pGates,WELL.pSpans);
 $("cards").innerHTML=WELL.cards.map(c=>`<div class="card${c.cur?' cur':''}"><h4>${c.t}</h4><div class="big">${c.big}</div><ul>${c.li.map(x=>`<li>${x}</li>`).join("")}</ul></div>`).join("");
+
+/* economics card (issue #849) — proxy cost, benchmark revenue verbatim,
+   coverage per the honest-state matrix; degraded states shown, never filled */
+if (WELL.economics) {
+  const E = WELL.economics, D = E.display || {};
+  const cell = (t, big, li) =>
+    `<div class="card"><h4>${t}</h4><div class="big">${big}</div><ul>${li.map(x=>`<li>${x}</li>`).join("")}</ul></div>`;
+  const cards = [];
+  if (E.construction_cost_mm_usd != null) {
+    const rc = E.rate_cells.map(c =>
+      `${c.activity} ${c.year_used} · $${(c.usd_per_day/1000).toFixed(0)}k/d (${c.band}${c.rate_status==="clamped"?" · clamped":""}${c.hpht_applied?" · HPHT":""})`);
+    cards.push(cell(D.cost_label || "Construction cost (proxy)",
+      `$${E.construction_cost_mm_usd} MM`,
+      rc.concat([D.cost_qualifier || "proxy"])));
+  } else {
+    cards.push(cell(D.cost_label || "Construction cost (proxy)", "—", ["insufficient day data"]));
+  }
+  if (E.revenue_mm_usd != null) {
+    cards.push(cell(D.revenue_label || "Revenue to date",
+      `$${E.revenue_mm_usd} MM`,
+      [E.revenue_source].concat(E.revenue_flag ? [`flag: ${E.revenue_flag}`] : [])));
+  } else {
+    cards.push(cell(D.revenue_label || "Revenue to date", "—", ["no benchmark revenue row"]));
+  }
+  if (E.coverage_status === "suppressed") {
+    cards.push(cell(D.coverage_label || "Coverage", "—", [E.coverage_reason || "not meaningful"]));
+  } else {
+    const q = E.coverage_status === "degraded" ? ` <small>(${E.coverage_reason})</small>` : "";
+    cards.push(cell(D.coverage_label || "Gross-revenue coverage (indicative)",
+      `${E.coverage_ratio}×${q}`, ["upper bound — see note below"]));
+  }
+  const N = E.norms || {};
+  if (N.state === "ok") {
+    const li = [`field median ${N.field_median} d (n=${N.field_n})`];
+    if (N.well_vs_field_pct != null) li.push(`this well ${N.well_vs_field_pct>0?"+":""}${N.well_vs_field_pct}% vs field`);
+    if (N.play_median != null) {
+      li.push(`play median ${N.play_median} d (n=${N.play_n})`);
+      if (N.well_vs_play_pct != null) li.push(`this well ${N.well_vs_play_pct>0?"+":""}${N.well_vs_play_pct}% vs play`);
+    }
+    cards.push(cell("Drill days vs norm", "→", li.concat([`<a href="../norms/drill.html#${WELL.economics.field_id||""}">stage distribution →</a>`])));
+  } else {
+    cards.push(cell("Drill days vs norm", "—", ["norms pending (#848)"]));
+  }
+  $("econ").innerHTML = cards.join("");
+  $("econ-note").textContent = (E.notes && E.notes[0]) || "";
+  $("econ-section").hidden = false;
+}
 </script>

--- a/reports/lower_tertiary/lifecycle/wells/big_foot_A002_well.html
+++ b/reports/lower_tertiary/lifecycle/wells/big_foot_A002_well.html
@@ -72,6 +72,8 @@
   .card .big{font-family:var(--mono);font-size:19px;font-weight:700;font-variant-numeric:tabular-nums}
   .card ul{margin:6px 0 0;padding-left:15px} .card li{font-size:12.5px;color:var(--muted);margin-bottom:2px}
   .foot{border-top:1px solid var(--line);padding:16px clamp(18px,2.4vw,30px);display:flex;flex-wrap:wrap;gap:6px 18px;justify-content:space-between;font-size:11px;color:var(--muted);font-family:var(--mono)}
+  .econ-note{font-size:11px;line-height:1.5;color:#5a6b7b;margin:10px 2px 0;max-width:900px}
+  @media (prefers-color-scheme:dark){.econ-note{color:#8fa3b5}}
 </style>
 
 <div class="wrap"><div class="sheet">
@@ -92,6 +94,11 @@
     <section><p class="lane-label">Well construction · rig-day scale</p><div class="scrollx"><div class="tl" id="tlc"></div></div></section>
     <section><p class="lane-label">Production life · calendar years</p><div class="scrollx"><div class="tl" id="tlp"></div></div></section>
     <section><p class="lane-label">Stage detail</p><div class="cards" id="cards"></div></section>
+    <section id="econ-section" hidden>
+      <p class="lane-label">Economics (proxy) · rig-days × day-rate vs gross revenue</p>
+      <div class="cards" id="econ"></div>
+      <p class="econ-note" id="econ-note"></p>
+    </section>
   </div>
   <footer class="foot">
     <span>Data: BSEE WAR (spud/complete/workover milestones) + V30 drilling workbook (native rig-days, TD, mud wt) + OGOR-A (first oil, cum, uptime). Draft tracer — refs #758/#754.</span>
@@ -307,7 +314,61 @@ const WELL = {
         "no P&A"
       ]
     }
-  ]
+  ],
+  "economics": {
+    "schema_version": "1.0",
+    "drill_cost_mm_usd": 7.02,
+    "completion_cost_mm_usd": 40.32,
+    "construction_cost_mm_usd": 47.34,
+    "rate_cells": [
+      {
+        "activity": "drilling",
+        "band": "deep",
+        "year_requested": 2024,
+        "year_used": 2024,
+        "usd_per_day": 540000.0,
+        "rate_status": "exact",
+        "vintage_fallback": "spud_year",
+        "hpht_applied": false
+      },
+      {
+        "activity": "completion",
+        "band": "deep",
+        "year_requested": 2025,
+        "year_used": 2025,
+        "usd_per_day": 240000.0,
+        "rate_status": "exact",
+        "vintage_fallback": "first_oil_year",
+        "hpht_applied": false
+      }
+    ],
+    "revenue_mm_usd": 103.4,
+    "revenue_flag": "",
+    "revenue_source": "gross · BSEE monthly production × EIA WTI monthly (benchmark)",
+    "coverage_ratio": 2.2,
+    "coverage_status": "indicative",
+    "coverage_reason": null,
+    "status": "producing",
+    "notes": [
+      "Nominal-USD proxy: day rates are nominal per-vintage-year; revenue is nominal realized; the coverage ratio mixes vintages and excludes royalty (~18.75%), working interest, services, mob/demob, opex, facilities, P&A and discounting — an indicative upper bound only."
+    ],
+    "field_id": "big_foot",
+    "norms": {
+      "state": "ok",
+      "field_median": 36.5,
+      "field_n": 24,
+      "well_vs_field_pct": -64.4,
+      "play_median": 47.0,
+      "play_n": 160,
+      "well_vs_play_pct": -72.3
+    },
+    "display": {
+      "cost_label": "Construction cost (proxy)",
+      "cost_qualifier": "proxy · medium confidence · excl. mob/demob & services",
+      "revenue_label": "Revenue to date",
+      "coverage_label": "Gross-revenue coverage (indicative)"
+    }
+  }
 };
 const $=id=>document.getElementById(id);
 document.title = WELL.title + " — Well Life-Cycle";
@@ -336,4 +397,51 @@ function renderTL(el,axis,gates,spans){
 renderTL($("tlc"),WELL.cAxis,WELL.cGates,WELL.cSpans);
 renderTL($("tlp"),WELL.pAxis,WELL.pGates,WELL.pSpans);
 $("cards").innerHTML=WELL.cards.map(c=>`<div class="card${c.cur?' cur':''}"><h4>${c.t}</h4><div class="big">${c.big}</div><ul>${c.li.map(x=>`<li>${x}</li>`).join("")}</ul></div>`).join("");
+
+/* economics card (issue #849) — proxy cost, benchmark revenue verbatim,
+   coverage per the honest-state matrix; degraded states shown, never filled */
+if (WELL.economics) {
+  const E = WELL.economics, D = E.display || {};
+  const cell = (t, big, li) =>
+    `<div class="card"><h4>${t}</h4><div class="big">${big}</div><ul>${li.map(x=>`<li>${x}</li>`).join("")}</ul></div>`;
+  const cards = [];
+  if (E.construction_cost_mm_usd != null) {
+    const rc = E.rate_cells.map(c =>
+      `${c.activity} ${c.year_used} · $${(c.usd_per_day/1000).toFixed(0)}k/d (${c.band}${c.rate_status==="clamped"?" · clamped":""}${c.hpht_applied?" · HPHT":""})`);
+    cards.push(cell(D.cost_label || "Construction cost (proxy)",
+      `$${E.construction_cost_mm_usd} MM`,
+      rc.concat([D.cost_qualifier || "proxy"])));
+  } else {
+    cards.push(cell(D.cost_label || "Construction cost (proxy)", "—", ["insufficient day data"]));
+  }
+  if (E.revenue_mm_usd != null) {
+    cards.push(cell(D.revenue_label || "Revenue to date",
+      `$${E.revenue_mm_usd} MM`,
+      [E.revenue_source].concat(E.revenue_flag ? [`flag: ${E.revenue_flag}`] : [])));
+  } else {
+    cards.push(cell(D.revenue_label || "Revenue to date", "—", ["no benchmark revenue row"]));
+  }
+  if (E.coverage_status === "suppressed") {
+    cards.push(cell(D.coverage_label || "Coverage", "—", [E.coverage_reason || "not meaningful"]));
+  } else {
+    const q = E.coverage_status === "degraded" ? ` <small>(${E.coverage_reason})</small>` : "";
+    cards.push(cell(D.coverage_label || "Gross-revenue coverage (indicative)",
+      `${E.coverage_ratio}×${q}`, ["upper bound — see note below"]));
+  }
+  const N = E.norms || {};
+  if (N.state === "ok") {
+    const li = [`field median ${N.field_median} d (n=${N.field_n})`];
+    if (N.well_vs_field_pct != null) li.push(`this well ${N.well_vs_field_pct>0?"+":""}${N.well_vs_field_pct}% vs field`);
+    if (N.play_median != null) {
+      li.push(`play median ${N.play_median} d (n=${N.play_n})`);
+      if (N.well_vs_play_pct != null) li.push(`this well ${N.well_vs_play_pct>0?"+":""}${N.well_vs_play_pct}% vs play`);
+    }
+    cards.push(cell("Drill days vs norm", "→", li.concat([`<a href="../norms/drill.html#${WELL.economics.field_id||""}">stage distribution →</a>`])));
+  } else {
+    cards.push(cell("Drill days vs norm", "—", ["norms pending (#848)"]));
+  }
+  $("econ").innerHTML = cards.join("");
+  $("econ-note").textContent = (E.notes && E.notes[0]) || "";
+  $("econ-section").hidden = false;
+}
 </script>

--- a/reports/lower_tertiary/lifecycle/wells/big_foot_A004_well.html
+++ b/reports/lower_tertiary/lifecycle/wells/big_foot_A004_well.html
@@ -72,6 +72,8 @@
   .card .big{font-family:var(--mono);font-size:19px;font-weight:700;font-variant-numeric:tabular-nums}
   .card ul{margin:6px 0 0;padding-left:15px} .card li{font-size:12.5px;color:var(--muted);margin-bottom:2px}
   .foot{border-top:1px solid var(--line);padding:16px clamp(18px,2.4vw,30px);display:flex;flex-wrap:wrap;gap:6px 18px;justify-content:space-between;font-size:11px;color:var(--muted);font-family:var(--mono)}
+  .econ-note{font-size:11px;line-height:1.5;color:#5a6b7b;margin:10px 2px 0;max-width:900px}
+  @media (prefers-color-scheme:dark){.econ-note{color:#8fa3b5}}
 </style>
 
 <div class="wrap"><div class="sheet">
@@ -92,6 +94,11 @@
     <section><p class="lane-label">Well construction · rig-day scale</p><div class="scrollx"><div class="tl" id="tlc"></div></div></section>
     <section><p class="lane-label">Production life · calendar years</p><div class="scrollx"><div class="tl" id="tlp"></div></div></section>
     <section><p class="lane-label">Stage detail</p><div class="cards" id="cards"></div></section>
+    <section id="econ-section" hidden>
+      <p class="lane-label">Economics (proxy) · rig-days × day-rate vs gross revenue</p>
+      <div class="cards" id="econ"></div>
+      <p class="econ-note" id="econ-note"></p>
+    </section>
   </div>
   <footer class="foot">
     <span>Data: BSEE WAR (spud/complete/workover milestones) + V30 drilling workbook (native rig-days, TD, mud wt) + OGOR-A (first oil, cum, uptime). Draft tracer — refs #758/#754.</span>
@@ -278,8 +285,7 @@ const WELL = {
       "li": [
         "TD 22,253 ft",
         "16.4 ppg mud",
-        "spud Mar 2019",
-        "<a href=\"../../drilling-insights.html\">GoM LT drilling learning curve &rarr;</a>"
+        "spud Mar 2019"
       ]
     },
     {
@@ -303,8 +309,7 @@ const WELL = {
       "t": "Workover",
       "big": "1 event",
       "li": [
-        "Aug 2020 · Workover",
-        "<a href=\"../../intervention-db/intervention-stats-brief.html\">Intervention serviceability &amp; access gap &rarr;</a>"
+        "Aug 2020 · Workover"
       ]
     },
     {
@@ -312,11 +317,64 @@ const WELL = {
       "big": "—",
       "li": [
         "still producing",
-        "no P&A",
-        "<a href=\"../../decommissioning/pa-liability-wave.html\">GoM P&amp;A liability wave &rarr;</a>"
+        "no P&A"
       ]
     }
-  ]
+  ],
+  "economics": {
+    "schema_version": "1.0",
+    "drill_cost_mm_usd": 5.7,
+    "completion_cost_mm_usd": 21.84,
+    "construction_cost_mm_usd": 27.54,
+    "rate_cells": [
+      {
+        "activity": "drilling",
+        "band": "deep",
+        "year_requested": 2019,
+        "year_used": 2020,
+        "usd_per_day": 380000.0,
+        "rate_status": "clamped",
+        "vintage_fallback": "spud_year",
+        "hpht_applied": false
+      },
+      {
+        "activity": "completion",
+        "band": "deep",
+        "year_requested": 2019,
+        "year_used": 2020,
+        "usd_per_day": 140000.0,
+        "rate_status": "clamped",
+        "vintage_fallback": "first_oil_year",
+        "hpht_applied": false
+      }
+    ],
+    "revenue_mm_usd": 2324.5,
+    "revenue_flag": "",
+    "revenue_source": "gross · BSEE monthly production × EIA WTI monthly (benchmark)",
+    "coverage_ratio": 84.4,
+    "coverage_status": "degraded",
+    "coverage_reason": "clamped-rate proxy (vintage outside rate DB range)",
+    "status": "producing",
+    "notes": [
+      "Nominal-USD proxy: day rates are nominal per-vintage-year; revenue is nominal realized; the coverage ratio mixes vintages and excludes royalty (~18.75%), working interest, services, mob/demob, opex, facilities, P&A and discounting — an indicative upper bound only."
+    ],
+    "field_id": "big_foot",
+    "norms": {
+      "state": "ok",
+      "field_median": 36.5,
+      "field_n": 24,
+      "well_vs_field_pct": -58.9,
+      "play_median": 47.0,
+      "play_n": 160,
+      "well_vs_play_pct": -68.1
+    },
+    "display": {
+      "cost_label": "Construction cost (proxy)",
+      "cost_qualifier": "proxy · medium confidence · excl. mob/demob & services",
+      "revenue_label": "Revenue to date",
+      "coverage_label": "Gross-revenue coverage (indicative)"
+    }
+  }
 };
 const $=id=>document.getElementById(id);
 document.title = WELL.title + " — Well Life-Cycle";
@@ -345,4 +403,51 @@ function renderTL(el,axis,gates,spans){
 renderTL($("tlc"),WELL.cAxis,WELL.cGates,WELL.cSpans);
 renderTL($("tlp"),WELL.pAxis,WELL.pGates,WELL.pSpans);
 $("cards").innerHTML=WELL.cards.map(c=>`<div class="card${c.cur?' cur':''}"><h4>${c.t}</h4><div class="big">${c.big}</div><ul>${c.li.map(x=>`<li>${x}</li>`).join("")}</ul></div>`).join("");
+
+/* economics card (issue #849) — proxy cost, benchmark revenue verbatim,
+   coverage per the honest-state matrix; degraded states shown, never filled */
+if (WELL.economics) {
+  const E = WELL.economics, D = E.display || {};
+  const cell = (t, big, li) =>
+    `<div class="card"><h4>${t}</h4><div class="big">${big}</div><ul>${li.map(x=>`<li>${x}</li>`).join("")}</ul></div>`;
+  const cards = [];
+  if (E.construction_cost_mm_usd != null) {
+    const rc = E.rate_cells.map(c =>
+      `${c.activity} ${c.year_used} · $${(c.usd_per_day/1000).toFixed(0)}k/d (${c.band}${c.rate_status==="clamped"?" · clamped":""}${c.hpht_applied?" · HPHT":""})`);
+    cards.push(cell(D.cost_label || "Construction cost (proxy)",
+      `$${E.construction_cost_mm_usd} MM`,
+      rc.concat([D.cost_qualifier || "proxy"])));
+  } else {
+    cards.push(cell(D.cost_label || "Construction cost (proxy)", "—", ["insufficient day data"]));
+  }
+  if (E.revenue_mm_usd != null) {
+    cards.push(cell(D.revenue_label || "Revenue to date",
+      `$${E.revenue_mm_usd} MM`,
+      [E.revenue_source].concat(E.revenue_flag ? [`flag: ${E.revenue_flag}`] : [])));
+  } else {
+    cards.push(cell(D.revenue_label || "Revenue to date", "—", ["no benchmark revenue row"]));
+  }
+  if (E.coverage_status === "suppressed") {
+    cards.push(cell(D.coverage_label || "Coverage", "—", [E.coverage_reason || "not meaningful"]));
+  } else {
+    const q = E.coverage_status === "degraded" ? ` <small>(${E.coverage_reason})</small>` : "";
+    cards.push(cell(D.coverage_label || "Gross-revenue coverage (indicative)",
+      `${E.coverage_ratio}×${q}`, ["upper bound — see note below"]));
+  }
+  const N = E.norms || {};
+  if (N.state === "ok") {
+    const li = [`field median ${N.field_median} d (n=${N.field_n})`];
+    if (N.well_vs_field_pct != null) li.push(`this well ${N.well_vs_field_pct>0?"+":""}${N.well_vs_field_pct}% vs field`);
+    if (N.play_median != null) {
+      li.push(`play median ${N.play_median} d (n=${N.play_n})`);
+      if (N.well_vs_play_pct != null) li.push(`this well ${N.well_vs_play_pct>0?"+":""}${N.well_vs_play_pct}% vs play`);
+    }
+    cards.push(cell("Drill days vs norm", "→", li.concat([`<a href="../norms/drill.html#${WELL.economics.field_id||""}">stage distribution →</a>`])));
+  } else {
+    cards.push(cell("Drill days vs norm", "—", ["norms pending (#848)"]));
+  }
+  $("econ").innerHTML = cards.join("");
+  $("econ-note").textContent = (E.notes && E.notes[0]) || "";
+  $("econ-section").hidden = false;
+}
 </script>

--- a/reports/lower_tertiary/lifecycle/wells/big_foot_A006_well.html
+++ b/reports/lower_tertiary/lifecycle/wells/big_foot_A006_well.html
@@ -72,6 +72,8 @@
   .card .big{font-family:var(--mono);font-size:19px;font-weight:700;font-variant-numeric:tabular-nums}
   .card ul{margin:6px 0 0;padding-left:15px} .card li{font-size:12.5px;color:var(--muted);margin-bottom:2px}
   .foot{border-top:1px solid var(--line);padding:16px clamp(18px,2.4vw,30px);display:flex;flex-wrap:wrap;gap:6px 18px;justify-content:space-between;font-size:11px;color:var(--muted);font-family:var(--mono)}
+  .econ-note{font-size:11px;line-height:1.5;color:#5a6b7b;margin:10px 2px 0;max-width:900px}
+  @media (prefers-color-scheme:dark){.econ-note{color:#8fa3b5}}
 </style>
 
 <div class="wrap"><div class="sheet">
@@ -92,6 +94,11 @@
     <section><p class="lane-label">Well construction · rig-day scale</p><div class="scrollx"><div class="tl" id="tlc"></div></div></section>
     <section><p class="lane-label">Production life · calendar years</p><div class="scrollx"><div class="tl" id="tlp"></div></div></section>
     <section><p class="lane-label">Stage detail</p><div class="cards" id="cards"></div></section>
+    <section id="econ-section" hidden>
+      <p class="lane-label">Economics (proxy) · rig-days × day-rate vs gross revenue</p>
+      <div class="cards" id="econ"></div>
+      <p class="econ-note" id="econ-note"></p>
+    </section>
   </div>
   <footer class="foot">
     <span>Data: BSEE WAR (spud/complete/workover milestones) + V30 drilling workbook (native rig-days, TD, mud wt) + OGOR-A (first oil, cum, uptime). Draft tracer — refs #758/#754.</span>
@@ -317,7 +324,61 @@ const WELL = {
         "no P&A"
       ]
     }
-  ]
+  ],
+  "economics": {
+    "schema_version": "1.0",
+    "drill_cost_mm_usd": 6.84,
+    "completion_cost_mm_usd": 31.36,
+    "construction_cost_mm_usd": 38.2,
+    "rate_cells": [
+      {
+        "activity": "drilling",
+        "band": "deep",
+        "year_requested": 2020,
+        "year_used": 2020,
+        "usd_per_day": 380000.0,
+        "rate_status": "exact",
+        "vintage_fallback": "spud_year",
+        "hpht_applied": false
+      },
+      {
+        "activity": "completion",
+        "band": "deep",
+        "year_requested": 2020,
+        "year_used": 2020,
+        "usd_per_day": 140000.0,
+        "rate_status": "exact",
+        "vintage_fallback": "first_oil_year",
+        "hpht_applied": false
+      }
+    ],
+    "revenue_mm_usd": 1576.2,
+    "revenue_flag": "",
+    "revenue_source": "gross · BSEE monthly production × EIA WTI monthly (benchmark)",
+    "coverage_ratio": 41.3,
+    "coverage_status": "indicative",
+    "coverage_reason": null,
+    "status": "producing",
+    "notes": [
+      "Nominal-USD proxy: day rates are nominal per-vintage-year; revenue is nominal realized; the coverage ratio mixes vintages and excludes royalty (~18.75%), working interest, services, mob/demob, opex, facilities, P&A and discounting — an indicative upper bound only."
+    ],
+    "field_id": "big_foot",
+    "norms": {
+      "state": "ok",
+      "field_median": 36.5,
+      "field_n": 24,
+      "well_vs_field_pct": -50.7,
+      "play_median": 47.0,
+      "play_n": 160,
+      "well_vs_play_pct": -61.7
+    },
+    "display": {
+      "cost_label": "Construction cost (proxy)",
+      "cost_qualifier": "proxy · medium confidence · excl. mob/demob & services",
+      "revenue_label": "Revenue to date",
+      "coverage_label": "Gross-revenue coverage (indicative)"
+    }
+  }
 };
 const $=id=>document.getElementById(id);
 document.title = WELL.title + " — Well Life-Cycle";
@@ -346,4 +407,51 @@ function renderTL(el,axis,gates,spans){
 renderTL($("tlc"),WELL.cAxis,WELL.cGates,WELL.cSpans);
 renderTL($("tlp"),WELL.pAxis,WELL.pGates,WELL.pSpans);
 $("cards").innerHTML=WELL.cards.map(c=>`<div class="card${c.cur?' cur':''}"><h4>${c.t}</h4><div class="big">${c.big}</div><ul>${c.li.map(x=>`<li>${x}</li>`).join("")}</ul></div>`).join("");
+
+/* economics card (issue #849) — proxy cost, benchmark revenue verbatim,
+   coverage per the honest-state matrix; degraded states shown, never filled */
+if (WELL.economics) {
+  const E = WELL.economics, D = E.display || {};
+  const cell = (t, big, li) =>
+    `<div class="card"><h4>${t}</h4><div class="big">${big}</div><ul>${li.map(x=>`<li>${x}</li>`).join("")}</ul></div>`;
+  const cards = [];
+  if (E.construction_cost_mm_usd != null) {
+    const rc = E.rate_cells.map(c =>
+      `${c.activity} ${c.year_used} · $${(c.usd_per_day/1000).toFixed(0)}k/d (${c.band}${c.rate_status==="clamped"?" · clamped":""}${c.hpht_applied?" · HPHT":""})`);
+    cards.push(cell(D.cost_label || "Construction cost (proxy)",
+      `$${E.construction_cost_mm_usd} MM`,
+      rc.concat([D.cost_qualifier || "proxy"])));
+  } else {
+    cards.push(cell(D.cost_label || "Construction cost (proxy)", "—", ["insufficient day data"]));
+  }
+  if (E.revenue_mm_usd != null) {
+    cards.push(cell(D.revenue_label || "Revenue to date",
+      `$${E.revenue_mm_usd} MM`,
+      [E.revenue_source].concat(E.revenue_flag ? [`flag: ${E.revenue_flag}`] : [])));
+  } else {
+    cards.push(cell(D.revenue_label || "Revenue to date", "—", ["no benchmark revenue row"]));
+  }
+  if (E.coverage_status === "suppressed") {
+    cards.push(cell(D.coverage_label || "Coverage", "—", [E.coverage_reason || "not meaningful"]));
+  } else {
+    const q = E.coverage_status === "degraded" ? ` <small>(${E.coverage_reason})</small>` : "";
+    cards.push(cell(D.coverage_label || "Gross-revenue coverage (indicative)",
+      `${E.coverage_ratio}×${q}`, ["upper bound — see note below"]));
+  }
+  const N = E.norms || {};
+  if (N.state === "ok") {
+    const li = [`field median ${N.field_median} d (n=${N.field_n})`];
+    if (N.well_vs_field_pct != null) li.push(`this well ${N.well_vs_field_pct>0?"+":""}${N.well_vs_field_pct}% vs field`);
+    if (N.play_median != null) {
+      li.push(`play median ${N.play_median} d (n=${N.play_n})`);
+      if (N.well_vs_play_pct != null) li.push(`this well ${N.well_vs_play_pct>0?"+":""}${N.well_vs_play_pct}% vs play`);
+    }
+    cards.push(cell("Drill days vs norm", "→", li.concat([`<a href="../norms/drill.html#${WELL.economics.field_id||""}">stage distribution →</a>`])));
+  } else {
+    cards.push(cell("Drill days vs norm", "—", ["norms pending (#848)"]));
+  }
+  $("econ").innerHTML = cards.join("");
+  $("econ-note").textContent = (E.notes && E.notes[0]) || "";
+  $("econ-section").hidden = false;
+}
 </script>

--- a/reports/lower_tertiary/lifecycle/wells/big_foot_A008_well.html
+++ b/reports/lower_tertiary/lifecycle/wells/big_foot_A008_well.html
@@ -72,6 +72,8 @@
   .card .big{font-family:var(--mono);font-size:19px;font-weight:700;font-variant-numeric:tabular-nums}
   .card ul{margin:6px 0 0;padding-left:15px} .card li{font-size:12.5px;color:var(--muted);margin-bottom:2px}
   .foot{border-top:1px solid var(--line);padding:16px clamp(18px,2.4vw,30px);display:flex;flex-wrap:wrap;gap:6px 18px;justify-content:space-between;font-size:11px;color:var(--muted);font-family:var(--mono)}
+  .econ-note{font-size:11px;line-height:1.5;color:#5a6b7b;margin:10px 2px 0;max-width:900px}
+  @media (prefers-color-scheme:dark){.econ-note{color:#8fa3b5}}
 </style>
 
 <div class="wrap"><div class="sheet">
@@ -92,6 +94,11 @@
     <section><p class="lane-label">Well construction · rig-day scale</p><div class="scrollx"><div class="tl" id="tlc"></div></div></section>
     <section><p class="lane-label">Production life · calendar years</p><div class="scrollx"><div class="tl" id="tlp"></div></div></section>
     <section><p class="lane-label">Stage detail</p><div class="cards" id="cards"></div></section>
+    <section id="econ-section" hidden>
+      <p class="lane-label">Economics (proxy) · rig-days × day-rate vs gross revenue</p>
+      <div class="cards" id="econ"></div>
+      <p class="econ-note" id="econ-note"></p>
+    </section>
   </div>
   <footer class="foot">
     <span>Data: BSEE WAR (spud/complete/workover milestones) + V30 drilling workbook (native rig-days, TD, mud wt) + OGOR-A (first oil, cum, uptime). Draft tracer — refs #758/#754.</span>
@@ -313,7 +320,61 @@ const WELL = {
         "no P&A"
       ]
     }
-  ]
+  ],
+  "economics": {
+    "schema_version": "1.0",
+    "drill_cost_mm_usd": 44.84,
+    "completion_cost_mm_usd": 28.7,
+    "construction_cost_mm_usd": 73.54,
+    "rate_cells": [
+      {
+        "activity": "drilling",
+        "band": "deep",
+        "year_requested": 2013,
+        "year_used": 2020,
+        "usd_per_day": 380000.0,
+        "rate_status": "clamped",
+        "vintage_fallback": "spud_year",
+        "hpht_applied": false
+      },
+      {
+        "activity": "completion",
+        "band": "deep",
+        "year_requested": 2022,
+        "year_used": 2022,
+        "usd_per_day": 175000.0,
+        "rate_status": "exact",
+        "vintage_fallback": "first_oil_year",
+        "hpht_applied": false
+      }
+    ],
+    "revenue_mm_usd": 359.1,
+    "revenue_flag": "",
+    "revenue_source": "gross · BSEE monthly production × EIA WTI monthly (benchmark)",
+    "coverage_ratio": 4.9,
+    "coverage_status": "degraded",
+    "coverage_reason": "clamped-rate proxy (vintage outside rate DB range)",
+    "status": "producing",
+    "notes": [
+      "Nominal-USD proxy: day rates are nominal per-vintage-year; revenue is nominal realized; the coverage ratio mixes vintages and excludes royalty (~18.75%), working interest, services, mob/demob, opex, facilities, P&A and discounting — an indicative upper bound only."
+    ],
+    "field_id": "big_foot",
+    "norms": {
+      "state": "ok",
+      "field_median": 36.5,
+      "field_n": 24,
+      "well_vs_field_pct": 223.3,
+      "play_median": 47.0,
+      "play_n": 160,
+      "well_vs_play_pct": 151.1
+    },
+    "display": {
+      "cost_label": "Construction cost (proxy)",
+      "cost_qualifier": "proxy · medium confidence · excl. mob/demob & services",
+      "revenue_label": "Revenue to date",
+      "coverage_label": "Gross-revenue coverage (indicative)"
+    }
+  }
 };
 const $=id=>document.getElementById(id);
 document.title = WELL.title + " — Well Life-Cycle";
@@ -342,4 +403,51 @@ function renderTL(el,axis,gates,spans){
 renderTL($("tlc"),WELL.cAxis,WELL.cGates,WELL.cSpans);
 renderTL($("tlp"),WELL.pAxis,WELL.pGates,WELL.pSpans);
 $("cards").innerHTML=WELL.cards.map(c=>`<div class="card${c.cur?' cur':''}"><h4>${c.t}</h4><div class="big">${c.big}</div><ul>${c.li.map(x=>`<li>${x}</li>`).join("")}</ul></div>`).join("");
+
+/* economics card (issue #849) — proxy cost, benchmark revenue verbatim,
+   coverage per the honest-state matrix; degraded states shown, never filled */
+if (WELL.economics) {
+  const E = WELL.economics, D = E.display || {};
+  const cell = (t, big, li) =>
+    `<div class="card"><h4>${t}</h4><div class="big">${big}</div><ul>${li.map(x=>`<li>${x}</li>`).join("")}</ul></div>`;
+  const cards = [];
+  if (E.construction_cost_mm_usd != null) {
+    const rc = E.rate_cells.map(c =>
+      `${c.activity} ${c.year_used} · $${(c.usd_per_day/1000).toFixed(0)}k/d (${c.band}${c.rate_status==="clamped"?" · clamped":""}${c.hpht_applied?" · HPHT":""})`);
+    cards.push(cell(D.cost_label || "Construction cost (proxy)",
+      `$${E.construction_cost_mm_usd} MM`,
+      rc.concat([D.cost_qualifier || "proxy"])));
+  } else {
+    cards.push(cell(D.cost_label || "Construction cost (proxy)", "—", ["insufficient day data"]));
+  }
+  if (E.revenue_mm_usd != null) {
+    cards.push(cell(D.revenue_label || "Revenue to date",
+      `$${E.revenue_mm_usd} MM`,
+      [E.revenue_source].concat(E.revenue_flag ? [`flag: ${E.revenue_flag}`] : [])));
+  } else {
+    cards.push(cell(D.revenue_label || "Revenue to date", "—", ["no benchmark revenue row"]));
+  }
+  if (E.coverage_status === "suppressed") {
+    cards.push(cell(D.coverage_label || "Coverage", "—", [E.coverage_reason || "not meaningful"]));
+  } else {
+    const q = E.coverage_status === "degraded" ? ` <small>(${E.coverage_reason})</small>` : "";
+    cards.push(cell(D.coverage_label || "Gross-revenue coverage (indicative)",
+      `${E.coverage_ratio}×${q}`, ["upper bound — see note below"]));
+  }
+  const N = E.norms || {};
+  if (N.state === "ok") {
+    const li = [`field median ${N.field_median} d (n=${N.field_n})`];
+    if (N.well_vs_field_pct != null) li.push(`this well ${N.well_vs_field_pct>0?"+":""}${N.well_vs_field_pct}% vs field`);
+    if (N.play_median != null) {
+      li.push(`play median ${N.play_median} d (n=${N.play_n})`);
+      if (N.well_vs_play_pct != null) li.push(`this well ${N.well_vs_play_pct>0?"+":""}${N.well_vs_play_pct}% vs play`);
+    }
+    cards.push(cell("Drill days vs norm", "→", li.concat([`<a href="../norms/drill.html#${WELL.economics.field_id||""}">stage distribution →</a>`])));
+  } else {
+    cards.push(cell("Drill days vs norm", "—", ["norms pending (#848)"]));
+  }
+  $("econ").innerHTML = cards.join("");
+  $("econ-note").textContent = (E.notes && E.notes[0]) || "";
+  $("econ-section").hidden = false;
+}
 </script>

--- a/reports/lower_tertiary/lifecycle/wells/well_lifecycle_template.html
+++ b/reports/lower_tertiary/lifecycle/wells/well_lifecycle_template.html
@@ -72,6 +72,8 @@
   .card .big{font-family:var(--mono);font-size:19px;font-weight:700;font-variant-numeric:tabular-nums}
   .card ul{margin:6px 0 0;padding-left:15px} .card li{font-size:12.5px;color:var(--muted);margin-bottom:2px}
   .foot{border-top:1px solid var(--line);padding:16px clamp(18px,2.4vw,30px);display:flex;flex-wrap:wrap;gap:6px 18px;justify-content:space-between;font-size:11px;color:var(--muted);font-family:var(--mono)}
+  .econ-note{font-size:11px;line-height:1.5;color:#5a6b7b;margin:10px 2px 0;max-width:900px}
+  @media (prefers-color-scheme:dark){.econ-note{color:#8fa3b5}}
 </style>
 
 <div class="wrap"><div class="sheet">
@@ -92,6 +94,11 @@
     <section><p class="lane-label">Well construction · rig-day scale</p><div class="scrollx"><div class="tl" id="tlc"></div></div></section>
     <section><p class="lane-label">Production life · calendar years</p><div class="scrollx"><div class="tl" id="tlp"></div></div></section>
     <section><p class="lane-label">Stage detail</p><div class="cards" id="cards"></div></section>
+    <section id="econ-section" hidden>
+      <p class="lane-label">Economics (proxy) · rig-days × day-rate vs gross revenue</p>
+      <div class="cards" id="econ"></div>
+      <p class="econ-note" id="econ-note"></p>
+    </section>
   </div>
   <footer class="foot">
     <span>Data: BSEE WAR (spud/complete/workover milestones) + V30 drilling workbook (native rig-days, TD, mud wt) + OGOR-A (first oil, cum, uptime). Draft tracer — refs #758/#754.</span>
@@ -128,4 +135,51 @@ function renderTL(el,axis,gates,spans){
 renderTL($("tlc"),WELL.cAxis,WELL.cGates,WELL.cSpans);
 renderTL($("tlp"),WELL.pAxis,WELL.pGates,WELL.pSpans);
 $("cards").innerHTML=WELL.cards.map(c=>`<div class="card${c.cur?' cur':''}"><h4>${c.t}</h4><div class="big">${c.big}</div><ul>${c.li.map(x=>`<li>${x}</li>`).join("")}</ul></div>`).join("");
+
+/* economics card (issue #849) — proxy cost, benchmark revenue verbatim,
+   coverage per the honest-state matrix; degraded states shown, never filled */
+if (WELL.economics) {
+  const E = WELL.economics, D = E.display || {};
+  const cell = (t, big, li) =>
+    `<div class="card"><h4>${t}</h4><div class="big">${big}</div><ul>${li.map(x=>`<li>${x}</li>`).join("")}</ul></div>`;
+  const cards = [];
+  if (E.construction_cost_mm_usd != null) {
+    const rc = E.rate_cells.map(c =>
+      `${c.activity} ${c.year_used} · $${(c.usd_per_day/1000).toFixed(0)}k/d (${c.band}${c.rate_status==="clamped"?" · clamped":""}${c.hpht_applied?" · HPHT":""})`);
+    cards.push(cell(D.cost_label || "Construction cost (proxy)",
+      `$${E.construction_cost_mm_usd} MM`,
+      rc.concat([D.cost_qualifier || "proxy"])));
+  } else {
+    cards.push(cell(D.cost_label || "Construction cost (proxy)", "—", ["insufficient day data"]));
+  }
+  if (E.revenue_mm_usd != null) {
+    cards.push(cell(D.revenue_label || "Revenue to date",
+      `$${E.revenue_mm_usd} MM`,
+      [E.revenue_source].concat(E.revenue_flag ? [`flag: ${E.revenue_flag}`] : [])));
+  } else {
+    cards.push(cell(D.revenue_label || "Revenue to date", "—", ["no benchmark revenue row"]));
+  }
+  if (E.coverage_status === "suppressed") {
+    cards.push(cell(D.coverage_label || "Coverage", "—", [E.coverage_reason || "not meaningful"]));
+  } else {
+    const q = E.coverage_status === "degraded" ? ` <small>(${E.coverage_reason})</small>` : "";
+    cards.push(cell(D.coverage_label || "Gross-revenue coverage (indicative)",
+      `${E.coverage_ratio}×${q}`, ["upper bound — see note below"]));
+  }
+  const N = E.norms || {};
+  if (N.state === "ok") {
+    const li = [`field median ${N.field_median} d (n=${N.field_n})`];
+    if (N.well_vs_field_pct != null) li.push(`this well ${N.well_vs_field_pct>0?"+":""}${N.well_vs_field_pct}% vs field`);
+    if (N.play_median != null) {
+      li.push(`play median ${N.play_median} d (n=${N.play_n})`);
+      if (N.well_vs_play_pct != null) li.push(`this well ${N.well_vs_play_pct>0?"+":""}${N.well_vs_play_pct}% vs play`);
+    }
+    cards.push(cell("Drill days vs norm", "→", li.concat([`<a href="../norms/drill.html#${WELL.economics.field_id||""}">stage distribution →</a>`])));
+  } else {
+    cards.push(cell("Drill days vs norm", "—", ["norms pending (#848)"]));
+  }
+  $("econ").innerHTML = cards.join("");
+  $("econ-note").textContent = (E.notes && E.notes[0]) || "";
+  $("econ-section").hidden = false;
+}
 </script>

--- a/scripts/lower_tertiary/build_well_timelines.py
+++ b/scripts/lower_tertiary/build_well_timelines.py
@@ -20,9 +20,14 @@ Usage
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
-HERE = Path(__file__).resolve().parents[2] / "reports/lower_tertiary/lifecycle/wells"
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "src"))
+sys.path.insert(0, str(REPO / "packages/worldenergydata-bsee/src"))
+
+HERE = REPO / "reports/lower_tertiary/lifecycle/wells"
 TEMPLATE = HERE / "well_lifecycle_template.html"
 FACTS = HERE / "_wells.json"
 GENERATED = "Generated 2026-07-04"
@@ -236,13 +241,50 @@ def build_index(rows: list[dict]) -> str:
 """
 
 
+def _economics_context():
+    """Load the #849 economics substrate once (config, rates, revenue, norms)."""
+    import yaml
+
+    from worldenergydata.bsee.analysis.cost.regional_loader import RegionalCostLoader
+    from worldenergydata.field_development import well_economics as we
+
+    cfg = yaml.safe_load((REPO / "config/well_economics.yml").read_text())
+    src = cfg["sources"]
+    rates_dir = REPO / src["rates_dir"]
+    loader = RegionalCostLoader(config_dir=rates_dir)  # explicit, not parents[7]
+    revenue_map = we.load_revenue_map(REPO / src["benchmark_csv"])
+    field_facts = {
+        f["id"]: f for f in json.loads((REPO / src["facts_json"]).read_text())
+    }
+    norms_path = REPO / src["norms_json"]
+    return we, cfg, loader, rates_dir, revenue_map, field_facts, norms_path
+
+
 def main():
     data = json.loads(FACTS.read_text())
     fields = data["fields"]
+    we, econ_cfg, loader, rates_dir, revenue_map, field_facts, norms_path = (
+        _economics_context()
+    )
     rows = []
     for w in data["wells"]:
         field = fields[w["field_id"]]
         well = facts_to_well(w, field)
+        # --- economics card payload (issue #849) ---
+        ff = field_facts.get(w["field_id"], {})
+        econ = we.compute_well_economics(
+            w,
+            {"id": w["field_id"], "water_depth_ft": ff.get("water_depth_ft")},
+            revenue=revenue_map.get(w["api"]),
+            loader=loader,
+            rates_dir=rates_dir,
+            cfg=econ_cfg,
+        )
+        payload = econ.to_json()
+        payload["field_id"] = w["field_id"]
+        payload["norms"] = we.norms_comparison(w, w["field_id"], norms_path)
+        payload["display"] = econ_cfg["display"]
+        well["economics"] = payload
         fname = f"{w['field_id']}_{w['slot']}_well.html"
         (HERE / fname).write_text(render(well))
         cum = w.get("cum_oil_mmbbl") or 0

--- a/src/worldenergydata/field_development/well_economics.py
+++ b/src/worldenergydata/field_development/well_economics.py
@@ -1,0 +1,359 @@
+# ABOUTME: Per-well economics engine (issue #849) — rig-day proxy construction
+# ABOUTME: cost, benchmark revenue verbatim, coverage matrix with honest states.
+"""Per-well economics for the well life-cycle timeline pages.
+
+Turns observed well quantities into defensible proxy estimates:
+
+- construction cost = rig-days x day-rate (``RegionalCostLoader``, the
+  ``day_rates.yml`` database) — rig-days come SOLELY from the well facts
+  record, never from benchmark calendar spans;
+- revenue = the benchmark's ``est_revenue_mm`` verbatim (gross, BSEE monthly
+  production x EIA WTI monthly) — never recomputed;
+- gross-revenue coverage (indicative, upper bound) — degraded or suppressed
+  per an explicit state matrix; no number is ever fabricated.
+
+All monetary policy lives in ``config/well_economics.yml`` and
+``config/analysis/cost_data/day_rates.yml``; this module holds no rates.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+from worldenergydata.bsee.analysis.cost.models import (
+    ActivityType,
+    WaterDepthBand,
+    classify_water_depth_band,
+)
+
+SCHEMA_VERSION = "1.0"
+FT_TO_M = 0.3048
+
+USD_PER_MM = 1_000_000
+
+
+@dataclass(frozen=True)
+class RateCell:
+    activity: str
+    band: str
+    year_requested: int
+    year_used: int
+    usd_per_day: float
+    rate_status: str  # exact | clamped
+    vintage_fallback: str  # spud_year | first_oil_year | td_year_early_biased
+    hpht_applied: bool
+
+
+@dataclass(frozen=True)
+class WellEconomics:
+    drill_cost_usd: float | None
+    completion_cost_usd: float | None
+    construction_cost_usd: float | None
+    rate_cells: list[RateCell]
+    revenue_mm_usd: float | None
+    revenue_flag: str | None
+    revenue_source: str
+    coverage_ratio: float | None
+    coverage_status: str  # indicative | degraded | suppressed
+    coverage_reason: str | None
+    status: str
+    notes: list[str] = field(default_factory=list)
+
+    def to_json(self) -> dict:
+        def mm(v):
+            return None if v is None else round(v / USD_PER_MM, 2)
+
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "drill_cost_mm_usd": mm(self.drill_cost_usd),
+            "completion_cost_mm_usd": mm(self.completion_cost_usd),
+            "construction_cost_mm_usd": mm(self.construction_cost_usd),
+            "rate_cells": [
+                {
+                    "activity": c.activity,
+                    "band": c.band,
+                    "year_requested": c.year_requested,
+                    "year_used": c.year_used,
+                    "usd_per_day": c.usd_per_day,
+                    "rate_status": c.rate_status,
+                    "vintage_fallback": c.vintage_fallback,
+                    "hpht_applied": c.hpht_applied,
+                }
+                for c in self.rate_cells
+            ],
+            "revenue_mm_usd": self.revenue_mm_usd,
+            "revenue_flag": self.revenue_flag,
+            "revenue_source": self.revenue_source,
+            "coverage_ratio": (
+                None if self.coverage_ratio is None else round(self.coverage_ratio, 1)
+            ),
+            "coverage_status": self.coverage_status,
+            "coverage_reason": self.coverage_reason,
+            "status": self.status,
+            "notes": list(self.notes),
+        }
+
+
+REVENUE_SOURCE = "gross · BSEE monthly production × EIA WTI monthly (benchmark)"
+
+NOMINAL_NOTE = (
+    "Nominal-USD proxy: day rates are nominal per-vintage-year; revenue is "
+    "nominal realized; the coverage ratio mixes vintages and excludes "
+    "royalty (~18.75%), working interest, services, mob/demob, opex, "
+    "facilities, P&A and discounting — an indicative upper bound only."
+)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def water_depth_band_from_ft(depth_ft: float) -> WaterDepthBand:
+    """Classify water depth given FEET (the classifier itself takes metres)."""
+    return classify_water_depth_band(depth_ft * FT_TO_M)
+
+
+def rate_db_year_range(rates_dir: str | Path) -> tuple[int, int]:
+    """Derive the (min, max) indexed year across all cells of day_rates.yml.
+
+    No hardcoded years: the range comes from the database itself so a future
+    #844 refresh widens the clamp window automatically.
+    """
+    with open(Path(rates_dir) / "day_rates.yml") as fh:
+        doc = yaml.safe_load(fh)
+    years: set[int] = set()
+
+    def walk(node):
+        if isinstance(node, dict):
+            for k, v in node.items():
+                if isinstance(k, int) or (isinstance(k, str) and str(k).isdigit()):
+                    years.add(int(k))
+                else:
+                    walk(v)
+
+    walk(doc.get("regions", {}))
+    if not years:
+        raise ValueError(f"no year-indexed rates found under {rates_dir}")
+    return min(years), max(years)
+
+
+def _year_of(datestr) -> int | None:
+    if not datestr:
+        return None
+    try:
+        return int(str(datestr)[:4])
+    except ValueError:
+        return None
+
+
+def load_revenue_map(csv_path: str | Path) -> dict[str, tuple[float, str]]:
+    """api12 -> (est_revenue_mm, revenue_flag), string-keyed.
+
+    Uses the csv module (strings in) so the api12 int64-dtype join hazard
+    cannot occur.
+    """
+    out: dict[str, tuple[float, str]] = {}
+    with open(csv_path, newline="") as fh:
+        for r in csv.DictReader(fh):
+            api = (r.get("api12") or "").strip().zfill(12)
+            raw = (r.get("est_revenue_mm") or "").strip()
+            if not api or not raw:
+                continue
+            try:
+                mm = float(raw)
+            except ValueError:
+                continue
+            out[api] = (mm, (r.get("revenue_flag") or "").strip())
+    return out
+
+
+def norms_comparison(well: dict, field_id: str, norms_path: str | Path) -> dict:
+    """Well-vs-field/play drill-days comparison from the #848 norms contract.
+
+    Degrades to ``{"state": "pending"}`` on absent, malformed, or partial
+    contract — never crashes, never fabricates.
+    """
+    p = Path(norms_path)
+    if not p.exists():
+        return {"state": "pending"}
+    try:
+        doc = json.loads(p.read_text())
+        entry = next(
+            e
+            for e in doc["entries"]
+            if e["field_id"] == field_id
+            and e["metric_id"] == "drill_days_median"
+            and e.get("field")
+        )
+    except (json.JSONDecodeError, KeyError, StopIteration):
+        return {"state": "pending"}
+    days = well.get("drilling_rig_days")
+    field_median = entry["field"]["value"]
+    out = {
+        "state": "ok",
+        "field_median": field_median,
+        "field_n": entry["field"]["n"],
+    }
+    if days:
+        out["well_vs_field_pct"] = round((days - field_median) / field_median * 100, 1)
+    play = entry.get("play") or {}
+    if play.get("status") == "ok" and play.get("metric"):
+        out["play_median"] = play["metric"]["value"]
+        out["play_n"] = play["metric"]["n"]
+        if days:
+            out["well_vs_play_pct"] = round(
+                (days - out["play_median"]) / out["play_median"] * 100, 1
+            )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# core computation
+# ---------------------------------------------------------------------------
+
+
+def _rate_cell(
+    loader,
+    year_range: tuple[int, int],
+    activity: ActivityType,
+    band: WaterDepthBand,
+    year_requested: int,
+    vintage_fallback: str,
+    hpht: bool,
+    region: str,
+) -> RateCell:
+    lo, hi = year_range
+    year_used = min(max(year_requested, lo), hi)
+    usd = loader.get_day_rate(region, band, activity, year_used, hpht=hpht)
+    return RateCell(
+        activity=activity.value,
+        band=band.value,
+        year_requested=year_requested,
+        year_used=year_used,
+        usd_per_day=usd,
+        rate_status="exact" if year_used == year_requested else "clamped",
+        vintage_fallback=vintage_fallback,
+        hpht_applied=hpht,
+    )
+
+
+def compute_well_economics(
+    well: dict,
+    field_ctx: dict,
+    revenue: tuple[float, str] | None,
+    loader,
+    rates_dir: str | Path,
+    cfg: dict,
+) -> WellEconomics:
+    """Compute the economics card payload for one well.
+
+    ``revenue`` is a ``(est_revenue_mm, revenue_flag)`` tuple projected from
+    the benchmark row — passing anything else raises (structural guard so
+    benchmark calendar-day columns can never reach the cost path).
+    """
+    if revenue is not None and not (isinstance(revenue, tuple) and len(revenue) == 2):
+        raise TypeError("revenue must be a (est_revenue_mm, revenue_flag) tuple")
+
+    region = cfg["region"]
+    hpht = bool(cfg.get("hpht_fields", {}).get(field_ctx["id"], False))
+    band = water_depth_band_from_ft(field_ctx["water_depth_ft"])
+    year_range = rate_db_year_range(rates_dir)
+
+    notes = [NOMINAL_NOTE]
+    rate_cells: list[RateCell] = []
+
+    drill_days = well.get("drilling_rig_days") or 0
+    compl_days = well.get("completion_rig_days") or 0
+
+    drill_cost = compl_cost = total_cost = None
+    if drill_days > 0 or compl_days > 0:
+        spud_year = _year_of(well.get("spud_date"))
+        if drill_days > 0 and spud_year:
+            cell = _rate_cell(
+                loader,
+                year_range,
+                ActivityType.DRILLING,
+                band,
+                spud_year,
+                "spud_year",
+                hpht,
+                region,
+            )
+            rate_cells.append(cell)
+            drill_cost = drill_days * cell.usd_per_day
+        if compl_days > 0:
+            fo_year = _year_of(well.get("first_oil"))
+            td_year = _year_of(well.get("td_date"))
+            if fo_year:
+                year, fb = fo_year, "first_oil_year"
+            elif td_year:
+                year, fb = td_year, "td_year_early_biased"
+            else:
+                year, fb = None, None
+            if year:
+                cell = _rate_cell(
+                    loader,
+                    year_range,
+                    ActivityType.COMPLETION,
+                    band,
+                    year,
+                    fb,
+                    hpht,
+                    region,
+                )
+                rate_cells.append(cell)
+                compl_cost = compl_days * cell.usd_per_day
+        parts = [c for c in (drill_cost, compl_cost) if c is not None]
+        total_cost = sum(parts) if parts else None
+
+    rev_mm = rev_flag = None
+    if revenue is not None:
+        rev_mm, rev_flag = revenue
+
+    # --- coverage matrix (plan r3) ---
+    status = well.get("status") or "unknown"
+    clean_flags = cfg.get("clean_revenue_flags", [""])
+    producing = status in cfg.get("producing_statuses", ["producing"])
+    clamped = any(c.rate_status == "clamped" for c in rate_cells)
+
+    ratio = reason = None
+    if total_cost is None:
+        coverage = "suppressed"
+        reason = "insufficient day data — no proxy cost"
+    elif rev_mm is None:
+        coverage = "suppressed"
+        reason = "no benchmark revenue row"
+    elif not producing:
+        coverage = "suppressed"
+        reason = f"well status '{status}' — ratio not meaningful"
+    else:
+        ratio = rev_mm * USD_PER_MM / total_cost
+        if clamped:
+            coverage = "degraded"
+            reason = "clamped-rate proxy (vintage outside rate DB range)"
+        elif rev_flag not in clean_flags:
+            coverage = "degraded"
+            reason = f"revenue flagged '{rev_flag}'"
+        else:
+            coverage = "indicative"
+
+    return WellEconomics(
+        drill_cost_usd=drill_cost,
+        completion_cost_usd=compl_cost,
+        construction_cost_usd=total_cost,
+        rate_cells=rate_cells,
+        revenue_mm_usd=rev_mm,
+        revenue_flag=rev_flag,
+        revenue_source=REVENUE_SOURCE,
+        coverage_ratio=ratio,
+        coverage_status=coverage,
+        coverage_reason=reason,
+        status=status,
+        notes=notes,
+    )

--- a/tests/unit/field_development/test_well_economics.py
+++ b/tests/unit/field_development/test_well_economics.py
@@ -1,0 +1,375 @@
+# ABOUTME: TDD suite for per-well economics (issue #849) — rig-day proxy cost,
+# ABOUTME: benchmark revenue verbatim, coverage matrix with honest degradation.
+
+from pathlib import Path
+
+import pytest
+
+from worldenergydata.bsee.analysis.cost.models import WaterDepthBand
+from worldenergydata.bsee.analysis.cost.regional_loader import RegionalCostLoader
+from worldenergydata.field_development import well_economics as we
+
+REPO = Path(__file__).resolve().parents[3]
+
+FIXTURE_DAY_RATES = """
+metadata:
+  version: "0.0-test"
+  hpht_premium_factor: 1.30
+regions:
+  gom:
+    drilling:
+      deep:
+        2020: 100000
+        2022: 120000
+        2025: 175000
+        confidence: medium
+    completion:
+      deep:
+        2020: 80000
+        2025: 125000
+        confidence: medium
+"""
+
+
+@pytest.fixture()
+def rates_dir(tmp_path):
+    d = tmp_path / "cost_data"
+    d.mkdir()
+    (d / "day_rates.yml").write_text(FIXTURE_DAY_RATES)
+    return d
+
+
+@pytest.fixture()
+def loader(rates_dir):
+    return RegionalCostLoader(config_dir=rates_dir)
+
+
+CFG = {
+    "region": "gom",
+    "hpht_fields": {"big_foot": False},
+    "clean_revenue_flags": [""],
+    "producing_statuses": ["producing"],
+}
+
+FIELD_CTX = {"id": "big_foot", "water_depth_ft": 5200}
+
+A004 = {
+    "api": "608124006001",
+    "slot": "A004",
+    "field_id": "big_foot",
+    "spud_date": "2019-03-10",
+    "td_date": "2019-03-25",
+    "drilling_rig_days": 15,
+    "completion_rig_days": 156,
+    "first_oil": "2019-06-01",
+    "status": "producing",
+}
+
+A008 = {
+    "api": "608124006800",
+    "slot": "A008",
+    "field_id": "big_foot",
+    "spud_date": "2013-01-22",
+    "td_date": "2021-12-02",
+    "drilling_rig_days": 118,
+    "completion_rig_days": 164,
+    "first_oil": "2022-07-01",
+    "status": "producing",
+}
+
+
+# 1 — exact unit arithmetic USD -> $MM
+
+
+def test_cost_units_exact(loader, rates_dir):
+    econ = we.compute_well_economics(
+        A004,
+        FIELD_CTX,
+        revenue=(2324.5, ""),
+        loader=loader,
+        rates_dir=rates_dir,
+        cfg=CFG,
+    )
+    # drilling: 2019 clamps to 2020 rate 100k -> 15 d = 1.5 MUSD… NO:
+    # 15 * 100_000 = 1_500_000 USD; completion vintage = first-oil year 2019
+    # -> clamps to 2020 rate 80k -> 156 * 80_000 = 12_480_000 USD
+    assert econ.drill_cost_usd == 1_500_000
+    assert econ.completion_cost_usd == 12_480_000
+    assert econ.construction_cost_usd == 13_980_000
+    js = econ.to_json()
+    assert js["construction_cost_mm_usd"] == 13.98
+    assert "construction_cost_usd" not in js  # serialized in $MM only
+
+
+# 2 — rig-days only; benchmark calendar days cannot reach the cost path
+
+
+def test_cost_uses_rig_days_never_benchmark_calendar(loader, rates_dir):
+    econ = we.compute_well_economics(
+        A008,
+        FIELD_CTX,
+        revenue=(359.1, ""),
+        loader=loader,
+        rates_dir=rates_dir,
+        cfg=CFG,
+    )
+    # 118 rig-days (NOT the ~3,400-day calendar span 2013→2021)
+    drill_cell = next(c for c in econ.rate_cells if c.activity == "drilling")
+    assert econ.drill_cost_usd == 118 * drill_cell.usd_per_day
+    # structural guard: compute takes a (mm, flag) tuple, never a bench row dict
+    with pytest.raises(TypeError):
+        we.compute_well_economics(
+            A008,
+            FIELD_CTX,
+            revenue={"drilling_days": 3400, "est_revenue_mm": 359.1},  # type: ignore
+            loader=loader,
+            rates_dir=rates_dir,
+            cfg=CFG,
+        )
+
+
+# 3 — rate year: exact in range, clamped below range (derived from YAML, not literals)
+
+
+def test_rate_year_exact_in_range_and_clamped_below(loader, rates_dir):
+    lo, hi = we.rate_db_year_range(rates_dir)
+    assert (lo, hi) == (2020, 2025)
+    well_2022 = dict(A004, spud_date="2022-06-01", first_oil="2022-09-01")
+    econ = we.compute_well_economics(
+        well_2022,
+        FIELD_CTX,
+        revenue=(1.0, ""),
+        loader=loader,
+        rates_dir=rates_dir,
+        cfg=CFG,
+    )
+    drill_cell = next(c for c in econ.rate_cells if c.activity == "drilling")
+    assert drill_cell.rate_status == "exact"
+    assert drill_cell.usd_per_day == 120000
+    econ_old = we.compute_well_economics(
+        A008,
+        FIELD_CTX,
+        revenue=(359.1, ""),
+        loader=loader,
+        rates_dir=rates_dir,
+        cfg=CFG,
+    )
+    old_drill = next(c for c in econ_old.rate_cells if c.activity == "drilling")
+    assert old_drill.rate_status == "clamped"  # spud 2013 < 2020
+    assert old_drill.year_used == lo
+
+
+# 4 — completion vintage fallback hierarchy: first-oil year, then TD year
+
+
+def test_vintage_fallback_hierarchy(loader, rates_dir):
+    econ = we.compute_well_economics(
+        A008,
+        FIELD_CTX,
+        revenue=(359.1, ""),
+        loader=loader,
+        rates_dir=rates_dir,
+        cfg=CFG,
+    )
+    compl = next(c for c in econ.rate_cells if c.activity == "completion")
+    assert compl.year_requested == 2022  # first oil 2022-07, NOT TD year 2021
+    assert compl.vintage_fallback == "first_oil_year"
+    no_fo = dict(A008, first_oil=None)
+    econ2 = we.compute_well_economics(
+        no_fo, FIELD_CTX, revenue=None, loader=loader, rates_dir=rates_dir, cfg=CFG
+    )
+    compl2 = next(c for c in econ2.rate_cells if c.activity == "completion")
+    assert compl2.year_requested == 2021  # TD year fallback
+    assert compl2.vintage_fallback == "td_year_early_biased"
+
+
+# 5 — ft->m banding via the existing classifier; boundary pinned in both units
+
+
+def test_depth_band_ft_to_m_boundaries():
+    assert we.water_depth_band_from_ft(5200) == WaterDepthBand.DEEP  # 1585 m
+    # shallow/mid boundary is 300 m = 984.25 ft (the YAML's "~1,000 ft" is
+    # approximate): 984 ft = 299.9 m SHALLOW; 1,000 ft = 304.8 m is MID
+    assert we.water_depth_band_from_ft(984) == WaterDepthBand.SHALLOW
+    assert we.water_depth_band_from_ft(1000) == WaterDepthBand.MID
+    # mid/deep boundary is 1,524 m = 5,000.0 ft exactly; <=1524 m is MID
+    assert we.water_depth_band_from_ft(5000) == WaterDepthBand.MID  # 1524.0 m
+    assert we.water_depth_band_from_ft(5001) == WaterDepthBand.DEEP  # 1524.3 m
+    assert we.water_depth_band_from_ft(4999) == WaterDepthBand.MID
+    assert we.water_depth_band_from_ft(10001) == WaterDepthBand.ULTRA_DEEP
+    # the trap this pins: feet fed into the metres classifier would misprice
+    from worldenergydata.bsee.analysis.cost.models import classify_water_depth_band
+
+    assert classify_water_depth_band(5200) == WaterDepthBand.ULTRA_DEEP  # wrong-unit
+    assert we.water_depth_band_from_ft(5200) != classify_water_depth_band(5200)
+
+
+# 6 — loader contract against the real class + fixture YAML
+
+
+def test_loader_contract_against_real_class(loader):
+    from worldenergydata.bsee.analysis.cost.models import ActivityType
+
+    rate = loader.get_day_rate("gom", WaterDepthBand.DEEP, ActivityType.DRILLING, 2022)
+    assert rate == 120000.0
+    assert (
+        loader.get_day_rate(
+            "gom", WaterDepthBand.DEEP, ActivityType.DRILLING, 2022, hpht=True
+        )
+        == 120000.0 * 1.30
+    )
+
+
+# 7 — golden join against the REAL benchmark CSV (string keys, all 5 tracer wells)
+
+
+def test_golden_join_real_benchmark_csv():
+    csv_path = (
+        REPO / "reports/lower_tertiary/lt_well_benchmark_lower_tertiary_2010_latest.csv"
+    )
+    revmap = we.load_revenue_map(csv_path)
+    expected = {
+        "608124006001": 2324.5,
+        "608124006603": 1576.2,
+        "608124006200": 910.3,
+        "608124006800": 359.1,
+        "608124006302": 103.4,
+    }
+    for api, mm in expected.items():
+        rev = revmap.get(api)
+        assert rev is not None, f"missing benchmark row for {api}"
+        assert rev[0] == mm
+        assert rev[1] == ""  # clean flag
+
+
+# 8 — coverage matrix
+
+
+def test_coverage_matrix(loader, rates_dir):
+    kw = dict(loader=loader, rates_dir=rates_dir, cfg=CFG)
+    clean = we.compute_well_economics(A004, FIELD_CTX, revenue=(2324.5, ""), **kw)
+    assert clean.coverage_status == "degraded"  # A004 spud 2019 -> clamped rate
+    in_range = dict(A004, spud_date="2022-06-01", first_oil="2022-09-01")
+    ok = we.compute_well_economics(in_range, FIELD_CTX, revenue=(100.0, ""), **kw)
+    assert ok.coverage_status == "indicative"
+    assert ok.coverage_ratio == pytest.approx(
+        100.0 * 1e6 / ok.construction_cost_usd, rel=1e-6
+    )
+    flagged = we.compute_well_economics(
+        in_range, FIELD_CTX, revenue=(100.0, "partial"), **kw
+    )
+    assert flagged.coverage_status == "degraded"
+    shut_in = we.compute_well_economics(
+        dict(in_range, status="shut-in"), FIELD_CTX, revenue=(100.0, ""), **kw
+    )
+    assert shut_in.coverage_status == "suppressed"
+    zero_days = we.compute_well_economics(
+        dict(in_range, drilling_rig_days=0, completion_rig_days=0),
+        FIELD_CTX,
+        revenue=(100.0, ""),
+        **kw,
+    )
+    assert zero_days.coverage_status == "suppressed"
+    assert zero_days.construction_cost_usd is None
+    no_rev = we.compute_well_economics(in_range, FIELD_CTX, revenue=None, **kw)
+    assert no_rev.coverage_status == "suppressed"
+    assert no_rev.revenue_mm_usd is None
+
+
+# 9 — norms chips degradation variants
+
+
+def test_norms_degradation_variants(tmp_path):
+    well = dict(A004, drilling_rig_days=15)
+    missing = we.norms_comparison(well, "big_foot", tmp_path / "absent.json")
+    assert missing == {"state": "pending"}
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json")
+    assert we.norms_comparison(well, "big_foot", bad) == {"state": "pending"}
+    partial = tmp_path / "partial.json"
+    partial.write_text('{"schema_version": "1.0", "entries": []}')
+    assert we.norms_comparison(well, "big_foot", partial) == {"state": "pending"}
+    good = tmp_path / "good.json"
+    good.write_text(
+        """
+{"schema_version": "1.0", "entries": [
+  {"field_id": "big_foot", "stage": "drill", "metric_id": "drill_days_median",
+   "unit": "days", "field_status": "ok",
+   "field": {"value": 36.5, "n": 24, "basis": "calendar_days",
+             "population": "xlsx_wellbores", "aggregation": "median"},
+   "play": {"status": "ok", "method": "leave_one_field_out", "reason": null,
+            "metric": {"value": 47.0, "n": 160, "basis": "calendar_days",
+                       "population": "xlsx_wellbores", "aggregation": "median"}},
+   "country": {"status": "roadmap", "metric": null, "method": null,
+               "reason": "x"},
+   "delta_play_pct": -22.3, "delta_country_pct": null}
+]}
+"""
+    )
+    cmp_ = we.norms_comparison(well, "big_foot", good)
+    assert cmp_["state"] == "ok"
+    assert cmp_["field_median"] == 36.5
+    assert cmp_["play_median"] == 47.0
+    assert cmp_["well_vs_field_pct"] == pytest.approx((15 - 36.5) / 36.5 * 100, abs=0.1)
+
+
+# 10 — no hardcoded monetary literals in the module
+
+
+def test_no_hardcoded_monetary_literals():
+    src = (REPO / "src/worldenergydata/field_development/well_economics.py").read_text()
+    import re
+
+    # forbid any 5+ digit numeric literal except the USD->MM divisor
+    numerics = set(re.findall(r"(?<![\w.])(\d{5,})(?![\w.])", src)) - {"1_000_000"}
+    numerics -= {n for n in numerics if "_" in n}
+    assert numerics == set(), f"hardcoded numerics found: {numerics}"
+    assert "FT_TO_M = 0.3048" in src
+
+
+# 11 — hpht is config-gated; mud weight never consulted
+
+
+def test_hpht_flag_config_gated(loader, rates_dir):
+    hot_cfg = dict(CFG, hpht_fields={"big_foot": True})
+    well = dict(A004, spud_date="2022-06-01", first_oil="2022-09-01", mud_weight_ppg=99)
+    base = we.compute_well_economics(
+        well, FIELD_CTX, revenue=None, loader=loader, rates_dir=rates_dir, cfg=CFG
+    )
+    hot = we.compute_well_economics(
+        well, FIELD_CTX, revenue=None, loader=loader, rates_dir=rates_dir, cfg=hot_cfg
+    )
+    assert hot.drill_cost_usd == pytest.approx(base.drill_cost_usd * 1.30)
+    src = (REPO / "src/worldenergydata/field_development/well_economics.py").read_text()
+    assert "mud_weight" not in src
+
+
+# 12 — serialization schema completeness + determinism
+
+
+def test_economics_schema_and_provenance(loader, rates_dir):
+    econ = we.compute_well_economics(
+        A004,
+        FIELD_CTX,
+        revenue=(2324.5, ""),
+        loader=loader,
+        rates_dir=rates_dir,
+        cfg=CFG,
+    )
+    j1 = econ.to_json()
+    j2 = econ.to_json()
+    assert j1 == j2
+    assert j1["schema_version"] == we.SCHEMA_VERSION
+    for cell in j1["rate_cells"]:
+        assert {
+            "activity",
+            "band",
+            "year_requested",
+            "year_used",
+            "usd_per_day",
+            "rate_status",
+            "vintage_fallback",
+            "hpht_applied",
+        } <= set(cell)
+    assert j1["revenue_source"].startswith("gross")
+    assert any("nominal" in n.lower() for n in j1["notes"])  # vintage-mix disclosure


### PR DESCRIPTION
## Per-well economics card — D&C days → cost, production → revenue, coverage

Closes #849. Implements the owner-approved r3 plan (workspace-hub `docs/plans/2026-07-06-issue-wed-849-per-well-economics.md`; r1 MAJOR/8 + r2 MAJOR/11 pre-approval). Completes the drill-down chain: field poster → well timeline → **money**, with well-vs-norm chips consuming #848's `_norms.json` (merged in #862).

### What ships
- **`well_economics.py`** — proxy construction cost = rig-days × `RegionalCostLoader` day-rates (explicit `config_dir`; DB year range derived from `day_rates.yml` itself; out-of-range vintages `clamped` and flagged); revenue = benchmark `est_revenue_mm` **verbatim** (string-keyed join — the int64 dtype hazard structurally cannot occur); **gross-revenue coverage (indicative, upper bound)** with the `indicative / degraded / suppressed` matrix.
- Review-driven correctness baked in: completion vintage uses **first-oil-year before TD-year** (fallback recorded, `early_biased` flagged); ft→m banding reuses `classify_water_depth_band` via `FT_TO_M` (the feet-into-metres trap would misprice Big Foot ULTRA_DEEP, ~+20% — test-pinned); `bench_row` is projected to `(revenue, flag)` before compute so the 29× calendar-vs-rig-day contradiction (A008: 3,400 vs 118) can never reach the cost path.
- All 5 Big Foot well pages gain the **Economics (proxy)** card + nominal-USD/royalty/WI disclosure note + drill-days-vs-norm chips (graceful `norms pending` degradation).
- `config/well_economics.yml` holds all policy; **zero hardcoded rates** (test-enforced guard over the module source).

### Verification on real data
A004: cost **$27.54MM** (15 d × $380k drill + 156 d × $140k completion, both clamped 2019→2020 → coverage honestly reports `degraded`), revenue **$2,324.5MM** (clean flag), norms chips live: −58.9% vs field median, −68.1% vs play. 12 unit tests incl. the real-CSV golden join (all 5 tracer wells, exact values). Lint mirrored at CI lockfile pins (black 25.9.0 / isort 8.0.1 / flake8 7.3.0).
