### PR TITLE
feat(spain): add BOE density factors for Amposta and Dorada

### DIFF
--- a/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
@@ -1,14 +1,12 @@
 {
-  "registry_version": "2026-07-06-boe-partial",
+  "registry_version": "2026-07-06-boe-partial-2",
   "registry_date": "2026-07-06",
   "coverage_status": "missing",
-  "coverage_note": "Casablanca and Tarraco have accepted BOE regulator-record API values. Strict refreshes still fail closed until accepted cited factors cover every current CORES oil field.",
+  "coverage_note": "Amposta, Casablanca, Dorada, and Tarraco have accepted BOE regulator-record API values. Strict refreshes still fail closed until accepted cited factors cover every current CORES oil field.",
   "source_gap_fields": [
     "Albatros",
-    "Amposta",
     "Ayoluengo",
     "Boquer\u00f3n",
-    "Dorada",
     "Gaviota",
     "Montanazo-Lubina",
     "Rodaballo",
@@ -16,6 +14,25 @@
     "Viura (1)"
   ],
   "factors": [
+    {
+      "field_name": "Amposta",
+      "aliases": [
+        "amposta",
+        "san carlos i",
+        "san carlos ii"
+      ],
+      "api_gravity_deg": 17.0,
+      "api_gravity_min_deg": null,
+      "api_gravity_max_deg": null,
+      "bbl_per_tonne": 6.600967486990584,
+      "measurement_basis": "BOE national crude price order for crude from the San Carlos I and II (Amposta) exploitation concessions, delivered at the destination port",
+      "source_title": "BOE N\u00fam. 122, Orden de 12 de mayo de 1976: San Carlos I and II (Amposta) crude sales price",
+      "source_url": "https://www.boe.es/boe/dias/1976/05/21/pdfs/A09838-09839.pdf",
+      "source_class": "regulator_record",
+      "evidence_note": "The BOE order fixes the sales price for crude from the San Carlos I and II (Amposta) exploitation concessions and states 17\u00b0 API with 5.5% sulfur.",
+      "confidence": "high",
+      "accepted_for_conversion": true
+    },
     {
       "field_name": "Casablanca",
       "aliases": [
@@ -30,6 +47,23 @@
       "source_url": "https://www.boe.es/boe/dias/1977/07/14/pdfs/A15865-15866.pdf",
       "source_class": "regulator_record",
       "evidence_note": "The BOE order fixes the sales price for crude from the Casablanca exploitation and states 33\u00b0 API with 0.2% sulfur at the wellhead.",
+      "confidence": "high",
+      "accepted_for_conversion": true
+    },
+    {
+      "field_name": "Dorada",
+      "aliases": [
+        "dorada"
+      ],
+      "api_gravity_deg": 21.3,
+      "api_gravity_min_deg": null,
+      "api_gravity_max_deg": null,
+      "bbl_per_tonne": 6.792106612876507,
+      "measurement_basis": "BOE national crude price order for crude from the Dorada exploitation concession, stated at field shipment position",
+      "source_title": "BOE N\u00fam. 151, Orden de 16 de junio de 1978: Dorada crude sales price",
+      "source_url": "https://www.boe.es/boe/dias/1978/06/26/pdfs/A15132-15132.pdf",
+      "source_class": "regulator_record",
+      "evidence_note": "The BOE order fixes the sales price for crude from the Dorada exploitation concession and states 21.3\u00b0 API with 0.59% sulfur.",
       "confidence": "high",
       "accepted_for_conversion": true
     },

--- a/tests/unit/spain/test_cores_density.py
+++ b/tests/unit/spain/test_cores_density.py
@@ -169,31 +169,51 @@ def test_default_density_registry_file_loads_from_package_data():
 
 def test_default_density_registry_accepts_boe_regulator_fields():
     factors = load_crude_density_factors()
-    source_url = "https://www.boe.es/boe/dias/1977/07/14/pdfs/A15865-15866.pdf"
+    casablanca_tarraco_url = (
+        "https://www.boe.es/boe/dias/1977/07/14/pdfs/A15865-15866.pdf"
+    )
+    amposta_url = "https://www.boe.es/boe/dias/1976/05/21/pdfs/A09838-09839.pdf"
+    dorada_url = "https://www.boe.es/boe/dias/1978/06/26/pdfs/A15132-15132.pdf"
+
+    amposta = factors["amposta"]
+    assert amposta.field_name == "Amposta"
+    assert amposta.source_class == "regulator_record"
+    assert amposta.source_url == amposta_url
+    assert amposta.accepted_for_conversion is True
+    assert amposta.api_gravity_deg == pytest.approx(17.0)
+    assert amposta.bbl_per_tonne == pytest.approx(6.600967486990584)
 
     casablanca = factors["casablanca"]
     assert casablanca.field_name == "Casablanca"
     assert casablanca.source_class == "regulator_record"
-    assert casablanca.source_url == source_url
+    assert casablanca.source_url == casablanca_tarraco_url
     assert casablanca.accepted_for_conversion is True
     assert casablanca.api_gravity_deg == pytest.approx(33.0)
     assert casablanca.bbl_per_tonne == pytest.approx(7.312182839124249)
 
+    dorada = factors["dorada"]
+    assert dorada.field_name == "Dorada"
+    assert dorada.source_class == "regulator_record"
+    assert dorada.source_url == dorada_url
+    assert dorada.accepted_for_conversion is True
+    assert dorada.api_gravity_deg == pytest.approx(21.3)
+    assert dorada.bbl_per_tonne == pytest.approx(6.792106612876507)
+
     tarraco = factors["tarraco"]
     assert tarraco.field_name == "Tarraco"
     assert tarraco.source_class == "regulator_record"
-    assert tarraco.source_url == source_url
+    assert tarraco.source_url == casablanca_tarraco_url
     assert tarraco.accepted_for_conversion is True
     assert tarraco.api_gravity_deg == pytest.approx(35.0)
     assert tarraco.bbl_per_tonne == pytest.approx(7.401084758140957)
 
     audit = build_oil_conversion_audit(
-        ["Casablanca", "Tarraco"],
+        ["Amposta", "Casablanca", "Dorada", "Tarraco"],
         factors,
         allow_default_density=False,
     )
 
-    assert audit.used_field_names == ("Casablanca", "Tarraco")
+    assert audit.used_field_names == ("Amposta", "Casablanca", "Dorada", "Tarraco")
     assert audit.defaulted_fields == ()
     assert audit.missing_fields == ()
 
@@ -206,10 +226,8 @@ def test_default_density_registry_keeps_current_fields_missing():
     expected_fields = payload["source_gap_fields"]
     assert expected_fields == [
         "Albatros",
-        "Amposta",
         "Ayoluengo",
         "Boquerón",
-        "Dorada",
         "Gaviota",
         "Montanazo-Lubina",
         "Rodaballo",
@@ -229,6 +247,10 @@ def test_default_density_registry_keeps_current_fields_missing():
 
 
 def test_default_density_registry_partially_covers_current_cores_fields():
+    registry_path = files("worldenergydata.spain").joinpath(
+        "data/cores/crude_density_factors.json"
+    )
+    payload = json.loads(registry_path.read_text())
     current_fields = [
         "Albatros",
         "Amposta",
@@ -245,17 +267,22 @@ def test_default_density_registry_partially_covers_current_cores_fields():
     ]
     expected_gap_fields = [
         "Albatros",
-        "Amposta",
         "Ayoluengo",
         "Boquerón",
-        "Dorada",
         "Gaviota",
         "Montanazo-Lubina",
         "Rodaballo",
         "Salmonete",
         "Viura (1)",
     ]
+    expected_used_fields = ["Amposta", "Casablanca", "Dorada", "Tarraco"]
     factors = load_crude_density_factors()
+
+    assert payload["coverage_status"] == "missing"
+    assert payload["source_gap_fields"] == expected_gap_fields
+    assert sorted([*expected_gap_fields, *expected_used_fields]) == sorted(
+        current_fields
+    )
 
     with pytest.raises(CoresDensityCoverageError) as exc_info:
         build_oil_conversion_audit(
@@ -266,7 +293,9 @@ def test_default_density_registry_partially_covers_current_cores_fields():
     message = str(exc_info.value)
     for field_name in expected_gap_fields:
         assert field_name in message
+    assert "Amposta" not in message
     assert "Casablanca" not in message
+    assert "Dorada" not in message
     assert "Tarraco" not in message
 
     defaulted_audit = build_oil_conversion_audit(
@@ -275,7 +304,7 @@ def test_default_density_registry_partially_covers_current_cores_fields():
         allow_default_density=True,
     )
 
-    assert defaulted_audit.used_field_names == ("Casablanca", "Tarraco")
+    assert defaulted_audit.used_field_names == tuple(expected_used_fields)
     assert defaulted_audit.defaulted_fields == tuple(expected_gap_fields)
     assert defaulted_audit.missing_fields == ()
 


### PR DESCRIPTION
## Summary
- Adds accepted BOE regulator-record API/density conversion factors for Amposta (17 API) and Dorada (21.3 API).
- Updates the registry coverage metadata so the current CORES gap list removes Amposta and Dorada while strict mode remains fail-closed for the remaining eight fields.
- Strengthens density tests to pin source URLs, conversion constants, strict/default coverage behavior, and registry metadata drift.

## Verification
- `.venv/bin/python -m pytest tests/unit/core tests/unit/common tests/contracts tests/workflows tests/unit/spain -q` (545 passed, 2 skipped)
- `scripts/legal/legal-sanity-scan.sh` (PASS)
- `uv run --with bandit bandit tests/unit/spain/test_cores_density.py -ll -ii` (No issues identified)
- `.venv/bin/python -m black --check tests/unit/spain/test_cores_density.py && .venv/bin/python -m isort --check-only tests/unit/spain/test_cores_density.py`
- `git diff --check`
- `python -m json.tool packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json`

Refs https://github.com/vamseeachanta/worldenergydata/issues/807