### PR TITLE
feat(spain): surface Albatros density assumptions

### DIFF
--- a/packages/worldenergydata-spain/src/worldenergydata/spain/reports/cores_density_audit.py
+++ b/packages/worldenergydata-spain/src/worldenergydata/spain/reports/cores_density_audit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 from typing import Any, cast
 from urllib.parse import urlparse
@@ -46,20 +47,36 @@ def oil_conversion_limitations(audit: dict[str, Any] | None) -> list[str]:
     coverage_status = audit["coverage_status"]
     defaulted_fields = list(audit["defaulted_fields"])
     missing_fields = list(audit["missing_fields"])
+    limitations = []
     if coverage_status == "missing" or missing_fields:
-        return [
-            "oil_tonnes_to_bbl_conversion_deferred_to_issue_807",
-            _field_list_limitation(
-                "oil_tonnes_to_bbl_has_missing_fields", missing_fields
-            ),
-        ]
+        limitations.extend(
+            [
+                _field_list_limitation(
+                    "oil_tonnes_to_bbl_has_missing_fields", missing_fields
+                ),
+                _field_list_limitation(
+                    "oil_tonnes_to_bbl_blocked_by_missing_density_source",
+                    missing_fields,
+                ),
+            ]
+        )
     if coverage_status == "defaulted" or defaulted_fields:
+        limitations.extend(
+            [
+                _field_list_limitation(
+                    "oil_tonnes_to_bbl_has_defaulted_fields",
+                    defaulted_fields,
+                ),
+                _default_factor_limitation(
+                    defaulted_fields,
+                    audit.get("default_bbl_per_tonne"),
+                ),
+            ]
+        )
+    if limitations:
         return [
             "oil_tonnes_to_bbl_conversion_deferred_to_issue_807",
-            _field_list_limitation(
-                "oil_tonnes_to_bbl_has_defaulted_fields",
-                defaulted_fields,
-            ),
+            *limitations,
         ]
     if coverage_status == "complete" and not defaulted_fields and not missing_fields:
         return ["oil_tonnes_to_bbl_uses_cited_field_density_factors"]
@@ -80,6 +97,18 @@ def _field_list_limitation(marker: str, fields: list[str]) -> str:
     if not fields:
         return marker
     return f"{marker}: {', '.join(str(field) for field in fields)}"
+
+
+def _default_factor_limitation(fields: list[str], value: Any) -> str:
+    marker = "oil_tonnes_to_bbl_assumes_default_factor"
+    if not fields:
+        return marker
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return _field_list_limitation(marker, fields)
+    if not math.isfinite(float(value)):
+        return _field_list_limitation(marker, fields)
+    field_assumptions = ", ".join(f"{field}={value:g}" for field in fields)
+    return f"{marker}: {field_assumptions}"
 
 
 def _validated_oil_conversion_audit(audit: Any, source_name: str) -> dict[str, Any]:
@@ -161,7 +190,12 @@ def _validate_default_bbl_per_tonne(
     if not audit["defaulted_fields"]:
         return
     value = audit.get("default_bbl_per_tonne")
-    if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+        or value <= 0
+    ):
         raise CoresDensityAuditError(f"{source_name} missing default_bbl_per_tonne")
 
 

--- a/tests/unit/spain/test_cores_field_development_density.py
+++ b/tests/unit/spain/test_cores_field_development_density.py
@@ -35,12 +35,12 @@ def test_build_report_replaces_deferred_caveat_with_density_provenance(tmp_path)
 
 
 def test_report_preserves_defaulted_density_limitations(tmp_path):
-    _write_cache(tmp_path, extra_rows=[_cache_row("Casablanca", 2025, 1, 5.0, pd.NA)])
+    _write_cache(tmp_path, extra_rows=[_cache_row("Albatros", 2025, 1, 5.0, pd.NA)])
     _write_density_sidecar(
         tmp_path,
         coverage_status="defaulted",
         used_fields=["Ayoluengo"],
-        defaulted_fields=["Casablanca"],
+        defaulted_fields=["Albatros"],
     )
 
     summary = build_report(tmp_path)
@@ -52,11 +52,53 @@ def test_report_preserves_defaulted_density_limitations(tmp_path):
         "oil_tonnes_to_bbl_conversion_deferred_to_issue_807" in summary["limitations"]
     )
     assert any(
-        item == "oil_tonnes_to_bbl_has_defaulted_fields: Casablanca"
+        item == "oil_tonnes_to_bbl_has_defaulted_fields: Albatros"
         for item in summary["limitations"]
     )
-    assert "oil_tonnes_to_bbl_has_defaulted_fields: Casablanca" in html
+    assert any(
+        item == "oil_tonnes_to_bbl_assumes_default_factor: Albatros=7.33"
+        for item in summary["limitations"]
+    )
+    assert "oil_tonnes_to_bbl_has_defaulted_fields: Albatros" in visible_html
+    assert "oil_tonnes_to_bbl_assumes_default_factor: Albatros=7.33" in visible_html
     assert "7.33" in visible_html
+
+
+def test_report_preserves_default_assumption_when_missing_fields_also_block_conversion(
+    tmp_path,
+):
+    _write_cache(
+        tmp_path,
+        extra_rows=[
+            _cache_row("Albatros", 2025, 1, 5.0, pd.NA),
+            _cache_row("Casablanca", 2025, 1, 6.0, pd.NA),
+        ],
+    )
+    _write_density_sidecar(
+        tmp_path,
+        coverage_status="missing",
+        used_fields=["Ayoluengo"],
+        defaulted_fields=["Albatros"],
+        missing_fields=["Casablanca"],
+    )
+
+    summary = build_report(tmp_path)
+    html = render_spain_cores_html(summary)
+    visible_html = html.split('<script type="application/json"', 1)[0]
+
+    assert any(
+        item == "oil_tonnes_to_bbl_blocked_by_missing_density_source: Casablanca"
+        for item in summary["limitations"]
+    )
+    assert any(
+        item == "oil_tonnes_to_bbl_assumes_default_factor: Albatros=7.33"
+        for item in summary["limitations"]
+    )
+    assert (
+        "oil_tonnes_to_bbl_blocked_by_missing_density_source: Casablanca"
+        in visible_html
+    )
+    assert "oil_tonnes_to_bbl_assumes_default_factor: Albatros=7.33" in visible_html
 
 
 def test_report_preserves_missing_density_limitations(tmp_path):
@@ -79,7 +121,15 @@ def test_report_preserves_missing_density_limitations(tmp_path):
         item == "oil_tonnes_to_bbl_has_missing_fields: Albatros"
         for item in summary["limitations"]
     )
-    assert "oil_tonnes_to_bbl_has_missing_fields: Albatros" in html
+    assert any(
+        item == "oil_tonnes_to_bbl_blocked_by_missing_density_source: Albatros"
+        for item in summary["limitations"]
+    )
+    visible_html = html.split('<script type="application/json"', 1)[0]
+    assert "oil_tonnes_to_bbl_has_missing_fields: Albatros" in visible_html
+    assert (
+        "oil_tonnes_to_bbl_blocked_by_missing_density_source: Albatros" in visible_html
+    )
 
 
 def test_report_rejects_malformed_density_sidecar(tmp_path):
@@ -130,6 +180,32 @@ def test_report_rejects_defaulted_sidecar_without_default_bbl_per_tonne(tmp_path
     _mutate_density_sidecar(
         tmp_path,
         lambda sidecar: sidecar.pop("default_bbl_per_tonne"),
+    )
+
+    with pytest.raises(CoresReportError, match="default_bbl_per_tonne"):
+        build_report(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "default_bbl_per_tonne",
+    [float("nan"), float("inf")],
+)
+def test_report_rejects_defaulted_sidecar_with_non_finite_default_bbl_per_tonne(
+    tmp_path,
+    default_bbl_per_tonne,
+):
+    _write_cache(tmp_path, extra_rows=[_cache_row("Albatros", 2025, 1, 5.0, pd.NA)])
+    _write_density_sidecar(
+        tmp_path,
+        coverage_status="defaulted",
+        used_fields=["Ayoluengo"],
+        defaulted_fields=["Albatros"],
+    )
+    _mutate_density_sidecar(
+        tmp_path,
+        lambda sidecar: sidecar.update(
+            {"default_bbl_per_tonne": default_bbl_per_tonne}
+        ),
     )
 
     with pytest.raises(CoresReportError, match="default_bbl_per_tonne"):


### PR DESCRIPTION
## Summary

Refs https://github.com/vamseeachanta/worldenergydata/issues/807.

This PR makes Spain CORES field-development density outputs explicitly surface Albatros-related conversion risk:

- missing density source coverage now emits `oil_tonnes_to_bbl_blocked_by_missing_density_source: <field>`
- defaulted density coverage now emits `oil_tonnes_to_bbl_assumes_default_factor: <field>=<factor>`
- mixed missing/defaulted audits now preserve both the blocker and carried-assumption limitations
- non-finite default conversion factors (`NaN`, `inf`) are rejected before report rendering

This does not redo issue 809. It only improves the issue 807 density-output contract for downstream field-development analysis.

## Verification

- RED: new focused tests failed for missing mixed-gap assumption output and non-finite default factor validation.
- `pytest tests/unit/spain/test_cores_field_development_density.py -q --no-cov`
- `pytest tests/unit/spain/test_cores_density.py tests/unit/spain/test_cores_live_density.py tests/unit/spain/test_cores_live.py tests/unit/spain/test_cores_loader.py tests/unit/spain/test_cores_field_development_density.py tests/unit/spain/test_cores_field_development_report.py tests/unit/scheduler/test_spain_cores_refresh.py -q --no-cov`
- `pytest tests/unit/core tests/unit/common tests/contracts tests/workflows tests/unit/spain -q --no-cov`
- `black --check` on touched files
- `isort --check-only` on touched files
- `git diff --check`
- `scripts/legal/legal-sanity-scan.sh`
- `bandit` on touched files

## Review

Two read-only adversarial reviewers flagged:

- whole-document HTML assertions could pass through embedded JSON instead of visible caveats
- mixed missing/defaulted audits could drop the default-factor assumption
- non-finite default factors could leak through validation

All three findings are covered by tests and fixed in this PR.
