### PR TITLE
feat(spain): add BOE-backed CORES density factors

### DIFF
--- a/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
@@ -1,21 +1,54 @@
 {
-  "registry_version": "2026-07-06-source-gap",
+  "registry_version": "2026-07-06-boe-partial",
   "registry_date": "2026-07-06",
   "coverage_status": "missing",
-  "coverage_note": "No CORES oil field currently has an accepted field-applicable crude density/API conversion factor in this registry. Strict refreshes fail closed until accepted cited factors are added.",
+  "coverage_note": "Casablanca and Tarraco have accepted BOE regulator-record API values. Strict refreshes still fail closed until accepted cited factors cover every current CORES oil field.",
   "source_gap_fields": [
     "Albatros",
     "Amposta",
     "Ayoluengo",
     "Boquer\u00f3n",
-    "Casablanca",
     "Dorada",
     "Gaviota",
     "Montanazo-Lubina",
     "Rodaballo",
     "Salmonete",
-    "Tarraco",
     "Viura (1)"
   ],
-  "factors": []
+  "factors": [
+    {
+      "field_name": "Casablanca",
+      "aliases": [
+        "casablanca"
+      ],
+      "api_gravity_deg": 33.0,
+      "api_gravity_min_deg": null,
+      "api_gravity_max_deg": null,
+      "bbl_per_tonne": 7.312182839124249,
+      "measurement_basis": "BOE national crude price order for crude from the Casablanca exploitation, stated at wellhead",
+      "source_title": "BOE N\u00fam. 167, Orden de 25 de mayo de 1977: Casablanca and Tarraco crude sales prices",
+      "source_url": "https://www.boe.es/boe/dias/1977/07/14/pdfs/A15865-15866.pdf",
+      "source_class": "regulator_record",
+      "evidence_note": "The BOE order fixes the sales price for crude from the Casablanca exploitation and states 33\u00b0 API with 0.2% sulfur at the wellhead.",
+      "confidence": "high",
+      "accepted_for_conversion": true
+    },
+    {
+      "field_name": "Tarraco",
+      "aliases": [
+        "tarraco"
+      ],
+      "api_gravity_deg": 35.0,
+      "api_gravity_min_deg": null,
+      "api_gravity_max_deg": null,
+      "bbl_per_tonne": 7.401084758140957,
+      "measurement_basis": "BOE national crude price order for crude from the Tarraco concession, stated at wellhead",
+      "source_title": "BOE N\u00fam. 167, Orden de 25 de mayo de 1977: Casablanca and Tarraco crude sales prices",
+      "source_url": "https://www.boe.es/boe/dias/1977/07/14/pdfs/A15865-15866.pdf",
+      "source_class": "regulator_record",
+      "evidence_note": "The BOE order fixes the sales price for crude from the Tarraco concession and states 35\u00b0 API with 0.2% sulfur at the wellhead.",
+      "confidence": "high",
+      "accepted_for_conversion": true
+    }
+  ]
 }

--- a/tests/unit/spain/test_cores_density.py
+++ b/tests/unit/spain/test_cores_density.py
@@ -167,12 +167,55 @@ def test_default_density_registry_file_loads_from_package_data():
     assert isinstance(factors, dict)
 
 
+def test_default_density_registry_accepts_boe_regulator_fields():
+    factors = load_crude_density_factors()
+    source_url = "https://www.boe.es/boe/dias/1977/07/14/pdfs/A15865-15866.pdf"
+
+    casablanca = factors["casablanca"]
+    assert casablanca.field_name == "Casablanca"
+    assert casablanca.source_class == "regulator_record"
+    assert casablanca.source_url == source_url
+    assert casablanca.accepted_for_conversion is True
+    assert casablanca.api_gravity_deg == pytest.approx(33.0)
+    assert casablanca.bbl_per_tonne == pytest.approx(7.312182839124249)
+
+    tarraco = factors["tarraco"]
+    assert tarraco.field_name == "Tarraco"
+    assert tarraco.source_class == "regulator_record"
+    assert tarraco.source_url == source_url
+    assert tarraco.accepted_for_conversion is True
+    assert tarraco.api_gravity_deg == pytest.approx(35.0)
+    assert tarraco.bbl_per_tonne == pytest.approx(7.401084758140957)
+
+    audit = build_oil_conversion_audit(
+        ["Casablanca", "Tarraco"],
+        factors,
+        allow_default_density=False,
+    )
+
+    assert audit.used_field_names == ("Casablanca", "Tarraco")
+    assert audit.defaulted_fields == ()
+    assert audit.missing_fields == ()
+
+
 def test_default_density_registry_keeps_current_fields_missing():
     registry_path = files("worldenergydata.spain").joinpath(
         "data/cores/crude_density_factors.json"
     )
     payload = json.loads(registry_path.read_text())
     expected_fields = payload["source_gap_fields"]
+    assert expected_fields == [
+        "Albatros",
+        "Amposta",
+        "Ayoluengo",
+        "Boquerón",
+        "Dorada",
+        "Gaviota",
+        "Montanazo-Lubina",
+        "Rodaballo",
+        "Salmonete",
+        "Viura (1)",
+    ]
 
     with pytest.raises(CoresDensityCoverageError) as exc_info:
         build_oil_conversion_audit(
@@ -183,6 +226,58 @@ def test_default_density_registry_keeps_current_fields_missing():
     message = str(exc_info.value)
     for field_name in expected_fields:
         assert field_name in message
+
+
+def test_default_density_registry_partially_covers_current_cores_fields():
+    current_fields = [
+        "Albatros",
+        "Amposta",
+        "Ayoluengo",
+        "Boquerón",
+        "Casablanca",
+        "Dorada",
+        "Gaviota",
+        "Montanazo-Lubina",
+        "Rodaballo",
+        "Salmonete",
+        "Tarraco",
+        "Viura (1)",
+    ]
+    expected_gap_fields = [
+        "Albatros",
+        "Amposta",
+        "Ayoluengo",
+        "Boquerón",
+        "Dorada",
+        "Gaviota",
+        "Montanazo-Lubina",
+        "Rodaballo",
+        "Salmonete",
+        "Viura (1)",
+    ]
+    factors = load_crude_density_factors()
+
+    with pytest.raises(CoresDensityCoverageError) as exc_info:
+        build_oil_conversion_audit(
+            current_fields,
+            factors,
+            allow_default_density=False,
+        )
+    message = str(exc_info.value)
+    for field_name in expected_gap_fields:
+        assert field_name in message
+    assert "Casablanca" not in message
+    assert "Tarraco" not in message
+
+    defaulted_audit = build_oil_conversion_audit(
+        current_fields,
+        factors,
+        allow_default_density=True,
+    )
+
+    assert defaulted_audit.used_field_names == ("Casablanca", "Tarraco")
+    assert defaulted_audit.defaulted_fields == tuple(expected_gap_fields)
+    assert defaulted_audit.missing_fields == ()
 
 
 def test_crude_density_factor_rejects_secondary_article_conversion_directly(tmp_path):


### PR DESCRIPTION
## Summary
- Add accepted BOE regulator-record API/density factors for Casablanca (33 API, 7.312182839124249 bbl/tonne) and Tarraco (35 API, 7.401084758140957 bbl/tonne).
- Keep registry coverage_status as missing and retain the remaining 10 CORES oil fields in source_gap_fields.
- Add regression tests pinning the BOE source URL, fixed conversion constants, remaining gap list, and full 12-field strict/default audit behavior.

Refs https://github.com/vamseeachanta/worldenergydata/issues/807. Partial progress only; issue 807 remains open.

## Verification
- .venv/bin/python -m pytest tests/unit/spain/test_cores_density.py -q -> 19 passed
- .venv/bin/python -m pytest tests/unit/spain/test_cores_density.py tests/unit/spain/test_cores_field_development_density.py tests/unit/spain/test_cores_field_development_report.py tests/unit/spain/test_cores_live.py tests/unit/spain/test_cores_live_density.py tests/unit/spain/test_cores_loader.py tests/unit/scheduler/test_spain_cores_refresh.py -q -> 85 passed
- .venv/bin/python -m pytest tests/unit/core tests/unit/common tests/contracts tests/workflows tests/unit/spain -q -> 545 passed, 2 skipped
- scripts/legal/legal-sanity-scan.sh -> PASS
- .venv/bin/python -m json.tool packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json -> PASS
- git diff --check; black --check; isort --check-only -> PASS
- uv run --with bandit bandit tests/unit/spain/test_cores_density.py -ll -ii -> no issues

## Review Notes
- Two read-only adversarial review agents found no blockers.
- Package-wide Bandit scan still reports pre-existing B310 at packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_source.py:290; this PR does not touch that code and the CI security job is non-blocking.