### PR TITLE
feat(spain): accept Gaviota derived density factor

### DIFF
--- a/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json
@@ -1,11 +1,10 @@
 {
-  "registry_version": "2026-07-07-cited-partial-9",
+  "registry_version": "2026-07-07-cited-partial-10",
   "registry_date": "2026-07-07",
   "coverage_status": "missing",
-  "coverage_note": "Amposta, Casablanca, Dorada, Montanazo-Lubina, and Tarraco have accepted BOE regulator-record API values. Ayoluengo has an accepted archived-operator 37\u00b0 API value. Boquer\u00f3n, Rodaballo, and Salmonete have accepted technical-literature API values from reservoir-geochemistry articles. Albatros and Gaviota have evidence-only OGJ Worldwide Production API leads, and Viura (1) has an evidence-only gas-condensate cut lead; these evidence-only entries have no accepted representative conversion factor. Strict refreshes still fail closed until accepted cited factors cover every current CORES oil field.",
+  "coverage_note": "Amposta, Casablanca, Dorada, Montanazo-Lubina, and Tarraco have accepted BOE regulator-record API values. Ayoluengo has an accepted archived-operator 37\u00b0 API value. Gaviota has an accepted derived bbl/t factor from Murphy 1993 Form 10-K net condensate rates grossed up by working interest and direct CORES tonnes. Boquer\u00f3n, Rodaballo, and Salmonete have accepted technical-literature API values from reservoir-geochemistry articles. Albatros has an evidence-only OGJ Worldwide Production API lead, and Viura (1) has an evidence-only gas-condensate cut lead; these evidence-only entries have no accepted representative conversion factor. Strict refreshes still fail closed until accepted cited factors cover every current CORES oil field.",
   "source_gap_fields": [
     "Albatros",
-    "Gaviota",
     "Viura (1)"
   ],
   "factors": [
@@ -119,17 +118,21 @@
       "aliases": [
         "gaviota"
       ],
-      "api_gravity_deg": 52.7,
+      "api_gravity_deg": null,
       "api_gravity_min_deg": null,
       "api_gravity_max_deg": null,
-      "bbl_per_tonne": null,
-      "measurement_basis": "Oil & Gas Journal Worldwide Production table lists Gaviota under Spain/Repsol with a 52.7\u00b0 API column value; this trade-press table is retained as a source lead only and is not treated as a conversion-eligible representative produced stream",
-      "source_title": "Worldwide Production, Oil & Gas Journal, Dec. 25, 1995",
-      "source_url": "https://img.ogj.com/files/base/ebm/ogj/document/2009/06/content_dam_ogj_en_downloadables_survey_downloads_worldwide_production_1995_worldwide_production_leftcolumn_downloadable_worldwide_production_1995.pdf",
-      "source_class": "industry_technical_article",
-      "evidence_note": "The Spain/Repsol table row lists offshore Gaviota, discovered in 1980, at 8,300 ft depth, 2 producing oil wells, 123 b/d average production, and 52.7\u00b0 API gravity. The registry keeps Gaviota in source_gap_fields because OGJ trade-press evidence is not a conversion-eligible representative source under the approved #807 source policy.",
+      "bbl_per_tonne": 8.289443405190332,
+      "measurement_basis": "Derived Gaviota condensate bbl/t factor: Murphy 1993 Form 10-K states net Gaviota condensate rates of 239 b/d in 1992 and 103 b/d in 1993 for its 18% interest; the registry grosses those rates to field barrels and divides by direct CORES gross tonnes of 58,602.8 t in 1992 and 25,218.0 t in 1993",
+      "source_title": "Murphy Oil 1993 Form 10-K and CORES Indigenous Crude Oil Production workbook: Gaviota condensate basis",
+      "source_url": "https://ir.murphyoilcorp.com/static-files/791c4744-6f71-41e5-a4dc-c95c654414d3",
+      "source_class": "securities_filing",
+      "evidence_note": "Murphy's filing identifies the Gaviota field at an 18% interest and reports average daily condensate rates of 239 b/d in 1992 and 103 b/d in 1993. CORES records gross Gaviota oil/condensate production of 58,602.8 t in 1992 and 25,218.0 t in 1993. The accepted factor is a weighted two-year net-to-gross derivation, not a stated API or density.",
       "confidence": "medium",
-      "accepted_for_conversion": false
+      "accepted_for_conversion": true,
+      "supporting_source_urls": [
+        "https://www.cores.es/sites/default/files/archivos/estadisticas/crude-oil-production.xlsx",
+        "https://www.cores.es/en/estadisticas"
+      ]
     },
     {
       "field_name": "Montanazo-Lubina",

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_density.py
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/production/cores_density.py
@@ -8,6 +8,7 @@ import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Mapping
+from urllib.parse import urlparse
 
 DEFAULT_OIL_BBL_PER_TONNE = 7.33
 
@@ -64,6 +65,7 @@ class CoresCrudeDensityFactor:
     evidence_note: str
     confidence: str
     accepted_for_conversion: bool
+    supporting_source_urls: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         validate_crude_density_factor(self)
@@ -149,6 +151,14 @@ def validate_crude_density_factor(factor: CoresCrudeDensityFactor) -> None:
     for alias in factor.aliases:
         if not isinstance(alias, str) or not alias.strip():
             raise ValueError("aliases must be non-empty strings")
+    if not isinstance(factor.supporting_source_urls, tuple):
+        raise ValueError("supporting_source_urls must be a tuple")
+    for url in factor.supporting_source_urls:
+        if not isinstance(url, str) or not url.strip():
+            raise ValueError("supporting_source_urls must contain non-empty strings")
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("supporting_source_urls must contain HTTP(S) URLs")
     if not isinstance(factor.accepted_for_conversion, bool):
         raise ValueError("accepted_for_conversion must be boolean")
     if factor.source_class not in _ALLOWED_SOURCE_CLASSES:
@@ -199,6 +209,9 @@ def load_crude_density_factors(
     for entry in entries:
         if "accepted_for_conversion" not in entry:
             raise ValueError("accepted_for_conversion is required")
+        supporting_source_urls = entry.get("supporting_source_urls", ())
+        if not isinstance(supporting_source_urls, list | tuple):
+            raise ValueError("supporting_source_urls must be a list")
         factor = CoresCrudeDensityFactor(
             field_name=entry.get("field_name"),
             aliases=tuple(entry.get("aliases", ())),
@@ -213,6 +226,7 @@ def load_crude_density_factors(
             evidence_note=entry.get("evidence_note"),
             confidence=entry.get("confidence"),
             accepted_for_conversion=entry.get("accepted_for_conversion", False),
+            supporting_source_urls=tuple(supporting_source_urls),
         )
         factor_keys: set[str] = set()
         for key in (factor.field_name, *factor.aliases):

--- a/packages/worldenergydata-spain/src/worldenergydata/spain/reports/cores_density_audit.py
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/reports/cores_density_audit.py
@@ -316,6 +316,7 @@ def _validate_factor_scalar_fields(
                 f"{source_name} factors[{index}] missing {key}"
             )
     _validate_http_url(factor["source_url"], source_name, index)
+    _validate_supporting_source_urls(factor, source_name, index)
     if not isinstance(factor["aliases"], list):
         raise CoresDensityAuditError(
             f"{source_name} factors[{index}] aliases must be a list"
@@ -350,6 +351,7 @@ def _validate_factor_with_registry_rules(
             evidence_note=factor["evidence_note"],
             confidence=factor["confidence"],
             accepted_for_conversion=factor["accepted_for_conversion"],
+            supporting_source_urls=tuple(factor["supporting_source_urls"]),
         )
     except (TypeError, ValueError) as exc:
         raise CoresDensityAuditError(f"{source_name} factors[{index}] {exc}") from exc
@@ -361,6 +363,29 @@ def _validate_http_url(value: str, source_name: str, index: int) -> None:
         raise CoresDensityAuditError(
             f"{source_name} factors[{index}] invalid source_url"
         )
+
+
+def _validate_supporting_source_urls(
+    factor: dict[str, Any],
+    source_name: str,
+    index: int,
+) -> None:
+    urls = factor["supporting_source_urls"]
+    if not isinstance(urls, list):
+        raise CoresDensityAuditError(
+            f"{source_name} factors[{index}] supporting_source_urls must be a list"
+        )
+    for url_index, url in enumerate(urls):
+        if not isinstance(url, str):
+            raise CoresDensityAuditError(
+                f"{source_name} factors[{index}] supporting_source_urls[{url_index}]"
+                " must be a string"
+            )
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise CoresDensityAuditError(
+                f"{source_name} factors[{index}] invalid supporting_source_urls"
+            )
 
 
 def _read_json(path: Path) -> dict[str, Any]:
@@ -381,6 +406,7 @@ _FACTOR_KEYS = (
     "evidence_note",
     "confidence",
     "accepted_for_conversion",
+    "supporting_source_urls",
 )
 _REQUIRED_TEXT_KEYS = (
     "field_name",

--- a/tests/unit/spain/test_cores_density.py
+++ b/tests/unit/spain/test_cores_density.py
@@ -62,6 +62,21 @@ def test_density_registry_requires_citation_fields(tmp_path):
         load_crude_density_factors(path)
 
 
+def test_density_registry_rejects_malformed_supporting_source_urls(tmp_path):
+    with pytest.raises(ValueError, match="supporting_source_urls"):
+        _factor(supporting_source_urls="https://example.test/supporting")
+
+    with pytest.raises(ValueError, match="supporting_source_urls"):
+        _factor(supporting_source_urls=("not-a-url",))
+
+    path = tmp_path / "density.json"
+    entry = _factor().__dict__
+    entry["supporting_source_urls"] = "https://example.test/supporting"
+    _write_registry(path, [entry])
+    with pytest.raises(ValueError, match="supporting_source_urls"):
+        load_crude_density_factors(path)
+
+
 def test_density_registry_rejects_legacy_list_payload(tmp_path):
     path = tmp_path / "density.json"
     path.write_text(json.dumps([_factor().__dict__]), encoding="utf-8")
@@ -334,7 +349,7 @@ def test_default_density_registry_accepts_ayoluengo_operator_api_factor():
     assert defaulted_audit.missing_fields == ()
 
 
-def test_default_density_registry_retains_ogj_api_leads_as_source_gaps():
+def test_default_density_registry_retains_albatros_ogj_api_lead_as_source_gap():
     registry_path = files("worldenergydata.spain").joinpath(
         "data/cores/crude_density_factors.json"
     )
@@ -346,42 +361,79 @@ def test_default_density_registry_retains_ogj_api_leads_as_source_gaps():
         "1997_worldwide_production_leftcolumn_downloadable_worldwide_production_"
         "1997.pdf"
     )
-    gaviota_url = (
-        "https://img.ogj.com/files/base/ebm/ogj/document/2009/06/"
-        "content_dam_ogj_en_downloadables_survey_downloads_worldwide_production_"
-        "1995_worldwide_production_leftcolumn_downloadable_worldwide_production_"
-        "1995.pdf"
-    )
 
-    for field_name, key, source_url in (
-        ("Albatros", "albatros", albatros_url),
-        ("Gaviota", "gaviota", gaviota_url),
-    ):
-        factor = factors[key]
-        assert factor.field_name == field_name
-        assert factor.source_class == "industry_technical_article"
-        assert factor.source_url == source_url
-        assert factor.accepted_for_conversion is False
-        assert factor.api_gravity_deg == pytest.approx(52.7)
-        assert factor.api_gravity_min_deg is None
-        assert factor.api_gravity_max_deg is None
-        assert factor.bbl_per_tonne is None
-        assert field_name in payload["source_gap_fields"]
+    factor = factors["albatros"]
+    assert factor.field_name == "Albatros"
+    assert factor.source_class == "industry_technical_article"
+    assert factor.source_url == albatros_url
+    assert factor.accepted_for_conversion is False
+    assert factor.api_gravity_deg == pytest.approx(52.7)
+    assert factor.api_gravity_min_deg is None
+    assert factor.api_gravity_max_deg is None
+    assert factor.bbl_per_tonne is None
+    assert "Albatros" in payload["source_gap_fields"]
 
     with pytest.raises(CoresDensityCoverageError, match="Albatros"):
         build_oil_conversion_audit(
-            ["Albatros", "Gaviota"],
+            ["Albatros"],
             factors,
             allow_default_density=False,
         )
 
     defaulted_audit = build_oil_conversion_audit(
-        ["Albatros", "Gaviota"],
+        ["Albatros"],
         factors,
         allow_default_density=True,
     )
     assert defaulted_audit.used_field_names == ()
-    assert defaulted_audit.defaulted_fields == ("Albatros", "Gaviota")
+    assert defaulted_audit.defaulted_fields == ("Albatros",)
+    assert defaulted_audit.missing_fields == ()
+
+
+def test_default_density_registry_accepts_gaviota_murphy_cores_derived_factor():
+    registry_path = files("worldenergydata.spain").joinpath(
+        "data/cores/crude_density_factors.json"
+    )
+    payload = json.loads(registry_path.read_text())
+    factors = load_crude_density_factors()
+    murphy_url = (
+        "https://ir.murphyoilcorp.com/static-files/"
+        "791c4744-6f71-41e5-a4dc-c95c654414d3"
+    )
+    cores_workbook_url = (
+        "https://www.cores.es/sites/default/files/archivos/estadisticas/"
+        "crude-oil-production.xlsx"
+    )
+    cores_stats_url = "https://www.cores.es/en/estadisticas"
+
+    gaviota = factors["gaviota"]
+    assert gaviota.field_name == "Gaviota"
+    assert gaviota.source_class == "securities_filing"
+    assert gaviota.source_url == murphy_url
+    assert gaviota.supporting_source_urls == (cores_workbook_url, cores_stats_url)
+    assert gaviota.accepted_for_conversion is True
+    assert gaviota.api_gravity_deg is None
+    assert gaviota.api_gravity_min_deg is None
+    assert gaviota.api_gravity_max_deg is None
+    assert gaviota.bbl_per_tonne == pytest.approx(8.289443405190332)
+    assert "Gaviota" not in payload["source_gap_fields"]
+
+    audit = build_oil_conversion_audit(
+        ["Gaviota"],
+        factors,
+        allow_default_density=False,
+    )
+    assert audit.used_field_names == ("Gaviota",)
+    assert audit.defaulted_fields == ()
+    assert audit.missing_fields == ()
+
+    defaulted_audit = build_oil_conversion_audit(
+        ["Gaviota"],
+        factors,
+        allow_default_density=True,
+    )
+    assert defaulted_audit.used_field_names == ("Gaviota",)
+    assert defaulted_audit.defaulted_fields == ()
     assert defaulted_audit.missing_fields == ()
 
 
@@ -432,7 +484,6 @@ def test_default_density_registry_keeps_current_fields_missing():
     expected_fields = payload["source_gap_fields"]
     assert expected_fields == [
         "Albatros",
-        "Gaviota",
         "Viura (1)",
     ]
 
@@ -468,7 +519,6 @@ def test_default_density_registry_partially_covers_current_cores_fields():
     ]
     expected_gap_fields = [
         "Albatros",
-        "Gaviota",
         "Viura (1)",
     ]
     expected_used_fields = [
@@ -477,6 +527,7 @@ def test_default_density_registry_partially_covers_current_cores_fields():
         "Boquerón",
         "Casablanca",
         "Dorada",
+        "Gaviota",
         "Montanazo-Lubina",
         "Rodaballo",
         "Salmonete",

--- a/tests/unit/spain/test_cores_field_development_density.py
+++ b/tests/unit/spain/test_cores_field_development_density.py
@@ -60,12 +60,12 @@ def test_report_preserves_defaulted_density_limitations(tmp_path):
 
 
 def test_report_preserves_missing_density_limitations(tmp_path):
-    _write_cache(tmp_path, extra_rows=[_cache_row("Gaviota", 2025, 1, 5.0, pd.NA)])
+    _write_cache(tmp_path, extra_rows=[_cache_row("Albatros", 2025, 1, 5.0, pd.NA)])
     _write_density_sidecar(
         tmp_path,
         coverage_status="missing",
         used_fields=["Ayoluengo"],
-        missing_fields=["Gaviota"],
+        missing_fields=["Albatros"],
     )
 
     summary = build_report(tmp_path)
@@ -76,10 +76,10 @@ def test_report_preserves_missing_density_limitations(tmp_path):
         "oil_tonnes_to_bbl_conversion_deferred_to_issue_807" in summary["limitations"]
     )
     assert any(
-        item == "oil_tonnes_to_bbl_has_missing_fields: Gaviota"
+        item == "oil_tonnes_to_bbl_has_missing_fields: Albatros"
         for item in summary["limitations"]
     )
-    assert "oil_tonnes_to_bbl_has_missing_fields: Gaviota" in html
+    assert "oil_tonnes_to_bbl_has_missing_fields: Albatros" in html
 
 
 def test_report_rejects_malformed_density_sidecar(tmp_path):
@@ -91,6 +91,18 @@ def test_report_rejects_malformed_density_sidecar(tmp_path):
     sidecar_path.write_text(_json_text(sidecar), encoding="utf-8")
 
     with pytest.raises(CoresReportError, match="source_url"):
+        build_report(tmp_path)
+
+
+def test_report_rejects_malformed_supporting_source_urls(tmp_path):
+    _write_cache(tmp_path)
+    _write_density_sidecar(tmp_path)
+    sidecar_path = tmp_path / "normalized" / "cores_oil_density_factors.json"
+    sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
+    sidecar["factors"][0]["supporting_source_urls"] = "not-a-list"
+    sidecar_path.write_text(_json_text(sidecar), encoding="utf-8")
+
+    with pytest.raises(CoresReportError, match="supporting_source_urls"):
         build_report(tmp_path)
 
 
@@ -404,4 +416,5 @@ def _density_factor() -> dict:
         "evidence_note": "Synthetic test citation",
         "confidence": "high",
         "accepted_for_conversion": True,
+        "supporting_source_urls": [],
     }


### PR DESCRIPTION
## Summary

- Accept Gaviota as a field-specific CORES oil/condensate conversion factor using a two-source derivation.
- Primary source: Murphy Oil 1993 Form 10-K / annual report net daily Gaviota condensate rates, grossed up by Murphy's 18% interest.
- Supporting source: direct CORES Indigenous Crude Oil Production workbook gross Gaviota tonnes.
- Add `supporting_source_urls` to density factors and validate that field in registry loading and report-side sidecar rehydration.
- Leave strict gaps as Albatros and Viura (1).

Refs #807

## Derivation

Murphy source:
- Gaviota field interest: 18%.
- 1992 net condensate rate: 239 b/d.
- 1993 net condensate rate: 103 b/d.
- Murphy's statistics section identifies production rates as net.

CORES source:
- Direct official workbook: `https://www.cores.es/sites/default/files/archivos/estadisticas/crude-oil-production.xlsx`
- 1992 Gaviota gross tonnes: 58,602.8 t.
- 1993 Gaviota gross tonnes: 25,218.0 t.

Arithmetic:
- 1992: `239 / 0.18 * 366 / 58602.8 = 8.292550299075585 bbl/t`.
- 1993: `103 / 0.18 * 365 / 25218.0 = 8.282223455908919 bbl/t`.
- Weighted: `(239 / 0.18 * 366 + 103 / 0.18 * 365) / (58602.8 + 25218.0) = 8.289443405190332 bbl/t`.

This is not a stated API/density source; the registry records `api_gravity_deg: null` and documents the net-to-gross derivation.

## TDD / Review

- RED: Gaviota acceptance and source-gap tests failed while Gaviota remained an OGJ evidence-only gap.
- RED: malformed `supporting_source_urls` tests failed for both registry loading and report sidecar validation.
- Source validation agents accepted the Murphy+CORES candidate, with the required caveat that Murphy net rates must be grossed up by 18% before pairing with CORES gross tonnes.
- Adversarial review initially BLOCKED schema/report validation holes for `supporting_source_urls`; fixed with fail-closed validation and tests.
- Source-policy re-review noted the old OGJ lead wording was not structurally retained; removed the stale claim rather than adding another evidence schema in this slice.

## Verification

- `uv run python -m pytest tests/unit/spain/test_cores_density.py -q --no-cov` -> `23 passed`
- `uv run python -m pytest tests/unit/spain/test_cores_density.py tests/unit/spain/test_cores_field_development_density.py -q --no-cov` -> `40 passed`
- `uv run python -m pytest tests/unit/spain/test_cores_density.py tests/unit/spain/test_cores_live_density.py tests/unit/spain/test_cores_live.py tests/unit/spain/test_cores_loader.py tests/unit/spain/test_cores_field_development_density.py tests/unit/spain/test_cores_field_development_report.py tests/unit/scheduler/test_spain_cores_refresh.py -q --no-cov` -> `93 passed`
- `uv run python -m pytest tests/unit/core tests/unit/common tests/contracts tests/workflows tests/unit/spain -q --no-cov` -> `573 passed, 2 skipped`
- `git diff --check`
- `python -m json.tool packages/worldenergydata-spain/src/worldenergydata/spain/data/cores/crude_density_factors.json >/dev/null`
- `uv run --with black --with isort python -m black --check ...`
- `uv run --with isort python -m isort --check-only ...`
- `scripts/legal/legal-sanity-scan.sh` -> PASS
- `uv run --with bandit python -m bandit ... -ll -ii -q` -> exit 0

## Remaining #807 Gaps

- Albatros
- Viura (1)
