### PR TITLE
feat(spain): add Salmonete density factor

### DIFF
--- a/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
@@ -1,13 +1,12 @@
 {
-  "registry_version": "2026-07-06-cited-partial-4",
-  "registry_date": "2026-07-06",
+  "registry_version": "2026-07-07-cited-partial-5",
+  "registry_date": "2026-07-07",
   "coverage_status": "missing",
-  "coverage_note": "Amposta, Casablanca, Dorada, Montanazo-Lubina, and Tarraco have accepted BOE regulator-record API values. Boquer\u00f3n and Rodaballo have accepted technical-literature API values from a Fuel reservoir-geochemistry article. Strict refreshes still fail closed until accepted cited factors cover every current CORES oil field.",
+  "coverage_note": "Amposta, Casablanca, Dorada, Montanazo-Lubina, and Tarraco have accepted BOE regulator-record API values. Boquer\u00f3n, Rodaballo, and Salmonete have accepted technical-literature API values from reservoir-geochemistry articles. Strict refreshes still fail closed until accepted cited factors cover every current CORES oil field.",
   "source_gap_fields": [
     "Albatros",
     "Ayoluengo",
     "Gaviota",
-    "Salmonete",
     "Viura (1)"
   ],
   "factors": [
@@ -115,6 +114,23 @@
       "source_url": "https://doi.org/10.1016/j.fuel.2004.06.027",
       "source_class": "technical_literature",
       "evidence_note": "The Fuel article states that Boquer\u00f3n and Rodaballo fields produce at their respective wells; Table 1 lists Rodaballo oil at 41.3\u00b0 API.",
+      "confidence": "high",
+      "accepted_for_conversion": true
+    },
+    {
+      "field_name": "Salmonete",
+      "aliases": [
+        "salmonete"
+      ],
+      "api_gravity_deg": 44.9,
+      "api_gravity_min_deg": null,
+      "api_gravity_max_deg": null,
+      "bbl_per_tonne": 7.841149257273662,
+      "measurement_basis": "Organic Geochemistry technical-literature study of Tarragona Basin oils; crude oils were obtained from producing wells and Table 1 maps column A to Salmonete",
+      "source_title": "Petroleum geochemistry of the Tarragona basin (Spanish Mediterranean off-shore)",
+      "source_url": "https://doi.org/10.1016/0146-6380(86)90044-6",
+      "source_class": "technical_literature",
+      "evidence_note": "The article states that crude oils were obtained from producing wells; Table 1 lists column A at 3700 m depth with 44.9\u00b0 API, 0.10% sulfur, and 82% saturates, and maps column A to Salmonete.",
       "confidence": "high",
       "accepted_for_conversion": true
     },

--- a/tests/unit/spain/test_cores_density.py
+++ b/tests/unit/spain/test_cores_density.py
@@ -176,6 +176,7 @@ def test_default_density_registry_accepts_cited_source_fields():
     dorada_url = "https://www.boe.es/boe/dias/1978/06/26/pdfs/A15132-15132.pdf"
     montanazo_lubina_url = "https://www.boe.es/diario_boe/txt.php?id=BOE-A-2012-6772"
     boqueron_rodaballo_url = "https://doi.org/10.1016/j.fuel.2004.06.027"
+    salmonete_url = "https://doi.org/10.1016/0146-6380(86)90044-6"
 
     amposta = factors["amposta"]
     assert amposta.field_name == "Amposta"
@@ -247,6 +248,14 @@ def test_default_density_registry_accepts_cited_source_fields():
     assert rodaballo.api_gravity_deg == pytest.approx(41.3)
     assert rodaballo.bbl_per_tonne == pytest.approx(7.681125803043588)
 
+    salmonete = factors["salmonete"]
+    assert salmonete.field_name == "Salmonete"
+    assert salmonete.source_class == "technical_literature"
+    assert salmonete.source_url == salmonete_url
+    assert salmonete.accepted_for_conversion is True
+    assert salmonete.api_gravity_deg == pytest.approx(44.9)
+    assert salmonete.bbl_per_tonne == pytest.approx(7.841149257273662)
+
     tarraco = factors["tarraco"]
     assert tarraco.field_name == "Tarraco"
     assert tarraco.source_class == "regulator_record"
@@ -263,6 +272,7 @@ def test_default_density_registry_accepts_cited_source_fields():
             "Dorada",
             "Montanazo-Lubina",
             "Rodaballo",
+            "Salmonete",
             "Tarraco",
         ],
         factors,
@@ -276,6 +286,7 @@ def test_default_density_registry_accepts_cited_source_fields():
         "Dorada",
         "Montanazo-Lubina",
         "Rodaballo",
+        "Salmonete",
         "Tarraco",
     )
     assert audit.defaulted_fields == ()
@@ -292,7 +303,6 @@ def test_default_density_registry_keeps_current_fields_missing():
         "Albatros",
         "Ayoluengo",
         "Gaviota",
-        "Salmonete",
         "Viura (1)",
     ]
 
@@ -330,7 +340,6 @@ def test_default_density_registry_partially_covers_current_cores_fields():
         "Albatros",
         "Ayoluengo",
         "Gaviota",
-        "Salmonete",
         "Viura (1)",
     ]
     expected_used_fields = [
@@ -340,6 +349,7 @@ def test_default_density_registry_partially_covers_current_cores_fields():
         "Dorada",
         "Montanazo-Lubina",
         "Rodaballo",
+        "Salmonete",
         "Tarraco",
     ]
     factors = load_crude_density_factors()
@@ -365,6 +375,7 @@ def test_default_density_registry_partially_covers_current_cores_fields():
     assert "Dorada" not in message
     assert "Montanazo-Lubina" not in message
     assert "Rodaballo" not in message
+    assert "Salmonete" not in message
     assert "Tarraco" not in message
 
     defaulted_audit = build_oil_conversion_audit(


### PR DESCRIPTION
## Summary
- Add a cited Salmonete crude density/API factor from the Organic Geochemistry Tarragona Basin article.
- Use the article's Table 1 Salmonete value of 44.9 API and the repo conversion formula for `7.841149257273662` bbl/tonne.
- Remove Salmonete from `source_gap_fields`; remaining gaps are Albatros, Ayoluengo, Gaviota, and Viura (1).

Refs #807

## Source
- DOI: https://doi.org/10.1016/0146-6380(86)90044-6
- OSTI/ETDE metadata: https://www.osti.gov/etdeweb/biblio/7151083
- Source text inspected via the accessible article copy: crude oils obtained from producing wells; Table 1 maps column A to Salmonete and lists 44.9 API.

## Verification
- RED first: focused registry tests failed on missing `salmonete` and stale `source_gap_fields`.
- `.venv/bin/python -m pytest tests/unit/spain/test_cores_density.py::test_default_density_registry_accepts_cited_source_fields tests/unit/spain/test_cores_density.py::test_default_density_registry_keeps_current_fields_missing tests/unit/spain/test_cores_density.py::test_default_density_registry_partially_covers_current_cores_fields -q --no-cov` -> 3 passed
- `.venv/bin/python -m pytest tests/unit/spain/test_cores_density.py -q --no-cov` -> 19 passed
- `.venv/bin/python -m pytest tests/unit/spain/test_cores_density.py tests/unit/spain/test_cores_field_development_density.py tests/unit/spain/test_cores_field_development_report.py tests/unit/spain/test_cores_live.py tests/unit/spain/test_cores_live_density.py tests/unit/spain/test_cores_loader.py tests/unit/scheduler/test_spain_cores_refresh.py -q --no-cov` -> 86 passed
- `.venv/bin/python -m pytest tests/unit/core tests/unit/common tests/contracts tests/workflows tests/unit/spain -q --no-cov` -> 545 passed, 2 skipped
- `git diff --check` -> passed
- `.venv/bin/python -m json.tool packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json` -> passed
- `.venv/bin/python -m black --check tests/unit/spain/test_cores_density.py` -> passed
- `.venv/bin/python -m isort --check-only tests/unit/spain/test_cores_density.py` -> passed
- `scripts/legal/legal-sanity-scan.sh` -> PASS
- `uv run bandit tests/unit/spain/test_cores_density.py -ll -ii -q` -> passed
- `gitleaks` -> not installed in this environment

## Security note
- Broader Spain Bandit scope still reports pre-existing B310 at `packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_source.py:290` (`urlopen`, blamed to `29d1a135d`), outside this PR diff.

## Adversarial review
- Inline artifact review checked source support, conversion formula consistency, strict missing-field behavior, aliases, and remaining gaps. No blocking defects found for this two-file slice.
