### PR TITLE
feat(spain): retain Viura condensate source lead

### DIFF
--- a/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
@@ -1,8 +1,8 @@
 {
-  "registry_version": "2026-07-07-cited-partial-7",
+  "registry_version": "2026-07-07-cited-partial-8",
   "registry_date": "2026-07-07",
   "coverage_status": "missing",
-  "coverage_note": "Amposta, Casablanca, Dorada, Montanazo-Lubina, and Tarraco have accepted BOE regulator-record API values. Boquer\u00f3n, Rodaballo, and Salmonete have accepted technical-literature API values from reservoir-geochemistry articles. Albatros and Gaviota have evidence-only OGJ Worldwide Production API leads, and Ayoluengo has an evidence-only heterogeneous 20\u00b0 to 39\u00b0 API range; these evidence-only entries have no accepted representative conversion factor. Strict refreshes still fail closed until accepted cited factors cover every current CORES oil field.",
+  "coverage_note": "Amposta, Casablanca, Dorada, Montanazo-Lubina, and Tarraco have accepted BOE regulator-record API values. Boquer\u00f3n, Rodaballo, and Salmonete have accepted technical-literature API values from reservoir-geochemistry articles. Albatros and Gaviota have evidence-only OGJ Worldwide Production API leads, Ayoluengo has an evidence-only heterogeneous 20\u00b0 to 39\u00b0 API range, and Viura (1) has an evidence-only gas-condensate cut lead; these evidence-only entries have no accepted representative conversion factor. Strict refreshes still fail closed until accepted cited factors cover every current CORES oil field.",
   "source_gap_fields": [
     "Albatros",
     "Ayoluengo",
@@ -201,6 +201,25 @@
       "evidence_note": "The BOE order fixes the sales price for crude from the Tarraco concession and states 35\u00b0 API with 0.2% sulfur at the wellhead.",
       "confidence": "high",
       "accepted_for_conversion": true
+    },
+    {
+      "field_name": "Viura (1)",
+      "aliases": [
+        "viura 1",
+        "viura-1",
+        "viura1"
+      ],
+      "api_gravity_deg": null,
+      "api_gravity_min_deg": null,
+      "api_gravity_max_deg": null,
+      "bbl_per_tonne": null,
+      "measurement_basis": "H&P/Prospex research note states that Viura reservoir gas has a minor condensate cut of 3.5 stb/mmcf, but does not provide condensate density, API gravity, or a tonnes-to-barrels conversion basis",
+      "source_title": "Prospex Energy | H&P Research, Viura restarts and Poland licensing milestone, 22 October 2025",
+      "source_url": "https://prospex.energy/wp-content/uploads/2025/10/Prospex-Viura-Restart-and-Poland-22nd-Oct-2025.pdf",
+      "source_class": "industry_technical_article",
+      "evidence_note": "The research note describes Viura as a gas field and states that the reservoir produces gas with a minor condensate cut of 3.5 stb/mmcf. Because no liquid density/API value is cited, the registry preserves this as a source lead only and keeps Viura (1) in source_gap_fields for strict conversion.",
+      "confidence": "medium",
+      "accepted_for_conversion": false
     }
   ]
 }

--- a/tests/unit/spain/test_cores_density.py
+++ b/tests/unit/spain/test_cores_density.py
@@ -383,6 +383,45 @@ def test_default_density_registry_retains_ogj_api_leads_as_source_gaps():
     assert defaulted_audit.missing_fields == ()
 
 
+def test_default_density_registry_retains_viura_condensate_lead_as_source_gap():
+    registry_path = files("worldenergydata.spain").joinpath(
+        "data/cores/crude_density_factors.json"
+    )
+    payload = json.loads(registry_path.read_text())
+    factors = load_crude_density_factors()
+    viura_url = (
+        "https://prospex.energy/wp-content/uploads/2025/10/"
+        "Prospex-Viura-Restart-and-Poland-22nd-Oct-2025.pdf"
+    )
+
+    viura = factors["viura1"]
+    assert viura.field_name == "Viura (1)"
+    assert viura.source_class == "industry_technical_article"
+    assert viura.source_url == viura_url
+    assert viura.accepted_for_conversion is False
+    assert viura.api_gravity_deg is None
+    assert viura.api_gravity_min_deg is None
+    assert viura.api_gravity_max_deg is None
+    assert viura.bbl_per_tonne is None
+    assert "Viura (1)" in payload["source_gap_fields"]
+
+    with pytest.raises(CoresDensityCoverageError, match="Viura"):
+        build_oil_conversion_audit(
+            ["Viura (1)"],
+            factors,
+            allow_default_density=False,
+        )
+
+    defaulted_audit = build_oil_conversion_audit(
+        ["Viura (1)"],
+        factors,
+        allow_default_density=True,
+    )
+    assert defaulted_audit.used_field_names == ()
+    assert defaulted_audit.defaulted_fields == ("Viura (1)",)
+    assert defaulted_audit.missing_fields == ()
+
+
 def test_default_density_registry_keeps_current_fields_missing():
     registry_path = files("worldenergydata.spain").joinpath(
         "data/cores/crude_density_factors.json"


### PR DESCRIPTION
## Summary
- Retain `Viura (1)` as an evidence-only CORES crude density source lead.
- Record the 2025 Prospex/H&P Viura condensate-cut reference without enabling conversion.
- Keep `Viura (1)` in `source_gap_fields`: no density/API or tonnes-to-barrels basis is available from this source.

## Source treatment
- Source: Prospex Energy / H&P Research, `Viura restarts and Poland licensing milestone`, 22 October 2025.
- Evidence lead: the note describes Viura as a producing gas field and states a minor condensate cut of `3.5 stb/mmcf`.
- Conversion stance: `accepted_for_conversion=false`, `bbl_per_tonne=null`, because condensate cut is not a crude density/API factor.

## Verification
- TDD RED: new targeted test first failed with `KeyError: 'viura1'` before the registry entry.
- Fresh checks before PR:
  - `git diff --check origin/main...HEAD`
  - `.venv/bin/python -m json.tool packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json >/dev/null`
  - `.venv/bin/python -m black --check tests/unit/spain/test_cores_density.py`
  - `.venv/bin/python -m isort --check-only tests/unit/spain/test_cores_density.py`
  - `.venv/bin/python -m pytest tests/unit/spain/test_cores_density.py tests/unit/spain/test_cores_field_development_density.py tests/unit/spain/test_cores_field_development_report.py tests/unit/spain/test_cores_live.py tests/unit/spain/test_cores_live_density.py tests/unit/spain/test_cores_loader.py tests/unit/scheduler/test_spain_cores_refresh.py -q --no-cov` -> 89 passed
  - `scripts/legal/legal-sanity-scan.sh` -> no files to scan after commit
  - `bandit tests/unit/spain/test_cores_density.py -ll -ii -q`

Refs #807
