### PR TITLE
feat(hub): kept-displayed BSEE performance stats on field life-cycle posters (#756)

### DIFF
--- a/config/repo_structure.yml
+++ b/config/repo_structure.yml
@@ -349,6 +349,7 @@ temporary_exceptions:
       - reports/lower_tertiary/julia_npv_stackup.html
       - reports/lower_tertiary/lifecycle/_facts.json
       - reports/lower_tertiary/lifecycle/_norms.json
+      - reports/lower_tertiary/lifecycle/_performance.json
       - reports/lower_tertiary/lifecycle/norms/drill.html
       - reports/lower_tertiary/lifecycle/norms/complete.html
       - reports/lower_tertiary/lifecycle/norms/produce.html

--- a/reports/lower_tertiary/lifecycle/_performance.json
+++ b/reports/lower_tertiary/lifecycle/_performance.json
@@ -1,0 +1,96 @@
+{
+  "fields": {
+    "anchor": {
+      "avg_decline_pct_yr": 0.0,
+      "avg_uptime_pct": 88.1,
+      "breakeven_wti": 380.0,
+      "cum_oil_mmbbl": 18.6,
+      "display": "Anchor",
+      "eur_mmbbl": 998,
+      "interventions": 0,
+      "npv_mm": -1586.9,
+      "sens_mm_per_dollar": 5.1,
+      "wells": 3
+    },
+    "big_foot": {
+      "avg_decline_pct_yr": 17.2,
+      "avg_uptime_pct": 88.2,
+      "breakeven_wti": 153.0,
+      "cum_oil_mmbbl": 78.7,
+      "display": "Big Foot",
+      "eur_mmbbl": 1324,
+      "interventions": 6,
+      "npv_mm": -989.0,
+      "sens_mm_per_dollar": 12.1,
+      "wells": 8
+    },
+    "cascade_chinook": {
+      "avg_decline_pct_yr": 35.9,
+      "avg_uptime_pct": 94.6,
+      "breakeven_wti": 338.0,
+      "cum_oil_mmbbl": 39.7,
+      "display": "Cascade Chinook",
+      "eur_mmbbl": 92,
+      "interventions": 0,
+      "npv_mm": -1480.5,
+      "sens_mm_per_dollar": 5.5,
+      "wells": 3
+    },
+    "jack_st_malo": {
+      "avg_decline_pct_yr": 18.4,
+      "avg_uptime_pct": 89.7,
+      "breakeven_wti": 79.0,
+      "cum_oil_mmbbl": 438.8,
+      "display": "Jack St Malo",
+      "eur_mmbbl": 1117,
+      "interventions": 6,
+      "npv_mm": -804.5,
+      "sens_mm_per_dollar": 52.3,
+      "wells": 24
+    },
+    "julia": {
+      "avg_decline_pct_yr": 12.2,
+      "avg_uptime_pct": 96.3,
+      "breakeven_wti": 95.0,
+      "cum_oil_mmbbl": 77.5,
+      "display": "Julia",
+      "eur_mmbbl": 256,
+      "interventions": 0,
+      "npv_mm": -482.8,
+      "sens_mm_per_dollar": 17.2,
+      "wells": 4
+    },
+    "shenandoah": {
+      "avg_decline_pct_yr": 5.4,
+      "avg_uptime_pct": 80.2,
+      "breakeven_wti": 376.0,
+      "cum_oil_mmbbl": 21.2,
+      "display": "Shenandoah",
+      "eur_mmbbl": 1577,
+      "interventions": 1,
+      "npv_mm": -991.3,
+      "sens_mm_per_dollar": 3.2,
+      "wells": 4
+    },
+    "stones": {
+      "avg_decline_pct_yr": 21.4,
+      "avg_uptime_pct": 76.9,
+      "breakeven_wti": 165.0,
+      "cum_oil_mmbbl": 89.0,
+      "display": "Stones",
+      "eur_mmbbl": 509,
+      "interventions": 3,
+      "npv_mm": -1460.8,
+      "sens_mm_per_dollar": 14.9,
+      "wells": 10
+    }
+  },
+  "meta": {
+    "inputs": [
+      "reports/lower_tertiary/lt_well_benchmark_lower_tertiary_2010_latest.csv",
+      "reports/lower_tertiary/field_economics_<slug>.md"
+    ],
+    "regenerate": "uv run python scripts/lower_tertiary/build_field_performance_comparison.py",
+    "source": "BSEE OGOR-A per-well benchmark + V30 cost model, life-to-date (not full-cycle)"
+  }
+}

--- a/reports/lower_tertiary/lifecycle/anchor_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/anchor_lifecycle.html
@@ -302,6 +302,10 @@
             <h3>Reservoir &amp; HPHT</h3>
             <dl class="kv" id="f-reservoir"></dl>
           </div>
+          <div class="card" id="f-performance-card" hidden>
+            <h3>Field performance · BSEE life-to-date</h3>
+            <dl class="kv" id="f-performance"></dl>
+          </div>
         </div>
       </section>
 
@@ -556,7 +560,19 @@ const FIELD = {
       "stage": "abandon",
       "state": "unavailable"
     }
-  ]
+  ],
+  "performance": {
+    "avg_decline_pct_yr": 0.0,
+    "avg_uptime_pct": 88.1,
+    "breakeven_wti": 380.0,
+    "cum_oil_mmbbl": 18.6,
+    "display": "Anchor",
+    "eur_mmbbl": 998,
+    "interventions": 0,
+    "npv_mm": -1586.9,
+    "sens_mm_per_dollar": 5.1,
+    "wells": 3
+  }
 };
 
 /* ---------------- render ---------------- */
@@ -727,6 +743,29 @@ if (FIELD.reservoir) {
   $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-reservoir-card").hidden = false;
   if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
+
+/* field performance — BSEE life-to-date; honesty-gated, nulls render as em dash */
+if (FIELD.performance) {
+  const p = FIELD.performance;
+  const DASH = "—";
+  const unit = (v, d, u) => v == null
+    ? `<span class="mut">${DASH}</span>`
+    : `${Number(v).toLocaleString("en-US", {minimumFractionDigits:d, maximumFractionDigits:d})}${u}`;
+  const rows = [
+    ["Benchmark wells", unit(p.wells, 0, "")],
+    ["Cum oil", unit(p.cum_oil_mmbbl, 1, " MMbbl")],
+    ["EUR", unit(p.eur_mmbbl, 0, " MMbbl")],
+    ["Avg uptime", unit(p.avg_uptime_pct, 1, "%")],
+    ["Avg decline", unit(p.avg_decline_pct_yr, 1, "%/yr")],
+    ["Interventions", unit(p.interventions, 0, "")],
+    ["NPV @10%", unit(p.npv_mm, 1, " $MM")],
+    ["WTI break-even", unit(p.breakeven_wti, 0, " $/bbl")],
+    ["NPV per +$1/bbl", unit(p.sens_mm_per_dollar, 1, " $MM")],
+  ];
+  $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-performance-card").hidden = false;
+  $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
 }
 
 /* host facts + working interest */

--- a/reports/lower_tertiary/lifecycle/big_foot_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/big_foot_lifecycle.html
@@ -302,6 +302,10 @@
             <h3>Reservoir &amp; HPHT</h3>
             <dl class="kv" id="f-reservoir"></dl>
           </div>
+          <div class="card" id="f-performance-card" hidden>
+            <h3>Field performance · BSEE life-to-date</h3>
+            <dl class="kv" id="f-performance"></dl>
+          </div>
         </div>
       </section>
 
@@ -569,7 +573,19 @@ const FIELD = {
       "stage": "abandon",
       "state": "unavailable"
     }
-  ]
+  ],
+  "performance": {
+    "avg_decline_pct_yr": 17.2,
+    "avg_uptime_pct": 88.2,
+    "breakeven_wti": 153.0,
+    "cum_oil_mmbbl": 78.7,
+    "display": "Big Foot",
+    "eur_mmbbl": 1324,
+    "interventions": 6,
+    "npv_mm": -989.0,
+    "sens_mm_per_dollar": 12.1,
+    "wells": 8
+  }
 };
 
 /* ---------------- render ---------------- */
@@ -740,6 +756,29 @@ if (FIELD.reservoir) {
   $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-reservoir-card").hidden = false;
   if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
+
+/* field performance — BSEE life-to-date; honesty-gated, nulls render as em dash */
+if (FIELD.performance) {
+  const p = FIELD.performance;
+  const DASH = "—";
+  const unit = (v, d, u) => v == null
+    ? `<span class="mut">${DASH}</span>`
+    : `${Number(v).toLocaleString("en-US", {minimumFractionDigits:d, maximumFractionDigits:d})}${u}`;
+  const rows = [
+    ["Benchmark wells", unit(p.wells, 0, "")],
+    ["Cum oil", unit(p.cum_oil_mmbbl, 1, " MMbbl")],
+    ["EUR", unit(p.eur_mmbbl, 0, " MMbbl")],
+    ["Avg uptime", unit(p.avg_uptime_pct, 1, "%")],
+    ["Avg decline", unit(p.avg_decline_pct_yr, 1, "%/yr")],
+    ["Interventions", unit(p.interventions, 0, "")],
+    ["NPV @10%", unit(p.npv_mm, 1, " $MM")],
+    ["WTI break-even", unit(p.breakeven_wti, 0, " $/bbl")],
+    ["NPV per +$1/bbl", unit(p.sens_mm_per_dollar, 1, " $MM")],
+  ];
+  $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-performance-card").hidden = false;
+  $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
 }
 
 /* host facts + working interest */

--- a/reports/lower_tertiary/lifecycle/cascade_chinook_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/cascade_chinook_lifecycle.html
@@ -302,6 +302,10 @@
             <h3>Reservoir &amp; HPHT</h3>
             <dl class="kv" id="f-reservoir"></dl>
           </div>
+          <div class="card" id="f-performance-card" hidden>
+            <h3>Field performance · BSEE life-to-date</h3>
+            <dl class="kv" id="f-performance"></dl>
+          </div>
         </div>
       </section>
 
@@ -534,7 +538,19 @@ const FIELD = {
       "stage": "abandon",
       "state": "unavailable"
     }
-  ]
+  ],
+  "performance": {
+    "avg_decline_pct_yr": 35.9,
+    "avg_uptime_pct": 94.6,
+    "breakeven_wti": 338.0,
+    "cum_oil_mmbbl": 39.7,
+    "display": "Cascade Chinook",
+    "eur_mmbbl": 92,
+    "interventions": 0,
+    "npv_mm": -1480.5,
+    "sens_mm_per_dollar": 5.5,
+    "wells": 3
+  }
 };
 
 /* ---------------- render ---------------- */
@@ -705,6 +721,29 @@ if (FIELD.reservoir) {
   $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-reservoir-card").hidden = false;
   if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
+
+/* field performance — BSEE life-to-date; honesty-gated, nulls render as em dash */
+if (FIELD.performance) {
+  const p = FIELD.performance;
+  const DASH = "—";
+  const unit = (v, d, u) => v == null
+    ? `<span class="mut">${DASH}</span>`
+    : `${Number(v).toLocaleString("en-US", {minimumFractionDigits:d, maximumFractionDigits:d})}${u}`;
+  const rows = [
+    ["Benchmark wells", unit(p.wells, 0, "")],
+    ["Cum oil", unit(p.cum_oil_mmbbl, 1, " MMbbl")],
+    ["EUR", unit(p.eur_mmbbl, 0, " MMbbl")],
+    ["Avg uptime", unit(p.avg_uptime_pct, 1, "%")],
+    ["Avg decline", unit(p.avg_decline_pct_yr, 1, "%/yr")],
+    ["Interventions", unit(p.interventions, 0, "")],
+    ["NPV @10%", unit(p.npv_mm, 1, " $MM")],
+    ["WTI break-even", unit(p.breakeven_wti, 0, " $/bbl")],
+    ["NPV per +$1/bbl", unit(p.sens_mm_per_dollar, 1, " $MM")],
+  ];
+  $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-performance-card").hidden = false;
+  $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
 }
 
 /* host facts + working interest */

--- a/reports/lower_tertiary/lifecycle/jack_st_malo_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/jack_st_malo_lifecycle.html
@@ -302,6 +302,10 @@
             <h3>Reservoir &amp; HPHT</h3>
             <dl class="kv" id="f-reservoir"></dl>
           </div>
+          <div class="card" id="f-performance-card" hidden>
+            <h3>Field performance · BSEE life-to-date</h3>
+            <dl class="kv" id="f-performance"></dl>
+          </div>
         </div>
       </section>
 
@@ -556,7 +560,19 @@ const FIELD = {
       "stage": "abandon",
       "state": "unavailable"
     }
-  ]
+  ],
+  "performance": {
+    "avg_decline_pct_yr": 18.4,
+    "avg_uptime_pct": 89.7,
+    "breakeven_wti": 79.0,
+    "cum_oil_mmbbl": 438.8,
+    "display": "Jack St Malo",
+    "eur_mmbbl": 1117,
+    "interventions": 6,
+    "npv_mm": -804.5,
+    "sens_mm_per_dollar": 52.3,
+    "wells": 24
+  }
 };
 
 /* ---------------- render ---------------- */
@@ -727,6 +743,29 @@ if (FIELD.reservoir) {
   $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-reservoir-card").hidden = false;
   if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
+
+/* field performance — BSEE life-to-date; honesty-gated, nulls render as em dash */
+if (FIELD.performance) {
+  const p = FIELD.performance;
+  const DASH = "—";
+  const unit = (v, d, u) => v == null
+    ? `<span class="mut">${DASH}</span>`
+    : `${Number(v).toLocaleString("en-US", {minimumFractionDigits:d, maximumFractionDigits:d})}${u}`;
+  const rows = [
+    ["Benchmark wells", unit(p.wells, 0, "")],
+    ["Cum oil", unit(p.cum_oil_mmbbl, 1, " MMbbl")],
+    ["EUR", unit(p.eur_mmbbl, 0, " MMbbl")],
+    ["Avg uptime", unit(p.avg_uptime_pct, 1, "%")],
+    ["Avg decline", unit(p.avg_decline_pct_yr, 1, "%/yr")],
+    ["Interventions", unit(p.interventions, 0, "")],
+    ["NPV @10%", unit(p.npv_mm, 1, " $MM")],
+    ["WTI break-even", unit(p.breakeven_wti, 0, " $/bbl")],
+    ["NPV per +$1/bbl", unit(p.sens_mm_per_dollar, 1, " $MM")],
+  ];
+  $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-performance-card").hidden = false;
+  $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
 }
 
 /* host facts + working interest */

--- a/reports/lower_tertiary/lifecycle/julia_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/julia_lifecycle.html
@@ -302,6 +302,10 @@
             <h3>Reservoir &amp; HPHT</h3>
             <dl class="kv" id="f-reservoir"></dl>
           </div>
+          <div class="card" id="f-performance-card" hidden>
+            <h3>Field performance · BSEE life-to-date</h3>
+            <dl class="kv" id="f-performance"></dl>
+          </div>
         </div>
       </section>
 
@@ -559,7 +563,19 @@ const FIELD = {
       "stage": "abandon",
       "state": "unavailable"
     }
-  ]
+  ],
+  "performance": {
+    "avg_decline_pct_yr": 12.2,
+    "avg_uptime_pct": 96.3,
+    "breakeven_wti": 95.0,
+    "cum_oil_mmbbl": 77.5,
+    "display": "Julia",
+    "eur_mmbbl": 256,
+    "interventions": 0,
+    "npv_mm": -482.8,
+    "sens_mm_per_dollar": 17.2,
+    "wells": 4
+  }
 };
 
 /* ---------------- render ---------------- */
@@ -730,6 +746,29 @@ if (FIELD.reservoir) {
   $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-reservoir-card").hidden = false;
   if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
+
+/* field performance — BSEE life-to-date; honesty-gated, nulls render as em dash */
+if (FIELD.performance) {
+  const p = FIELD.performance;
+  const DASH = "—";
+  const unit = (v, d, u) => v == null
+    ? `<span class="mut">${DASH}</span>`
+    : `${Number(v).toLocaleString("en-US", {minimumFractionDigits:d, maximumFractionDigits:d})}${u}`;
+  const rows = [
+    ["Benchmark wells", unit(p.wells, 0, "")],
+    ["Cum oil", unit(p.cum_oil_mmbbl, 1, " MMbbl")],
+    ["EUR", unit(p.eur_mmbbl, 0, " MMbbl")],
+    ["Avg uptime", unit(p.avg_uptime_pct, 1, "%")],
+    ["Avg decline", unit(p.avg_decline_pct_yr, 1, "%/yr")],
+    ["Interventions", unit(p.interventions, 0, "")],
+    ["NPV @10%", unit(p.npv_mm, 1, " $MM")],
+    ["WTI break-even", unit(p.breakeven_wti, 0, " $/bbl")],
+    ["NPV per +$1/bbl", unit(p.sens_mm_per_dollar, 1, " $MM")],
+  ];
+  $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-performance-card").hidden = false;
+  $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
 }
 
 /* host facts + working interest */

--- a/reports/lower_tertiary/lifecycle/kaskida_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/kaskida_lifecycle.html
@@ -302,6 +302,10 @@
             <h3>Reservoir &amp; HPHT</h3>
             <dl class="kv" id="f-reservoir"></dl>
           </div>
+          <div class="card" id="f-performance-card" hidden>
+            <h3>Field performance · BSEE life-to-date</h3>
+            <dl class="kv" id="f-performance"></dl>
+          </div>
         </div>
       </section>
 
@@ -522,7 +526,8 @@ const FIELD = {
       "stage": "abandon",
       "state": "unavailable"
     }
-  ]
+  ],
+  "performance": null
 };
 
 /* ---------------- render ---------------- */
@@ -693,6 +698,29 @@ if (FIELD.reservoir) {
   $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-reservoir-card").hidden = false;
   if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
+
+/* field performance — BSEE life-to-date; honesty-gated, nulls render as em dash */
+if (FIELD.performance) {
+  const p = FIELD.performance;
+  const DASH = "—";
+  const unit = (v, d, u) => v == null
+    ? `<span class="mut">${DASH}</span>`
+    : `${Number(v).toLocaleString("en-US", {minimumFractionDigits:d, maximumFractionDigits:d})}${u}`;
+  const rows = [
+    ["Benchmark wells", unit(p.wells, 0, "")],
+    ["Cum oil", unit(p.cum_oil_mmbbl, 1, " MMbbl")],
+    ["EUR", unit(p.eur_mmbbl, 0, " MMbbl")],
+    ["Avg uptime", unit(p.avg_uptime_pct, 1, "%")],
+    ["Avg decline", unit(p.avg_decline_pct_yr, 1, "%/yr")],
+    ["Interventions", unit(p.interventions, 0, "")],
+    ["NPV @10%", unit(p.npv_mm, 1, " $MM")],
+    ["WTI break-even", unit(p.breakeven_wti, 0, " $/bbl")],
+    ["NPV per +$1/bbl", unit(p.sens_mm_per_dollar, 1, " $MM")],
+  ];
+  $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-performance-card").hidden = false;
+  $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
 }
 
 /* host facts + working interest */

--- a/reports/lower_tertiary/lifecycle/lifecycle_template.html
+++ b/reports/lower_tertiary/lifecycle/lifecycle_template.html
@@ -301,6 +301,10 @@
             <h3>Reservoir &amp; HPHT</h3>
             <dl class="kv" id="f-reservoir"></dl>
           </div>
+          <div class="card" id="f-performance-card" hidden>
+            <h3>Field performance · BSEE life-to-date</h3>
+            <dl class="kv" id="f-performance"></dl>
+          </div>
         </div>
       </section>
 
@@ -527,6 +531,29 @@ if (FIELD.reservoir) {
   $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-reservoir-card").hidden = false;
   if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
+
+/* field performance — BSEE life-to-date; honesty-gated, nulls render as em dash */
+if (FIELD.performance) {
+  const p = FIELD.performance;
+  const DASH = "—";
+  const unit = (v, d, u) => v == null
+    ? `<span class="mut">${DASH}</span>`
+    : `${Number(v).toLocaleString("en-US", {minimumFractionDigits:d, maximumFractionDigits:d})}${u}`;
+  const rows = [
+    ["Benchmark wells", unit(p.wells, 0, "")],
+    ["Cum oil", unit(p.cum_oil_mmbbl, 1, " MMbbl")],
+    ["EUR", unit(p.eur_mmbbl, 0, " MMbbl")],
+    ["Avg uptime", unit(p.avg_uptime_pct, 1, "%")],
+    ["Avg decline", unit(p.avg_decline_pct_yr, 1, "%/yr")],
+    ["Interventions", unit(p.interventions, 0, "")],
+    ["NPV @10%", unit(p.npv_mm, 1, " $MM")],
+    ["WTI break-even", unit(p.breakeven_wti, 0, " $/bbl")],
+    ["NPV per +$1/bbl", unit(p.sens_mm_per_dollar, 1, " $MM")],
+  ];
+  $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-performance-card").hidden = false;
+  $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
 }
 
 /* host facts + working interest */

--- a/reports/lower_tertiary/lifecycle/north_platte_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/north_platte_lifecycle.html
@@ -302,6 +302,10 @@
             <h3>Reservoir &amp; HPHT</h3>
             <dl class="kv" id="f-reservoir"></dl>
           </div>
+          <div class="card" id="f-performance-card" hidden>
+            <h3>Field performance · BSEE life-to-date</h3>
+            <dl class="kv" id="f-performance"></dl>
+          </div>
         </div>
       </section>
 
@@ -518,7 +522,8 @@ const FIELD = {
       "stage": "abandon",
       "state": "unavailable"
     }
-  ]
+  ],
+  "performance": null
 };
 
 /* ---------------- render ---------------- */
@@ -689,6 +694,29 @@ if (FIELD.reservoir) {
   $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-reservoir-card").hidden = false;
   if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
+
+/* field performance — BSEE life-to-date; honesty-gated, nulls render as em dash */
+if (FIELD.performance) {
+  const p = FIELD.performance;
+  const DASH = "—";
+  const unit = (v, d, u) => v == null
+    ? `<span class="mut">${DASH}</span>`
+    : `${Number(v).toLocaleString("en-US", {minimumFractionDigits:d, maximumFractionDigits:d})}${u}`;
+  const rows = [
+    ["Benchmark wells", unit(p.wells, 0, "")],
+    ["Cum oil", unit(p.cum_oil_mmbbl, 1, " MMbbl")],
+    ["EUR", unit(p.eur_mmbbl, 0, " MMbbl")],
+    ["Avg uptime", unit(p.avg_uptime_pct, 1, "%")],
+    ["Avg decline", unit(p.avg_decline_pct_yr, 1, "%/yr")],
+    ["Interventions", unit(p.interventions, 0, "")],
+    ["NPV @10%", unit(p.npv_mm, 1, " $MM")],
+    ["WTI break-even", unit(p.breakeven_wti, 0, " $/bbl")],
+    ["NPV per +$1/bbl", unit(p.sens_mm_per_dollar, 1, " $MM")],
+  ];
+  $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-performance-card").hidden = false;
+  $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
 }
 
 /* host facts + working interest */

--- a/reports/lower_tertiary/lifecycle/shenandoah_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/shenandoah_lifecycle.html
@@ -302,6 +302,10 @@
             <h3>Reservoir &amp; HPHT</h3>
             <dl class="kv" id="f-reservoir"></dl>
           </div>
+          <div class="card" id="f-performance-card" hidden>
+            <h3>Field performance · BSEE life-to-date</h3>
+            <dl class="kv" id="f-performance"></dl>
+          </div>
         </div>
       </section>
 
@@ -552,7 +556,19 @@ const FIELD = {
       "stage": "abandon",
       "state": "unavailable"
     }
-  ]
+  ],
+  "performance": {
+    "avg_decline_pct_yr": 5.4,
+    "avg_uptime_pct": 80.2,
+    "breakeven_wti": 376.0,
+    "cum_oil_mmbbl": 21.2,
+    "display": "Shenandoah",
+    "eur_mmbbl": 1577,
+    "interventions": 1,
+    "npv_mm": -991.3,
+    "sens_mm_per_dollar": 3.2,
+    "wells": 4
+  }
 };
 
 /* ---------------- render ---------------- */
@@ -723,6 +739,29 @@ if (FIELD.reservoir) {
   $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-reservoir-card").hidden = false;
   if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
+
+/* field performance — BSEE life-to-date; honesty-gated, nulls render as em dash */
+if (FIELD.performance) {
+  const p = FIELD.performance;
+  const DASH = "—";
+  const unit = (v, d, u) => v == null
+    ? `<span class="mut">${DASH}</span>`
+    : `${Number(v).toLocaleString("en-US", {minimumFractionDigits:d, maximumFractionDigits:d})}${u}`;
+  const rows = [
+    ["Benchmark wells", unit(p.wells, 0, "")],
+    ["Cum oil", unit(p.cum_oil_mmbbl, 1, " MMbbl")],
+    ["EUR", unit(p.eur_mmbbl, 0, " MMbbl")],
+    ["Avg uptime", unit(p.avg_uptime_pct, 1, "%")],
+    ["Avg decline", unit(p.avg_decline_pct_yr, 1, "%/yr")],
+    ["Interventions", unit(p.interventions, 0, "")],
+    ["NPV @10%", unit(p.npv_mm, 1, " $MM")],
+    ["WTI break-even", unit(p.breakeven_wti, 0, " $/bbl")],
+    ["NPV per +$1/bbl", unit(p.sens_mm_per_dollar, 1, " $MM")],
+  ];
+  $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-performance-card").hidden = false;
+  $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
 }
 
 /* host facts + working interest */

--- a/reports/lower_tertiary/lifecycle/stones_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/stones_lifecycle.html
@@ -302,6 +302,10 @@
             <h3>Reservoir &amp; HPHT</h3>
             <dl class="kv" id="f-reservoir"></dl>
           </div>
+          <div class="card" id="f-performance-card" hidden>
+            <h3>Field performance · BSEE life-to-date</h3>
+            <dl class="kv" id="f-performance"></dl>
+          </div>
         </div>
       </section>
 
@@ -549,7 +553,19 @@ const FIELD = {
       "stage": "abandon",
       "state": "unavailable"
     }
-  ]
+  ],
+  "performance": {
+    "avg_decline_pct_yr": 21.4,
+    "avg_uptime_pct": 76.9,
+    "breakeven_wti": 165.0,
+    "cum_oil_mmbbl": 89.0,
+    "display": "Stones",
+    "eur_mmbbl": 509,
+    "interventions": 3,
+    "npv_mm": -1460.8,
+    "sens_mm_per_dollar": 14.9,
+    "wells": 10
+  }
 };
 
 /* ---------------- render ---------------- */
@@ -720,6 +736,29 @@ if (FIELD.reservoir) {
   $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-reservoir-card").hidden = false;
   if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
+
+/* field performance — BSEE life-to-date; honesty-gated, nulls render as em dash */
+if (FIELD.performance) {
+  const p = FIELD.performance;
+  const DASH = "—";
+  const unit = (v, d, u) => v == null
+    ? `<span class="mut">${DASH}</span>`
+    : `${Number(v).toLocaleString("en-US", {minimumFractionDigits:d, maximumFractionDigits:d})}${u}`;
+  const rows = [
+    ["Benchmark wells", unit(p.wells, 0, "")],
+    ["Cum oil", unit(p.cum_oil_mmbbl, 1, " MMbbl")],
+    ["EUR", unit(p.eur_mmbbl, 0, " MMbbl")],
+    ["Avg uptime", unit(p.avg_uptime_pct, 1, "%")],
+    ["Avg decline", unit(p.avg_decline_pct_yr, 1, "%/yr")],
+    ["Interventions", unit(p.interventions, 0, "")],
+    ["NPV @10%", unit(p.npv_mm, 1, " $MM")],
+    ["WTI break-even", unit(p.breakeven_wti, 0, " $/bbl")],
+    ["NPV per +$1/bbl", unit(p.sens_mm_per_dollar, 1, " $MM")],
+  ];
+  $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-performance-card").hidden = false;
+  $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
 }
 
 /* host facts + working interest */

--- a/reports/lower_tertiary/lifecycle/tiber_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/tiber_lifecycle.html
@@ -302,6 +302,10 @@
             <h3>Reservoir &amp; HPHT</h3>
             <dl class="kv" id="f-reservoir"></dl>
           </div>
+          <div class="card" id="f-performance-card" hidden>
+            <h3>Field performance · BSEE life-to-date</h3>
+            <dl class="kv" id="f-performance"></dl>
+          </div>
         </div>
       </section>
 
@@ -504,7 +508,8 @@ const FIELD = {
       "stage": "abandon",
       "state": "unavailable"
     }
-  ]
+  ],
+  "performance": null
 };
 
 /* ---------------- render ---------------- */
@@ -675,6 +680,29 @@ if (FIELD.reservoir) {
   $("f-reservoir").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-reservoir-card").hidden = false;
   if (r.source_note) $("f-prov").textContent = FIELD.provenance + " · Reservoir: " + r.source_note;
+}
+
+/* field performance — BSEE life-to-date; honesty-gated, nulls render as em dash */
+if (FIELD.performance) {
+  const p = FIELD.performance;
+  const DASH = "—";
+  const unit = (v, d, u) => v == null
+    ? `<span class="mut">${DASH}</span>`
+    : `${Number(v).toLocaleString("en-US", {minimumFractionDigits:d, maximumFractionDigits:d})}${u}`;
+  const rows = [
+    ["Benchmark wells", unit(p.wells, 0, "")],
+    ["Cum oil", unit(p.cum_oil_mmbbl, 1, " MMbbl")],
+    ["EUR", unit(p.eur_mmbbl, 0, " MMbbl")],
+    ["Avg uptime", unit(p.avg_uptime_pct, 1, "%")],
+    ["Avg decline", unit(p.avg_decline_pct_yr, 1, "%/yr")],
+    ["Interventions", unit(p.interventions, 0, "")],
+    ["NPV @10%", unit(p.npv_mm, 1, " $MM")],
+    ["WTI break-even", unit(p.breakeven_wti, 0, " $/bbl")],
+    ["NPV per +$1/bbl", unit(p.sens_mm_per_dollar, 1, " $MM")],
+  ];
+  $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
+  $("f-performance-card").hidden = false;
+  $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
 }
 
 /* host facts + working interest */

--- a/scripts/build_pages.py
+++ b/scripts/build_pages.py
@@ -424,6 +424,12 @@ def build_lower_tertiary(available_viz: dict[str, bool]) -> list[tuple]:
         if (lifecycle_src / "_norms.json").exists():
             # stage pages cite ../_norms.json as their provenance link
             shutil.copy2(lifecycle_src / "_norms.json", lifecycle_dst / "_norms.json")
+        if (lifecycle_src / "_performance.json").exists():
+            # per-field BSEE performance contract consumed by the posters (#756)
+            shutil.copy2(
+                lifecycle_src / "_performance.json",
+                lifecycle_dst / "_performance.json",
+            )
 
     # --- Drilling learning-curve front door (issue #775) ---
     # Self-contained HTML (inline CSS + inline-SVG charts) built by

--- a/scripts/lower_tertiary/build_field_performance_comparison.py
+++ b/scripts/lower_tertiary/build_field_performance_comparison.py
@@ -15,12 +15,28 @@ Pure stdlib; same inputs -> byte-identical output.
 from __future__ import annotations
 
 import csv
+import json
 import re
 from pathlib import Path
 
 REPORTS = Path(__file__).resolve().parents[2] / "reports" / "lower_tertiary"
 BENCH = REPORTS / "lt_well_benchmark_lower_tertiary_2010_latest.csv"
 OUT = REPORTS / "lt_field_performance_comparison.md"
+CONTRACT = REPORTS / "lifecycle" / "_performance.json"
+
+CONTRACT_META = {
+    "source": (
+        "BSEE OGOR-A per-well benchmark + V30 cost model, "
+        "life-to-date (not full-cycle)"
+    ),
+    "inputs": [
+        "reports/lower_tertiary/lt_well_benchmark_lower_tertiary_2010_latest.csv",
+        "reports/lower_tertiary/field_economics_<slug>.md",
+    ],
+    "regenerate": (
+        "uv run python scripts/lower_tertiary/build_field_performance_comparison.py"
+    ),
+}
 
 _NPV = re.compile(r"terminal cumulative NPV \*\*\$(-?[\d,]+\.?\d*) M")
 _BE = re.compile(r"zero at a flat-equivalent realized WTI of \$([\d,]+)/bbl")
@@ -53,7 +69,8 @@ def _econ(field: str) -> dict:
     return out
 
 
-def build() -> str:
+def _aggregate() -> dict[str, dict]:
+    """Per-field roll-up of the per-well benchmark (single source of the math)."""
     rows = list(csv.DictReader(BENCH.open(encoding="utf-8")))
     fields: dict[str, dict] = {}
     for r in rows:
@@ -78,9 +95,16 @@ def build() -> str:
             f["decline"].append(float(r["decline_annual_pct"]))
         f["interv"] += int(float(r["interventions"] or 0))
         f["eur"] += float(r["eur_mmbbl"] or 0)
+    return fields
 
-    def avg(xs: list[float]) -> float:
-        return sum(xs) / len(xs) if xs else 0.0
+
+def _avg(xs: list[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def build() -> str:
+    fields = _aggregate()
+    avg = _avg
 
     ordered = sorted(fields.items(), key=lambda kv: kv[1]["cum"], reverse=True)
 
@@ -134,9 +158,36 @@ def build() -> str:
     return "\n".join(lines)
 
 
+def build_contract() -> str:
+    """Machine-readable per-field performance contract (same aggregation as the
+    md renderer). Keyed by canonical id (`_slug` == life-cycle poster id).
+    Benchmark-derived numbers rounded to the table's displayed precision;
+    economics keys are nullable (None when the report regexes miss)."""
+    fields = _aggregate()
+    out: dict[str, dict] = {}
+    for field, f in fields.items():
+        e = _econ(field)
+        out[_slug(field)] = {
+            "display": field,
+            "wells": f["wells"],
+            "cum_oil_mmbbl": round(f["cum"], 1),
+            "eur_mmbbl": round(f["eur"]),
+            "avg_uptime_pct": round(_avg(f["uptime"]), 1),
+            "avg_decline_pct_yr": round(_avg(f["decline"]), 1),
+            "interventions": f["interv"],
+            "npv_mm": e.get("npv_mm"),
+            "breakeven_wti": e.get("breakeven_wti"),
+            "sens_mm_per_dollar": e.get("sens_mm_per_dollar"),
+        }
+    payload = {"meta": CONTRACT_META, "fields": out}
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
 def main() -> int:
     OUT.write_text(build(), encoding="utf-8")
     print(f"wrote {OUT.relative_to(REPORTS.parents[1])}")
+    CONTRACT.write_text(build_contract(), encoding="utf-8")
+    print(f"wrote {CONTRACT.relative_to(REPORTS.parents[1])}")
     return 0
 
 

--- a/scripts/lower_tertiary/build_lifecycle_posters.py
+++ b/scripts/lower_tertiary/build_lifecycle_posters.py
@@ -401,10 +401,19 @@ def main():
     if norms_path.exists():
         norms_chips = json.loads(norms_path.read_text()).get("chips", {})
 
+    # Field-performance stats (issue #756): attach the per-field BSEE
+    # life-to-date contract when present. Only the 7 producing fields have a
+    # record; None makes the template hide the card (honesty-gated).
+    perf_fields = {}
+    perf_path = HERE / "_performance.json"
+    if perf_path.exists():
+        perf_fields = json.loads(perf_path.read_text()).get("fields", {})
+
     fields = []
     for f in facts:
         field = facts_to_field(f)
         field["norms"] = norms_chips.get(f["id"], [])
+        field["performance"] = perf_fields.get(f["id"])
         out = HERE / f"{f['id']}_lifecycle.html"
         out.write_text(render(field))
         fields.append(field)

--- a/tests/unit/lower_tertiary/test_performance_contract.py
+++ b/tests/unit/lower_tertiary/test_performance_contract.py
@@ -1,0 +1,139 @@
+"""Contract tests for the Lower Tertiary field-performance sidecar
+(reports/lower_tertiary/lifecycle/_performance.json).
+
+These guard the machine-readable per-field performance contract that the
+life-cycle poster builder consumes: keyed by canonical id (a subset of the
+`_facts.json` ids), exactly the seven producing fields, required keys present
+and numeric-or-null typed, and the emitter deterministic + non-destructive to
+the committed comparison markdown.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from tests.test_markers import unit  # noqa: E402
+
+PERF_PATH = (
+    PROJECT_ROOT / "reports" / "lower_tertiary" / "lifecycle" / "_performance.json"
+)
+FACTS_PATH = PROJECT_ROOT / "reports" / "lower_tertiary" / "lifecycle" / "_facts.json"
+MD_PATH = (
+    PROJECT_ROOT / "reports" / "lower_tertiary" / "lt_field_performance_comparison.md"
+)
+EMITTER_PATH = (
+    PROJECT_ROOT
+    / "scripts"
+    / "lower_tertiary"
+    / "build_field_performance_comparison.py"
+)
+
+PRODUCING_IDS = {
+    "jack_st_malo",
+    "stones",
+    "big_foot",
+    "julia",
+    "cascade_chinook",
+    "shenandoah",
+    "anchor",
+}
+
+REQUIRED_KEYS = {
+    "display",
+    "wells",
+    "cum_oil_mmbbl",
+    "eur_mmbbl",
+    "avg_uptime_pct",
+    "avg_decline_pct_yr",
+    "interventions",
+    "npv_mm",
+    "breakeven_wti",
+    "sens_mm_per_dollar",
+}
+
+NUMERIC_OR_NULL = (
+    "wells",
+    "cum_oil_mmbbl",
+    "eur_mmbbl",
+    "avg_uptime_pct",
+    "avg_decline_pct_yr",
+    "interventions",
+    "npv_mm",
+    "breakeven_wti",
+    "sens_mm_per_dollar",
+)
+
+
+def _load_perf():
+    return json.loads(PERF_PATH.read_text())["fields"]
+
+
+def _facts_ids():
+    return {rec["id"] for rec in json.loads(FACTS_PATH.read_text())}
+
+
+def _load_emitter():
+    spec = importlib.util.spec_from_file_location(
+        "build_field_performance_comparison", EMITTER_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@unit
+def test_keys_are_facts_members():
+    facts = _facts_ids()
+    for fid in _load_perf():
+        assert fid in facts, f"{fid} not a member of _facts.json id set"
+
+
+@unit
+def test_exactly_seven_producing_fields():
+    assert set(_load_perf()) == PRODUCING_IDS
+
+
+@unit
+def test_required_keys_and_types():
+    for fid, rec in _load_perf().items():
+        missing = REQUIRED_KEYS - set(rec)
+        assert not missing, f"{fid} missing keys: {missing}"
+        assert isinstance(rec["display"], str)
+        for key in NUMERIC_OR_NULL:
+            val = rec[key]
+            assert val is None or isinstance(
+                val, (int, float)
+            ), f"{fid}.{key} not None-or-number: {val!r}"
+
+
+@unit
+def test_jack_st_malo_anchor_values():
+    # Values must trace to the committed comparison table.
+    jsm = _load_perf()["jack_st_malo"]
+    assert jsm["display"] == "Jack St Malo"
+    assert jsm["wells"] == 24
+    assert jsm["cum_oil_mmbbl"] == 438.8
+    assert jsm["eur_mmbbl"] == 1117
+    assert jsm["npv_mm"] == -804.5
+    assert jsm["breakeven_wti"] == 79.0
+    assert jsm["sens_mm_per_dollar"] == 52.3
+
+
+@unit
+def test_emitter_is_deterministic():
+    mod = _load_emitter()
+    assert mod.build_contract() == mod.build_contract()
+    # And byte-identical to what is committed on disk.
+    assert mod.build_contract() == PERF_PATH.read_text()
+
+
+@unit
+def test_emitter_leaves_markdown_byte_identical():
+    mod = _load_emitter()
+    assert mod.build() == MD_PATH.read_text()


### PR DESCRIPTION
Closes #756

Adds the remaining field-hub slice from epic #754: a kept-displayed
"Field performance · BSEE life-to-date" card on the Lower Tertiary
life-cycle posters, joining the per-well benchmark + per-field economics
to each field by canonical id.

## What changed (4 tiny commits)
1. **Contract emitter** — `build_field_performance_comparison.py` gains
   `build_contract()` writing `reports/lower_tertiary/lifecycle/_performance.json`
   (keyed by canonical id, exactly the 7 producing fields, nullable economics,
   `sort_keys`+`indent=2`+trailing newline). Aggregation is single-sourced via
   the extracted `_aggregate()`; the comparison markdown stays **byte-identical**.
   New contract unit tests + allowlist the sidecar in `config/repo_structure.yml`.
2. **Builder consumes** — poster builder loads the sidecar (mirroring the
   `_norms.json` optional-sidecar pattern) and attaches `field["performance"]`
   per id (None → template hides the card).
3. **Template** — honesty-gated card with 9 metric rows (benchmark wells,
   cum oil, EUR, uptime, decline, interventions, NPV @10%, WTI break-even,
   NPV sensitivity), em dash for nulls, life-to-date provenance suffix. No
   external requests; no links to unpublished pages.
4. **Regenerate + publish** — 10 posters + index regenerated (7 producing
   fields show data; kaskida/north_platte/tiber keep the card hidden);
   `build_pages.py` publishes `_performance.json` next to `_norms.json`.

## Verification (all local, before opening)
- `lt_field_performance_comparison.md` byte-identical (`git diff --stat` empty).
- 10 posters contain `f-performance-card`; Jack St Malo shows the 9 rows
  (24 wells, 438.8 cum, EUR 1117, NPV -804.5, BE 79, sens 52.3).
- CDN grep clean (`cdn|unpkg|jsdelivr` → exit 1); posters self-contained.
- `uv run pytest tests/unit/lower_tertiary tests/unit/site` → 269 passed, 137 skipped.
- Link-graph gate (#870) **run locally** → 7 passed (CI does not route it for this diff).
- `tests/repo_structure/` → sidecar adds zero violations (13 baseline unchanged).
- Both builders idempotent (`git status` clean after re-run); `uv.lock` NOT in diff.

## Base reconciliation
Plan drafted against `main` @ `c6283160`; branched from `origin/main` @ `aab0fde8`
(includes #876 fields-registry + #880 report-number fixes). All plan anchors
re-verified by content against the current tree; #880 did not touch the
performance/emitter path, no material changes. One addition beyond the plan
text: `config/repo_structure.yml` allowlist entry for `_performance.json`
(the `reports/` generated-artifact root requires explicit per-file allowlisting;
mirrors the `_norms.json` entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)