### PR TITLE
refactor(brand): extract tracked tokens.css single-source for capability templates (#908)

### DIFF
--- a/reports/capabilities/assets/tokens.css
+++ b/reports/capabilities/assets/tokens.css
@@ -1,0 +1,1 @@
+:root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}

--- a/scripts/capabilities/build_onepagers.py
+++ b/scripts/capabilities/build_onepagers.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 _REPO = Path(__file__).resolve().parents[2]
 _OUT = _REPO / "reports" / "capabilities" / "pdf"
+_TOKENS = (_REPO / "reports" / "capabilities" / "assets" / "tokens.css").read_text(encoding="utf-8").strip()
 _SITE = "https://vamseeachanta.github.io/worldenergydata"
 _CHROME = os.environ.get("CHROME") or shutil.which("google-chrome") or shutil.which(
     "google-chrome-stable"
@@ -190,7 +191,7 @@ SPECS: list[dict] = [
 _TEMPLATE = """<!doctype html><html lang="en"><head><meta charset="utf-8">
 <style>
   @page{{size:A4;margin:0}}
-  :root{{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}}
+  {tokens}
   *{{box-sizing:border-box;margin:0;padding:0}}
   body{{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#fff;
        width:210mm;min-height:297mm;padding:18mm 18mm 14mm}}
@@ -337,7 +338,7 @@ _API_TEMPLATE = """<!doctype html><html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{title} — API call</title>
 <style>
-  :root{{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}}
+  {tokens}
   *{{box-sizing:border-box;margin:0;padding:0}}
   body{{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}}
   .wrap{{max-width:1000px;margin:0 auto;padding:22px}}
@@ -414,7 +415,7 @@ def _render_api_html(spec: dict, env: dict) -> str:
     for step in env["how_to_run"]:
         label = {"telegram": "Telegram", "http": "HTTP", "cli": "CLI"}.get(step["via"], step["via"])
         howsteps += f"<li><b>{label}.</b> {html.escape(step['step'])}</li>"
-    return _API_TEMPLATE.format(
+    return _API_TEMPLATE.format(tokens=_TOKENS, 
         logo=_LOGO, title=html.escape(spec["title"]), std=html.escape(spec["std"]),
         verb=verb, reqsnippet=reqsnippet,
         envelope=html.escape(_json.dumps(env, indent=2)),
@@ -440,7 +441,7 @@ def _render_html(spec: dict) -> str:
                'border:1px solid var(--line);border-radius:10px;font-size:12.5px">'
                f'<b>Ask Deckhand:</b> &ldquo;{html.escape(_prompt_for(spec))}&rdquo; '
                '&mdash; send to @the_deckhand_bot to run it live.</div>')
-    return _TEMPLATE.format(
+    return _TEMPLATE.format(tokens=_TOKENS, 
         logo=_LOGO, std=html.escape(spec["std"]), title=html.escape(spec["title"]),
         blurb=html.escape(spec["blurb"]), figs=figs, bullets=bullets, live=html.escape(live),
         ask=ask,

--- a/tests/unit/cli/test_capability_brand.py
+++ b/tests/unit/cli/test_capability_brand.py
@@ -1,0 +1,40 @@
+"""Tracked brand tokens as the single source for the capability generator (#908).
+
+Both one-pager templates (PDF + interactive API) previously duplicated the same
+:root token block. They now read it from one tracked file,
+reports/capabilities/assets/tokens.css, so the navy/teal identity lives in one
+editable place that non-generated pages can also link. Byte-identical output.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[3]
+_TOKENS = _REPO / "reports" / "capabilities" / "assets" / "tokens.css"
+_GEN = _REPO / "scripts" / "capabilities" / "build_onepagers.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("onepagers_brand", _GEN)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_tokens_css_tracked_and_navy_teal():
+    assert _TOKENS.exists(), "reports/capabilities/assets/tokens.css must exist"
+    css = _TOKENS.read_text(encoding="utf-8")
+    assert "--navy:#0B3D91" in css
+    assert "--teal:#0f8a7e" in css
+
+
+def test_generator_reads_tracked_tokens():
+    mod = _load()
+    # module reads the tracked file into _TOKENS
+    assert mod._TOKENS == _TOKENS.read_text(encoding="utf-8").strip()
+    # and a rendered page carries the resolved tokens
+    spec = next(s for s in mod.SPECS if s.get("kind") == "work")
+    html = mod._render_api_html(spec, mod._api_envelope(spec))
+    assert ":root{--navy:#0B3D91" in html


### PR DESCRIPTION
Follow-up slice of the worldenergydata brand plan (#908, status:plan-approved).

Both one-pager templates (PDF `_TEMPLATE` + interactive `_API_TEMPLATE`) duplicated the same `:root` navy/teal token block. Extracted to a tracked **`reports/capabilities/assets/tokens.css`** that both templates read via a `{tokens}` field — one editable source that non-generated atlas/index pages can also link.

- **Byte-identical**: PDF + API renders unchanged after extraction (verified programmatically); committed `api/*.html` unchanged.
- **TDD**: `test_capability_brand.py` (tokens tracked + navy/teal, generator reads it, rendered page carries resolved tokens); a11y test still passes — 27 total.
- **Lint** clean (black/isort/flake8, CI-matched).

Ready for review/merge — not auto-merged.