### PR TITLE
feat(spain): add BOE Montanazo-Lubina density factor

### DIFF
--- a/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
@@ -1,13 +1,12 @@
 {
-  "registry_version": "2026-07-06-cited-partial-3",
+  "registry_version": "2026-07-06-cited-partial-4",
   "registry_date": "2026-07-06",
   "coverage_status": "missing",
-  "coverage_note": "Amposta, Casablanca, Dorada, and Tarraco have accepted BOE regulator-record API values. Boquer\u00f3n and Rodaballo have accepted technical-literature API values from a Fuel reservoir-geochemistry article. Strict refreshes still fail closed until accepted cited factors cover every current CORES oil field.",
+  "coverage_note": "Amposta, Casablanca, Dorada, Montanazo-Lubina, and Tarraco have accepted BOE regulator-record API values. Boquer\u00f3n and Rodaballo have accepted technical-literature API values from a Fuel reservoir-geochemistry article. Strict refreshes still fail closed until accepted cited factors cover every current CORES oil field.",
   "source_gap_fields": [
     "Albatros",
     "Ayoluengo",
     "Gaviota",
-    "Montanazo-Lubina",
     "Salmonete",
     "Viura (1)"
   ],
@@ -80,6 +79,25 @@
       "source_url": "https://www.boe.es/boe/dias/1978/06/26/pdfs/A15132-15132.pdf",
       "source_class": "regulator_record",
       "evidence_note": "The BOE order fixes the sales price for crude from the Dorada exploitation concession and states 21.3\u00b0 API with 0.59% sulfur.",
+      "confidence": "high",
+      "accepted_for_conversion": true
+    },
+    {
+      "field_name": "Montanazo-Lubina",
+      "aliases": [
+        "montanazo-lubina",
+        "montanazo lubina",
+        "montanazolubina"
+      ],
+      "api_gravity_deg": 32.584375993836886,
+      "api_gravity_min_deg": 30.81,
+      "api_gravity_max_deg": 33.33,
+      "bbl_per_tonne": 7.293707953255592,
+      "measurement_basis": "BOE environmental declaration gives separate Montanazo and Lubina API values; combined CORES field factor is a derived recoverable-reserves-weighted proxy from stated reserves of 1.2 MMbbl Montanazo and 2.9 MMbbl Lubina",
+      "source_title": "BOE-A-2012-6772, Resoluci\u00f3n de 7 de mayo de 2012: Desarrollo de los campos de Montanazo y Lubina, Tarragona",
+      "source_url": "https://www.boe.es/diario_boe/txt.php?id=BOE-A-2012-6772",
+      "source_class": "regulator_record",
+      "evidence_note": "The BOE declaration states recoverable reserves of 1.2 MMbbl for Montanazo and 2.9 MMbbl for Lubina, average production of 3,000 bbl/d per well, and crude properties of 30.81\u00b0 API for Montanazo and 33.33\u00b0 API for Lubina; this registry derives a combined proxy only for the combined CORES field name.",
       "confidence": "high",
       "accepted_for_conversion": true
     },

--- a/tests/unit/spain/test_cores_density.py
+++ b/tests/unit/spain/test_cores_density.py
@@ -174,6 +174,7 @@ def test_default_density_registry_accepts_cited_source_fields():
     )
     amposta_url = "https://www.boe.es/boe/dias/1976/05/21/pdfs/A09838-09839.pdf"
     dorada_url = "https://www.boe.es/boe/dias/1978/06/26/pdfs/A15132-15132.pdf"
+    montanazo_lubina_url = "https://www.boe.es/diario_boe/txt.php?id=BOE-A-2012-6772"
     boqueron_rodaballo_url = "https://doi.org/10.1016/j.fuel.2004.06.027"
 
     amposta = factors["amposta"]
@@ -208,6 +209,36 @@ def test_default_density_registry_accepts_cited_source_fields():
     assert dorada.api_gravity_deg == pytest.approx(21.3)
     assert dorada.bbl_per_tonne == pytest.approx(6.792106612876507)
 
+    montanazo_lubina = factors["montanazolubina"]
+    assert montanazo_lubina.field_name == "Montanazo-Lubina"
+    assert montanazo_lubina.source_class == "regulator_record"
+    assert montanazo_lubina.source_url == montanazo_lubina_url
+    assert montanazo_lubina.accepted_for_conversion is True
+    assert montanazo_lubina.api_gravity_min_deg == pytest.approx(30.81)
+    assert montanazo_lubina.api_gravity_max_deg == pytest.approx(33.33)
+    expected_combined_factor = (1.2 + 2.9) / (
+        (1.2 / bbl_per_tonne_from_api(30.81)) + (2.9 / bbl_per_tonne_from_api(33.33))
+    )
+    assert montanazo_lubina.api_gravity_deg == pytest.approx(32.584375993836886)
+    assert montanazo_lubina.bbl_per_tonne == pytest.approx(expected_combined_factor)
+    assert bbl_per_tonne_from_api(montanazo_lubina.api_gravity_deg) == pytest.approx(
+        expected_combined_factor
+    )
+    assert "montanazo" not in factors
+    assert "lubina" not in factors
+    with pytest.raises(CoresDensityCoverageError, match="Montanazo"):
+        build_oil_conversion_audit(
+            ["Montanazo"],
+            factors,
+            allow_default_density=False,
+        )
+    with pytest.raises(CoresDensityCoverageError, match="Lubina"):
+        build_oil_conversion_audit(
+            ["Lubina"],
+            factors,
+            allow_default_density=False,
+        )
+
     rodaballo = factors["rodaballo"]
     assert rodaballo.field_name == "Rodaballo"
     assert rodaballo.source_class == "technical_literature"
@@ -225,7 +256,15 @@ def test_default_density_registry_accepts_cited_source_fields():
     assert tarraco.bbl_per_tonne == pytest.approx(7.401084758140957)
 
     audit = build_oil_conversion_audit(
-        ["Amposta", "Boquerón", "Casablanca", "Dorada", "Rodaballo", "Tarraco"],
+        [
+            "Amposta",
+            "Boquerón",
+            "Casablanca",
+            "Dorada",
+            "Montanazo-Lubina",
+            "Rodaballo",
+            "Tarraco",
+        ],
         factors,
         allow_default_density=False,
     )
@@ -235,6 +274,7 @@ def test_default_density_registry_accepts_cited_source_fields():
         "Boquerón",
         "Casablanca",
         "Dorada",
+        "Montanazo-Lubina",
         "Rodaballo",
         "Tarraco",
     )
@@ -252,7 +292,6 @@ def test_default_density_registry_keeps_current_fields_missing():
         "Albatros",
         "Ayoluengo",
         "Gaviota",
-        "Montanazo-Lubina",
         "Salmonete",
         "Viura (1)",
     ]
@@ -291,7 +330,6 @@ def test_default_density_registry_partially_covers_current_cores_fields():
         "Albatros",
         "Ayoluengo",
         "Gaviota",
-        "Montanazo-Lubina",
         "Salmonete",
         "Viura (1)",
     ]
@@ -300,6 +338,7 @@ def test_default_density_registry_partially_covers_current_cores_fields():
         "Boquerón",
         "Casablanca",
         "Dorada",
+        "Montanazo-Lubina",
         "Rodaballo",
         "Tarraco",
     ]
@@ -324,6 +363,7 @@ def test_default_density_registry_partially_covers_current_cores_fields():
     assert "Boquerón" not in message
     assert "Casablanca" not in message
     assert "Dorada" not in message
+    assert "Montanazo-Lubina" not in message
     assert "Rodaballo" not in message
     assert "Tarraco" not in message
 


### PR DESCRIPTION
## Summary
- Add a cited Montanazo-Lubina crude density/API factor from BOE-A-2012-6772.
- Derive the combined CORES-field factor as a recoverable-reserves-weighted proxy from BOE-stated 30.81 API Montanazo, 33.33 API Lubina, and 1.2/2.9 MMbbl reserves.
- Remove Montanazo-Lubina from `source_gap_fields`; remaining gaps are Albatros, Ayoluengo, Gaviota, Salmonete, and Viura (1).
- Pin strict-mode behavior so individual `Montanazo` and `Lubina` lookups still fail closed rather than using the combined proxy.

Refs #807

## Source
- BOE-A-2012-6772: https://www.boe.es/diario_boe/txt.php?id=BOE-A-2012-6772

## Verification
- `.venv/bin/python -m pytest tests/unit/spain/test_cores_density.py -q --no-cov` -> 19 passed
- `.venv/bin/python -m pytest tests/unit/spain/test_cores_density.py tests/unit/spain/test_cores_field_development_density.py tests/unit/spain/test_cores_field_development_report.py tests/unit/spain/test_cores_live.py tests/unit/spain/test_cores_live_density.py tests/unit/spain/test_cores_loader.py tests/unit/scheduler/test_spain_cores_refresh.py -q --no-cov` -> 86 passed
- `.venv/bin/python -m pytest tests/unit/core tests/unit/common tests/contracts tests/workflows tests/unit/spain -q --no-cov` -> 545 passed, 2 skipped
- `git diff --check` -> passed
- `.venv/bin/python -m json.tool packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json` -> passed
- `.venv/bin/python -m black --check tests/unit/spain/test_cores_density.py` -> passed
- `.venv/bin/python -m isort --check-only tests/unit/spain/test_cores_density.py` -> passed
- `scripts/legal/legal-sanity-scan.sh` -> PASS
- `uv run bandit tests/unit/spain/test_cores_density.py -ll -ii -q` -> passed
- `gitleaks` -> not installed in this environment

## Security note
- Broader Spain Bandit scope still reports pre-existing B310 at `packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_source.py:290` (`urlopen`, blamed to `29d1a135d`), outside this PR diff.

## Adversarial review
- Initial read-only review found a real alias defect: individual `montanazo`/`lubina` aliases would use the combined factor.
- Fixed by removing individual aliases, labeling the factor as a derived proxy, and adding tests proving individual component lookups fail closed.
- Two reviewer re-checks returned APPROVE / no blocking defects.
