### PR TITLE
feat(spain): accept Ayoluengo operator density factor

### DIFF
--- a/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/_metadata.json
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/_metadata.json
@@ -2,27 +2,47 @@
   "conversion": "oil_bbl = tonnes * cited_field_density_factors",
   "conversion_factors": {
     "gas_gwh_to_mcf": 3290.0,
-    "oil_tonnes_to_bbl_default": 7.33
+    "oil_tonnes_to_bbl_by_field": {
+      "Ayoluengo": 7.489986677157665
+    }
   },
   "license_note": "CORES attribution required; cite source URL and latest-update date.",
   "normalized_unit": "bbl",
   "oil_conversion_audit": {
     "conversion_basis": "cited_field_density_factors",
-    "coverage_status": "defaulted",
-    "default_bbl_per_tonne": 7.33,
-    "defaulted_fields": [
-      "Ayoluengo"
+    "coverage_status": "complete",
+    "default_bbl_per_tonne": null,
+    "defaulted_fields": [],
+    "factors": [
+      {
+        "accepted_for_conversion": true,
+        "aliases": [
+          "ayoluengo"
+        ],
+        "api_gravity_deg": 37.0,
+        "api_gravity_max_deg": null,
+        "api_gravity_min_deg": null,
+        "bbl_per_tonne": 7.489986677157665,
+        "confidence": "medium",
+        "evidence_note": "The archived operator page lists Ayoluengo as LGO's largest Spanish onshore oilfield, states low-sulphur crude at 37\u00b0 API, and notes produced crude sales to industrial users. No structured min/max API range is recorded for this operator source.",
+        "field_name": "Ayoluengo",
+        "measurement_basis": "Archived LGO Energy operator page identifies the Ayoluengo oilfield as producing low-sulphur crude at 37\u00b0 API",
+        "source_class": "operator_record",
+        "source_title": "LGO Energy Spain operation overview: Ayoluengo Oilfield",
+        "source_url": "https://web.archive.org/web/20170202034751id_/http://www.lgo-energy.com/operations-detail/2755723-spain"
+      }
     ],
-    "factors": [],
-    "generated_at": "2026-07-04T00:00:00Z",
+    "generated_at": "2026-07-07T00:00:00Z",
     "missing_fields": [],
     "oil_field_count": 1,
-    "registry_date": "2026-07-04",
-    "registry_version": "fixture-default-density",
+    "registry_date": "2026-07-07",
+    "registry_version": "2026-07-07-cited-partial-9",
     "schema_version": 1,
-    "used_fields": []
+    "used_fields": [
+      "Ayoluengo"
+    ]
   },
-  "sample_extracted_date": "2026-07-04",
+  "sample_extracted_date": "2026-07-07",
   "sample_field": "Ayoluengo",
   "sample_row_count": 6,
   "source_name": "CORES Indigenous Crude Oil Production",

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/ayoluengo_oil_sample.csv
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/ayoluengo_oil_sample.csv
@@ -1,7 +1,7 @@
 field_name,year,month,oil_bbl,gas_mcf
-Ayoluengo,1968,1,69356.46,0.0
-Ayoluengo,1968,2,92160.09,0.0
-Ayoluengo,1968,3,87468.89,0.0
-Ayoluengo,1968,4,101175.99,0.0
-Ayoluengo,1968,5,96712.02,0.0
-Ayoluengo,1968,6,55656.69,0.0
+Ayoluengo,1968,1,70870.25,0.0
+Ayoluengo,1968,2,94171.60,0.0
+Ayoluengo,1968,3,89378.01,0.0
+Ayoluengo,1968,4,103384.29,0.0
+Ayoluengo,1968,5,98822.88,0.0
+Ayoluengo,1968,6,56871.47,0.0

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
@@ -1,11 +1,10 @@
 {
-  "registry_version": "2026-07-07-cited-partial-8",
+  "registry_version": "2026-07-07-cited-partial-9",
   "registry_date": "2026-07-07",
   "coverage_status": "missing",
-  "coverage_note": "Amposta, Casablanca, Dorada, Montanazo-Lubina, and Tarraco have accepted BOE regulator-record API values. Boquer\u00f3n, Rodaballo, and Salmonete have accepted technical-literature API values from reservoir-geochemistry articles. Albatros and Gaviota have evidence-only OGJ Worldwide Production API leads, Ayoluengo has an evidence-only heterogeneous 20\u00b0 to 39\u00b0 API range, and Viura (1) has an evidence-only gas-condensate cut lead; these evidence-only entries have no accepted representative conversion factor. Strict refreshes still fail closed until accepted cited factors cover every current CORES oil field.",
+  "coverage_note": "Amposta, Casablanca, Dorada, Montanazo-Lubina, and Tarraco have accepted BOE regulator-record API values. Ayoluengo has an accepted archived-operator 37\u00b0 API value. Boquer\u00f3n, Rodaballo, and Salmonete have accepted technical-literature API values from reservoir-geochemistry articles. Albatros and Gaviota have evidence-only OGJ Worldwide Production API leads, and Viura (1) has an evidence-only gas-condensate cut lead; these evidence-only entries have no accepted representative conversion factor. Strict refreshes still fail closed until accepted cited factors cover every current CORES oil field.",
   "source_gap_fields": [
     "Albatros",
-    "Ayoluengo",
     "Gaviota",
     "Viura (1)"
   ],
@@ -51,17 +50,17 @@
       "aliases": [
         "ayoluengo"
       ],
-      "api_gravity_deg": null,
-      "api_gravity_min_deg": 20.0,
-      "api_gravity_max_deg": 39.0,
-      "bbl_per_tonne": null,
-      "measurement_basis": "Ayoluengo field technical guide gives a heterogeneous 20\u00b0 to 39\u00b0 API crude density range; no representative produced stream, field average, or production-weighted split is cited",
-      "source_title": "El campo de petr\u00f3leo de Ayoluengo: 50 a\u00f1os de historia",
-      "source_url": "https://sargentesdelalora.com/wp-content/uploads/2017/02/libro-50-aniversario.pdf",
-      "source_class": "technical_literature",
-      "evidence_note": "The guide identifies Ayoluengo as Spain's only commercial onshore oil field, states the field's crude quality is heterogeneous, and gives crude density ranging from 20\u00b0 to 39\u00b0 API. The registry preserves that range as evidence only and keeps Ayoluengo in source_gap_fields for strict conversion.",
+      "api_gravity_deg": 37.0,
+      "api_gravity_min_deg": null,
+      "api_gravity_max_deg": null,
+      "bbl_per_tonne": 7.489986677157665,
+      "measurement_basis": "Archived LGO Energy operator page identifies the Ayoluengo oilfield as producing low-sulphur crude at 37\u00b0 API",
+      "source_title": "LGO Energy Spain operation overview: Ayoluengo Oilfield",
+      "source_url": "https://web.archive.org/web/20170202034751id_/http://www.lgo-energy.com/operations-detail/2755723-spain",
+      "source_class": "operator_record",
+      "evidence_note": "The archived operator page lists Ayoluengo as LGO's largest Spanish onshore oilfield, states low-sulphur crude at 37\u00b0 API, and notes produced crude sales to industrial users. No structured min/max API range is recorded for this operator source.",
       "confidence": "medium",
-      "accepted_for_conversion": false
+      "accepted_for_conversion": true
     },
     {
       "field_name": "Boquer\u00f3n",

--- a/tests/unit/spain/test_cores_density.py
+++ b/tests/unit/spain/test_cores_density.py
@@ -293,42 +293,44 @@ def test_default_density_registry_accepts_cited_source_fields():
     assert audit.missing_fields == ()
 
 
-def test_default_density_registry_retains_ayoluengo_range_as_source_gap():
+def test_default_density_registry_accepts_ayoluengo_operator_api_factor():
     registry_path = files("worldenergydata.spain").joinpath(
         "data/cores/crude_density_factors.json"
     )
     payload = json.loads(registry_path.read_text())
     factors = load_crude_density_factors()
     ayoluengo_url = (
-        "https://sargentesdelalora.com/wp-content/uploads/2017/02/"
-        "libro-50-aniversario.pdf"
+        "https://web.archive.org/web/20170202034751id_/"
+        "http://www.lgo-energy.com/operations-detail/2755723-spain"
     )
 
     ayoluengo = factors["ayoluengo"]
     assert ayoluengo.field_name == "Ayoluengo"
-    assert ayoluengo.source_class == "technical_literature"
+    assert ayoluengo.source_class == "operator_record"
     assert ayoluengo.source_url == ayoluengo_url
-    assert ayoluengo.accepted_for_conversion is False
-    assert ayoluengo.api_gravity_min_deg == pytest.approx(20.0)
-    assert ayoluengo.api_gravity_max_deg == pytest.approx(39.0)
-    assert ayoluengo.api_gravity_deg is None
-    assert ayoluengo.bbl_per_tonne is None
-    assert "Ayoluengo" in payload["source_gap_fields"]
+    assert ayoluengo.accepted_for_conversion is True
+    assert ayoluengo.api_gravity_deg == pytest.approx(37.0)
+    assert ayoluengo.api_gravity_min_deg is None
+    assert ayoluengo.api_gravity_max_deg is None
+    assert ayoluengo.bbl_per_tonne == pytest.approx(7.489986677157665)
+    assert "Ayoluengo" not in payload["source_gap_fields"]
 
-    with pytest.raises(CoresDensityCoverageError, match="Ayoluengo"):
-        build_oil_conversion_audit(
-            ["Ayoluengo"],
-            factors,
-            allow_default_density=False,
-        )
+    audit = build_oil_conversion_audit(
+        ["Ayoluengo"],
+        factors,
+        allow_default_density=False,
+    )
+    assert audit.used_field_names == ("Ayoluengo",)
+    assert audit.defaulted_fields == ()
+    assert audit.missing_fields == ()
 
     defaulted_audit = build_oil_conversion_audit(
         ["Ayoluengo"],
         factors,
         allow_default_density=True,
     )
-    assert defaulted_audit.used_field_names == ()
-    assert defaulted_audit.defaulted_fields == ("Ayoluengo",)
+    assert defaulted_audit.used_field_names == ("Ayoluengo",)
+    assert defaulted_audit.defaulted_fields == ()
     assert defaulted_audit.missing_fields == ()
 
 
@@ -430,7 +432,6 @@ def test_default_density_registry_keeps_current_fields_missing():
     expected_fields = payload["source_gap_fields"]
     assert expected_fields == [
         "Albatros",
-        "Ayoluengo",
         "Gaviota",
         "Viura (1)",
     ]
@@ -467,12 +468,12 @@ def test_default_density_registry_partially_covers_current_cores_fields():
     ]
     expected_gap_fields = [
         "Albatros",
-        "Ayoluengo",
         "Gaviota",
         "Viura (1)",
     ]
     expected_used_fields = [
         "Amposta",
+        "Ayoluengo",
         "Boquerón",
         "Casablanca",
         "Dorada",

--- a/tests/unit/spain/test_cores_live.py
+++ b/tests/unit/spain/test_cores_live.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import json
+from importlib.resources import files
 
 import pandas as pd
 import pytest
@@ -15,6 +16,12 @@ from worldenergydata.spain.production.cores_live import (
     refresh_ayoluengo_fixture,
 )
 from worldenergydata.spain.production.cores_loader import TONNES_TO_BBL
+
+AYOLUENGO_OPERATOR_URL = (
+    "https://web.archive.org/web/20170202034751id_/"
+    "http://www.lgo-energy.com/operations-detail/2755723-spain"
+)
+AYOLUENGO_OPERATOR_BBL_PER_TONNE = 7.489986677157665
 
 
 def test_discover_resolves_official_workbook_links_from_statistics_page_html(tmp_path):
@@ -86,7 +93,7 @@ def test_download_all_writes_raw_files_atomically_and_records_metadata(tmp_path)
     )
 
 
-def test_refresh_ayoluengo_fixture_writes_stable_sample_and_metadata(tmp_path):
+def test_refresh_ayoluengo_fixture_without_audit_records_legacy_default(tmp_path):
     oil = pd.DataFrame(
         [
             {"field_name": "Other", "year": 2026, "month": 1, "oil_bbl": 1.0},
@@ -143,6 +150,27 @@ def test_refresh_ayoluengo_fixture_writes_stable_sample_and_metadata(tmp_path):
     assert audit["defaulted_fields"] == ["Ayoluengo"]
     assert audit["default_bbl_per_tonne"] == TONNES_TO_BBL
     assert written_metadata["workbooks"]["oil"]["sha256"] == "abc123"
+
+
+def test_committed_ayoluengo_fixture_uses_cited_operator_density_factor():
+    cores_data = files("worldenergydata.spain").joinpath("data/cores")
+    metadata = json.loads(cores_data.joinpath("_metadata.json").read_text())
+    sample = pd.read_csv(cores_data.joinpath("ayoluengo_oil_sample.csv"))
+    source_tonnes = [9462.0, 12573.0, 11933.0, 13803.0, 13194.0, 7593.0]
+
+    assert metadata["conversion_factors"]["oil_tonnes_to_bbl_by_field"] == {
+        "Ayoluengo": AYOLUENGO_OPERATOR_BBL_PER_TONNE
+    }
+    audit = metadata["oil_conversion_audit"]
+    assert audit["coverage_status"] == "complete"
+    assert audit["used_fields"] == ["Ayoluengo"]
+    assert audit["defaulted_fields"] == []
+    assert audit["default_bbl_per_tonne"] is None
+    assert audit["factors"][0]["source_url"] == AYOLUENGO_OPERATOR_URL
+    assert sample["oil_bbl"].tolist() == pytest.approx(
+        [tonnes * AYOLUENGO_OPERATOR_BBL_PER_TONNE for tonnes in source_tonnes],
+        abs=0.01,
+    )
 
 
 def _fake_workbook_responses(oil_bytes, gas_bytes):

--- a/tests/unit/spain/test_cores_live_density.py
+++ b/tests/unit/spain/test_cores_live_density.py
@@ -22,8 +22,8 @@ from worldenergydata.spain.production.cores_loader import GWH_TO_MCF, TONNES_TO_
 def test_live_loader_allows_legacy_default_only_when_explicit(tmp_path):
     _write_live_workbooks(
         tmp_path,
-        pd.DataFrame([_workbook_row("Ayoluengo", 2.0)]),
-        pd.DataFrame([_workbook_row("Ayoluengo", 3.0)]),
+        pd.DataFrame([_workbook_row("Albatros", 2.0)]),
+        pd.DataFrame([_workbook_row("Albatros", 3.0)]),
     )
 
     loader = CoresLiveProductionLoader(
@@ -40,10 +40,10 @@ def test_live_loader_allows_legacy_default_only_when_explicit(tmp_path):
     assert all_products.iloc[0]["oil_bbl"] == pytest.approx(2.0 * TONNES_TO_BBL)
     assert all_products.iloc[0]["gas_mcf"] == pytest.approx(3.0 * GWH_TO_MCF)
     assert loader.oil_conversion_audit is not None
-    assert loader.oil_conversion_audit.defaulted_fields == ("Ayoluengo",)
+    assert loader.oil_conversion_audit.defaulted_fields == ("Albatros",)
     sidecar = _read_density_sidecar(tmp_path)
     assert sidecar["coverage_status"] == "defaulted"
-    assert sidecar["defaulted_fields"] == ["Ayoluengo"]
+    assert sidecar["defaulted_fields"] == ["Albatros"]
     assert sidecar["default_bbl_per_tonne"] == TONNES_TO_BBL
     assert (tmp_path / "normalized" / "cores_oil_production.csv").exists()
     assert (tmp_path / "normalized" / "cores_gas_production.csv").exists()
@@ -63,12 +63,12 @@ def test_live_loader_default_registry_fails_closed_on_source_gaps(tmp_path):
     raw_dir.mkdir()
     _write_cores_xlsx(
         raw_dir / DEFAULT_WORKBOOKS["oil"].filename,
-        pd.DataFrame([_workbook_row("Ayoluengo", 2.0)]),
+        pd.DataFrame([_workbook_row("Albatros", 2.0)]),
     )
 
     loader = CoresLiveProductionLoader(cache_root=tmp_path)
 
-    with pytest.raises(CoresDensityCoverageError, match="Ayoluengo"):
+    with pytest.raises(CoresDensityCoverageError, match="Albatros"):
         loader.load_oil_production()
 
 


### PR DESCRIPTION
## Summary

- Accept Ayoluengo as a cited field-specific CORES density factor using the archived LGO Energy operator page: 37 API, `7.489986677157665` bbl/t.
- Remove Ayoluengo from `source_gap_fields`; remaining strict gaps are Albatros, Gaviota, and Viura (1).
- Update the committed Ayoluengo sample fixture and `_metadata.json` from legacy 7.33 default provenance to cited field-density provenance.
- Keep structured Ayoluengo `api_gravity_min_deg` / `api_gravity_max_deg` null so the accepted record only stores values supported by its operator source.

Refs #807

## Source Evidence

- Source: https://web.archive.org/web/20170202034751id_/http://www.lgo-energy.com/operations-detail/2755723-spain
- The archived operator page identifies the Ayoluengo oilfield and states: “Low sulphur crude, 37 degree API”.
- The page also describes produced crude sales, supporting that the value applies to the produced stream, not only discovery-test evidence.

## TDD / Review

- RED: `tests/unit/spain/test_cores_density.py::test_default_density_registry_accepts_ayoluengo_operator_api_factor` failed before the registry update.
- RED: `tests/unit/spain/test_cores_live.py::test_committed_ayoluengo_fixture_uses_cited_operator_density_factor` failed before the committed fixture metadata/sample update.
- Adversarial source-policy review initially BLOCKED on unsupported structured 20-39 API min/max; fixed by nulling structured min/max for the operator-sourced record.
- Adversarial behavior/downstream review initially BLOCKED on stale committed fixture default provenance; fixed by updating `_metadata.json`, `ayoluengo_oil_sample.csv`, and adding committed-artifact coverage.
- Re-review verdicts: `APPROVE_WITH_MINOR`; addressed both minor test-quality notes before this PR.

## Verification

- `.venv/bin/python -m pytest tests/unit/spain/test_cores_density.py tests/unit/spain/test_cores_live.py tests/unit/spain/test_cores_live_density.py tests/unit/spain/test_cores_loader.py tests/unit/spain/test_cores_field_development_density.py tests/unit/spain/test_cores_field_development_report.py tests/unit/scheduler/test_spain_cores_refresh.py -q --no-cov` -> `90 passed`
- `.venv/bin/python -m pytest tests/unit/core tests/unit/common tests/contracts tests/workflows tests/unit/spain -q --no-cov` -> `572 passed, 2 skipped`
- `git diff --check`
- `python -m json.tool` on both changed JSON files
- `.venv/bin/python -m black --check tests/unit/spain/test_cores_density.py tests/unit/spain/test_cores_live.py tests/unit/spain/test_cores_live_density.py`
- `.venv/bin/python -m isort --check-only tests/unit/spain/test_cores_density.py tests/unit/spain/test_cores_live.py tests/unit/spain/test_cores_live_density.py`
- `scripts/legal/legal-sanity-scan.sh` -> PASS
- `uv run bandit tests/unit/spain/test_cores_density.py tests/unit/spain/test_cores_live.py tests/unit/spain/test_cores_live_density.py -ll -ii -q` -> exit 0

## Follow-up Leads Not Included

- Gaviota has a candidate Murphy 1993 10-K + CORES tonnes derived bbl/t basis. It needs its own TDD/review pass because it is a two-source derivation rather than a stated API/density value.
- Albatros and Viura remain unresolved source gaps under the current strict field-specific policy.
