### PR TITLE
docs(fdas): link Buckskin validation from capabilities

### DIFF
--- a/reports/capabilities/index.html
+++ b/reports/capabilities/index.html
@@ -208,10 +208,11 @@
 
   <section class="chan" id="validation">
     <div class="chanhead"><h2>Sanctioned against frozen baselines</h2><a class="onepager" href="pdf/sec-validation.pdf" download>Section 1-pager &darr;</a></div>
-    <p class="note"><strong>Full validation &mdash; three linked reports:</strong>
+    <p class="note"><strong>Full validation &mdash; four linked reports:</strong>
        <a href="../wo-april-2026-validation.html">World&nbsp;Oil April&nbsp;2026 article validation</a> (all four article tables reconciled, per-discrepancy comparison tables, BOEM reserves cross-check) &middot;
        <a href="../completion/verification.html">live D&amp;C reconciliation &amp; 217-wellbore verification</a> &middot;
        <a href="../fdas-revision-comparison.html">FDAS revision comparison &amp; V50-vs-wed reconciliation</a> (D&amp;C and financials, field-by-field and well-by-well) &mdash;
+       <a href="../economics-buckskin.html">Buckskin V50-KC economics recompute</a> (KC lease/D&amp;C input set and wed V50 NPV) &mdash;
        every D&amp;C and financial number reconciled against the article on the current <strong>wed&nbsp;canonical (V50 / latest)</strong> basis.</p>
     <p class="note"><span class="pub">■ sanctioned-baseline</span> = reproduces the frozen V30 golden baseline within tolerance (CI-guarded; V30 retained as the reproduction anchor, superseded by V50/latest for presented numbers);
        <span class="der">■ data-derived</span> = aggregated directly from public regulatory filings.</p>

--- a/tests/unit/lower_tertiary/test_buckskin_v50_report.py
+++ b/tests/unit/lower_tertiary/test_buckskin_v50_report.py
@@ -12,6 +12,7 @@ import scripts.lower_tertiary.regenerate_field_economics_v50 as regen
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 FDAS_DIR = PROJECT_ROOT / "docs/modules/bsee/analysis/production/FDAS_V30"
 REPORTS_DIR = PROJECT_ROOT / "reports/lower_tertiary"
+CAPABILITIES_PAGE = PROJECT_ROOT / "reports/capabilities/index.html"
 
 BUCKSKIN_LEASES = {"G25806", "G25813", "G25814", "G25815", "G25823", "G32650"}
 
@@ -72,3 +73,15 @@ def test_pages_builder_indexes_buckskin_v50_report():
     }
 
     assert reports["buckskin"] == "field_economics_buckskin_v50.md"
+
+
+def test_capabilities_validation_section_links_key_validation_reports():
+    html = CAPABILITIES_PAGE.read_text(encoding="utf-8")
+    validation_section = html.split('<section class="chan" id="validation">', 1)[1]
+    validation_section = validation_section.split("</section>", 1)[0]
+
+    assert "four linked reports" in validation_section
+    assert "../wo-april-2026-validation.html" in validation_section
+    assert "../completion/verification.html" in validation_section
+    assert "../fdas-revision-comparison.html" in validation_section
+    assert "../economics-buckskin.html" in validation_section


### PR DESCRIPTION
## Summary
- Adds the Buckskin V50-KC economics recompute link to the capabilities validation section.
- Updates the validation intro from three to four linked reports.
- Adds a regression test that guards the four key validation hrefs.

## Verification
- RED: targeted test failed before the HTML change because `four linked reports` was absent.
- GREEN: `PYTHONPATH='packages/worldenergydata-bsee/src:src' /mnt/local-analysis/worldenergydata/.venv/bin/python -m pytest tests/unit/lower_tertiary/test_buckskin_v50_report.py -q --no-cov` -> `6 passed in 2.57s`.
- `/mnt/local-analysis/worldenergydata/.venv/bin/python scripts/build_pages.py --domains capabilities` -> built `public/capabilities/index.html`.
- `rg -n "four linked reports|economics-buckskin|wo-april-2026-validation|completion/verification|fdas-revision-comparison" public/capabilities/index.html` -> all four hrefs present.
- `git diff --check` -> passed.
- `scripts/legal/legal-sanity-scan.sh` -> `legal-sanity-scan: PASS`.
