### PR TITLE
fix(lower-tertiary): first-oil override in stackup + per-field frozen-ref header (#875)

### DIFF
--- a/packages/worldenergydata-bsee/src/worldenergydata/lower_tertiary/v30_financial_reproducer.py
+++ b/packages/worldenergydata-bsee/src/worldenergydata/lower_tertiary/v30_financial_reproducer.py
@@ -1167,7 +1167,11 @@ def _build_perwell_monthly_dnc(
     return per_well, shared
 
 
-def build_well_npv_stackup(dev_name: str, end_date: str | None = None) -> dict:
+def build_well_npv_stackup(
+    dev_name: str,
+    end_date: str | None = None,
+    first_oil_overrides: dict[str, str] | None = None,
+) -> dict:
     """Decompose a development's NPV into per-well contributions that sum exactly.
 
     This is an ADDITIVE presentation helper layered on :func:`build_field_npv_timeline`.
@@ -1195,6 +1199,11 @@ def build_well_npv_stackup(dev_name: str, end_date: str | None = None) -> dict:
         Optional upper date bound (``YYYY-MM-DD``). ``None`` => frozen V30 window
         (matches :func:`build_field_npv_timeline` with ``end_date=None``); a value
         extends the production + WTI window to that date.
+    first_oil_overrides : dict | None
+        Per-development first-oil corrections (e.g.
+        ``latest_runner.FIRST_OIL_CORRECTIONS``). MUST match whatever is passed to
+        :func:`build_field_npv_timeline` for the same report, or the stackup's
+        field NPV will not equal the headline field NPV it decomposes.
 
     Returns
     -------
@@ -1214,8 +1223,14 @@ def build_well_npv_stackup(dev_name: str, end_date: str | None = None) -> dict:
         the single-block (no decomposition) case.
       - ``blocks_note`` : str describing block-scope availability.
     """
-    # 1) Authoritative field timeline (frozen path untouched).
-    field = build_field_npv_timeline(dev_name, end_date=end_date)
+    # 1) Authoritative field timeline (frozen path untouched). The first-oil
+    #    overrides MUST flow through here so the reconstructed field (and every
+    #    per-well split below) uses the same corrected first-oil window as the
+    #    headline timeline — otherwise the stackup silently reverts to the golden
+    #    first oil and contradicts the field NPV it claims to decompose.
+    field = build_field_npv_timeline(
+        dev_name, end_date=end_date, first_oil_overrides=first_oil_overrides
+    )
     field_terminal = field["terminal_npv_usd"]
     dev_system = field["dev_system"]
     first_oil = field["first_oil"]
@@ -1247,7 +1262,9 @@ def build_well_npv_stackup(dev_name: str, end_date: str | None = None) -> dict:
     fopw = _build_fopw_map()
 
     # 2) Reconstruct the field full_range (identical to build_field_npv_timeline).
-    production = reproduce_v30_production(end_date=prod_end)
+    production = reproduce_v30_production(
+        end_date=prod_end, first_oil_overrides=first_oil_overrides
+    )
     if dev_name not in production:
         raise ValueError(f"{dev_name!r} has no production timeline (exploration-only)")
     monthly = production[dev_name]["monthly_production"].copy()

--- a/scripts/lower_tertiary/generate_field_economics_report.py
+++ b/scripts/lower_tertiary/generate_field_economics_report.py
@@ -172,10 +172,18 @@ def build_report(
     ops_end = end_date if is_latest else "2025-05-31"
     start_label = "2000-09"
     end_label = pd.Timestamp(ops_end).strftime("%Y-%m")
+    # Frozen-V30 financials (no end_date, so independent of the latest window):
+    # the headline reconciliation AND the per-field reference NPV in the window
+    # header. Compute here so the header shows THIS field's frozen NPV, not a
+    # hardcoded constant.
+    fin = reproduce_v30_financials()
+    sanctioned_npv = fin[dev_name]["npv_usd"]
+    _ref_mm = sanctioned_npv / 1e6
+    _ref_str = f"-${abs(_ref_mm):,.1f}M" if _ref_mm < 0 else f"${_ref_mm:,.1f}M"
     if is_latest:
         window_label = (
             f"{start_label} -> {end_label} (latest); "
-            f"frozen V30 reference NPV = -$530.6M"
+            f"frozen V30 reference NPV = {_ref_str}"
         )
     else:
         window_label = f"{start_label} -> {end_label} (V30 frozen window)"
@@ -199,9 +207,7 @@ def build_report(
             return None
         return float(prior["cumulative_npv_usd"].iloc[-1])
 
-    # Full financials for the headline reconciliation.
-    fin = reproduce_v30_financials()
-    sanctioned_npv = fin[dev_name]["npv_usd"]
+    # (fin / sanctioned_npv computed above, before the window header.)
 
     # Latest revenue/oil comparison (read once; reused by the summary + the
     # Financial Summary table below). None for the frozen report.
@@ -429,7 +435,11 @@ def build_report(
     lines.append("")
 
     # ===================== WELL-LEVEL NPV STACKUP ==========================
-    stk = build_well_npv_stackup(dev_name, end_date=end_date)
+    # Pass the same first-oil overrides as the headline timeline so the stackup's
+    # field NPV matches the field NPV it claims to decompose (Cascade Chinook fix).
+    stk = build_well_npv_stackup(
+        dev_name, end_date=end_date, first_oil_overrides=first_oil_overrides
+    )
     lines.append("## Well-Level NPV Stackup")
     lines.append("")
     lines.append(

--- a/tests/unit/lower_tertiary/test_well_npv_stackup.py
+++ b/tests/unit/lower_tertiary/test_well_npv_stackup.py
@@ -87,3 +87,46 @@ class TestWellStackupSumsToField:
             assert w["gross_npv_usd"] + w["shared_npv_usd"] == pytest.approx(
                 w["net_npv_usd"], abs=0.01
             )
+
+
+class TestWellStackupHonoursFirstOilOverride:
+    """Regression: the stackup must apply the SAME first-oil overrides as the
+    headline timeline. Cascade Chinook carries a first-oil correction
+    (2014-01 -> 2012-09); before this fix ``build_well_npv_stackup`` ignored the
+    override and silently reverted to the golden window, so its field NPV
+    contradicted the headline field NPV it claims to decompose (a ~$99.5M split
+    in the published field_economics_cascade_chinook_v50.md)."""
+
+    OVERRIDES = {"Cascade Chinook": "2012-09-01"}
+
+    def test_stackup_field_npv_matches_timeline_under_override(self):
+        _ensure_ogor_or_skip()
+        end_date = "2026-04-30"
+        field = build_field_npv_timeline(
+            "Cascade Chinook", end_date=end_date, first_oil_overrides=self.OVERRIDES
+        )
+        stk = build_well_npv_stackup(
+            "Cascade Chinook", end_date=end_date, first_oil_overrides=self.OVERRIDES
+        )
+        # The authoritative field NPV the stackup reports must equal the headline.
+        assert stk["field_terminal_npv_usd"] == pytest.approx(
+            field["terminal_npv_usd"], abs=0.01
+        )
+        # And the per-well decomposition still sums to it exactly.
+        assert stk["sum_well_npv_usd"] == pytest.approx(
+            field["terminal_npv_usd"], abs=0.01
+        )
+        assert abs(stk["residual_usd"]) < 0.01
+
+    def test_override_actually_moves_the_number(self):
+        """Guard against a vacuous test: the override must change the stackup's
+        field NPV vs. no override (else the propagation could silently regress)."""
+        _ensure_ogor_or_skip()
+        end_date = "2026-04-30"
+        with_override = build_well_npv_stackup(
+            "Cascade Chinook", end_date=end_date, first_oil_overrides=self.OVERRIDES
+        )["field_terminal_npv_usd"]
+        without = build_well_npv_stackup("Cascade Chinook", end_date=end_date)[
+            "field_terminal_npv_usd"
+        ]
+        assert with_override != pytest.approx(without, abs=1.0)


### PR DESCRIPTION
## Two confirmed report-number bugs in the canonical LT-economics path

Both surfaced by the canonical-pipeline bug hunt for #875 and **confirmed to affect published `field_economics_*_v50.md` numbers** (the only two of ~30 findings that touch a published figure; the rest are latent and tracked on #875).

### 1. `build_well_npv_stackup` ignored `first_oil_overrides`
`build_field_npv_timeline` applies the Cascade Chinook first-oil correction (2014-01 → 2012-09), but the stackup rebuilt the field with the **golden** first oil, so its field NPV and per-well split silently used the wrong window. The published `field_economics_cascade_chinook_v50.md` stated the same field's NPV as both **−$1,580.0M** (headline) and **−$1,480.5M** (stackup) — a ~$99.5M internal contradiction.
**Fix:** thread `first_oil_overrides` through `build_well_npv_stackup` → `build_field_npv_timeline` + `reproduce_v30_production`, and pass it from the report generator's stackup call.
**Test:** `TestWellStackupHonoursFirstOilOverride` asserts the stackup field NPV equals the headline timeline NPV under the Cascade override — **passes (235s)**; a second guard asserts the override actually moves the number.

### 2. Hardcoded `−$530.6M` frozen-reference in every report header
`generate_field_economics_report` hardcoded **Julia's** frozen V30 reference NPV (−$530.6M) into the "Data window" header of **every** latest/v50 report, so Stones printed −$530.6M (real −$1,479.5M), Anchor −$1,732.8M, Big Foot −$1,063.4M, etc. The correct per-field `sanctioned_npv` was already computed lower in the same function.
**Fix:** compute `sanctioned_npv` before the header and interpolate it (sign-aware format).

### Scope / safety
- Both fixes touch **only** the latest/v50 presentation path; the frozen-V30 reproduction is unchanged.
- The published `field_economics_*_v50.md` are **generated artifacts** — they need regeneration (`scripts/lower_tertiary/regenerate_field_economics_v50.py`) to reflect these fixes. Each field takes ~5 OGOR reproductions (~9 min), so regeneration is a separate step (CI or a follow-up run), not bundled here.

Refs #875.
