### PR TITLE
feat(spain): retain OGJ density source leads

### DIFF
--- a/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
@@ -1,8 +1,8 @@
 {
-  "registry_version": "2026-07-07-cited-partial-6",
+  "registry_version": "2026-07-07-cited-partial-7",
   "registry_date": "2026-07-07",
   "coverage_status": "missing",
-  "coverage_note": "Amposta, Casablanca, Dorada, Montanazo-Lubina, and Tarraco have accepted BOE regulator-record API values. Boquer\u00f3n, Rodaballo, and Salmonete have accepted technical-literature API values from reservoir-geochemistry articles. Ayoluengo has an evidence-only heterogeneous 20\u00b0 to 39\u00b0 API range but no accepted representative conversion factor. Strict refreshes still fail closed until accepted cited factors cover every current CORES oil field.",
+  "coverage_note": "Amposta, Casablanca, Dorada, Montanazo-Lubina, and Tarraco have accepted BOE regulator-record API values. Boquer\u00f3n, Rodaballo, and Salmonete have accepted technical-literature API values from reservoir-geochemistry articles. Albatros and Gaviota have evidence-only OGJ Worldwide Production API leads, and Ayoluengo has an evidence-only heterogeneous 20\u00b0 to 39\u00b0 API range; these evidence-only entries have no accepted representative conversion factor. Strict refreshes still fail closed until accepted cited factors cover every current CORES oil field.",
   "source_gap_fields": [
     "Albatros",
     "Ayoluengo",
@@ -10,6 +10,23 @@
     "Viura (1)"
   ],
   "factors": [
+    {
+      "field_name": "Albatros",
+      "aliases": [
+        "albatros"
+      ],
+      "api_gravity_deg": 52.7,
+      "api_gravity_min_deg": null,
+      "api_gravity_max_deg": null,
+      "bbl_per_tonne": null,
+      "measurement_basis": "Oil & Gas Journal Worldwide Production table lists Albatros under Spain/Repsol with a 52.7\u00b0 API column value; this trade-press table is retained as a source lead only and is not treated as a conversion-eligible representative produced stream",
+      "source_title": "Worldwide Production, Oil & Gas Journal, Dec. 29, 1997",
+      "source_url": "https://img.ogj.com/files/base/ebm/ogj/document/2009/06/content_dam_ogj_en_downloadables_survey_downloads_worldwide_production_1997_worldwide_production_leftcolumn_downloadable_worldwide_production_1997.pdf",
+      "source_class": "industry_technical_article",
+      "evidence_note": "The Spain/Repsol table row lists offshore Albatros, discovered in 1991, at 6,890 ft depth, 1 producing oil well, 130 b/d average production, and 52.7\u00b0 API gravity. The registry keeps Albatros in source_gap_fields because OGJ trade-press evidence is not a conversion-eligible representative source under the approved #807 source policy.",
+      "confidence": "medium",
+      "accepted_for_conversion": false
+    },
     {
       "field_name": "Amposta",
       "aliases": [
@@ -97,6 +114,23 @@
       "evidence_note": "The BOE order fixes the sales price for crude from the Dorada exploitation concession and states 21.3\u00b0 API with 0.59% sulfur.",
       "confidence": "high",
       "accepted_for_conversion": true
+    },
+    {
+      "field_name": "Gaviota",
+      "aliases": [
+        "gaviota"
+      ],
+      "api_gravity_deg": 52.7,
+      "api_gravity_min_deg": null,
+      "api_gravity_max_deg": null,
+      "bbl_per_tonne": null,
+      "measurement_basis": "Oil & Gas Journal Worldwide Production table lists Gaviota under Spain/Repsol with a 52.7\u00b0 API column value; this trade-press table is retained as a source lead only and is not treated as a conversion-eligible representative produced stream",
+      "source_title": "Worldwide Production, Oil & Gas Journal, Dec. 25, 1995",
+      "source_url": "https://img.ogj.com/files/base/ebm/ogj/document/2009/06/content_dam_ogj_en_downloadables_survey_downloads_worldwide_production_1995_worldwide_production_leftcolumn_downloadable_worldwide_production_1995.pdf",
+      "source_class": "industry_technical_article",
+      "evidence_note": "The Spain/Repsol table row lists offshore Gaviota, discovered in 1980, at 8,300 ft depth, 2 producing oil wells, 123 b/d average production, and 52.7\u00b0 API gravity. The registry keeps Gaviota in source_gap_fields because OGJ trade-press evidence is not a conversion-eligible representative source under the approved #807 source policy.",
+      "confidence": "medium",
+      "accepted_for_conversion": false
     },
     {
       "field_name": "Montanazo-Lubina",

--- a/tests/unit/spain/test_cores_density.py
+++ b/tests/unit/spain/test_cores_density.py
@@ -332,6 +332,57 @@ def test_default_density_registry_retains_ayoluengo_range_as_source_gap():
     assert defaulted_audit.missing_fields == ()
 
 
+def test_default_density_registry_retains_ogj_api_leads_as_source_gaps():
+    registry_path = files("worldenergydata.spain").joinpath(
+        "data/cores/crude_density_factors.json"
+    )
+    payload = json.loads(registry_path.read_text())
+    factors = load_crude_density_factors()
+    albatros_url = (
+        "https://img.ogj.com/files/base/ebm/ogj/document/2009/06/"
+        "content_dam_ogj_en_downloadables_survey_downloads_worldwide_production_"
+        "1997_worldwide_production_leftcolumn_downloadable_worldwide_production_"
+        "1997.pdf"
+    )
+    gaviota_url = (
+        "https://img.ogj.com/files/base/ebm/ogj/document/2009/06/"
+        "content_dam_ogj_en_downloadables_survey_downloads_worldwide_production_"
+        "1995_worldwide_production_leftcolumn_downloadable_worldwide_production_"
+        "1995.pdf"
+    )
+
+    for field_name, key, source_url in (
+        ("Albatros", "albatros", albatros_url),
+        ("Gaviota", "gaviota", gaviota_url),
+    ):
+        factor = factors[key]
+        assert factor.field_name == field_name
+        assert factor.source_class == "industry_technical_article"
+        assert factor.source_url == source_url
+        assert factor.accepted_for_conversion is False
+        assert factor.api_gravity_deg == pytest.approx(52.7)
+        assert factor.api_gravity_min_deg is None
+        assert factor.api_gravity_max_deg is None
+        assert factor.bbl_per_tonne is None
+        assert field_name in payload["source_gap_fields"]
+
+    with pytest.raises(CoresDensityCoverageError, match="Albatros"):
+        build_oil_conversion_audit(
+            ["Albatros", "Gaviota"],
+            factors,
+            allow_default_density=False,
+        )
+
+    defaulted_audit = build_oil_conversion_audit(
+        ["Albatros", "Gaviota"],
+        factors,
+        allow_default_density=True,
+    )
+    assert defaulted_audit.used_field_names == ()
+    assert defaulted_audit.defaulted_fields == ("Albatros", "Gaviota")
+    assert defaulted_audit.missing_fields == ()
+
+
 def test_default_density_registry_keeps_current_fields_missing():
     registry_path = files("worldenergydata.spain").joinpath(
         "data/cores/crude_density_factors.json"


### PR DESCRIPTION
## Summary
- Add evidence-only Albatros and Gaviota density/API source leads from Oil & Gas Journal Worldwide Production PDFs.
- Preserve the cited 52.7 API values in the registry without `bbl_per_tonne` conversion factors.
- Keep Albatros and Gaviota in `source_gap_fields`; strict conversion still fails closed and explicit default mode still defaults them.

## Source Evidence
- Albatros: OGJ Worldwide Production, Dec. 29, 1997. Spain/Repsol row lists Albatros with 52.7 API.
  https://img.ogj.com/files/base/ebm/ogj/document/2009/06/content_dam_ogj_en_downloadables_survey_downloads_worldwide_production_1997_worldwide_production_leftcolumn_downloadable_worldwide_production_1997.pdf
- Gaviota: OGJ Worldwide Production, Dec. 25, 1995. Spain/Repsol row lists Gaviota with 52.7 API.
  https://img.ogj.com/files/base/ebm/ogj/document/2009/06/content_dam_ogj_en_downloadables_survey_downloads_worldwide_production_1995_worldwide_production_leftcolumn_downloadable_worldwide_production_1995.pdf

These are deliberately classified as `industry_technical_article` and `accepted_for_conversion=false` under the approved #807 source policy. A stronger regulator/operator/filing/crude-assay/technical-literature source is still required before these fields can drive `oil_bbl` conversion.

## Verification
- RED observed first: `test_default_density_registry_retains_ogj_api_leads_as_source_gaps` failed with `KeyError: 'albatros'`.
- `.venv/bin/python -m pytest tests/unit/spain/test_cores_density.py -q --no-cov` -> 21 passed
- `.venv/bin/python -m pytest tests/unit/spain/test_cores_density.py tests/unit/spain/test_cores_field_development_density.py tests/unit/spain/test_cores_field_development_report.py tests/unit/spain/test_cores_live.py tests/unit/spain/test_cores_live_density.py tests/unit/spain/test_cores_loader.py tests/unit/scheduler/test_spain_cores_refresh.py -q --no-cov` -> 88 passed
- `.venv/bin/python -m pytest tests/unit/core tests/unit/common tests/contracts tests/workflows tests/unit/spain -q --no-cov` -> 570 passed, 2 skipped
- `git diff --check` / `git diff --check origin/main...HEAD` -> pass
- `.venv/bin/python -m json.tool packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json` -> pass
- `.venv/bin/python -m black --check tests/unit/spain/test_cores_density.py` -> pass
- `.venv/bin/python -m isort --check-only tests/unit/spain/test_cores_density.py` -> pass

## Security / Legal
- `scripts/legal/legal-sanity-scan.sh` before commit -> PASS
- `bandit tests/unit/spain/test_cores_density.py -ll -ii -q` -> pass
- Broader Spain Bandit still reports only pre-existing B310 at `packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_source.py:290`, outside this diff.
- `gitleaks` is not installed in this environment.

## Review
- Parallel source-policy reviewer: no findings; residual risk is that stronger source evidence is still required before conversion acceptance.
- Parallel behavior/test reviewer: no findings; relevant density tests passed.

Refs #807
