### PR TITLE
feat(hub): wire poster economics links

### DIFF
--- a/reports/lower_tertiary/lifecycle/anchor_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/anchor_lifecycle.html
@@ -190,6 +190,17 @@
   .card { background: var(--panel-2); border:1px solid var(--line); border-radius:10px;
     padding: 18px 20px; }
   .card h3 { margin:0 0 12px; font-size: 15px; letter-spacing:-.01em; }
+  .econ-card { border-left: 3px solid var(--good); }
+  .econ-card p { margin:0 0 14px; color:var(--muted); font-size:12.5px; line-height:1.45; }
+  .econ-open { display:inline-flex; align-items:center; justify-content:center; width:100%;
+    min-height:36px; padding:8px 12px; border-radius:8px; text-decoration:none; font-weight:800;
+    font-size:13px; color:#fff; background:var(--done); border:1px solid var(--done-deep); }
+  .econ-open:hover { background:var(--done-deep); }
+  .econ-foot { margin-top:12px; padding-top:10px; border-top:1px solid var(--line); }
+  .econ-chip { display:inline-flex; align-items:center; gap:5px; font-family:var(--mono);
+    font-size:10.5px; line-height:1; color:var(--muted); text-decoration:none; padding:5px 8px;
+    border:1px solid var(--line); border-radius:999px; background:color-mix(in srgb, var(--line) 18%, transparent); }
+  .econ-chip:hover { color:var(--ink); border-color:var(--muted); }
   .act { display:grid; grid-template-columns: repeat(2,1fr); gap: 14px 22px; }
   @media (max-width:560px){ .act { grid-template-columns:1fr; } }
   .act h4 { margin:0 0 5px; font-family:var(--mono); font-size:11px; letter-spacing:.08em;
@@ -306,6 +317,14 @@
             <h3>Field performance · BSEE life-to-date</h3>
             <dl class="kv" id="f-performance"></dl>
           </div>
+          <div class="card econ-card" id="f-economics-card" hidden>
+            <h3>Field economics · V30 monthly cash-flow model</h3>
+            <p>Monthly cash-flow detail, NPV narrative, and price-sensitivity context. Headline figures remain in the performance card above.</p>
+            <a class="econ-open" id="f-economics-link" href="#">Open full economics →</a>
+            <div class="econ-foot" id="f-economics-foot" hidden>
+              <a class="econ-chip" id="f-benchmark-link" href="#">Well benchmarking ↗</a>
+            </div>
+          </div>
         </div>
       </section>
 
@@ -367,6 +386,8 @@ const FIELD = {
   "wellsHref": null,
   "wellsCount": 0,
   "assetsHref": null,
+  "economics_href": "../economics-anchor.html",
+  "benchmark_href": "../benchmark.html",
   "name": "Anchor",
   "operator": "Chevron",
   "region": "Green Canyon 807 · US Gulf of Mexico",
@@ -766,6 +787,15 @@ if (FIELD.performance) {
   $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-performance-card").hidden = false;
   $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
+}
+
+if (FIELD.economics_href) {
+  $("f-economics-link").href = FIELD.economics_href;
+  $("f-economics-card").hidden = false;
+  if (FIELD.benchmark_href) {
+    $("f-benchmark-link").href = FIELD.benchmark_href;
+    $("f-economics-foot").hidden = false;
+  }
 }
 
 /* host facts + working interest */

--- a/reports/lower_tertiary/lifecycle/big_foot_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/big_foot_lifecycle.html
@@ -190,6 +190,17 @@
   .card { background: var(--panel-2); border:1px solid var(--line); border-radius:10px;
     padding: 18px 20px; }
   .card h3 { margin:0 0 12px; font-size: 15px; letter-spacing:-.01em; }
+  .econ-card { border-left: 3px solid var(--good); }
+  .econ-card p { margin:0 0 14px; color:var(--muted); font-size:12.5px; line-height:1.45; }
+  .econ-open { display:inline-flex; align-items:center; justify-content:center; width:100%;
+    min-height:36px; padding:8px 12px; border-radius:8px; text-decoration:none; font-weight:800;
+    font-size:13px; color:#fff; background:var(--done); border:1px solid var(--done-deep); }
+  .econ-open:hover { background:var(--done-deep); }
+  .econ-foot { margin-top:12px; padding-top:10px; border-top:1px solid var(--line); }
+  .econ-chip { display:inline-flex; align-items:center; gap:5px; font-family:var(--mono);
+    font-size:10.5px; line-height:1; color:var(--muted); text-decoration:none; padding:5px 8px;
+    border:1px solid var(--line); border-radius:999px; background:color-mix(in srgb, var(--line) 18%, transparent); }
+  .econ-chip:hover { color:var(--ink); border-color:var(--muted); }
   .act { display:grid; grid-template-columns: repeat(2,1fr); gap: 14px 22px; }
   @media (max-width:560px){ .act { grid-template-columns:1fr; } }
   .act h4 { margin:0 0 5px; font-family:var(--mono); font-size:11px; letter-spacing:.08em;
@@ -306,6 +317,14 @@
             <h3>Field performance · BSEE life-to-date</h3>
             <dl class="kv" id="f-performance"></dl>
           </div>
+          <div class="card econ-card" id="f-economics-card" hidden>
+            <h3>Field economics · V30 monthly cash-flow model</h3>
+            <p>Monthly cash-flow detail, NPV narrative, and price-sensitivity context. Headline figures remain in the performance card above.</p>
+            <a class="econ-open" id="f-economics-link" href="#">Open full economics →</a>
+            <div class="econ-foot" id="f-economics-foot" hidden>
+              <a class="econ-chip" id="f-benchmark-link" href="#">Well benchmarking ↗</a>
+            </div>
+          </div>
         </div>
       </section>
 
@@ -367,6 +386,8 @@ const FIELD = {
   "wellsHref": "wells/",
   "wellsCount": 5,
   "assetsHref": null,
+  "economics_href": "../economics-big_foot.html",
+  "benchmark_href": "../benchmark.html",
   "name": "Big Foot",
   "operator": "Chevron",
   "region": "Walker Ridge 29 (G16942) · US Gulf of Mexico",
@@ -779,6 +800,15 @@ if (FIELD.performance) {
   $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-performance-card").hidden = false;
   $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
+}
+
+if (FIELD.economics_href) {
+  $("f-economics-link").href = FIELD.economics_href;
+  $("f-economics-card").hidden = false;
+  if (FIELD.benchmark_href) {
+    $("f-benchmark-link").href = FIELD.benchmark_href;
+    $("f-economics-foot").hidden = false;
+  }
 }
 
 /* host facts + working interest */

--- a/reports/lower_tertiary/lifecycle/cascade_chinook_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/cascade_chinook_lifecycle.html
@@ -190,6 +190,17 @@
   .card { background: var(--panel-2); border:1px solid var(--line); border-radius:10px;
     padding: 18px 20px; }
   .card h3 { margin:0 0 12px; font-size: 15px; letter-spacing:-.01em; }
+  .econ-card { border-left: 3px solid var(--good); }
+  .econ-card p { margin:0 0 14px; color:var(--muted); font-size:12.5px; line-height:1.45; }
+  .econ-open { display:inline-flex; align-items:center; justify-content:center; width:100%;
+    min-height:36px; padding:8px 12px; border-radius:8px; text-decoration:none; font-weight:800;
+    font-size:13px; color:#fff; background:var(--done); border:1px solid var(--done-deep); }
+  .econ-open:hover { background:var(--done-deep); }
+  .econ-foot { margin-top:12px; padding-top:10px; border-top:1px solid var(--line); }
+  .econ-chip { display:inline-flex; align-items:center; gap:5px; font-family:var(--mono);
+    font-size:10.5px; line-height:1; color:var(--muted); text-decoration:none; padding:5px 8px;
+    border:1px solid var(--line); border-radius:999px; background:color-mix(in srgb, var(--line) 18%, transparent); }
+  .econ-chip:hover { color:var(--ink); border-color:var(--muted); }
   .act { display:grid; grid-template-columns: repeat(2,1fr); gap: 14px 22px; }
   @media (max-width:560px){ .act { grid-template-columns:1fr; } }
   .act h4 { margin:0 0 5px; font-family:var(--mono); font-size:11px; letter-spacing:.08em;
@@ -306,6 +317,14 @@
             <h3>Field performance · BSEE life-to-date</h3>
             <dl class="kv" id="f-performance"></dl>
           </div>
+          <div class="card econ-card" id="f-economics-card" hidden>
+            <h3>Field economics · V30 monthly cash-flow model</h3>
+            <p>Monthly cash-flow detail, NPV narrative, and price-sensitivity context. Headline figures remain in the performance card above.</p>
+            <a class="econ-open" id="f-economics-link" href="#">Open full economics →</a>
+            <div class="econ-foot" id="f-economics-foot" hidden>
+              <a class="econ-chip" id="f-benchmark-link" href="#">Well benchmarking ↗</a>
+            </div>
+          </div>
         </div>
       </section>
 
@@ -367,6 +386,8 @@ const FIELD = {
   "wellsHref": null,
   "wellsCount": 0,
   "assetsHref": null,
+  "economics_href": "../economics-cascade_chinook.html",
+  "benchmark_href": "../benchmark.html",
   "name": "Cascade/Chinook",
   "operator": "MP Gulf of Mexico LLC (Murphy EXPRO)",
   "region": "Walker Ridge 206/250 (Cascade), 425/469 (Chinook) · US Gulf of Mexico",
@@ -744,6 +765,15 @@ if (FIELD.performance) {
   $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-performance-card").hidden = false;
   $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
+}
+
+if (FIELD.economics_href) {
+  $("f-economics-link").href = FIELD.economics_href;
+  $("f-economics-card").hidden = false;
+  if (FIELD.benchmark_href) {
+    $("f-benchmark-link").href = FIELD.benchmark_href;
+    $("f-economics-foot").hidden = false;
+  }
 }
 
 /* host facts + working interest */

--- a/reports/lower_tertiary/lifecycle/index.html
+++ b/reports/lower_tertiary/lifecycle/index.html
@@ -2,7 +2,8 @@
 <title>Lower Tertiary — Field Life-Cycle Posters</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
-  body{margin:0;font-family:system-ui,-apple-system,"Segoe UI",sans-serif;background:#eef2f6;color:#0c1a28}
+  body{margin:0;font-family:system-ui,-apple-system,"Segoe UI",sans-serif;
+       background:#eef2f6;color:#0c1a28}
   @media (prefers-color-scheme:dark){body{background:#0a141f;color:#e8eef4}}
   .w{max-width:720px;margin:0 auto;padding:40px 24px}
   h1{font-size:28px;letter-spacing:-.02em;margin:0 0 4px}
@@ -17,7 +18,8 @@
 <div class="w">
   <!-- nav-spine --><div class="nav-spine" style="font:12px/1.6 ui-monospace,SFMono-Regular,Menlo,monospace;margin:0 0 10px;opacity:.75"><a href="../index.html">worldenergydata</a> ▸ <a href="../capabilities/index.html">Capabilities</a> ▸ <span>Life-cycle gallery</span></div>
   <h1>Lower Tertiary field life-cycle posters</h1>
-  <p class="sub">Stage-gate "page 1" summaries · draft tracers for wed #738 · sorted by current phase</p>
+  <p class="sub">Stage-gate "page 1" summaries · draft tracers for wed #738 ·
+    sorted by current phase</p>
   <ul>
       <li><a href="kaskida_lifecycle.html">Kaskida</a><span>BP</span><span>Under construction</span></li>
       <li><a href="north_platte_lifecycle.html">North Platte (renamed Sparta)</a><span>Shell</span><span>Under construction</span></li>

--- a/reports/lower_tertiary/lifecycle/jack_st_malo_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/jack_st_malo_lifecycle.html
@@ -190,6 +190,17 @@
   .card { background: var(--panel-2); border:1px solid var(--line); border-radius:10px;
     padding: 18px 20px; }
   .card h3 { margin:0 0 12px; font-size: 15px; letter-spacing:-.01em; }
+  .econ-card { border-left: 3px solid var(--good); }
+  .econ-card p { margin:0 0 14px; color:var(--muted); font-size:12.5px; line-height:1.45; }
+  .econ-open { display:inline-flex; align-items:center; justify-content:center; width:100%;
+    min-height:36px; padding:8px 12px; border-radius:8px; text-decoration:none; font-weight:800;
+    font-size:13px; color:#fff; background:var(--done); border:1px solid var(--done-deep); }
+  .econ-open:hover { background:var(--done-deep); }
+  .econ-foot { margin-top:12px; padding-top:10px; border-top:1px solid var(--line); }
+  .econ-chip { display:inline-flex; align-items:center; gap:5px; font-family:var(--mono);
+    font-size:10.5px; line-height:1; color:var(--muted); text-decoration:none; padding:5px 8px;
+    border:1px solid var(--line); border-radius:999px; background:color-mix(in srgb, var(--line) 18%, transparent); }
+  .econ-chip:hover { color:var(--ink); border-color:var(--muted); }
   .act { display:grid; grid-template-columns: repeat(2,1fr); gap: 14px 22px; }
   @media (max-width:560px){ .act { grid-template-columns:1fr; } }
   .act h4 { margin:0 0 5px; font-family:var(--mono); font-size:11px; letter-spacing:.08em;
@@ -306,6 +317,14 @@
             <h3>Field performance · BSEE life-to-date</h3>
             <dl class="kv" id="f-performance"></dl>
           </div>
+          <div class="card econ-card" id="f-economics-card" hidden>
+            <h3>Field economics · V30 monthly cash-flow model</h3>
+            <p>Monthly cash-flow detail, NPV narrative, and price-sensitivity context. Headline figures remain in the performance card above.</p>
+            <a class="econ-open" id="f-economics-link" href="#">Open full economics →</a>
+            <div class="econ-foot" id="f-economics-foot" hidden>
+              <a class="econ-chip" id="f-benchmark-link" href="#">Well benchmarking ↗</a>
+            </div>
+          </div>
         </div>
       </section>
 
@@ -367,6 +386,8 @@ const FIELD = {
   "wellsHref": null,
   "wellsCount": 0,
   "assetsHref": null,
+  "economics_href": "../economics-jack_st_malo.html",
+  "benchmark_href": "../benchmark.html",
   "name": "Jack/St. Malo",
   "operator": "Chevron",
   "region": "Walker Ridge 678 (St. Malo) / 758-759 (Jack) · US Gulf of Mexico",
@@ -766,6 +787,15 @@ if (FIELD.performance) {
   $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-performance-card").hidden = false;
   $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
+}
+
+if (FIELD.economics_href) {
+  $("f-economics-link").href = FIELD.economics_href;
+  $("f-economics-card").hidden = false;
+  if (FIELD.benchmark_href) {
+    $("f-benchmark-link").href = FIELD.benchmark_href;
+    $("f-economics-foot").hidden = false;
+  }
 }
 
 /* host facts + working interest */

--- a/reports/lower_tertiary/lifecycle/julia_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/julia_lifecycle.html
@@ -190,6 +190,17 @@
   .card { background: var(--panel-2); border:1px solid var(--line); border-radius:10px;
     padding: 18px 20px; }
   .card h3 { margin:0 0 12px; font-size: 15px; letter-spacing:-.01em; }
+  .econ-card { border-left: 3px solid var(--good); }
+  .econ-card p { margin:0 0 14px; color:var(--muted); font-size:12.5px; line-height:1.45; }
+  .econ-open { display:inline-flex; align-items:center; justify-content:center; width:100%;
+    min-height:36px; padding:8px 12px; border-radius:8px; text-decoration:none; font-weight:800;
+    font-size:13px; color:#fff; background:var(--done); border:1px solid var(--done-deep); }
+  .econ-open:hover { background:var(--done-deep); }
+  .econ-foot { margin-top:12px; padding-top:10px; border-top:1px solid var(--line); }
+  .econ-chip { display:inline-flex; align-items:center; gap:5px; font-family:var(--mono);
+    font-size:10.5px; line-height:1; color:var(--muted); text-decoration:none; padding:5px 8px;
+    border:1px solid var(--line); border-radius:999px; background:color-mix(in srgb, var(--line) 18%, transparent); }
+  .econ-chip:hover { color:var(--ink); border-color:var(--muted); }
   .act { display:grid; grid-template-columns: repeat(2,1fr); gap: 14px 22px; }
   @media (max-width:560px){ .act { grid-template-columns:1fr; } }
   .act h4 { margin:0 0 5px; font-family:var(--mono); font-size:11px; letter-spacing:.08em;
@@ -306,6 +317,14 @@
             <h3>Field performance · BSEE life-to-date</h3>
             <dl class="kv" id="f-performance"></dl>
           </div>
+          <div class="card econ-card" id="f-economics-card" hidden>
+            <h3>Field economics · V30 monthly cash-flow model</h3>
+            <p>Monthly cash-flow detail, NPV narrative, and price-sensitivity context. Headline figures remain in the performance card above.</p>
+            <a class="econ-open" id="f-economics-link" href="#">Open full economics →</a>
+            <div class="econ-foot" id="f-economics-foot" hidden>
+              <a class="econ-chip" id="f-benchmark-link" href="#">Well benchmarking ↗</a>
+            </div>
+          </div>
         </div>
       </section>
 
@@ -367,6 +386,8 @@ const FIELD = {
   "wellsHref": null,
   "wellsCount": 0,
   "assetsHref": null,
+  "economics_href": "../economics-julia.html",
+  "benchmark_href": "../benchmark.html",
   "name": "Julia",
   "operator": "ExxonMobil",
   "region": "Walker Ridge 627 (WR 540/583/584/627/628) · US Gulf of Mexico",
@@ -769,6 +790,15 @@ if (FIELD.performance) {
   $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-performance-card").hidden = false;
   $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
+}
+
+if (FIELD.economics_href) {
+  $("f-economics-link").href = FIELD.economics_href;
+  $("f-economics-card").hidden = false;
+  if (FIELD.benchmark_href) {
+    $("f-benchmark-link").href = FIELD.benchmark_href;
+    $("f-economics-foot").hidden = false;
+  }
 }
 
 /* host facts + working interest */

--- a/reports/lower_tertiary/lifecycle/kaskida_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/kaskida_lifecycle.html
@@ -190,6 +190,17 @@
   .card { background: var(--panel-2); border:1px solid var(--line); border-radius:10px;
     padding: 18px 20px; }
   .card h3 { margin:0 0 12px; font-size: 15px; letter-spacing:-.01em; }
+  .econ-card { border-left: 3px solid var(--good); }
+  .econ-card p { margin:0 0 14px; color:var(--muted); font-size:12.5px; line-height:1.45; }
+  .econ-open { display:inline-flex; align-items:center; justify-content:center; width:100%;
+    min-height:36px; padding:8px 12px; border-radius:8px; text-decoration:none; font-weight:800;
+    font-size:13px; color:#fff; background:var(--done); border:1px solid var(--done-deep); }
+  .econ-open:hover { background:var(--done-deep); }
+  .econ-foot { margin-top:12px; padding-top:10px; border-top:1px solid var(--line); }
+  .econ-chip { display:inline-flex; align-items:center; gap:5px; font-family:var(--mono);
+    font-size:10.5px; line-height:1; color:var(--muted); text-decoration:none; padding:5px 8px;
+    border:1px solid var(--line); border-radius:999px; background:color-mix(in srgb, var(--line) 18%, transparent); }
+  .econ-chip:hover { color:var(--ink); border-color:var(--muted); }
   .act { display:grid; grid-template-columns: repeat(2,1fr); gap: 14px 22px; }
   @media (max-width:560px){ .act { grid-template-columns:1fr; } }
   .act h4 { margin:0 0 5px; font-family:var(--mono); font-size:11px; letter-spacing:.08em;
@@ -306,6 +317,14 @@
             <h3>Field performance · BSEE life-to-date</h3>
             <dl class="kv" id="f-performance"></dl>
           </div>
+          <div class="card econ-card" id="f-economics-card" hidden>
+            <h3>Field economics · V30 monthly cash-flow model</h3>
+            <p>Monthly cash-flow detail, NPV narrative, and price-sensitivity context. Headline figures remain in the performance card above.</p>
+            <a class="econ-open" id="f-economics-link" href="#">Open full economics →</a>
+            <div class="econ-foot" id="f-economics-foot" hidden>
+              <a class="econ-chip" id="f-benchmark-link" href="#">Well benchmarking ↗</a>
+            </div>
+          </div>
         </div>
       </section>
 
@@ -367,6 +386,8 @@ const FIELD = {
   "wellsHref": null,
   "wellsCount": 0,
   "assetsHref": null,
+  "economics_href": null,
+  "benchmark_href": "../benchmark.html",
   "name": "Kaskida",
   "operator": "BP",
   "region": "Keathley Canyon 292 · US Gulf of Mexico",
@@ -721,6 +742,15 @@ if (FIELD.performance) {
   $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-performance-card").hidden = false;
   $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
+}
+
+if (FIELD.economics_href) {
+  $("f-economics-link").href = FIELD.economics_href;
+  $("f-economics-card").hidden = false;
+  if (FIELD.benchmark_href) {
+    $("f-benchmark-link").href = FIELD.benchmark_href;
+    $("f-economics-foot").hidden = false;
+  }
 }
 
 /* host facts + working interest */

--- a/reports/lower_tertiary/lifecycle/lifecycle_template.html
+++ b/reports/lower_tertiary/lifecycle/lifecycle_template.html
@@ -190,6 +190,17 @@
   .card { background: var(--panel-2); border:1px solid var(--line); border-radius:10px;
     padding: 18px 20px; }
   .card h3 { margin:0 0 12px; font-size: 15px; letter-spacing:-.01em; }
+  .econ-card { border-left: 3px solid var(--good); }
+  .econ-card p { margin:0 0 14px; color:var(--muted); font-size:12.5px; line-height:1.45; }
+  .econ-open { display:inline-flex; align-items:center; justify-content:center; width:100%;
+    min-height:36px; padding:8px 12px; border-radius:8px; text-decoration:none; font-weight:800;
+    font-size:13px; color:#fff; background:var(--done); border:1px solid var(--done-deep); }
+  .econ-open:hover { background:var(--done-deep); }
+  .econ-foot { margin-top:12px; padding-top:10px; border-top:1px solid var(--line); }
+  .econ-chip { display:inline-flex; align-items:center; gap:5px; font-family:var(--mono);
+    font-size:10.5px; line-height:1; color:var(--muted); text-decoration:none; padding:5px 8px;
+    border:1px solid var(--line); border-radius:999px; background:color-mix(in srgb, var(--line) 18%, transparent); }
+  .econ-chip:hover { color:var(--ink); border-color:var(--muted); }
   .act { display:grid; grid-template-columns: repeat(2,1fr); gap: 14px 22px; }
   @media (max-width:560px){ .act { grid-template-columns:1fr; } }
   .act h4 { margin:0 0 5px; font-family:var(--mono); font-size:11px; letter-spacing:.08em;
@@ -304,6 +315,14 @@
           <div class="card" id="f-performance-card" hidden>
             <h3>Field performance · BSEE life-to-date</h3>
             <dl class="kv" id="f-performance"></dl>
+          </div>
+          <div class="card econ-card" id="f-economics-card" hidden>
+            <h3>Field economics · V30 monthly cash-flow model</h3>
+            <p>Monthly cash-flow detail, NPV narrative, and price-sensitivity context. Headline figures remain in the performance card above.</p>
+            <a class="econ-open" id="f-economics-link" href="#">Open full economics →</a>
+            <div class="econ-foot" id="f-economics-foot" hidden>
+              <a class="econ-chip" id="f-benchmark-link" href="#">Well benchmarking ↗</a>
+            </div>
           </div>
         </div>
       </section>
@@ -554,6 +573,15 @@ if (FIELD.performance) {
   $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-performance-card").hidden = false;
   $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
+}
+
+if (FIELD.economics_href) {
+  $("f-economics-link").href = FIELD.economics_href;
+  $("f-economics-card").hidden = false;
+  if (FIELD.benchmark_href) {
+    $("f-benchmark-link").href = FIELD.benchmark_href;
+    $("f-economics-foot").hidden = false;
+  }
 }
 
 /* host facts + working interest */

--- a/reports/lower_tertiary/lifecycle/north_platte_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/north_platte_lifecycle.html
@@ -190,6 +190,17 @@
   .card { background: var(--panel-2); border:1px solid var(--line); border-radius:10px;
     padding: 18px 20px; }
   .card h3 { margin:0 0 12px; font-size: 15px; letter-spacing:-.01em; }
+  .econ-card { border-left: 3px solid var(--good); }
+  .econ-card p { margin:0 0 14px; color:var(--muted); font-size:12.5px; line-height:1.45; }
+  .econ-open { display:inline-flex; align-items:center; justify-content:center; width:100%;
+    min-height:36px; padding:8px 12px; border-radius:8px; text-decoration:none; font-weight:800;
+    font-size:13px; color:#fff; background:var(--done); border:1px solid var(--done-deep); }
+  .econ-open:hover { background:var(--done-deep); }
+  .econ-foot { margin-top:12px; padding-top:10px; border-top:1px solid var(--line); }
+  .econ-chip { display:inline-flex; align-items:center; gap:5px; font-family:var(--mono);
+    font-size:10.5px; line-height:1; color:var(--muted); text-decoration:none; padding:5px 8px;
+    border:1px solid var(--line); border-radius:999px; background:color-mix(in srgb, var(--line) 18%, transparent); }
+  .econ-chip:hover { color:var(--ink); border-color:var(--muted); }
   .act { display:grid; grid-template-columns: repeat(2,1fr); gap: 14px 22px; }
   @media (max-width:560px){ .act { grid-template-columns:1fr; } }
   .act h4 { margin:0 0 5px; font-family:var(--mono); font-size:11px; letter-spacing:.08em;
@@ -306,6 +317,14 @@
             <h3>Field performance · BSEE life-to-date</h3>
             <dl class="kv" id="f-performance"></dl>
           </div>
+          <div class="card econ-card" id="f-economics-card" hidden>
+            <h3>Field economics · V30 monthly cash-flow model</h3>
+            <p>Monthly cash-flow detail, NPV narrative, and price-sensitivity context. Headline figures remain in the performance card above.</p>
+            <a class="econ-open" id="f-economics-link" href="#">Open full economics →</a>
+            <div class="econ-foot" id="f-economics-foot" hidden>
+              <a class="econ-chip" id="f-benchmark-link" href="#">Well benchmarking ↗</a>
+            </div>
+          </div>
         </div>
       </section>
 
@@ -367,6 +386,8 @@ const FIELD = {
   "wellsHref": null,
   "wellsCount": 0,
   "assetsHref": null,
+  "economics_href": null,
+  "benchmark_href": "../benchmark.html",
   "name": "North Platte (renamed Sparta)",
   "operator": "Shell",
   "region": "Garden Banks 959 (straddles GB 915/916/958/959) · US Gulf of Mexico",
@@ -717,6 +738,15 @@ if (FIELD.performance) {
   $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-performance-card").hidden = false;
   $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
+}
+
+if (FIELD.economics_href) {
+  $("f-economics-link").href = FIELD.economics_href;
+  $("f-economics-card").hidden = false;
+  if (FIELD.benchmark_href) {
+    $("f-benchmark-link").href = FIELD.benchmark_href;
+    $("f-economics-foot").hidden = false;
+  }
 }
 
 /* host facts + working interest */

--- a/reports/lower_tertiary/lifecycle/shenandoah_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/shenandoah_lifecycle.html
@@ -190,6 +190,17 @@
   .card { background: var(--panel-2); border:1px solid var(--line); border-radius:10px;
     padding: 18px 20px; }
   .card h3 { margin:0 0 12px; font-size: 15px; letter-spacing:-.01em; }
+  .econ-card { border-left: 3px solid var(--good); }
+  .econ-card p { margin:0 0 14px; color:var(--muted); font-size:12.5px; line-height:1.45; }
+  .econ-open { display:inline-flex; align-items:center; justify-content:center; width:100%;
+    min-height:36px; padding:8px 12px; border-radius:8px; text-decoration:none; font-weight:800;
+    font-size:13px; color:#fff; background:var(--done); border:1px solid var(--done-deep); }
+  .econ-open:hover { background:var(--done-deep); }
+  .econ-foot { margin-top:12px; padding-top:10px; border-top:1px solid var(--line); }
+  .econ-chip { display:inline-flex; align-items:center; gap:5px; font-family:var(--mono);
+    font-size:10.5px; line-height:1; color:var(--muted); text-decoration:none; padding:5px 8px;
+    border:1px solid var(--line); border-radius:999px; background:color-mix(in srgb, var(--line) 18%, transparent); }
+  .econ-chip:hover { color:var(--ink); border-color:var(--muted); }
   .act { display:grid; grid-template-columns: repeat(2,1fr); gap: 14px 22px; }
   @media (max-width:560px){ .act { grid-template-columns:1fr; } }
   .act h4 { margin:0 0 5px; font-family:var(--mono); font-size:11px; letter-spacing:.08em;
@@ -306,6 +317,14 @@
             <h3>Field performance · BSEE life-to-date</h3>
             <dl class="kv" id="f-performance"></dl>
           </div>
+          <div class="card econ-card" id="f-economics-card" hidden>
+            <h3>Field economics · V30 monthly cash-flow model</h3>
+            <p>Monthly cash-flow detail, NPV narrative, and price-sensitivity context. Headline figures remain in the performance card above.</p>
+            <a class="econ-open" id="f-economics-link" href="#">Open full economics →</a>
+            <div class="econ-foot" id="f-economics-foot" hidden>
+              <a class="econ-chip" id="f-benchmark-link" href="#">Well benchmarking ↗</a>
+            </div>
+          </div>
         </div>
       </section>
 
@@ -367,6 +386,8 @@ const FIELD = {
   "wellsHref": null,
   "wellsCount": 0,
   "assetsHref": null,
+  "economics_href": "../economics-shenandoah.html",
+  "benchmark_href": "../benchmark.html",
   "name": "Shenandoah",
   "operator": "Beacon Offshore Energy",
   "region": "Walker Ridge 52 (blocks 51, 52, N/2 53) · US Gulf of Mexico",
@@ -762,6 +783,15 @@ if (FIELD.performance) {
   $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-performance-card").hidden = false;
   $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
+}
+
+if (FIELD.economics_href) {
+  $("f-economics-link").href = FIELD.economics_href;
+  $("f-economics-card").hidden = false;
+  if (FIELD.benchmark_href) {
+    $("f-benchmark-link").href = FIELD.benchmark_href;
+    $("f-economics-foot").hidden = false;
+  }
 }
 
 /* host facts + working interest */

--- a/reports/lower_tertiary/lifecycle/stones_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/stones_lifecycle.html
@@ -190,6 +190,17 @@
   .card { background: var(--panel-2); border:1px solid var(--line); border-radius:10px;
     padding: 18px 20px; }
   .card h3 { margin:0 0 12px; font-size: 15px; letter-spacing:-.01em; }
+  .econ-card { border-left: 3px solid var(--good); }
+  .econ-card p { margin:0 0 14px; color:var(--muted); font-size:12.5px; line-height:1.45; }
+  .econ-open { display:inline-flex; align-items:center; justify-content:center; width:100%;
+    min-height:36px; padding:8px 12px; border-radius:8px; text-decoration:none; font-weight:800;
+    font-size:13px; color:#fff; background:var(--done); border:1px solid var(--done-deep); }
+  .econ-open:hover { background:var(--done-deep); }
+  .econ-foot { margin-top:12px; padding-top:10px; border-top:1px solid var(--line); }
+  .econ-chip { display:inline-flex; align-items:center; gap:5px; font-family:var(--mono);
+    font-size:10.5px; line-height:1; color:var(--muted); text-decoration:none; padding:5px 8px;
+    border:1px solid var(--line); border-radius:999px; background:color-mix(in srgb, var(--line) 18%, transparent); }
+  .econ-chip:hover { color:var(--ink); border-color:var(--muted); }
   .act { display:grid; grid-template-columns: repeat(2,1fr); gap: 14px 22px; }
   @media (max-width:560px){ .act { grid-template-columns:1fr; } }
   .act h4 { margin:0 0 5px; font-family:var(--mono); font-size:11px; letter-spacing:.08em;
@@ -306,6 +317,14 @@
             <h3>Field performance · BSEE life-to-date</h3>
             <dl class="kv" id="f-performance"></dl>
           </div>
+          <div class="card econ-card" id="f-economics-card" hidden>
+            <h3>Field economics · V30 monthly cash-flow model</h3>
+            <p>Monthly cash-flow detail, NPV narrative, and price-sensitivity context. Headline figures remain in the performance card above.</p>
+            <a class="econ-open" id="f-economics-link" href="#">Open full economics →</a>
+            <div class="econ-foot" id="f-economics-foot" hidden>
+              <a class="econ-chip" id="f-benchmark-link" href="#">Well benchmarking ↗</a>
+            </div>
+          </div>
         </div>
       </section>
 
@@ -367,6 +386,8 @@ const FIELD = {
   "wellsHref": null,
   "wellsCount": 0,
   "assetsHref": "assets/stones_assets.html",
+  "economics_href": "../economics-stones.html",
+  "benchmark_href": "../benchmark.html",
   "name": "Stones",
   "operator": "Shell",
   "region": "Walker Ridge 508 · US Gulf of Mexico",
@@ -759,6 +780,15 @@ if (FIELD.performance) {
   $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-performance-card").hidden = false;
   $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
+}
+
+if (FIELD.economics_href) {
+  $("f-economics-link").href = FIELD.economics_href;
+  $("f-economics-card").hidden = false;
+  if (FIELD.benchmark_href) {
+    $("f-benchmark-link").href = FIELD.benchmark_href;
+    $("f-economics-foot").hidden = false;
+  }
 }
 
 /* host facts + working interest */

--- a/reports/lower_tertiary/lifecycle/tiber_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/tiber_lifecycle.html
@@ -190,6 +190,17 @@
   .card { background: var(--panel-2); border:1px solid var(--line); border-radius:10px;
     padding: 18px 20px; }
   .card h3 { margin:0 0 12px; font-size: 15px; letter-spacing:-.01em; }
+  .econ-card { border-left: 3px solid var(--good); }
+  .econ-card p { margin:0 0 14px; color:var(--muted); font-size:12.5px; line-height:1.45; }
+  .econ-open { display:inline-flex; align-items:center; justify-content:center; width:100%;
+    min-height:36px; padding:8px 12px; border-radius:8px; text-decoration:none; font-weight:800;
+    font-size:13px; color:#fff; background:var(--done); border:1px solid var(--done-deep); }
+  .econ-open:hover { background:var(--done-deep); }
+  .econ-foot { margin-top:12px; padding-top:10px; border-top:1px solid var(--line); }
+  .econ-chip { display:inline-flex; align-items:center; gap:5px; font-family:var(--mono);
+    font-size:10.5px; line-height:1; color:var(--muted); text-decoration:none; padding:5px 8px;
+    border:1px solid var(--line); border-radius:999px; background:color-mix(in srgb, var(--line) 18%, transparent); }
+  .econ-chip:hover { color:var(--ink); border-color:var(--muted); }
   .act { display:grid; grid-template-columns: repeat(2,1fr); gap: 14px 22px; }
   @media (max-width:560px){ .act { grid-template-columns:1fr; } }
   .act h4 { margin:0 0 5px; font-family:var(--mono); font-size:11px; letter-spacing:.08em;
@@ -306,6 +317,14 @@
             <h3>Field performance · BSEE life-to-date</h3>
             <dl class="kv" id="f-performance"></dl>
           </div>
+          <div class="card econ-card" id="f-economics-card" hidden>
+            <h3>Field economics · V30 monthly cash-flow model</h3>
+            <p>Monthly cash-flow detail, NPV narrative, and price-sensitivity context. Headline figures remain in the performance card above.</p>
+            <a class="econ-open" id="f-economics-link" href="#">Open full economics →</a>
+            <div class="econ-foot" id="f-economics-foot" hidden>
+              <a class="econ-chip" id="f-benchmark-link" href="#">Well benchmarking ↗</a>
+            </div>
+          </div>
         </div>
       </section>
 
@@ -367,6 +386,8 @@ const FIELD = {
   "wellsHref": null,
   "wellsCount": 0,
   "assetsHref": null,
+  "economics_href": null,
+  "benchmark_href": "../benchmark.html",
   "name": "Tiber",
   "operator": "BP",
   "region": "Keathley Canyon 102 · US Gulf of Mexico",
@@ -703,6 +724,15 @@ if (FIELD.performance) {
   $("f-performance").innerHTML = rows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("");
   $("f-performance-card").hidden = false;
   $("f-prov").textContent += " · Performance: BSEE OGOR-A per-well benchmark + V30 economics, life-to-date (not full-cycle)";
+}
+
+if (FIELD.economics_href) {
+  $("f-economics-link").href = FIELD.economics_href;
+  $("f-economics-card").hidden = false;
+  if (FIELD.benchmark_href) {
+    $("f-benchmark-link").href = FIELD.benchmark_href;
+    $("f-economics-foot").hidden = false;
+  }
 }
 
 /* host facts + working interest */

--- a/scripts/lower_tertiary/build_lifecycle_posters.py
+++ b/scripts/lower_tertiary/build_lifecycle_posters.py
@@ -40,10 +40,13 @@ if str(_SCRIPTS) not in sys.path:
 
 import site_nav  # noqa: E402  (nav-spine helper, issue #850)
 
+from worldenergydata.common.fields_registry import load_fields  # noqa: E402
+
 HERE = Path(__file__).resolve().parents[2] / "reports/lower_tertiary/lifecycle"
 TEMPLATE = HERE / "lifecycle_template.html"
 FACTS = HERE / "_facts.json"
 TODAY_YEAR = 2026.5  # generated 2026-07-03; a fixed "you are here" marker on the axis
+FIELDS_REGISTRY = load_fields()
 
 PHASE_KEYS = [
     "acquire",
@@ -268,6 +271,14 @@ def facts_to_field(f: dict) -> dict:
         sorted(wells_dir.glob(f"{f['id']}_*_well.html")) if wells_dir.exists() else []
     )
     assets_page = HERE / "assets" / f"{f['id']}_assets.html"
+    registry_field = FIELDS_REGISTRY.by_id(f["id"])
+    if registry_field is None:
+        raise ValueError(f"Lifecycle facts id not in canonical registry: {f['id']}")
+    economics_href = (
+        f"../economics-{f['id']}.html"
+        if registry_field.surfaces.get("economics_page")
+        else None
+    )
 
     return {
         "id": f["id"],
@@ -276,6 +287,8 @@ def facts_to_field(f: dict) -> dict:
         "assetsHref": (
             f"assets/{f['id']}_assets.html" if assets_page.exists() else None
         ),
+        "economics_href": economics_href,
+        "benchmark_href": "../benchmark.html",
         "name": f["name"],
         "operator": f.get("operator", ""),
         "region": region,
@@ -328,7 +341,8 @@ def build_index(fields: list[dict]) -> str:
 <title>Lower Tertiary — Field Life-Cycle Posters</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
-  body{{margin:0;font-family:system-ui,-apple-system,"Segoe UI",sans-serif;background:#eef2f6;color:#0c1a28}}
+  body{{margin:0;font-family:system-ui,-apple-system,"Segoe UI",sans-serif;
+       background:#eef2f6;color:#0c1a28}}
   @media (prefers-color-scheme:dark){{body{{background:#0a141f;color:#e8eef4}}}}
   .w{{max-width:720px;margin:0 auto;padding:40px 24px}}
   h1{{font-size:28px;letter-spacing:-.02em;margin:0 0 4px}}
@@ -343,7 +357,8 @@ def build_index(fields: list[dict]) -> str:
 <div class="w">
   {site_nav.crumb_for("gallery")}
   <h1>Lower Tertiary field life-cycle posters</h1>
-  <p class="sub">Stage-gate "page 1" summaries · draft tracers for wed #738 · sorted by current phase</p>
+  <p class="sub">Stage-gate "page 1" summaries · draft tracers for wed #738 ·
+    sorted by current phase</p>
   <ul>
 {rows}
   </ul>
@@ -379,7 +394,10 @@ BIG_FOOT_FACTS = {
         "data_through": "2024-12",
         "projected_cop_year": 2038,
     },
-    "provenance": "Data: big_foot.yml + Chevron public disclosures + BSEE (dates to be reconciled in #375)",
+    "provenance": (
+        "Data: big_foot.yml + Chevron public disclosures + BSEE "
+        "(dates to be reconciled in #375)"
+    ),
 }
 
 
@@ -418,7 +436,8 @@ def main():
         out.write_text(render(field))
         fields.append(field)
         print(
-            f"  wrote {out.name}  ({field['statusLabel']}, phase={field['currentPhase']}, gates={len(field['gates'])})"
+            f"  wrote {out.name}  ({field['statusLabel']}, "
+            f"phase={field['currentPhase']}, gates={len(field['gates'])})"
         )
     (HERE / "index.html").write_text(build_index(fields))
     print(f"  wrote index.html  ({len(fields)} fields)")

--- a/tests/integration/site/test_public_link_graph.py
+++ b/tests/integration/site/test_public_link_graph.py
@@ -131,20 +131,63 @@ def test_zero_unresolved_internal_targets_and_fragments(public):
 
 
 FIELD_JSON_RE = re.compile(r"const FIELD = (\{.*?\n\});", re.S)
+POSTER_PAGE_RE = re.compile(r"^lifecycle/[^/]+_lifecycle\.html$")
 
 
-def _data_driven_edges(text):
+def _data_driven_edges(text, page_rel=None):
     """Hrefs embedded in the poster's FIELD JSON payload (rendered by JS)."""
+    is_poster_page = page_rel is not None and POSTER_PAGE_RE.match(page_rel)
     m = FIELD_JSON_RE.search(text)
     if not m:
+        if is_poster_page:
+            raise AssertionError(f"{page_rel}: missing FIELD JSON")
         return []
     try:
         field = json.loads(m.group(1))
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as exc:
+        if is_poster_page:
+            raise AssertionError(f"{page_rel}: invalid FIELD JSON") from exc
         return []
-    edges = [field.get("wellsHref"), field.get("assetsHref")]
+    edges = [
+        field.get("wellsHref"),
+        field.get("assetsHref"),
+        field.get("economics_href"),
+        field.get("benchmark_href"),
+    ]
     edges += [c.get("href") for c in field.get("norms", [])]
     return [e.split("#")[0] for e in edges if e]
+
+
+def test_data_driven_edges_include_economics_and_benchmark(public):
+    text = (public / "lifecycle/big_foot_lifecycle.html").read_text()
+    edges = set(_data_driven_edges(text, "lifecycle/big_foot_lifecycle.html"))
+
+    assert "../economics-big_foot.html" in edges
+    assert "../benchmark.html" in edges
+
+
+def test_data_driven_edges_fail_closed_for_malformed_poster_field_json():
+    with pytest.raises(AssertionError, match="missing FIELD JSON"):
+        _data_driven_edges("<html></html>", "lifecycle/big_foot_lifecycle.html")
+
+    with pytest.raises(AssertionError, match="invalid FIELD JSON"):
+        _data_driven_edges(
+            "const FIELD = {\n  nope\n};",
+            "lifecycle/big_foot_lifecycle.html",
+        )
+
+
+def test_data_driven_edges_resolve(public):
+    bad = []
+    for rel, _k, _c in scoped_pages():
+        text = (public / rel).read_text()
+        for target in _data_driven_edges(text, rel):
+            f = _resolve(public, rel, target)
+            if f.is_dir():
+                f = f / "index.html"
+            if not f.exists():
+                bad.append((rel, target))
+    assert not bad, f"unresolved data-driven targets: {bad}"
 
 
 def test_bfs_reachability_from_capabilities(public):
@@ -160,7 +203,7 @@ def test_bfs_reachability_from_capabilities(public):
             continue
         base = posixpath.dirname(cur)
         text = f.read_text()
-        for target in href_re.findall(text) + _data_driven_edges(text):
+        for target in href_re.findall(text) + _data_driven_edges(text, cur):
             if target.startswith(("http", "mailto:", "data:", "//")) or "${" in target:
                 continue
             nxt = posixpath.normpath(posixpath.join(base, target))

--- a/tests/unit/lower_tertiary/test_lifecycle_poster_links.py
+++ b/tests/unit/lower_tertiary/test_lifecycle_poster_links.py
@@ -1,0 +1,98 @@
+"""Contract tests for Lower Tertiary lifecycle poster link wiring.
+
+These guard the poster builder's consumption of the canonical field registry
+surfaces flags: economics links come from ``config/fields.yml`` and the
+benchmark link targets the published root benchmark page.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+from pathlib import Path
+
+from tests.test_markers import unit
+from worldenergydata.common.fields_registry import load_fields
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+FACTS_PATH = PROJECT_ROOT / "reports" / "lower_tertiary" / "lifecycle" / "_facts.json"
+BUILDER_PATH = (
+    PROJECT_ROOT / "scripts" / "lower_tertiary" / "build_lifecycle_posters.py"
+)
+
+ECONOMICS_HREF_RE = re.compile(r"^\.\./economics-[a-z_]+\.html$")
+
+
+def _load_builder():
+    spec = importlib.util.spec_from_file_location(
+        "build_lifecycle_posters", BUILDER_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _facts():
+    return json.loads(FACTS_PATH.read_text())
+
+
+def _fact_by_id(field_id):
+    return next(f for f in _facts() if f["id"] == field_id)
+
+
+@unit
+def test_registry_economics_flags_drive_poster_economics_links():
+    builder = _load_builder()
+    registry = load_fields()
+
+    fields = {f["id"]: builder.facts_to_field(f) for f in _facts()}
+    economics_ids = {
+        field.canonical_id
+        for field in registry.fields
+        if field.surfaces.get("lifecycle_poster")
+        and field.surfaces.get("economics_page")
+    }
+    no_economics_ids = set(fields) - economics_ids
+
+    assert economics_ids == {
+        "anchor",
+        "big_foot",
+        "cascade_chinook",
+        "jack_st_malo",
+        "julia",
+        "shenandoah",
+        "stones",
+    }
+    assert no_economics_ids == {"kaskida", "north_platte", "tiber"}
+
+    for field_id in economics_ids:
+        href = fields[field_id]["economics_href"]
+        assert href == f"../economics-{field_id}.html"
+        assert ECONOMICS_HREF_RE.match(href)
+
+    for field_id in no_economics_ids:
+        assert fields[field_id].get("economics_href") is None
+
+
+@unit
+def test_poster_fields_all_carry_published_benchmark_href():
+    builder = _load_builder()
+
+    hrefs = {builder.facts_to_field(f)["benchmark_href"] for f in _facts()}
+
+    assert hrefs == {"../benchmark.html"}
+
+
+@unit
+def test_rendered_poster_has_hidden_economics_card_and_secondary_benchmark_chip():
+    builder = _load_builder()
+
+    html = builder.render(builder.facts_to_field(_fact_by_id("big_foot")))
+
+    assert 'id="f-economics-card" hidden' in html
+    assert "Field economics · V30 monthly cash-flow model" in html
+    assert "Open full economics" in html
+    assert "Well benchmarking" in html
+    assert "FIELD.economics_href" in html
+    assert "FIELD.benchmark_href" in html


### PR DESCRIPTION
Goal: the field-hub posters gain an ECONOMICS subsection wired through the repo's canonical field-identity registry (`config/fields.yml` + `worldenergydata.common.fields_registry`), and well-benchmarking appears only as a small secondary chip, never a headline card. This is the poster builder's first consumption of the registry's `surfaces` flags.

Closes #757

## Deliverables
- `scripts/lower_tertiary/build_lifecycle_posters.py` loads the canonical field registry and emits `economics_href` only for the seven fields with `surfaces.economics_page: true`.
- `benchmark_href` points to the published `../benchmark.html` target for poster fields.
- `reports/lower_tertiary/lifecycle/lifecycle_template.html` adds a hidden economics card with the full economics CTA; benchmarking is a muted footer chip.
- Regenerated the 10 lifecycle posters and index.
- Hardened `tests/integration/site/test_public_link_graph.py` so data-driven poster hrefs include economics/benchmark links and fail closed when poster FIELD JSON is missing or invalid.
- Added unit coverage for the 7 true / 3 false economics split and benchmark href shape.

## Verification
- `uv run pytest tests/unit/lower_tertiary -q` -> 233 passed, 137 skipped.
- `uv run pytest tests/integration/site/test_public_link_graph.py -q` -> 10 passed. Local-only gate for this diff.
- `uv run --extra dev black --check scripts/lower_tertiary/build_lifecycle_posters.py tests/integration/site/test_public_link_graph.py tests/unit/lower_tertiary/test_lifecycle_poster_links.py` -> pass.
- `uv run --extra dev isort --check-only scripts/lower_tertiary/build_lifecycle_posters.py tests/integration/site/test_public_link_graph.py tests/unit/lower_tertiary/test_lifecycle_poster_links.py` -> pass.
- `uv run --extra dev flake8 scripts/lower_tertiary/build_lifecycle_posters.py tests/integration/site/test_public_link_graph.py tests/unit/lower_tertiary/test_lifecycle_poster_links.py` -> pass.
- `uv run python scripts/lower_tertiary/build_lifecycle_posters.py` -> idempotent diff hash stable.
- `grep -l 'economics_href' reports/lower_tertiary/lifecycle/*_lifecycle.html | wc -l` -> 10.
- `grep -l '"economics_href": "../economics-' reports/lower_tertiary/lifecycle/*_lifecycle.html | wc -l` -> 7.
- `grep -c '"economics_href": null'` for kaskida, north_platte, tiber -> 1 each.
- `grep -rEl 'https?://(cdn|unpkg|jsdelivr)' reports/lower_tertiary/lifecycle/; echo exit=$?` -> exit=1.
- `scripts/legal/legal-sanity-scan.sh` -> PASS.
- `git diff --name-only | grep -x uv.lock; echo exit=$?` -> exit=1.

## Review
- Code/artifact adversarial review found one Important issue: data-driven link graph failed open on missing/invalid poster FIELD JSON.
- Fixed by making poster FIELD extraction strict for `lifecycle/*_lifecycle.html` and adding a regression test.
