### PR TITLE
fix(fdas): use golden V30 refs in field reports

### DIFF
--- a/docs/modules/bsee/communications/email-review/reviewed/2026-07-08-fdas-canonicalization.md
+++ b/docs/modules/bsee/communications/email-review/reviewed/2026-07-08-fdas-canonicalization.md
@@ -1,0 +1,60 @@
+# FDAS Canonicalization Notes from Roy Shilling
+
+Source: Roy Shilling email text provided by Vamsee in the 2026-07-08 BSEE/FDAS
+analysis session.
+
+## Confirmed Direction
+
+- `worldenergydata` (`wed`) should become the canonical go-forward codebase for
+  Frontier-Deepwater Lower-Tertiary economics.
+- The current wed V30 reproduction quality is a valid reproduction gate: about
+  +/-0.1% oil and +/-1% NPV versus the frozen V30 baseline.
+- That validates the codebase and reproduction harness. It does not mean every
+  current wed assumption is final.
+- Roy's shipped V50 economic model is broader than wed's current window-only
+  "V50" run because it includes after-tax logic, NOL carryforward, changed cost
+  assumptions, and the expanded lease set.
+- Keep a pre-tax comparison case, but do not retreat to a pre-tax-only V30 model
+  as the sole go-forward model.
+
+## Required Follow-Ups
+
+1. Write a one-page V50 assumptions change log before accepting the V50 cost and
+   model changes as canonical: [#899](https://github.com/vamseeachanta/worldenergydata/issues/899).
+2. Settle the NPV reference-date convention. Roy recommends discounting from
+   first material project expenditure as the primary thesis case because long
+   pre-first-oil capital exposure is part of the Lower-Tertiary economics story:
+   [#900](https://github.com/vamseeachanta/worldenergydata/issues/900).
+3. Keep the D&C reconciliation closed. V50, V30, and wed D&C extraction match to
+   the day on the reconciled path; no well-level drill-down is needed when the
+   field-level delta is zero.
+4. Fix the actionable bug queue without blocking canonicalization on low-priority
+   latent issues: [#875](https://github.com/vamseeachanta/worldenergydata/issues/875).
+5. After the assumptions and NPV convention are settled, generate and freeze one
+   official `financial_project_summary_V50_canonical.xlsx` validation workbook:
+   [#901](https://github.com/vamseeachanta/worldenergydata/issues/901).
+
+## Bug Priority from Roy's Note
+
+Prioritize:
+
+- OGOR-A reader improvements: all file members, deduping, better parsing.
+- Product-code filtering so oil volumes are explicitly oil.
+- Targeted completion-day WAR remark check.
+- CAPEX timeline guard so project spend cannot fall outside the model window.
+- MIRR assumption fix after NPV-critical work.
+
+Do not let low-priority water-column labeling issues hold up the canonical
+economic model.
+
+## Current Commit Boundary
+
+This commit fixes stale frozen V30 reference values in per-field V50 reports by
+rendering the official V30 reference values from
+`config/analysis/lower_tertiary/golden_baseline_v30.yml`.
+
+It does not adopt Roy's full after-tax V50 model, settle the NPV discount
+reference convention, or generate the canonical V50 workbook. Those are tracked
+in [#899](https://github.com/vamseeachanta/worldenergydata/issues/899),
+[#900](https://github.com/vamseeachanta/worldenergydata/issues/900), and
+[#901](https://github.com/vamseeachanta/worldenergydata/issues/901).

--- a/reports/lower_tertiary/field_economics_cascade_chinook_v50.md
+++ b/reports/lower_tertiary/field_economics_cascade_chinook_v50.md
@@ -2,11 +2,11 @@
 
 **Development:** Cascade Chinook (subsea15) &middot; **Lease:** 2 leases (G16965, G16997) &middot; **First oil:** 2012-09-01 &middot; **Discount rate:** 10% annual
 
-**Data window:** 2000-09 -> 2026-04 (latest); frozen V30 reference NPV = -$1,477.2M
+**Data window:** 2000-09 -> 2026-04 (latest); frozen V30 reference NPV = -$1,474.1M
 
 ## Summary
 
-On public BSEE production + cost data, **Cascade Chinook** is **NPV-negative at 10%** life-to-date: terminal cumulative NPV **$-1,580.0 M** (frozen V30 sanctioned reference $-1,477.2 M).
+On public BSEE production + cost data, **Cascade Chinook** is **NPV-negative at 10%** life-to-date: terminal cumulative NPV **$-1,580.0 M** (frozen V30 sanctioned reference $-1,474.1 M).
 
 - **39.7 MMbbl** oil produced from **3 producing wells** (**14 total wellbores**), generating **$2,778 M** gross revenue.
 - A **high-capex, deepwater** signature: **$3,874 M** of one-time D&C + facilities capital is the dominant driver of the NPV.
@@ -18,14 +18,14 @@ On public BSEE production + cost data, **Cascade Chinook** is **NPV-negative at 
 
 ## NPV Timeline
 
-Cumulative discounted NPV evolution over field life, with critical well operations annotated. Terminal cumulative NPV = **$-1,580.0 M** (frozen V30 reference: $-1,477.2 M; delta -102.8 M).
+Cumulative discounted NPV evolution over field life, with critical well operations annotated. Terminal cumulative NPV = **$-1,580.0 M** (frozen V30 reference: $-1,474.1 M; delta -106.0 M).
 
 Cumulative NPV path (by year): `█▇▇▇▇▇▇▆▅▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁`  _start $-75M → trough $-1,611M (2018) → latest $-1,580M_
 
 | Year | Net Cashflow ($MM) | Cumulative NPV ($MM) | Critical Operations |
 |------|-------------------:|---------------------:|---------------------|
-| 2002 | -76.8 | -75.5 | Drilling (spud): 001<br>Sidetrack: 001 (608124000800) |
-| 2003 | -125.6 | -187.4 | Drilling (spud): 001 |
+| 2002 | -76.8 | -75.5 | Drilling (spud): 001<br>Sidetrack: 001 (608124000800)<br>Plug & abandon: 001 (608124000801) |
+| 2003 | -125.6 | -187.4 | Drilling (spud): 001<br>Temporary abandonment: 001 (608124001000) |
 | 2004 | 0.0 | -187.4 |  |
 | 2005 | -93.6 | -254.6 | Drilling (spud): 002<br>Sidetrack: 002 (608124001600) |
 | 2006 | 0.0 | -254.6 |  |
@@ -34,8 +34,8 @@ Cumulative NPV path (by year): `█▇▇▇▇▇▇▆▅▄▁▁▁▁▁▁
 | 2009 | -172.0 | -363.0 | Drilling (spud): 004<br>Drilling (spud): 002<br>Completion: CA003 (608124003800) |
 | 2010 | -344.0 | -515.9 | Drilling (spud): 002<br>Drilling (spud): CH002 |
 | 2011 | -600.0 | -759.6 |  |
-| 2012 | -1,801.8 | -1,421.4 | Sidetrack: 004 (608124004700)<br>Drilling (spud): CA004<br>Well online (first production): API 608124004602<br>Completion: CA004 (608124004701)<br>Drilling (spud): 005 |
-| 2013 | -226.8 | -1,497.3 | Drilling (spud): CA006<br>Completion: CA006 (608124008300) |
+| 2012 | -1,801.8 | -1,421.4 | Sidetrack: 004 (608124004700)<br>Drilling (spud): CA004<br>Well online (first production): API 608124004602<br>Completion: CA004 (608124004701)<br>Drilling (spud): 005<br>Plug & abandon: 005 (608124008200) |
+| 2013 | -226.8 | -1,497.3 | Drilling (spud): CA006<br>Completion: CA006 (608124008300)<br>Plug & abandon: 001 (608124001000) |
 | 2014 | 117.1 | -1,461.2 | Well online (first production): API 608124008300<br>Drilling (spud): CH004 |
 | 2015 | -159.6 | -1,506.0 | Completion: CH004 (608124009700) |
 | 2016 | -114.0 | -1,534.7 |  |
@@ -43,7 +43,7 @@ Cumulative NPV path (by year): `█▇▇▇▇▇▇▆▅▄▁▁▁▁▁▁
 | 2018 | -141.6 | -1,610.7 | Well online (first production): API 608124009700 |
 | 2019 | 110.8 | -1,589.6 |  |
 | 2020 | -35.9 | -1,595.6 | Workover: CA003 (608124003800) |
-| 2021 | 37.5 | -1,589.8 |  |
+| 2021 | 37.5 | -1,589.8 | Plug & abandon: 002 (608124001601) |
 | 2022 | 84.6 | -1,577.7 |  |
 | 2023 | 31.4 | -1,573.7 |  |
 | 2024 | -14.2 | -1,575.4 |  |
@@ -57,7 +57,9 @@ Cumulative NPV path (by year): `█▇▇▇▇▇▇▆▅▄▁▁▁▁▁▁
 | 2002-01-31 | Drilling (spud) | 001 | -0.8 |
 | 2002-04-16 | Sidetrack | 001 (608124000800) | -63.8 |
 | 2002-04-23 | Drilling (spud) | 001 | -63.8 |
+| 2002-06-04 | Plug & abandon | 001 (608124000801) | -75.5 |
 | 2003-01-13 | Drilling (spud) | 001 | -89.3 |
+| 2003-06-30 | Temporary abandonment | 001 (608124001000) | -187.4 |
 | 2005-03-19 | Drilling (spud) | 002 | -195.1 |
 | 2005-10-09 | Drilling (spud) | 002 | -241.9 |
 | 2005-10-09 | Sidetrack | 002 (608124001600) | -241.9 |
@@ -72,13 +74,16 @@ Cumulative NPV path (by year): `█▇▇▇▇▇▇▆▅▄▁▁▁▁▁▁
 | 2012-09-01 | Well online (first production) | API 608124004602 | -1,425.2 |
 | 2012-10-28 | Completion | CA004 (608124004701) | -1,425.0 |
 | 2012-12-18 | Drilling (spud) | 005 | -1,421.4 |
+| 2012-12-23 | Plug & abandon | 005 (608124008200) | -1,421.4 |
 | 2013-01-01 | Drilling (spud) | CA006 | -1,427.4 |
 | 2013-12-15 | Completion | CA006 (608124008300) | -1,497.3 |
+| 2013-12-16 | Plug & abandon | 001 (608124001000) | -1,497.3 |
 | 2014-01-01 | Well online (first production) | API 608124008300 | -1,502.8 |
 | 2014-12-07 | Drilling (spud) | CH004 | -1,461.2 |
 | 2015-04-05 | Completion | CH004 (608124009700) | -1,486.5 |
 | 2018-07-01 | Well online (first production) | API 608124009700 | -1,629.0 |
 | 2020-01-11 | Workover | CA003 (608124003800) | -1,588.5 |
+| 2021-12-05 | Plug & abandon | 002 (608124001601) | -1,589.8 |
 
 _Operations are derived deterministically from BSEE Well Activity Reports (`bin/war/`) and OGOR-A first-production dates (BSEE OGOR-A pickled .bin DataFrames (zip archives absent in checkout)). Activity codes: DRL=drilling, COM=completion, WO=workover, REC=recompletion, ST=sidetrack; re-entries detected via API completion-suffix changes on a shared wellbore. Markers are annotations only and do not feed the cashflow model._
 
@@ -138,7 +143,7 @@ _They are intentionally **not linked yet**: the geometry render must first be co
 
 | Metric | Latest | Frozen V30 (reference) |
 |--------|------:|------:|
-| **NPV @ 10%** | **$-1,580.0 M** | $-1,477.2 M |
+| **NPV @ 10%** | **$-1,580.0 M** | $-1,474.1 M |
 | Revenue | $2,778.0 M | $2,326.9 M |
 | Oil produced (MMbbl) | 39.7 | 34.3 |
 
@@ -155,15 +160,15 @@ _Latest NPV from `build_field_npv_timeline(dev, end_date)`; latest revenue/oil f
 | D&C cost | $1,973.6 M |
 | Facilities cost | $1,900.0 M |
 | Net cashflow (undiscounted) | $-3,820.3 M |
-| **NPV @ 10%** | **$-1,477.2 M** |
-| MIRR (annual) | -1.77% |
+| **NPV @ 10%** | **$-1,474.1 M** |
+| MIRR (annual) | -1.76% |
 | Producers | 3 |
 | Injectors | 0 |
 | Wellbores | 14 |
 
 _Return metric: **MIRR** is the sanctioned return measure for these developments, not IRR. Deepwater Lower-Tertiary cashflows are heavily front-loaded (large D&C + facilities outflows, then a long production tail), so the net-cashflow sign changes more than once and the IRR polynomial can have multiple — or no — real roots; MIRR (single reinvestment/finance rate at the 10% discount rate) is well-defined and unambiguous. NPV @ 10% remains the primary value metric._
 
-_Source-of-record: `config/analysis/lower_tertiary/golden_baseline_v30.yml`. NPV reproduced within golden-baseline tolerance by `worldenergydata.lower_tertiary.v30_financial_reproducer`._
+_Source-of-record for the frozen reference table: `config/analysis/lower_tertiary/golden_baseline_v30.yml`; latest window NPV is recomputed by `worldenergydata.lower_tertiary.v30_financial_reproducer`._
 
 ---
 

--- a/reports/lower_tertiary/field_economics_jack_st_malo_v50.md
+++ b/reports/lower_tertiary/field_economics_jack_st_malo_v50.md
@@ -2,11 +2,11 @@
 
 **Development:** Jack St Malo (subsea15) &middot; **Lease:** 6 leases (G17015, G17016, G18745, G18753, G20394, G21245) &middot; **First oil:** 2014-12-01 &middot; **Discount rate:** 10% annual
 
-**Data window:** 2000-09 -> 2026-04 (latest); frozen V30 reference NPV = -$945.0M
+**Data window:** 2000-09 -> 2026-04 (latest); frozen V30 reference NPV = -$881.1M
 
 ## Summary
 
-On public BSEE production + cost data, **Jack St Malo** is **NPV-negative at 10%** life-to-date: terminal cumulative NPV **$-804.5 M** (frozen V30 sanctioned reference $-945.0 M).
+On public BSEE production + cost data, **Jack St Malo** is **NPV-negative at 10%** life-to-date: terminal cumulative NPV **$-804.5 M** (frozen V30 sanctioned reference $-881.1 M).
 
 - **438.7 MMbbl** oil produced from **22 producing wells** (**73 total wellbores**), generating **$27,891 M** gross revenue.
 - A **high-capex, deepwater** signature: **$12,850 M** of one-time D&C + facilities capital is the dominant driver of the NPV.
@@ -18,36 +18,36 @@ On public BSEE production + cost data, **Jack St Malo** is **NPV-negative at 10%
 
 ## NPV Timeline
 
-Cumulative discounted NPV evolution over field life, with critical well operations annotated. Terminal cumulative NPV = **$-804.5 M** (frozen V30 reference: $-945.0 M; delta +140.5 M).
+Cumulative discounted NPV evolution over field life, with critical well operations annotated. Terminal cumulative NPV = **$-804.5 M** (frozen V30 reference: $-881.1 M; delta +76.6 M).
 
 Cumulative NPV path (by year): `█▇▇▇▇▇▇▇▆▆▆▆▆▅▁▁▁▁▂▃▃▄▄▅▅▆▆`  _start $-75M → trough $-3,155M (2014) → latest $-804M_
 
 | Year | Net Cashflow ($MM) | Cumulative NPV ($MM) | Critical Operations |
 |------|-------------------:|---------------------:|---------------------|
 | 2000 | -76.0 | -74.9 | Drilling (spud): 001<br>Sidetrack: 001 (608124000400) |
-| 2001 | -4.0 | -78.8 |  |
+| 2001 | -4.0 | -78.8 | Plug & abandon: 001 (608124000401) |
 | 2002 | 0.0 | -78.8 |  |
-| 2003 | -79.2 | -138.7 | Drilling (spud): 002 |
-| 2004 | -112.8 | -218.3 | Drilling (spud): 001<br>Sidetrack: 001 (608124001300) |
+| 2003 | -79.2 | -138.7 | Drilling (spud): 002<br>Temporary abandonment: 002 (608124001100) |
+| 2004 | -112.8 | -218.3 | Drilling (spud): 001<br>Sidetrack: 001 (608124001300)<br>Temporary abandonment: 001 (608124000402)<br>Plug & abandon: 001 (608124000402)<br>Temporary abandonment: 001 (608124001301) |
 | 2005 | -160.0 | -318.9 | Drilling (spud): PS002 |
 | 2006 | -149.6 | -405.7 | Completion: PS002 (608124001700)<br>Well online (first production): API 608124001700 |
 | 2007 | -133.6 | -473.7 | Drilling (spud): 002<br>Drilling (spud): 001<br>Drilling (spud): 003 |
-| 2008 | -364.8 | -648.7 | Drilling (spud): 002<br>Drilling (spud): 003 |
-| 2009 | -1.6 | -649.4 | Drilling (spud): 001 |
+| 2008 | -364.8 | -648.7 | Drilling (spud): 002<br>Drilling (spud): 003<br>Temporary abandonment: 002 (608124002703) |
+| 2009 | -1.6 | -649.4 | Drilling (spud): 001<br>Plug & abandon: 001 (608124004400) |
 | 2010 | 0.0 | -649.4 |  |
 | 2011 | -231.2 | -728.7 | Drilling (spud): PS001<br>Drilling (spud): PS005<br>Drilling (spud): PN001<br>Drilling (spud): PN002<br>Drilling (spud): PN003<br>Drilling (spud): PS003<br>Drilling (spud): PS004 |
-| 2012 | -584.4 | -921.3 | Drilling (spud): PS004<br>Sidetrack: PS004 (608124005102)<br>Well online (first production): API 608124005600<br>Drilling (spud): PS002 |
+| 2012 | -584.4 | -921.3 | Temporary abandonment: PS005 (608124005000)<br>Drilling (spud): PS004<br>Sidetrack: PS004 (608124005102)<br>Well online (first production): API 608124005600<br>Temporary abandonment: PS002 (608124001700)<br>Drilling (spud): PS002 |
 | 2013 | -624.8 | -1,106.4 | Well online (first production): API 608124001701 |
 | 2014 | -7,927.3 | -3,154.7 | Completion: PS001 (608124005700)<br>Well online (first production): API 608124005000<br>Well online (first production): API 608124005300 |
-| 2015 | 387.3 | -3,060.6 | Completion: PS005 (608124005000)<br>Well online (first production): API 608124005700<br>Workover: PS005 (608124005000)<br>Well online (first production): API 608124005103<br>Drilling (spud): PS001<br>Drilling (spud): PN007<br>Completion: PS001 (608124005201) |
-| 2016 | 583.9 | -2,932.8 | Completion: PS004 (608124005800)<br>Well online (first production): API 608124005800<br>Completion: PN002 (608124005400)<br>Well online (first production): API 608124005400<br>Completion: PN007 (608124010701)<br>Well online (first production): API 608124010701<br>Drilling (spud): PS001<br>Drilling (spud): PS002 |
+| 2015 | 387.3 | -3,060.6 | Completion: PS005 (608124005000)<br>Well online (first production): API 608124005700<br>Workover: PS005 (608124005000)<br>Temporary abandonment: PN003 (608124005500)<br>Well online (first production): API 608124005103<br>Temporary abandonment: PN002 (608124005400)<br>Drilling (spud): PS001<br>Drilling (spud): PN007<br>Completion: PS001 (608124005201) |
+| 2016 | 583.9 | -2,932.8 | Completion: PS004 (608124005800)<br>Well online (first production): API 608124005800<br>Completion: PN002 (608124005400)<br>Well online (first production): API 608124005400<br>Completion: PN007 (608124010701)<br>Well online (first production): API 608124010701<br>Temporary abandonment: PS001 (608124005201)<br>Drilling (spud): PS001<br>Drilling (spud): PS002 |
 | 2017 | 856.5 | -2,760.3 | Well online (first production): API 608124005203<br>Drilling (spud): PS007<br>Drilling (spud): PS008<br>Well online (first production): API 608124011400<br>Drilling (spud): PS005<br>Completion: PS007 (608124011504)<br>Well online (first production): API 608124011504 |
-| 2018 | 1,924.7 | -2,408.0 | Well online (first production): API 608124011801<br>Drilling (spud): PS007<br>Workover: PS007 (608124011504)<br>Drilling (spud): PS008<br>Well online (first production): API 608124012200<br>Well online (first production): API 608124011606<br>Drilling (spud): PS006 |
-| 2019 | 1,689.5 | -2,126.0 | Completion: PS003 (608124005600)<br>Drilling (spud): PS003<br>Well online (first production): API 608124012601<br>Drilling (spud): 001<br>Sidetrack: 001 (608124012800)<br>Sidetrack: 001 (608124012801)<br>Sidetrack: 001 (608124012802)<br>Sidetrack: 001 (608124012803)<br>Drilling (spud): PS009 |
-| 2020 | 651.7 | -2,026.5 | Well online (first production): API 608124012500<br>Drilling (spud): PN005<br>Drilling (spud): IS003<br>Completion: PS003 (608124012601)<br>Drilling (spud): IS001 |
-| 2021 | 1,675.7 | -1,796.6 | Well online (first production): API 608124013202<br>Workover: PS003 (608124005600)<br>Drilling (spud): PS006<br>Well online (first production): API 608124013600<br>Completion: PS009 (608124012804) |
+| 2018 | 1,924.7 | -2,408.0 | Well online (first production): API 608124011801<br>Drilling (spud): PS007<br>Workover: PS007 (608124011504)<br>Drilling (spud): PS008<br>Well online (first production): API 608124012200<br>Temporary abandonment: PS008 (608124011605)<br>Well online (first production): API 608124011606<br>Drilling (spud): PS006 |
+| 2019 | 1,689.5 | -2,126.0 | Completion: PS003 (608124005600)<br>Drilling (spud): PS003<br>Well online (first production): API 608124012601<br>Drilling (spud): 001<br>Sidetrack: 001 (608124012800)<br>Sidetrack: 001 (608124012801)<br>Sidetrack: 001 (608124012802)<br>Sidetrack: 001 (608124012803)<br>Drilling (spud): PS009<br>Temporary abandonment: PS006 (608124012500)<br>Temporary abandonment: PS009 (608124012804) |
+| 2020 | 651.7 | -2,026.5 | Well online (first production): API 608124012500<br>Plug & abandon: PN003 (608124005500)<br>Drilling (spud): PN005<br>Plug & abandon: 001 (608124001301)<br>Drilling (spud): IS003<br>Temporary abandonment: 001 (608124002900)<br>Completion: PS003 (608124012601)<br>Drilling (spud): IS001 |
+| 2021 | 1,675.7 | -1,796.6 | Well online (first production): API 608124013202<br>Workover: PS003 (608124005600)<br>Plug & abandon: 002 (608124001100)<br>Plug & abandon: 001 (608124002900)<br>Drilling (spud): PS006<br>Well online (first production): API 608124013600<br>Completion: PS009 (608124012804) |
 | 2022 | 2,797.6 | -1,445.6 | Well online (first production): API 608124012804<br>Workover: PS003 (608124012601)<br>Completion: IS003 (608124013300)<br>Completion: IS001 (608124013500) |
-| 2023 | 1,992.5 | -1,218.5 | Completion: PS008 (608124011606)<br>Drilling (spud): PS011<br>Well online (first production): API 608124014600<br>Drilling (spud): PS008 |
+| 2023 | 1,992.5 | -1,218.5 | Completion: PS008 (608124011606)<br>Plug & abandon: PS001 (608124005203)<br>Drilling (spud): PS011<br>Temporary abandonment: IS003 (608124013300)<br>Well online (first production): API 608124014600<br>Drilling (spud): PS008 |
 | 2024 | 1,994.1 | -1,011.7 | Well online (first production): API 608124015100<br>Workover: PN001 (608124005300)<br>Workover: PS008 (608124011606) |
 | 2025 | 1,580.4 | -862.5 | Completion: PS012 (608124015504)<br>Well online (first production): API 608124015504<br>Well online (first production): API 608124015400 |
 | 2026 | 658.9 | -804.5 |  |
@@ -59,11 +59,16 @@ Cumulative NPV path (by year): `█▇▇▇▇▇▇▇▆▆▆▆▆▅▁▁
 | 2000-09-21 | Drilling (spud) | 001 | -8.0 |
 | 2000-11-27 | Drilling (spud) | 001 | -50.7 |
 | 2000-12-21 | Sidetrack | 001 (608124000400) | -74.9 |
+| 2001-01-12 | Plug & abandon | 001 (608124000401) | -78.8 |
 | 2003-07-06 | Drilling (spud) | 002 | -94.7 |
+| 2003-10-23 | Temporary abandonment | 002 (608124001100) | -138.7 |
 | 2004-03-09 | Drilling (spud) | 001 | -151.8 |
 | 2004-05-16 | Sidetrack | 001 (608124001300) | -192.6 |
 | 2004-05-18 | Drilling (spud) | 001 | -192.6 |
 | 2004-05-21 | Drilling (spud) | 001 | -192.6 |
+| 2004-06-06 | Temporary abandonment | 001 (608124000402) | -213.8 |
+| 2004-06-27 | Plug & abandon | 001 (608124000402) | -213.8 |
+| 2004-07-04 | Temporary abandonment | 001 (608124001301) | -218.3 |
 | 2005-04-22 | Drilling (spud) | PS002 | -222.9 |
 | 2006-02-12 | Completion | PS002 (608124001700) | -320.3 |
 | 2006-08-01 | Well online (first production) | API 608124001700 | -405.7 |
@@ -74,7 +79,9 @@ Cumulative NPV path (by year): `█▇▇▇▇▇▇▇▆▆▆▆▆▅▁▁
 | 2008-06-04 | Drilling (spud) | 002 | -577.4 |
 | 2008-06-12 | Drilling (spud) | 002 | -577.4 |
 | 2008-08-23 | Drilling (spud) | 003 | -616.7 |
+| 2008-11-23 | Temporary abandonment | 002 (608124002703) | -648.7 |
 | 2009-07-19 | Drilling (spud) | 001 | -649.4 |
+| 2009-07-19 | Plug & abandon | 001 (608124004400) | -649.4 |
 | 2011-11-06 | Drilling (spud) | PS001 | -669.8 |
 | 2011-11-13 | Drilling (spud) | PS005 | -669.8 |
 | 2011-11-21 | Drilling (spud) | PN001 | -669.8 |
@@ -83,12 +90,14 @@ Cumulative NPV path (by year): `█▇▇▇▇▇▇▇▆▆▆▆▆▅▁▁
 | 2011-11-26 | Drilling (spud) | PS003 | -669.8 |
 | 2011-12-03 | Drilling (spud) | PS001 | -728.7 |
 | 2011-12-05 | Drilling (spud) | PS004 | -728.7 |
+| 2012-03-18 | Temporary abandonment | PS005 (608124005000) | -826.1 |
 | 2012-04-03 | Drilling (spud) | PS004 | -841.5 |
 | 2012-05-17 | Drilling (spud) | PS004 | -853.6 |
 | 2012-05-24 | Drilling (spud) | PS004 | -853.6 |
 | 2012-05-27 | Sidetrack | PS004 (608124005102) | -853.6 |
 | 2012-06-02 | Drilling (spud) | PS004 | -869.0 |
 | 2012-08-01 | Well online (first production) | API 608124005600 | -885.7 |
+| 2012-09-16 | Temporary abandonment | PS002 (608124001700) | -885.7 |
 | 2012-10-05 | Drilling (spud) | PS002 | -891.3 |
 | 2013-01-01 | Well online (first production) | API 608124001701 | -944.4 |
 | 2014-11-13 | Completion | PS001 (608124005700) | -1,402.8 |
@@ -97,7 +106,9 @@ Cumulative NPV path (by year): `█▇▇▇▇▇▇▇▆▆▆▆▆▅▁▁
 | 2015-01-16 | Completion | PS005 (608124005000) | -3,157.4 |
 | 2015-02-01 | Well online (first production) | API 608124005700 | -3,156.1 |
 | 2015-02-22 | Workover | PS005 (608124005000) | -3,156.1 |
+| 2015-03-29 | Temporary abandonment | PN003 (608124005500) | -3,146.1 |
 | 2015-07-01 | Well online (first production) | API 608124005103 | -3,104.6 |
+| 2015-07-26 | Temporary abandonment | PN002 (608124005400) | -3,104.6 |
 | 2015-08-10 | Drilling (spud) | PS001 | -3,094.7 |
 | 2015-10-29 | Drilling (spud) | PN007 | -3,072.1 |
 | 2015-11-02 | Completion | PS001 (608124005201) | -3,066.6 |
@@ -108,6 +119,7 @@ Cumulative NPV path (by year): `█▇▇▇▇▇▇▇▆▆▆▆▆▅▁▁
 | 2016-06-01 | Well online (first production) | API 608124005400 | -3,027.2 |
 | 2016-06-08 | Completion | PN007 (608124010701) | -3,027.2 |
 | 2016-08-01 | Well online (first production) | API 608124010701 | -3,002.3 |
+| 2016-08-21 | Temporary abandonment | PS001 (608124005201) | -3,002.3 |
 | 2016-09-12 | Drilling (spud) | PS001 | -2,984.4 |
 | 2016-10-30 | Drilling (spud) | PS001 | -2,962.2 |
 | 2016-12-17 | Drilling (spud) | PS002 | -2,932.8 |
@@ -132,6 +144,7 @@ Cumulative NPV path (by year): `█▇▇▇▇▇▇▇▆▆▆▆▆▅▁▁
 | 2018-05-20 | Drilling (spud) | PS008 | -2,632.7 |
 | 2018-05-30 | Drilling (spud) | PS008 | -2,632.7 |
 | 2018-06-01 | Well online (first production) | API 608124012200 | -2,606.1 |
+| 2018-08-12 | Temporary abandonment | PS008 (608124011605) | -2,526.1 |
 | 2018-08-31 | Drilling (spud) | PS008 | -2,526.1 |
 | 2018-12-01 | Well online (first production) | API 608124011606 | -2,408.0 |
 | 2018-12-23 | Drilling (spud) | PS006 | -2,408.0 |
@@ -148,15 +161,22 @@ Cumulative NPV path (by year): `█▇▇▇▇▇▇▇▆▆▆▆▆▅▁▁
 | 2019-11-16 | Drilling (spud) | 001 | -2,149.6 |
 | 2019-11-24 | Sidetrack | 001 (608124012803) | -2,149.6 |
 | 2019-11-28 | Drilling (spud) | PS009 | -2,149.6 |
+| 2019-12-22 | Temporary abandonment | PS006 (608124012500) | -2,126.0 |
+| 2019-12-22 | Temporary abandonment | PS009 (608124012804) | -2,126.0 |
 | 2020-05-01 | Well online (first production) | API 608124012500 | -2,080.4 |
+| 2020-05-15 | Plug & abandon | PN003 (608124005500) | -2,080.4 |
 | 2020-05-17 | Drilling (spud) | PN005 | -2,080.4 |
 | 2020-06-19 | Drilling (spud) | PN005 | -2,069.2 |
 | 2020-07-11 | Drilling (spud) | PN005 | -2,056.6 |
+| 2020-07-29 | Plug & abandon | 001 (608124001301) | -2,056.6 |
 | 2020-08-14 | Drilling (spud) | IS003 | -2,052.0 |
+| 2020-09-06 | Temporary abandonment | 001 (608124002900) | -2,047.1 |
 | 2020-09-16 | Completion | PS003 (608124012601) | -2,047.1 |
 | 2020-12-26 | Drilling (spud) | IS001 | -2,026.5 |
 | 2021-02-01 | Well online (first production) | API 608124013202 | -2,002.9 |
 | 2021-02-07 | Workover | PS003 (608124005600) | -2,002.9 |
+| 2021-03-11 | Plug & abandon | 002 (608124001100) | -1,980.7 |
+| 2021-03-29 | Plug & abandon | 001 (608124002900) | -1,980.7 |
 | 2021-04-11 | Drilling (spud) | PS006 | -1,962.0 |
 | 2021-08-01 | Well online (first production) | API 608124013600 | -1,886.0 |
 | 2021-08-17 | Completion | PS009 (608124012804) | -1,886.0 |
@@ -165,7 +185,9 @@ Cumulative NPV path (by year): `█▇▇▇▇▇▇▇▆▆▆▆▆▅▁▁
 | 2022-09-07 | Completion | IS003 (608124013300) | -1,520.1 |
 | 2022-12-30 | Completion | IS001 (608124013500) | -1,445.6 |
 | 2023-03-15 | Completion | PS008 (608124011606) | -1,384.8 |
+| 2023-03-16 | Plug & abandon | PS001 (608124005203) | -1,384.8 |
 | 2023-04-21 | Drilling (spud) | PS011 | -1,364.9 |
+| 2023-05-12 | Temporary abandonment | IS003 (608124013300) | -1,348.5 |
 | 2023-09-01 | Well online (first production) | API 608124014600 | -1,275.0 |
 | 2023-10-14 | Drilling (spud) | PS008 | -1,254.0 |
 | 2024-02-01 | Well online (first production) | API 608124015100 | -1,189.1 |
@@ -279,7 +301,7 @@ _They are intentionally **not linked yet**: the geometry render must first be co
 
 | Metric | Latest | Frozen V30 (reference) |
 |--------|------:|------:|
-| **NPV @ 10%** | **$-804.5 M** | $-945.0 M |
+| **NPV @ 10%** | **$-804.5 M** | $-881.1 M |
 | Revenue | $27,890.7 M | $25,648.5 M |
 | Oil produced (MMbbl) | 438.7 | 406.6 |
 
@@ -289,22 +311,22 @@ _Latest NPV from `build_field_npv_timeline(dev, end_date)`; latest revenue/oil f
 
 | Metric | Value |
 |--------|------:|
-| Revenue | $25,655.0 M |
-| Royalty | $4,810.3 M |
-| Variable opex | $1,626.7 M |
+| Revenue | $25,648.5 M |
+| Royalty | $4,809.1 M |
+| Variable opex | $1,626.3 M |
 | Fixed opex | $1,575.0 M |
 | D&C cost | $5,450.4 M |
 | Facilities cost | $7,400.0 M |
-| Net cashflow (undiscounted) | $4,792.6 M |
-| **NPV @ 10%** | **$-945.0 M** |
-| MIRR (annual) | 8.43% |
+| Net cashflow (undiscounted) | $4,787.7 M |
+| **NPV @ 10%** | **$-881.1 M** |
+| MIRR (annual) | 8.52% |
 | Producers | 22 |
 | Injectors | 4 |
 | Wellbores | 73 |
 
 _Return metric: **MIRR** is the sanctioned return measure for these developments, not IRR. Deepwater Lower-Tertiary cashflows are heavily front-loaded (large D&C + facilities outflows, then a long production tail), so the net-cashflow sign changes more than once and the IRR polynomial can have multiple — or no — real roots; MIRR (single reinvestment/finance rate at the 10% discount rate) is well-defined and unambiguous. NPV @ 10% remains the primary value metric._
 
-_Source-of-record: `config/analysis/lower_tertiary/golden_baseline_v30.yml`. NPV reproduced within golden-baseline tolerance by `worldenergydata.lower_tertiary.v30_financial_reproducer`._
+_Source-of-record for the frozen reference table: `config/analysis/lower_tertiary/golden_baseline_v30.yml`; latest window NPV is recomputed by `worldenergydata.lower_tertiary.v30_financial_reproducer`._
 
 ---
 

--- a/scripts/lower_tertiary/generate_field_economics_report.py
+++ b/scripts/lower_tertiary/generate_field_economics_report.py
@@ -117,6 +117,32 @@ def _read_latest_comparison(dev_name: str) -> dict | None:
     return None
 
 
+def _read_golden_v30_financials(dev_name: str) -> dict | None:
+    """Read the official frozen V30 financial row for *dev_name*.
+
+    Latest-window reports use this as the audited V30 reference column. The
+    reproducer can carry timing differences for specific fields, so the
+    published reference row must come from the golden baseline of record.
+    """
+    path = (
+        PROJECT_ROOT
+        / "config"
+        / "analysis"
+        / "lower_tertiary"
+        / "golden_baseline_v30.yml"
+    )
+    if not path.exists():
+        return None
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    for proj in (data or {}).get("projects", {}).values():
+        if proj.get("display_name") == dev_name:
+            return dict(proj)
+    return None
+
+
 def _sparkline(values: list[float]) -> str:
     """Unicode block sparkline (deterministic) for the cumulative NPV path."""
     blocks = "▁▂▃▄▅▆▇█"
@@ -197,7 +223,13 @@ def build_report(
         first_oil_overrides=first_oil_overrides if input_set != "v30" else None,
         input_set=input_set,
     )
-    sanctioned_npv = fin[dev_name]["npv_usd"]
+    official_v30_fin = (
+        _read_golden_v30_financials(dev_name)
+        if is_latest and input_set == "v30"
+        else None
+    )
+    reference_fin = official_v30_fin or fin[dev_name]
+    sanctioned_npv = reference_fin["npv_usd"]
     _ref_mm = sanctioned_npv / 1e6
     _ref_str = f"-${abs(_ref_mm):,.1f}M" if _ref_mm < 0 else f"${_ref_mm:,.1f}M"
     if is_latest and input_set == "v50_kc":
@@ -329,7 +361,7 @@ def build_report(
     # -------------------------- EXECUTIVE SUMMARY ---------------------------
     # Verdict-first headline so a client reads the bottom line before the
     # tables. All figures trace to the same model the detail sections use.
-    f0 = fin[dev_name]
+    f0 = reference_fin if is_latest and input_set == "v30" else fin[dev_name]
     sign = "NPV-negative" if terminal_npv < 0 else "NPV-positive"
     one_time_capital = f0["dnc_total_usd"] + f0["facilities_cost_usd"]
     oil_mm = cmp["latest_oil_bbl"] / 1e6 if cmp and cmp.get("latest_oil_bbl") else None
@@ -640,7 +672,7 @@ def build_report(
     lines.append("")
 
     # =========================== FINANCIAL SUMMARY ==========================
-    f = fin[dev_name]
+    f = reference_fin if is_latest and input_set == "v30" else fin[dev_name]
     rate_pct = f"{tl['discount_rate_annual'] * 100:.0f}"
     if is_latest and input_set == "v50_kc":
         lines.append("## Financial Summary")
@@ -749,8 +781,9 @@ def build_report(
         )
     else:
         lines.append(
-            "_Source-of-record: `config/analysis/lower_tertiary/golden_baseline_v30.yml`. "
-            "NPV reproduced within golden-baseline tolerance by "
+            "_Source-of-record for the frozen reference table: "
+            "`config/analysis/lower_tertiary/golden_baseline_v30.yml`; latest "
+            "window NPV is recomputed by "
             "`worldenergydata.lower_tertiary.v30_financial_reproducer`._"
         )
     lines.append("")

--- a/tests/unit/lower_tertiary/test_field_report_frozen_v30_reference.py
+++ b/tests/unit/lower_tertiary/test_field_report_frozen_v30_reference.py
@@ -1,0 +1,64 @@
+"""Regression tests for frozen V30 references in per-field economics reports."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+import scripts.lower_tertiary.generate_field_economics_report as field_report
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+REPORTS_DIR = PROJECT_ROOT / "reports" / "lower_tertiary"
+V30_BASELINE = (
+    PROJECT_ROOT / "config" / "analysis" / "lower_tertiary" / "golden_baseline_v30.yml"
+)
+
+FIELDS = [
+    ("jack_st_malo", "field_economics_jack_st_malo_v50.md"),
+    ("cascade_chinook", "field_economics_cascade_chinook_v50.md"),
+]
+
+EXPECTED_GOLDEN_NPV = {
+    "Jack St Malo": -881_064_818.72,
+    "Cascade Chinook": -1_474_083_632.85,
+}
+
+
+def _golden_npv_mm(project_id: str) -> float:
+    baseline = yaml.safe_load(V30_BASELINE.read_text(encoding="utf-8"))
+    return baseline["projects"][project_id]["npv_usd"] / 1e6
+
+
+def _usd_mm(value: float) -> str:
+    return f"${value:,.1f} M"
+
+
+def _compact_usd_mm(value: float) -> str:
+    if value < 0:
+        return f"-${abs(value):,.1f}M"
+    return f"${value:,.1f}M"
+
+
+@pytest.mark.parametrize("dev_name,expected", EXPECTED_GOLDEN_NPV.items())
+def test_generator_reads_golden_v30_reference_financials(dev_name, expected):
+    row = field_report._read_golden_v30_financials(dev_name)
+
+    assert row is not None
+    assert row["npv_usd"] == pytest.approx(expected, rel=1e-12)
+
+
+@pytest.mark.parametrize("project_id,report_name", FIELDS)
+def test_latest_report_uses_golden_v30_reference_npv(project_id, report_name):
+    md = (REPORTS_DIR / report_name).read_text(encoding="utf-8")
+    expected = _golden_npv_mm(project_id)
+
+    assert f"frozen V30 reference NPV = {_compact_usd_mm(expected)}" in md
+    assert re.search(
+        rf"\| \*\*NPV @ 10%\*\* \| \*\*\$[-0-9,.]+ M\*\* \| "
+        rf"{re.escape(_usd_mm(expected))} \|",
+        md,
+    )
+    assert f"| **NPV @ 10%** | **{_usd_mm(expected)}** |" in md


### PR DESCRIPTION
## Summary

- Makes latest-window per-field economics reports render frozen V30 reference rows from `golden_baseline_v30.yml`, not a fresh reproducer rerun.
- Regenerates Jack/St Malo and Cascade/Chinook V50 reports so frozen references match the authoritative V30 values:
  - Jack/St Malo: `-$881.1M`
  - Cascade/Chinook: `-$1,474.1M`
- Adds a regression test for the generator lookup and generated report cells.
- Adds Roy's 2026-07-08 canonicalization notes as a durable reviewed-email log.
- Creates/fans out follow-up tracking from Roy's note: #899, #900, #901; updates #651 and #875.

## Scope boundary

This fixes stale V30 reference values in the V50 report surface. It does not adopt Roy's full after-tax V50 model, settle the NPV discount-reference convention, or generate the canonical V50 workbook; those are tracked separately.

## Validation

- `PYTHONPATH='packages/worldenergydata-bsee/src:src' /mnt/local-analysis/worldenergydata/.venv/bin/python -m pytest tests/unit/lower_tertiary/test_field_report_frozen_v30_reference.py tests/unit/lower_tertiary/test_buckskin_v50_report.py -q` -> 9 passed
- `scripts/legal/legal-sanity-scan.sh` -> PASS before commit; no staged files after commit
- `git diff --check` -> PASS
- `PYTHONPATH='packages/worldenergydata-bsee/src:src' /mnt/local-analysis/worldenergydata/.venv/bin/python scripts/build_pages.py --domains lower_tertiary` -> built 15 pages into ignored `public/`

Refs #875, #899, #900, #901, #651.
