### PR TITLE
docs(validation): delta D&C days since Nov-2025 cutoff + section permalinks

### DIFF
--- a/reports/lower_tertiary/wo-april-2026-validation.md
+++ b/reports/lower_tertiary/wo-april-2026-validation.md
@@ -145,6 +145,25 @@ The article's Table 1/2 cost columns are the V30 assumptions deck (`lease_assump
 
 (Boost/WI pumps = booster + water-injection pump capital combined; OPEX = variable + fixed. Pre-FID fields carry exploration/appraisal D&C only.)
 
+### 4.7 Project financials — full WED model output (the article's Table 2 equivalent)
+
+The complete per-development financial summary from the same canonical workbook, published so the article team can inspect the WED side of every Table 2 cell and gain confidence in the tables we produce. Production and wells are BSEE-derived (OGOR-A / WAR); dollars are the V30 model on the assumptions deck; all money in $M, lifetime thru 2025-05:
+
+| Development | First oil | Oil produced (MMbbl) | Producer / injector wells | Total bores | Revenue | Royalty | OPEX | Net cash flow | NPV @10% | MIRR (annual) |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| Anchor | 2024-08 | 6.9 | 2 / 0 | 15 | 476 | 89 | 167 | −3,941 | −1,733 | −17.7% |
+| Big Foot | 2018-11 | 66.9 | 7 / 1 | 38 | 4,738 | 888 | 1,058 | −1,725 | −1,063 | 3.5% |
+| Cascade Chinook | 2014-01 | 34.3 | 3 / 0 | 14 | 2,327 | 436 | 1,837 | −3,820 | −1,474 | −1.8% |
+| Jack St Malo | 2014-12 | 406.6 | 22 / 4 | 73 | 25,649 | 4,809 | 3,201 | +4,788 | −881 | 8.5% |
+| Julia | 2016-03 | 70.9 | 4 / 0 | 9 | 4,715 | 884 | 1,119 | −13 | −531 | 6.3% |
+| Kaskida | pre-FID | 0 | 0 / 0 | 7 | 0 | 0 | 0 | −925 | −625 | — |
+| North Platte | pre-FID | 0 | 0 / 0 | 14 | 0 | 0 | 0 | −1,068 | −784 | — |
+| Shenandoah | 2025-02 | 0.004 | 1 / 0 | 23 | 0.3 | 0.1 | 13 | −3,879 | −1,166 | — |
+| Stones | 2016-09 | 83.7 | 10 / 2 | 22 | 5,582 | 1,047 | 1,610 | −3,306 | −1,480 | 2.7% |
+| Tiber | never | 0 | 0 / 0 | 2 | 0 | 0 | 0 | −275 | −228 | — |
+
+Cross-checks a reader can do immediately: the D2 duplicate row is visible here (Tiber's −275 / −228 are the values the article prints for Stones); D3's Cascade Chinook NCF is here in context; D4's OPEX columns are non-zero for Julia and Stones; Table 3's mean project NPV (−$1.19B) is the average of the NPV column. Per-field monthly cash-flow detail: the live economics pages ([Anchor](https://vamseeachanta.github.io/worldenergydata/economics-anchor.html) · [Big Foot](https://vamseeachanta.github.io/worldenergydata/economics-big_foot.html) · [Cascade–Chinook](https://vamseeachanta.github.io/worldenergydata/economics-cascade_chinook.html) · [Jack/St. Malo](https://vamseeachanta.github.io/worldenergydata/economics-jack_st_malo.html) · [Julia](https://vamseeachanta.github.io/worldenergydata/economics-julia.html) · [Shenandoah](https://vamseeachanta.github.io/worldenergydata/economics-shenandoah.html) · [Stones](https://vamseeachanta.github.io/worldenergydata/economics-stones.html)) and the [portfolio summary](https://vamseeachanta.github.io/worldenergydata/portfolio.html). Sanctioned-baseline figures are CI-guarded against `golden_baseline_v30.yml` — see [capabilities § validation](https://vamseeachanta.github.io/worldenergydata/capabilities/#validation).
+
 ## 5. Open asks to Roy / Chuck (their inputs, cited as theirs)
 
 1. **STOIIP source for Table 4** *(hard gap)* — no BOEM/BSEE source exists for STOIIP/OOIP; public record is operator FID press only (Buckskin ~5 Bbbl, Julia 6 Bbbl, Stones >2 Bboe, Tiber 4–6 Bbbl; Cascade/Chinook has no clean public figure). Need their basis for a consistent column.

--- a/reports/lower_tertiary/wo-april-2026-validation.md
+++ b/reports/lower_tertiary/wo-april-2026-validation.md
@@ -17,6 +17,7 @@ This document is the durable, single-source record of the validation — every n
 4. **Five discrepancies were found** and are documented with WED evidence and side-by-side comparison tables for QA hand-back (§4).
 5. **Free BOEM reserves + discovery dates are now in our refresh pipeline** (§5.1), which surfaced one substantive reserves discrepancy on Stones to resolve with the article team.
 6. **Open asks to the article team** (§5): STOIIP basis, cost-deck vintage, and the appraisal-well definition.
+7. **Refreshing to the current WAR vintage adds only 53 D&C days** (Big Foot +33, Stones +20) — all late-life well-servicing on wells drilled years ago; the nine matched developments are unchanged since the article's Nov-2025 cutoff (§3.1).
 
 ## 1. Headline finding
 
@@ -39,23 +40,45 @@ The article's four tables **are this repository's FDAS V30 model output**: `fina
 
 Our full-raw candidate extraction (canonical extractor reading raw BSEE WAR `.bin`; wed PR [#851](https://github.com/vamseeachanta/worldenergydata/pull/851), issue [#842](https://github.com/vamseeachanta/worldenergydata/issues/842)) vs the article, total D&C days:
 
-| Development | WED bores | WO bores | WED D&C | WO D&C | Δ days | Status |
-|---|---:|---:|---:|---:|---:|---|
-| Anchor | 17 | 17 | 1,825 | 1,825 | 0 | exact |
-| Cascade Chinook | 14 | 14 | 2,467 | 2,467 | 0 | exact |
-| Stones | 22 | 22 | 2,625 | 2,625 | 0 | exact |
-| Julia | 9 | 9 | 1,687 | 1,687 | 0 | exact |
-| Kaskida | 7 | 7 | 841 | 841 | 0 | exact |
-| Tiber | 2 | 2 | 250 | 250 | 0 | exact |
-| North Platte | 23 | 20 | 971 | 971 | 0 | days exact; +3 zero-day sidetracks |
-| Shenandoah | 23 | 23 | 2,370 | 2,346 | +24 | resolved (frozen V30 was −357) |
-| **Buckskin** | **25** | **24** | **2,056** | **2,004** | +52 | **recovered** — was missing entirely (shelf-only extract) |
-| Jack St Malo | 73 | 73 | 7,047 | 6,928 | +119 | open — suspect over-counted post-TD completion days; deferred bug [#846](https://github.com/vamseeachanta/worldenergydata/issues/846) |
-| Big Foot | 38 | — | 3,265 | — | — | WED-only: the article intentionally excluded Big Foot |
+The **Δ since Nov '25** column (added 2026-07-06) reports, of our current D&C total, how many days accrued **after the article's November-2025 data cutoff** — computed by re-running the canonical extractor against the 2026-02-19 WAR vintage twice (uncapped vs. capped at 2025-11-30) and differencing; see the [delta-increase analysis in §3.1](#3-1-d-c-days-accrued-since-the-article-s-nov-2025-cutoff).
+
+| Development | WED bores | WO bores | WED D&C | WO D&C | Δ vs WO | Δ since Nov '25 | Status |
+|---|---:|---:|---:|---:|---:|---:|---|
+| Anchor | 17 | 17 | 1,825 | 1,825 | 0 | 0 | exact |
+| Cascade Chinook | 14 | 14 | 2,467 | 2,467 | 0 | 0 | exact |
+| Stones | 22 | 22 | 2,625 | 2,625 | 0 | +20 | exact vs WO; +20 post-cutoff well-servicing days (§3.1) |
+| Julia | 9 | 9 | 1,687 | 1,687 | 0 | 0 | exact |
+| Kaskida | 7 | 7 | 841 | 841 | 0 | 0 | exact |
+| Tiber | 2 | 2 | 250 | 250 | 0 | 0 | exact |
+| North Platte | 23 | 20 | 971 | 971 | 0 | 0 | days exact; +3 zero-day sidetracks |
+| Shenandoah | 23 | 23 | 2,370 | 2,346 | +24 | 0 | resolved (frozen V30 was −357); Δ pre-dates cutoff |
+| **Buckskin** | **25** | **24** | **2,056** | **2,004** | +52 | 0 | **recovered** — was missing entirely (shelf-only extract) |
+| Jack St Malo | 73 | 73 | 7,047 | 6,928 | +119 | 0 | open — suspect over-counted post-TD completion days; deferred bug [#846](https://github.com/vamseeachanta/worldenergydata/issues/846) |
+| Big Foot | 38 | — | 3,265 | — | — | +33 | WED-only: article excluded Big Foot; +33 post-cutoff well-servicing days (§3.1) |
+| **Total (all 11)** | | | **25,404** | | | **+53** | 253 wells; +53 days since the Nov-2025 cutoff |
 
 Fidelity anchor: the candidate extraction reproduces the frozen V30 workbook **exactly** on Anchor (821 drilling / 1,004 completion days), pinned by `tests/integration/test_kc_ingest_fidelity.py`. Candidate totals: 253 wells / 25,404 D&C days across 26 leases, 11 developments.
 
 The like-for-like frozen-V30 reconciliation (217 wells, 22,478 WED vs 21,944 WO D&C days; matched-9 −2.5%) lives on the [verification page](https://vamseeachanta.github.io/worldenergydata/completion/verification.html) and in `scripts/completion/build_completion_report.py` (`WO_APRIL_2026_ARTICLE` frozen benchmark).
+
+### 3.1 D&C days accrued since the article's Nov-2025 cutoff
+
+The article's Table 1 was built on BSEE WAR data through **November 2025**. Our current extract reads the **2026-02-19** WAR vintage (latest rig-on-well activity 2026-02-16). To isolate what the newer data adds, the canonical extractor was re-run twice — once uncapped (which reproduces the **WED D&C** column above *to the day*: 25,404 total) and once with every WAR activity interval capped at 2025-11-30 — and the two differenced. The gap is the D&C days accrued after the article's cutoff:
+
+| Development | WED D&C (Feb-2026 vintage) | …capped at 2025-11-30 | Δ since Nov '25 | Nature of the added days | Latest activity |
+|---|---:|---:|---:|---|---|
+| Big Foot | 3,265 | 3,232 | +33 | post-TD rig-days on one well (TD 2020) | 2026-01-02 |
+| Stones | 2,625 | 2,605 | +20 | post-TD rig-days on three wells (TD 2018–2022) | 2025-12-17 |
+| All nine other developments | — | — | 0 | no rig-on-well activity after the cutoff | ≤ 2025-09-29 |
+| **Total** | **25,404** | **25,351** | **+53** | | 2026-02-16 |
+
+**Findings from the delta-increase analysis:**
+
+1. **The increment is small and concentrated: 53 D&C days, entirely on Big Foot (+33) and Stones (+20).** Every other Lower-Tertiary development shows zero post-cutoff activity in our feed — the article's November-2025 window already captured essentially all of their drilling and completion.
+2. **All 53 added days are completion-phase, none drilling** (`drill_delta = 0` for every well). Each traces to rig-on-well days on wells that reached total depth years ago (Big Foot 2020; Stones 2018–2022), so they are **late-life well-servicing / intervention days**, not new-well D&C — swept in by the extractor's simplified rule that counts every rig-day after TD as "completion" (the same accounting behaviour tracked for Jack St Malo in [#846](https://github.com/vamseeachanta/worldenergydata/issues/846)).
+3. **None of the WED-vs-article Δ days in §3 come from this newer data.** Shenandoah (+24), Buckskin (+52) and Jack St Malo (+119) all pre-date the cutoff (latest activity 2025-09, 2024-05 and 2025-05 respectively); those differences are recompletion accounting, the Buckskin recovery, and the JSM over-count — orthogonal to the data vintage. **Refreshing to the Feb-2026 vintage therefore leaves the reconciliation of the nine matched developments unchanged, and the article stands as printed for them.**
+
+*Reproduce:* re-run `docs/modules/bsee/analysis/production/FDAS_V30/extract_drilling_completion_days.py` against the `2026-02-19` WAR `.bin` feed with `leases_v21_kc.csv`, applying an `activity-day > 2025-11-30` filter on the same `WAR_START_DT`/`WAR_END_DT` daily index the extractor already unions.
 
 ## 4. Discrepancies found in the article (QA hand-back)
 
@@ -216,3 +239,4 @@ Discovery + first-production dates now sourced from BSEE Deepwater Qualified Fie
 | 2026-07-06 | All four article tables validated against `financial_project_summary.xlsx` (§1–2); five discrepancies documented with comparison tables (§4); STOIIP confirmed to have no government source (§5). |
 | 2026-07-06 | KC deepwater ingest landed (PR #851): canonical extractor reads raw WAR `.bin`; Buckskin becomes a matched row (§3); Anchor fidelity pinned exactly by test. Benchmark renamed to "World Oil April 2026 article" everywhere (PR #852). This report committed (PR #853). |
 | 2026-07-06 | BOEM reserves + discovery ingest landed (#847 / PR #861, plan #854 with two adversarial review rounds): annual Table 4 workbook + Deepwater Qualified Fields on refresh cadence; curated per-development table with citation columns; **Stones reserves discrepancy surfaced** (§5.1). Follow-on source family filed as #855. |
+| 2026-07-06 | Delta-increase analysis added (§3.1): current 2026-02-19 WAR vintage vs the article's Nov-2025 cutoff yields **+53 D&C days** (Big Foot +33, Stones +20), all post-TD well-servicing; Table 1 gains a **Δ since Nov '25** column. Section permalinks + an "On this page" contents nav added to the page. |

--- a/scripts/build_pages.py
+++ b/scripts/build_pages.py
@@ -80,6 +80,18 @@ _ITALIC = re.compile(r"(?<![A-Za-z0-9_])_([^_]+)_(?![A-Za-z0-9_])")
 _CODE = re.compile(r"`([^`]+)`")
 
 
+def _slug(text: str) -> str:
+    """Stable, human-readable heading id for deep-linking. Strips inline markup
+    (`code`, **bold**, links) and HTML entities, then lowercases and hyphenates.
+    e.g. "3. Field-level D&C reconciliation (Table 1)" -> "field-level-dc-reconciliation-table-1"."""
+    t = _LINK.sub(r"\1", text)            # keep link text, drop target
+    t = re.sub(r"&[#0-9a-zA-Z]+;", " ", t)  # drop HTML entities (&middot; etc.)
+    t = re.sub(r"[`*_]", "", t)             # drop inline-format markers
+    t = t.lower()
+    t = re.sub(r"[^a-z0-9]+", "-", t).strip("-")
+    return t
+
+
 def _inline(text: str) -> str:
     """Apply inline formatting. Text may already contain intentional raw HTML
     (e.g. &middot;, <br>), so we do NOT escape the whole string — only the
@@ -101,6 +113,32 @@ def _table(rows: list[str]) -> str:
         out.append("<tr>" + "".join(f"<td>{_inline(c)}</td>" for c in row) + "</tr>")
     out += ["</tbody></table></div>"]
     return "\n".join(out)
+
+
+def _toc(md: str, *, levels=(2,)) -> str:
+    """Build an ``<nav class="toc">`` contents box from a markdown document's
+    headings. Slugs are produced by the same `_slug` used by the heading
+    renderer, so the links always resolve. Fenced-code lines are skipped so a
+    ``#`` comment inside a code block is never mistaken for a heading."""
+    entries: list[tuple[str, str]] = []
+    in_code = False
+    for line in md.splitlines():
+        s = line.strip()
+        if s.startswith("```"):
+            in_code = not in_code
+            continue
+        if in_code:
+            continue
+        m = re.match(r"^(#{1,6})\s+(.*)$", s)
+        if m and len(m.group(1)) in levels:
+            text = m.group(2)
+            entries.append((_slug(text), text))
+    if not entries:
+        return ""
+    items = "".join(
+        f'<li><a href="#{slug}">{_inline(text)}</a></li>' for slug, text in entries
+    )
+    return f'<nav class="toc"><strong>On this page</strong><ol>{items}</ol></nav>'
 
 
 def md_to_html(md: str) -> str:
@@ -150,7 +188,14 @@ def md_to_html(md: str) -> str:
         if m:
             flush_para()
             level = len(m.group(1))
-            out.append(f"<h{level}>{_inline(m.group(2))}</h{level}>")
+            text = m.group(2)
+            slug = _slug(text)
+            # id + hover "#" anchor so every section is directly linkable/shareable.
+            out.append(
+                f'<h{level} id="{slug}">'
+                f'<a class="anchor" href="#{slug}" aria-label="Permalink to this section">#</a>'
+                f"{_inline(text)}</h{level}>"
+            )
             i += 1
             continue
 
@@ -261,6 +306,15 @@ main{max-width:960px;margin:0 auto;padding:28px 22px}
 .limits summary{cursor:pointer;font-weight:600;color:#8a5a00}
 .content h2{margin-top:1.6em;border-bottom:1px solid var(--line);padding-bottom:.2em}
 .content h3{margin-top:1.4em}
+.content h1,.content h2,.content h3,.content h4,.content h5,.content h6{scroll-margin-top:16px;position:relative}
+.content .anchor{position:absolute;left:-.85em;opacity:0;color:var(--muted);text-decoration:none;font-weight:400;padding-right:.15em;transition:opacity .12s}
+.content h1:hover .anchor,.content h2:hover .anchor,.content h3:hover .anchor,.content h4:hover .anchor,.content h5:hover .anchor,.content h6:hover .anchor,.content .anchor:focus{opacity:.6}
+:target{background:#fff6d8;border-radius:4px}
+nav.toc{background:var(--card);border:1px solid var(--line);border-radius:10px;padding:14px 18px;margin:0 0 26px}
+nav.toc strong{display:block;font-size:13px;text-transform:uppercase;letter-spacing:.04em;color:var(--muted);margin-bottom:8px}
+nav.toc ol{margin:0;padding-left:1.2em;columns:2;column-gap:32px;font-size:14px}
+nav.toc li{margin:.2em 0;break-inside:avoid}
+@media(max-width:620px){nav.toc ol{columns:1}.content .anchor{left:-.7em}}
 blockquote{margin:1em 0;padding:.6em 1em;background:#f0f3f7;border-left:4px solid var(--muted);border-radius:0 6px 6px 0;color:#374050}
 .table-wrap{overflow-x:auto;margin:1em 0}
 table{border-collapse:collapse;width:100%;font-size:14px;background:var(--card)}
@@ -442,7 +496,8 @@ def build_lower_tertiary(available_viz: dict[str, bool]) -> list[tuple]:
                 "World Oil April 2026 Article — Validation",
                 "All four article tables validated against the BSEE-derived model: "
                 "reconciliation, article errata, BOEM cross-check, and change log.",
-                md_to_html(val_md.read_text(encoding="utf-8")),
+                _toc(val_md.read_text(encoding="utf-8"))
+                + md_to_html(val_md.read_text(encoding="utf-8")),
                 provenance=(
                     "Every WED number is computed by repository code from BSEE/BOEM raw "
                     "data (WAR, OGOR-A, Reserves Inventory, Deepwater Qualified Fields); "


### PR DESCRIPTION
## What & why

Answers the WO-article-team question — *"how many drilling & completion days did we add past the article's November-2025 data cutoff?"* — and makes the validation report's sections directly linkable.

## Delta-increase analysis (new §3.1)

Re-ran the canonical extractor (`extract_drilling_completion_days.py`) against the current **2026-02-19 WAR vintage** twice — uncapped vs. capped at 2025-11-30 — and differenced. The uncapped run **reproduces the existing §3 "WED D&C" column to the day** (25,404 total), so the delta is trustworthy.

| Development | Δ since Nov '25 | Nature |
|---|---:|---|
| Big Foot | +33 | post-TD well-servicing (1 well, TD 2020) |
| Stones | +20 | post-TD well-servicing (3 wells, TD 2018–2022) |
| all 9 others | 0 | no rig activity after the cutoff |
| **Total** | **+53** | latest activity 2026-02-16 |

**Findings:**
1. The increment is small and concentrated: **53 D&C days**, only on Big Foot and Stones.
2. All 53 are **completion-phase, zero drilling** — late-life well-servicing on wells drilled years ago (the same "all rig-days after TD = completion" behaviour tracked in #846).
3. **None of the existing WED-vs-article deltas** (Shenandoah +24, Buckskin +52, JSM +119) come from the newer data — they all pre-date the cutoff. Refreshing to the Feb-2026 vintage leaves the nine matched developments unchanged, so **the article stands as printed** for them.

## Changes

- **`reports/lower_tertiary/wo-april-2026-validation.md`** — new §3.1; Table 1 gains a **`Δ since Nov '25`** column and renames the prior `Δ days` → `Δ vs WO` (disambiguates the two deltas); exec-summary bullet + change-log row.
- **`scripts/build_pages.py`** — every report heading now gets a stable slug `id` + a hover-`#` permalink, and the validation page gets an **"On this page"** contents nav (helpers `_slug`, `_toc`; anchor/TOC CSS). This makes sections shareable, e.g. `…/wo-april-2026-validation.html#3-field-level-d-c-reconciliation-table-1`.

## Verification

- Uncapped extractor totals reproduce all 11 per-field WED D&C figures exactly (grand total 25,404).
- Page re-rendered locally: new column, §3.1 anchor, in-table link to §3.1, and TOC all resolve; `build_pages.py` compiles clean.
- `public/*.html` intentionally not committed — CI rebuilds it from these sources.

*Reproduce:* `extract_drilling_completion_days.py` against the 2026-02-19 WAR `.bin` feed with `leases_v21_kc.csv`, filtering activity days `> 2025-11-30`.
