### PR TITLE
feat(spain): add Fuel density factors for Boquerón and Rodaballo

### DIFF
--- a/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
@@ -1,15 +1,13 @@
 {
-  "registry_version": "2026-07-06-boe-partial-2",
+  "registry_version": "2026-07-06-cited-partial-3",
   "registry_date": "2026-07-06",
   "coverage_status": "missing",
-  "coverage_note": "Amposta, Casablanca, Dorada, and Tarraco have accepted BOE regulator-record API values. Strict refreshes still fail closed until accepted cited factors cover every current CORES oil field.",
+  "coverage_note": "Amposta, Casablanca, Dorada, and Tarraco have accepted BOE regulator-record API values. Boquer\u00f3n and Rodaballo have accepted technical-literature API values from a Fuel reservoir-geochemistry article. Strict refreshes still fail closed until accepted cited factors cover every current CORES oil field.",
   "source_gap_fields": [
     "Albatros",
     "Ayoluengo",
-    "Boquer\u00f3n",
     "Gaviota",
     "Montanazo-Lubina",
-    "Rodaballo",
     "Salmonete",
     "Viura (1)"
   ],
@@ -30,6 +28,24 @@
       "source_url": "https://www.boe.es/boe/dias/1976/05/21/pdfs/A09838-09839.pdf",
       "source_class": "regulator_record",
       "evidence_note": "The BOE order fixes the sales price for crude from the San Carlos I and II (Amposta) exploitation concessions and states 17\u00b0 API with 5.5% sulfur.",
+      "confidence": "high",
+      "accepted_for_conversion": true
+    },
+    {
+      "field_name": "Boquer\u00f3n",
+      "aliases": [
+        "boqueron",
+        "boquer\u00f3n"
+      ],
+      "api_gravity_deg": 38.7,
+      "api_gravity_min_deg": null,
+      "api_gravity_max_deg": null,
+      "bbl_per_tonne": 7.565553308321867,
+      "measurement_basis": "Fuel technical-literature study of Western Mediterranean production oils; Boquer\u00f3n is a single-well field producing at its respective well",
+      "source_title": "FTIR and SUVF spectroscopy as an alternative method in reservoir studies. Application to Western Mediterranean oils",
+      "source_url": "https://doi.org/10.1016/j.fuel.2004.06.027",
+      "source_class": "technical_literature",
+      "evidence_note": "The Fuel article states that Boquer\u00f3n and Rodaballo fields produce at their respective wells; Table 1 lists Boquer\u00f3n oil at 38.7\u00b0 API.",
       "confidence": "high",
       "accepted_for_conversion": true
     },
@@ -64,6 +80,23 @@
       "source_url": "https://www.boe.es/boe/dias/1978/06/26/pdfs/A15132-15132.pdf",
       "source_class": "regulator_record",
       "evidence_note": "The BOE order fixes the sales price for crude from the Dorada exploitation concession and states 21.3\u00b0 API with 0.59% sulfur.",
+      "confidence": "high",
+      "accepted_for_conversion": true
+    },
+    {
+      "field_name": "Rodaballo",
+      "aliases": [
+        "rodaballo"
+      ],
+      "api_gravity_deg": 41.3,
+      "api_gravity_min_deg": null,
+      "api_gravity_max_deg": null,
+      "bbl_per_tonne": 7.681125803043588,
+      "measurement_basis": "Fuel technical-literature study of Western Mediterranean production oils; Rodaballo is a single-well field producing at its respective well",
+      "source_title": "FTIR and SUVF spectroscopy as an alternative method in reservoir studies. Application to Western Mediterranean oils",
+      "source_url": "https://doi.org/10.1016/j.fuel.2004.06.027",
+      "source_class": "technical_literature",
+      "evidence_note": "The Fuel article states that Boquer\u00f3n and Rodaballo fields produce at their respective wells; Table 1 lists Rodaballo oil at 41.3\u00b0 API.",
       "confidence": "high",
       "accepted_for_conversion": true
     },

--- a/tests/unit/spain/test_cores_density.py
+++ b/tests/unit/spain/test_cores_density.py
@@ -167,13 +167,14 @@ def test_default_density_registry_file_loads_from_package_data():
     assert isinstance(factors, dict)
 
 
-def test_default_density_registry_accepts_boe_regulator_fields():
+def test_default_density_registry_accepts_cited_source_fields():
     factors = load_crude_density_factors()
     casablanca_tarraco_url = (
         "https://www.boe.es/boe/dias/1977/07/14/pdfs/A15865-15866.pdf"
     )
     amposta_url = "https://www.boe.es/boe/dias/1976/05/21/pdfs/A09838-09839.pdf"
     dorada_url = "https://www.boe.es/boe/dias/1978/06/26/pdfs/A15132-15132.pdf"
+    boqueron_rodaballo_url = "https://doi.org/10.1016/j.fuel.2004.06.027"
 
     amposta = factors["amposta"]
     assert amposta.field_name == "Amposta"
@@ -191,6 +192,14 @@ def test_default_density_registry_accepts_boe_regulator_fields():
     assert casablanca.api_gravity_deg == pytest.approx(33.0)
     assert casablanca.bbl_per_tonne == pytest.approx(7.312182839124249)
 
+    boqueron = factors["boqueron"]
+    assert boqueron.field_name == "Boquerón"
+    assert boqueron.source_class == "technical_literature"
+    assert boqueron.source_url == boqueron_rodaballo_url
+    assert boqueron.accepted_for_conversion is True
+    assert boqueron.api_gravity_deg == pytest.approx(38.7)
+    assert boqueron.bbl_per_tonne == pytest.approx(7.565553308321867)
+
     dorada = factors["dorada"]
     assert dorada.field_name == "Dorada"
     assert dorada.source_class == "regulator_record"
@@ -198,6 +207,14 @@ def test_default_density_registry_accepts_boe_regulator_fields():
     assert dorada.accepted_for_conversion is True
     assert dorada.api_gravity_deg == pytest.approx(21.3)
     assert dorada.bbl_per_tonne == pytest.approx(6.792106612876507)
+
+    rodaballo = factors["rodaballo"]
+    assert rodaballo.field_name == "Rodaballo"
+    assert rodaballo.source_class == "technical_literature"
+    assert rodaballo.source_url == boqueron_rodaballo_url
+    assert rodaballo.accepted_for_conversion is True
+    assert rodaballo.api_gravity_deg == pytest.approx(41.3)
+    assert rodaballo.bbl_per_tonne == pytest.approx(7.681125803043588)
 
     tarraco = factors["tarraco"]
     assert tarraco.field_name == "Tarraco"
@@ -208,12 +225,19 @@ def test_default_density_registry_accepts_boe_regulator_fields():
     assert tarraco.bbl_per_tonne == pytest.approx(7.401084758140957)
 
     audit = build_oil_conversion_audit(
-        ["Amposta", "Casablanca", "Dorada", "Tarraco"],
+        ["Amposta", "Boquerón", "Casablanca", "Dorada", "Rodaballo", "Tarraco"],
         factors,
         allow_default_density=False,
     )
 
-    assert audit.used_field_names == ("Amposta", "Casablanca", "Dorada", "Tarraco")
+    assert audit.used_field_names == (
+        "Amposta",
+        "Boquerón",
+        "Casablanca",
+        "Dorada",
+        "Rodaballo",
+        "Tarraco",
+    )
     assert audit.defaulted_fields == ()
     assert audit.missing_fields == ()
 
@@ -227,10 +251,8 @@ def test_default_density_registry_keeps_current_fields_missing():
     assert expected_fields == [
         "Albatros",
         "Ayoluengo",
-        "Boquerón",
         "Gaviota",
         "Montanazo-Lubina",
-        "Rodaballo",
         "Salmonete",
         "Viura (1)",
     ]
@@ -268,14 +290,19 @@ def test_default_density_registry_partially_covers_current_cores_fields():
     expected_gap_fields = [
         "Albatros",
         "Ayoluengo",
-        "Boquerón",
         "Gaviota",
         "Montanazo-Lubina",
-        "Rodaballo",
         "Salmonete",
         "Viura (1)",
     ]
-    expected_used_fields = ["Amposta", "Casablanca", "Dorada", "Tarraco"]
+    expected_used_fields = [
+        "Amposta",
+        "Boquerón",
+        "Casablanca",
+        "Dorada",
+        "Rodaballo",
+        "Tarraco",
+    ]
     factors = load_crude_density_factors()
 
     assert payload["coverage_status"] == "missing"
@@ -294,8 +321,10 @@ def test_default_density_registry_partially_covers_current_cores_fields():
     for field_name in expected_gap_fields:
         assert field_name in message
     assert "Amposta" not in message
+    assert "Boquerón" not in message
     assert "Casablanca" not in message
     assert "Dorada" not in message
+    assert "Rodaballo" not in message
     assert "Tarraco" not in message
 
     defaulted_audit = build_oil_conversion_audit(


### PR DESCRIPTION
## Summary

Related issue: https://github.com/vamseeachanta/worldenergydata/issues/807

This PR adds the next cited CORES crude-density factors for Spain field-development conversion work:

- Adds Boquerón at 38.7 API and Rodaballo at 41.3 API from the Fuel technical-literature source `https://doi.org/10.1016/j.fuel.2004.06.027`.
- Marks both factors as accepted `technical_literature` sources and records the bbl/tonne conversion factors.
- Updates partial registry coverage metadata so strict mode still fail-closes for the remaining source gaps: Albatros, Ayoluengo, Gaviota, Montanazo-Lubina, Salmonete, Viura (1).
- Extends density-registry tests to cover accepted technical-literature fields and the reduced strict-mode gap list.

## Verification

- RED before registry update: focused density tests failed on missing Boquerón/Rodaballo factors and old gap list.
- `python -m json.tool packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json`
- `.venv/bin/python -m pytest tests/unit/spain/test_cores_density.py -q` -> 19 passed
- `.venv/bin/python -m pytest tests/unit/spain/test_cores_density.py tests/unit/spain/test_cores_field_development_density.py tests/unit/spain/test_cores_field_development_report.py tests/unit/spain/test_cores_live.py tests/unit/spain/test_cores_live_density.py tests/unit/spain/test_cores_loader.py tests/unit/scheduler/test_spain_cores_refresh.py -q` -> 86 passed
- `.venv/bin/python -m pytest tests/unit/core tests/unit/common tests/contracts tests/workflows tests/unit/spain -q` -> 545 passed, 2 skipped
- `git diff --check origin/main...HEAD`
- `.venv/bin/python -m black --check tests/unit/spain/test_cores_density.py`
- `.venv/bin/python -m isort --check-only tests/unit/spain/test_cores_density.py`
- `scripts/legal/legal-sanity-scan.sh` -> PASS before commit; no files to scan after commit
- `uv run bandit -r packages/worldenergydata-spain/src/worldenergydata/spain tests/unit/spain -ll -ii -q` reported pre-existing B310 in `cores_source.py:290`; this PR changes only registry JSON and tests

## Notes

A concurrent local pytest attempt hit `.test_performance.db` SQLite lock contention when two suites ran at once. The affected suite was rerun serially and passed.
