### PR TITLE
docs(fdas): add validation table link

### DIFF
--- a/reports/capabilities/index.html
+++ b/reports/capabilities/index.html
@@ -222,6 +222,7 @@
         <tr><td>V30 field economics</td><td>Julia (G20351) terminal NPV @10%</td><td class="val">&minus;$530.6 M</td><td class="pub">sanctioned golden_baseline_v30</td></tr>
         <tr><td>V30 field economics</td><td>Stones (G17001) terminal NPV @10%</td><td class="val">&minus;$1 479.5 M</td><td class="pub">sanctioned golden_baseline_v30</td></tr>
         <tr><td>V30 field economics</td><td>Anchor terminal NPV @10%</td><td class="val">&minus;$1 732.8 M</td><td class="pub">sanctioned golden_baseline_v30</td></tr>
+        <tr><td><a href="../fdas-revision-comparison.html">FDAS revision comparison</a></td><td>V50-vs-wed D&amp;C + component economics</td><td class="val">D&amp;C Δ=0; 40 component rows verified</td><td class="pub">2026-04 wed-latest reconciliation</td></tr>
         <tr><td>Julia price sensitivity</td><td>dNPV / d(realized WTI)</td><td class="val">+$16.3 M per $1/bbl</td><td class="pub">V30 model</td></tr>
         <tr><td>Julia breakeven</td><td>realized-WTI price at NPV = 0</td><td class="val">$99 / bbl</td><td class="pub">V30 model</td></tr>
         <tr><td>Julia MIRR</td><td>annual, life-to-date</td><td class="val">6.31 %</td><td class="pub">V30 model</td></tr>

--- a/tests/unit/lower_tertiary/test_buckskin_v50_report.py
+++ b/tests/unit/lower_tertiary/test_buckskin_v50_report.py
@@ -85,3 +85,20 @@ def test_capabilities_validation_section_links_key_validation_reports():
     assert "../completion/verification.html" in validation_section
     assert "../fdas-revision-comparison.html" in validation_section
     assert "../economics-buckskin.html" in validation_section
+
+
+def test_capabilities_validation_table_links_fdas_revision_comparison_row():
+    html = CAPABILITIES_PAGE.read_text(encoding="utf-8")
+    validation_section = html.split('<section class="chan" id="validation">', 1)[1]
+    validation_section = validation_section.split("</section>", 1)[0]
+    table_body = validation_section.split("<tbody>", 1)[1].split("</tbody>", 1)[0]
+
+    expected_row = (
+        '<tr><td><a href="../fdas-revision-comparison.html">'
+        "FDAS revision comparison</a></td>"
+        "<td>V50-vs-wed D&amp;C + component economics</td>"
+        '<td class="val">D&amp;C Δ=0; 40 component rows verified</td>'
+        '<td class="pub">2026-04 wed-latest reconciliation</td></tr>'
+    )
+
+    assert expected_row in table_body


### PR DESCRIPTION
## Summary
- Adds a dedicated row in the capabilities `#validation` table linking to `fdas-revision-comparison.html`.
- The row summarizes the V50-vs-wed D&C and component-economics reconciliation now published on that page.
- Adds a regression test so the link remains present as a table row, not only in the intro paragraph.

## Verification
- RED: `PYTHONPATH='packages/worldenergydata-bsee/src:src' /mnt/local-analysis/worldenergydata/.venv/bin/python -m pytest tests/unit/lower_tertiary/test_buckskin_v50_report.py::test_capabilities_validation_table_links_fdas_revision_comparison_row -q --no-cov` failed before the row was added.
- GREEN: `PYTHONPATH='packages/worldenergydata-bsee/src:src' /mnt/local-analysis/worldenergydata/.venv/bin/python -m pytest tests/unit/lower_tertiary/test_buckskin_v50_report.py -q --no-cov` -> `7 passed in 2.58s`.
- `/mnt/local-analysis/worldenergydata/.venv/bin/python scripts/build_pages.py --domains capabilities` -> built `public/capabilities/index.html`.
- `rg -n "FDAS revision comparison|V50-vs-wed D&amp;C \+ component economics|40 component rows verified|2026-04 wed-latest reconciliation|../fdas-revision-comparison.html" public/capabilities/index.html reports/capabilities/index.html` -> row present in source and rendered page.
- `git diff --check` -> passed.
- `scripts/legal/legal-sanity-scan.sh` -> `legal-sanity-scan: PASS`.
