### PR TITLE
feat(brand): a11y baseline + logo-home for capability API pages (#908)

### DIFF
--- a/reports/capabilities/api/benchmark.html
+++ b/reports/capabilities/api/benchmark.html
@@ -29,9 +29,12 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
   <g fill="none" stroke-width="3">
     <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
     <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
@@ -43,7 +46,7 @@
   <text x="74" y="43" font-family="Arial,Helvetica,sans-serif" font-size="31" font-weight="800" letter-spacing="-0.6">
     <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
   </text>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Well benchmarking</h1><div class="std">BSEE OGOR-A · 2010–latest</div>
 
   <div class="bigpanel">

--- a/reports/capabilities/api/completion.html
+++ b/reports/capabilities/api/completion.html
@@ -29,9 +29,12 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
   <g fill="none" stroke-width="3">
     <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
     <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
@@ -43,7 +46,7 @@
   <text x="74" y="43" font-family="Arial,Helvetica,sans-serif" font-size="31" font-weight="800" letter-spacing="-0.6">
     <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
   </text>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Drilling &amp; completion days</h1><div class="std">BSEE Well Activity Reports</div>
 
   <div class="bigpanel">

--- a/reports/capabilities/api/economics-anchor.html
+++ b/reports/capabilities/api/economics-anchor.html
@@ -29,9 +29,12 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
   <g fill="none" stroke-width="3">
     <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
     <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
@@ -43,7 +46,7 @@
   <text x="74" y="43" font-family="Arial,Helvetica,sans-serif" font-size="31" font-weight="800" letter-spacing="-0.6">
     <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
   </text>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Anchor field economics</h1><div class="std">BSEE OGOR-A · sanctioned V30</div>
 
   <div class="bigpanel">

--- a/reports/capabilities/api/economics-big_foot.html
+++ b/reports/capabilities/api/economics-big_foot.html
@@ -29,9 +29,12 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
   <g fill="none" stroke-width="3">
     <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
     <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
@@ -43,7 +46,7 @@
   <text x="74" y="43" font-family="Arial,Helvetica,sans-serif" font-size="31" font-weight="800" letter-spacing="-0.6">
     <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
   </text>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Big Foot field economics</h1><div class="std">BSEE OGOR-A · sanctioned V30</div>
 
   <div class="bigpanel">

--- a/reports/capabilities/api/economics-cascade_chinook.html
+++ b/reports/capabilities/api/economics-cascade_chinook.html
@@ -29,9 +29,12 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
   <g fill="none" stroke-width="3">
     <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
     <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
@@ -43,7 +46,7 @@
   <text x="74" y="43" font-family="Arial,Helvetica,sans-serif" font-size="31" font-weight="800" letter-spacing="-0.6">
     <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
   </text>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Cascade–Chinook field economics</h1><div class="std">BSEE OGOR-A · sanctioned V30</div>
 
   <div class="bigpanel">

--- a/reports/capabilities/api/economics-jack_st_malo.html
+++ b/reports/capabilities/api/economics-jack_st_malo.html
@@ -29,9 +29,12 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
   <g fill="none" stroke-width="3">
     <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
     <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
@@ -43,7 +46,7 @@
   <text x="74" y="43" font-family="Arial,Helvetica,sans-serif" font-size="31" font-weight="800" letter-spacing="-0.6">
     <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
   </text>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Jack / St. Malo field economics</h1><div class="std">BSEE OGOR-A · sanctioned V30</div>
 
   <div class="bigpanel">

--- a/reports/capabilities/api/economics-julia.html
+++ b/reports/capabilities/api/economics-julia.html
@@ -29,9 +29,12 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
   <g fill="none" stroke-width="3">
     <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
     <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
@@ -43,7 +46,7 @@
   <text x="74" y="43" font-family="Arial,Helvetica,sans-serif" font-size="31" font-weight="800" letter-spacing="-0.6">
     <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
   </text>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Julia field economics</h1><div class="std">BSEE OGOR-A · sanctioned V30</div>
 
   <div class="bigpanel">

--- a/reports/capabilities/api/economics-shenandoah.html
+++ b/reports/capabilities/api/economics-shenandoah.html
@@ -29,9 +29,12 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
   <g fill="none" stroke-width="3">
     <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
     <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
@@ -43,7 +46,7 @@
   <text x="74" y="43" font-family="Arial,Helvetica,sans-serif" font-size="31" font-weight="800" letter-spacing="-0.6">
     <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
   </text>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Shenandoah field economics</h1><div class="std">BSEE OGOR-A · sanctioned V30</div>
 
   <div class="bigpanel">

--- a/reports/capabilities/api/economics-stones.html
+++ b/reports/capabilities/api/economics-stones.html
@@ -29,9 +29,12 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
   <g fill="none" stroke-width="3">
     <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
     <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
@@ -43,7 +46,7 @@
   <text x="74" y="43" font-family="Arial,Helvetica,sans-serif" font-size="31" font-weight="800" letter-spacing="-0.6">
     <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
   </text>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Stones field economics</h1><div class="std">BSEE OGOR-A · sanctioned V30</div>
 
   <div class="bigpanel">

--- a/reports/capabilities/api/fd-bsee-matched.html
+++ b/reports/capabilities/api/fd-bsee-matched.html
@@ -29,9 +29,12 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
   <g fill="none" stroke-width="3">
     <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
     <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
@@ -43,7 +46,7 @@
   <text x="74" y="43" font-family="Arial,Helvetica,sans-serif" font-size="31" font-weight="800" letter-spacing="-0.6">
     <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
   </text>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>BSEE-matched fields</h1><div class="std">recommended vs as-built</div>
 
   <div class="bigpanel">

--- a/reports/capabilities/api/fd-playbook.html
+++ b/reports/capabilities/api/fd-playbook.html
@@ -29,9 +29,12 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
   <g fill="none" stroke-width="3">
     <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
     <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
@@ -43,7 +46,7 @@
   <text x="74" y="43" font-family="Arial,Helvetica,sans-serif" font-size="31" font-weight="800" letter-spacing="-0.6">
     <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
   </text>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Interactive playbook</h1><div class="std">live parameter sliders</div>
 
   <div class="bigpanel">

--- a/reports/capabilities/api/fd-portfolio.html
+++ b/reports/capabilities/api/fd-portfolio.html
@@ -29,9 +29,12 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
   <g fill="none" stroke-width="3">
     <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
     <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
@@ -43,7 +46,7 @@
   <text x="74" y="43" font-family="Arial,Helvetica,sans-serif" font-size="31" font-weight="800" letter-spacing="-0.6">
     <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
   </text>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Deepwater portfolio</h1><div class="std">10-field Gulf of Mexico</div>
 
   <div class="bigpanel">

--- a/reports/capabilities/api/fd-showcase.html
+++ b/reports/capabilities/api/fd-showcase.html
@@ -29,9 +29,12 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
   <g fill="none" stroke-width="3">
     <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
     <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
@@ -43,7 +46,7 @@
   <text x="74" y="43" font-family="Arial,Helvetica,sans-serif" font-size="31" font-weight="800" letter-spacing="-0.6">
     <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
   </text>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Field-development capability showcase</h1><div class="std">concept → schematic → economics</div>
 
   <div class="bigpanel">

--- a/reports/capabilities/api/imo.html
+++ b/reports/capabilities/api/imo.html
@@ -29,9 +29,12 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
   <g fill="none" stroke-width="3">
     <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
     <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
@@ -43,7 +46,7 @@
   <text x="74" y="43" font-family="Arial,Helvetica,sans-serif" font-size="31" font-weight="800" letter-spacing="-0.6">
     <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
   </text>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>IMO GISIS casualties</h1><div class="std">IMO GISIS public database</div>
 
   <div class="bigpanel">

--- a/reports/capabilities/api/mooring.html
+++ b/reports/capabilities/api/mooring.html
@@ -29,9 +29,12 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
   <g fill="none" stroke-width="3">
     <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
     <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
@@ -43,7 +46,7 @@
   <text x="74" y="43" font-family="Arial,Helvetica,sans-serif" font-size="31" font-weight="800" letter-spacing="-0.6">
     <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
   </text>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Mooring-fatigue grounded card</h1><div class="std">DNV-OS-E301 T-N curves</div>
 
   <div class="bigpanel">

--- a/reports/capabilities/api/ms-exec.html
+++ b/reports/capabilities/api/ms-exec.html
@@ -29,9 +29,12 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
   <g fill="none" stroke-width="3">
     <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
     <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
@@ -43,7 +46,7 @@
   <text x="74" y="43" font-family="Arial,Helvetica,sans-serif" font-size="31" font-weight="800" letter-spacing="-0.6">
     <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
   </text>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Marine safety analytics</h1><div class="std">TSB · IMO GISIS · MAIB</div>
 
   <div class="bigpanel">

--- a/reports/capabilities/api/ms-fatality.html
+++ b/reports/capabilities/api/ms-fatality.html
@@ -29,9 +29,12 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
   <g fill="none" stroke-width="3">
     <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
     <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
@@ -43,7 +46,7 @@
   <text x="74" y="43" font-family="Arial,Helvetica,sans-serif" font-size="31" font-weight="800" letter-spacing="-0.6">
     <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
   </text>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Fatality analysis</h1><div class="std">cross-database</div>
 
   <div class="bigpanel">

--- a/reports/capabilities/api/ms-foundering.html
+++ b/reports/capabilities/api/ms-foundering.html
@@ -29,9 +29,12 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
   <g fill="none" stroke-width="3">
     <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
     <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
@@ -43,7 +46,7 @@
   <text x="74" y="43" font-family="Arial,Helvetica,sans-serif" font-size="31" font-weight="800" letter-spacing="-0.6">
     <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
   </text>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Foundering analysis</h1><div class="std">cross-database</div>
 
   <div class="bigpanel">

--- a/reports/capabilities/api/ms-hatch.html
+++ b/reports/capabilities/api/ms-hatch.html
@@ -29,9 +29,12 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
   <g fill="none" stroke-width="3">
     <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
     <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
@@ -43,7 +46,7 @@
   <text x="74" y="43" font-family="Arial,Helvetica,sans-serif" font-size="31" font-weight="800" letter-spacing="-0.6">
     <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
   </text>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Hatch analysis</h1><div class="std">cross-database</div>
 
   <div class="bigpanel">

--- a/reports/capabilities/api/portfolio.html
+++ b/reports/capabilities/api/portfolio.html
@@ -29,9 +29,12 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
   <g fill="none" stroke-width="3">
     <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
     <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
@@ -43,7 +46,7 @@
   <text x="74" y="43" font-family="Arial,Helvetica,sans-serif" font-size="31" font-weight="800" letter-spacing="-0.6">
     <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
   </text>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Lower-Tertiary portfolio summary</h1><div class="std">field-by-field roll-up</div>
 
   <div class="bigpanel">

--- a/reports/capabilities/api/well-path.html
+++ b/reports/capabilities/api/well-path.html
@@ -29,9 +29,12 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}
+  .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents"><svg viewBox="0 0 400 64" xmlns="http://www.w3.org/2000/svg" aria-label="worldenergydata">
   <g fill="none" stroke-width="3">
     <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
     <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
@@ -43,7 +46,7 @@
   <text x="74" y="43" font-family="Arial,Helvetica,sans-serif" font-size="31" font-weight="800" letter-spacing="-0.6">
     <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
   </text>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Julia well paths (3D)</h1><div class="std">BSEE directional surveys</div>
 
   <div class="bigpanel">

--- a/scripts/capabilities/build_onepagers.py
+++ b/scripts/capabilities/build_onepagers.py
@@ -364,9 +364,12 @@ _API_TEMPLATE = """<!doctype html><html lang="en"><head><meta charset="utf-8">
   .copy{{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}}
   .how ol{{margin:8px 0 0 18px}} .how li{{font-size:13.5px;margin:7px 0;color:var(--ink)}}
   .how code{{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}}
+  /* a11y baseline (wh#3401 / #908): consistent keyboard focus + text-alternative helper */
+  :where(a,button,input,select,textarea,summary,[tabindex]):focus-visible{{outline:2px solid var(--teal);outline-offset:2px;border-radius:3px}}
+  .sr-only{{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}}
 </style></head>
 <body><div class="wrap">
-  <div class="top">{logo}<div class="kind">Workflow-API · self-contained call</div></div>
+  <div class="top"><a href="../" aria-label="Back to capabilities index" style="display:contents">{logo}</a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>{title}</h1><div class="std">{std}</div>
 
   <div class="bigpanel">

--- a/tests/unit/cli/test_capability_a11y.py
+++ b/tests/unit/cli/test_capability_a11y.py
@@ -1,0 +1,60 @@
+"""Brand/a11y baseline for generated capability API pages (wh#3401 / #908).
+
+Static checks (no heavyweight imports, matching test_capability_drift.py style):
+the interactive API template must carry the accessibility baseline and route its
+logo home; the PDF one-pager template must NOT (focus rings are screen-only).
+Generated api/*.html must reflect the template.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+_GEN = _REPO / "scripts" / "capabilities" / "build_onepagers.py"
+_API_DIR = _REPO / "reports" / "capabilities" / "api"
+
+
+def _src() -> str:
+    return _GEN.read_text(encoding="utf-8")
+
+
+def _api_template() -> str:
+    s = _src()
+    start = s.index("_API_TEMPLATE")
+    return s[start : s.index('"""', s.index('"""', start) + 3)]
+
+
+def _pdf_template() -> str:
+    s = _src()
+    start = s.index("_TEMPLATE = ")
+    return s[start : s.index('"""', s.index('"""', start) + 3)]
+
+
+def test_api_template_has_focus_visible():
+    assert ":focus-visible" in _api_template()
+
+
+def test_api_template_has_sr_only():
+    assert ".sr-only" in _api_template()
+
+
+def test_api_template_logo_links_home():
+    # logo wrapped in an anchor to the capabilities index (../ from api/)
+    assert re.search(r'<a href="\.\./"[^>]*>\{logo\}</a>', _api_template())
+
+
+def test_pdf_template_has_no_screen_only_a11y():
+    # focus rings are meaningless in print — must not leak into the PDF template
+    assert ":focus-visible" not in _pdf_template()
+
+
+@pytest.mark.skipif(not _API_DIR.exists(), reason="api artifacts not generated")
+@pytest.mark.parametrize("page", sorted(_API_DIR.glob("*.html")))
+def test_generated_api_pages_carry_baseline(page: Path):
+    html = page.read_text(encoding="utf-8")
+    assert ":focus-visible" in html, f"{page.name} missing focus-visible"
+    assert 'href="../"' in html, f"{page.name} missing logo-home link"


### PR DESCRIPTION
First increment of the worldenergydata brand rollout (child of workspace-hub#3401; plan #908, status:plan-approved).

wed's capability pages are generated by `scripts/capabilities/build_onepagers.py` and already ship the navy/teal brand (no recolour needed). This adds the shared **a11y baseline** at the generator source:
- **focus-visible + `.sr-only`** added to the SCREEN template `_API_TEMPLATE` only — the PDF one-pager template is deliberately untouched (focus rings are meaningless in print).
- **Logo → capabilities index** (`<a href="../">`, `display:contents` = zero layout change).
- **TDD** (`test_capability_a11y.py`): asserts the screen template carries the baseline + logo link, the PDF template does *not*, and every generated api page reflects it — all pass.
- Regenerated **21 api/*.html** (HTML-only, no PDF churn); per-page diff = exactly the two additions; screenshot-verified no visual regression.

**Lint:** black/isort/flake8 clean (matched CI toolchain via `uv run --all-extras`).
**Baseline note:** the lone failing test `TestSchedulerIndexMatchesConfig` is **pre-existing baseline-red** (MODULE_INDEX vs scheduler_config drift), unrelated to this diff (verified by stashing my changes — it still fails). 

Follow-ups for #908: extract a tracked brand.css + migrate the non-generated atlas/index pages + CI guard.

Ready for review/merge — I have **not** auto-merged (per wh merge-authorization).