### PR TITLE
feat(spain): retain Ayoluengo density evidence

### DIFF
--- a/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
@@ -1,8 +1,8 @@
 {
-  "registry_version": "2026-07-07-cited-partial-5",
+  "registry_version": "2026-07-07-cited-partial-6",
   "registry_date": "2026-07-07",
   "coverage_status": "missing",
-  "coverage_note": "Amposta, Casablanca, Dorada, Montanazo-Lubina, and Tarraco have accepted BOE regulator-record API values. Boquer\u00f3n, Rodaballo, and Salmonete have accepted technical-literature API values from reservoir-geochemistry articles. Strict refreshes still fail closed until accepted cited factors cover every current CORES oil field.",
+  "coverage_note": "Amposta, Casablanca, Dorada, Montanazo-Lubina, and Tarraco have accepted BOE regulator-record API values. Boquer\u00f3n, Rodaballo, and Salmonete have accepted technical-literature API values from reservoir-geochemistry articles. Ayoluengo has an evidence-only heterogeneous 20\u00b0 to 39\u00b0 API range but no accepted representative conversion factor. Strict refreshes still fail closed until accepted cited factors cover every current CORES oil field.",
   "source_gap_fields": [
     "Albatros",
     "Ayoluengo",
@@ -28,6 +28,23 @@
       "evidence_note": "The BOE order fixes the sales price for crude from the San Carlos I and II (Amposta) exploitation concessions and states 17\u00b0 API with 5.5% sulfur.",
       "confidence": "high",
       "accepted_for_conversion": true
+    },
+    {
+      "field_name": "Ayoluengo",
+      "aliases": [
+        "ayoluengo"
+      ],
+      "api_gravity_deg": null,
+      "api_gravity_min_deg": 20.0,
+      "api_gravity_max_deg": 39.0,
+      "bbl_per_tonne": null,
+      "measurement_basis": "Ayoluengo field technical guide gives a heterogeneous 20\u00b0 to 39\u00b0 API crude density range; no representative produced stream, field average, or production-weighted split is cited",
+      "source_title": "El campo de petr\u00f3leo de Ayoluengo: 50 a\u00f1os de historia",
+      "source_url": "https://sargentesdelalora.com/wp-content/uploads/2017/02/libro-50-aniversario.pdf",
+      "source_class": "technical_literature",
+      "evidence_note": "The guide identifies Ayoluengo as Spain's only commercial onshore oil field, states the field's crude quality is heterogeneous, and gives crude density ranging from 20\u00b0 to 39\u00b0 API. The registry preserves that range as evidence only and keeps Ayoluengo in source_gap_fields for strict conversion.",
+      "confidence": "medium",
+      "accepted_for_conversion": false
     },
     {
       "field_name": "Boquer\u00f3n",

--- a/tests/unit/spain/test_cores_density.py
+++ b/tests/unit/spain/test_cores_density.py
@@ -293,6 +293,45 @@ def test_default_density_registry_accepts_cited_source_fields():
     assert audit.missing_fields == ()
 
 
+def test_default_density_registry_retains_ayoluengo_range_as_source_gap():
+    registry_path = files("worldenergydata.spain").joinpath(
+        "data/cores/crude_density_factors.json"
+    )
+    payload = json.loads(registry_path.read_text())
+    factors = load_crude_density_factors()
+    ayoluengo_url = (
+        "https://sargentesdelalora.com/wp-content/uploads/2017/02/"
+        "libro-50-aniversario.pdf"
+    )
+
+    ayoluengo = factors["ayoluengo"]
+    assert ayoluengo.field_name == "Ayoluengo"
+    assert ayoluengo.source_class == "technical_literature"
+    assert ayoluengo.source_url == ayoluengo_url
+    assert ayoluengo.accepted_for_conversion is False
+    assert ayoluengo.api_gravity_min_deg == pytest.approx(20.0)
+    assert ayoluengo.api_gravity_max_deg == pytest.approx(39.0)
+    assert ayoluengo.api_gravity_deg is None
+    assert ayoluengo.bbl_per_tonne is None
+    assert "Ayoluengo" in payload["source_gap_fields"]
+
+    with pytest.raises(CoresDensityCoverageError, match="Ayoluengo"):
+        build_oil_conversion_audit(
+            ["Ayoluengo"],
+            factors,
+            allow_default_density=False,
+        )
+
+    defaulted_audit = build_oil_conversion_audit(
+        ["Ayoluengo"],
+        factors,
+        allow_default_density=True,
+    )
+    assert defaulted_audit.used_field_names == ()
+    assert defaulted_audit.defaulted_fields == ("Ayoluengo",)
+    assert defaulted_audit.missing_fields == ()
+
+
 def test_default_density_registry_keeps_current_fields_missing():
     registry_path = files("worldenergydata.spain").joinpath(
         "data/cores/crude_density_factors.json"


### PR DESCRIPTION
## Summary
- Add an Ayoluengo crude-density registry entry sourced to the field technical guide.
- Preserve the cited 20-39 API heterogeneous range as evidence-only, with no representative API and no bbl/tonne conversion factor.
- Keep Ayoluengo in `source_gap_fields`; strict conversion continues to fail closed and explicit default mode still defaults Ayoluengo.

## Source
- `El campo de petróleo de Ayoluengo: 50 años de historia`: https://sargentesdelalora.com/wp-content/uploads/2017/02/libro-50-aniversario.pdf
- Local text extraction confirmed the field-quality sentence: Ayoluengo crude quality is heterogeneous and density ranges from 20 to 39 API.

## Verification
- RED observed before JSON fix: 5 expected failures for accepted Ayoluengo conversion/stale source gaps.
- `.venv/bin/python -m pytest tests/unit/spain/test_cores_density.py -q --no-cov` -> 20 passed
- `.venv/bin/python -m pytest tests/unit/spain/test_cores_density.py tests/unit/spain/test_cores_field_development_density.py tests/unit/spain/test_cores_field_development_report.py tests/unit/spain/test_cores_live.py tests/unit/spain/test_cores_live_density.py tests/unit/spain/test_cores_loader.py tests/unit/scheduler/test_spain_cores_refresh.py -q --no-cov` -> 87 passed
- `.venv/bin/python -m pytest tests/unit/core tests/unit/common tests/contracts tests/workflows tests/unit/spain -q --no-cov` -> 569 passed, 2 skipped
- `git diff --check origin/main...HEAD` -> pass
- `.venv/bin/python -m json.tool packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json` -> pass
- `.venv/bin/python -m black --check tests/unit/spain/test_cores_density.py` -> pass
- `.venv/bin/python -m isort --check-only tests/unit/spain/test_cores_density.py` -> pass

## Security / Legal
- `scripts/legal/legal-sanity-scan.sh` on the dirty changed-file diff before commit -> PASS
- Post-commit diff-only legal scan has no candidates because the diff is committed.
- `scripts/legal/legal-sanity-scan.sh --all` still reports pre-existing ENIGMA deny-list matches in safety-analysis files outside this diff.
- `bandit tests/unit/spain/test_cores_density.py -ll -ii -q` -> pass
- `bandit -r packages/worldenergydata-spain/src/worldenergydata/spain tests/unit/spain -ll -ii -q` still reports only pre-existing B310 at `packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_source.py:290`.
- `gitleaks` is not installed in this environment.

## Review
- Parallel source/evidence and behavior/test reviewers initially found the accepted midpoint proxy was not defensible.
- Fixed by making Ayoluengo evidence-only and restoring fail-closed behavior.
- Both reviewers rechecked the revised diff and reported no findings.

Refs #807
