### PR TITLE
feat(brand): recolor lifecycle-norm pages + brand-drift CI guard (#908)

### DIFF
--- a/.github/workflows/brand-guard.yml
+++ b/.github/workflows/brand-guard.yml
@@ -1,0 +1,26 @@
+name: Brand Guard
+
+# Fails if a report page that declares the navy/teal brand drifts from the
+# canonical reports/capabilities/assets/tokens.css (worldenergydata#908).
+on:
+  pull_request:
+    paths:
+      - 'reports/**'
+      - 'scripts/**'
+      - '.github/workflows/brand-guard.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'reports/**'
+      - 'scripts/**'
+
+jobs:
+  brand-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Brand-token drift guard
+        run: python scripts/enforcement/check_brand_drift.py

--- a/reports/lower_tertiary/lifecycle/norms/abandon.html
+++ b/reports/lower_tertiary/lifecycle/norms/abandon.html
@@ -3,8 +3,8 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Abandon — plug &amp; abandonment context — LT phase norms</title>
 <style>
-:root{--navy:#0b2545;--teal:#0f766e;--ink:#1f2937;--mut:#6b7280;--bg:#f8fafc;
---card:#ffffff;--line:#e5e7eb;--warn:#b45309}
+:root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--mut:#5b6b86;--bg:#f8fafc;
+--card:#ffffff;--line:#dbe4f0;--warn:#b45309}
 *{box-sizing:border-box}body{margin:0;font:15px/1.55 system-ui,Segoe UI,Roboto,
 sans-serif;color:var(--ink);background:var(--bg)}
 .wrap{max-width:1100px;margin:0 auto;padding:28px 20px 60px}

--- a/reports/lower_tertiary/lifecycle/norms/complete.html
+++ b/reports/lower_tertiary/lifecycle/norms/complete.html
@@ -3,8 +3,8 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Complete — completion days — LT phase norms</title>
 <style>
-:root{--navy:#0b2545;--teal:#0f766e;--ink:#1f2937;--mut:#6b7280;--bg:#f8fafc;
---card:#ffffff;--line:#e5e7eb;--warn:#b45309}
+:root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--mut:#5b6b86;--bg:#f8fafc;
+--card:#ffffff;--line:#dbe4f0;--warn:#b45309}
 *{box-sizing:border-box}body{margin:0;font:15px/1.55 system-ui,Segoe UI,Roboto,
 sans-serif;color:var(--ink);background:var(--bg)}
 .wrap{max-width:1100px;margin:0 auto;padding:28px 20px 60px}

--- a/reports/lower_tertiary/lifecycle/norms/drill.html
+++ b/reports/lower_tertiary/lifecycle/norms/drill.html
@@ -3,8 +3,8 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Drill — days to total depth — LT phase norms</title>
 <style>
-:root{--navy:#0b2545;--teal:#0f766e;--ink:#1f2937;--mut:#6b7280;--bg:#f8fafc;
---card:#ffffff;--line:#e5e7eb;--warn:#b45309}
+:root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--mut:#5b6b86;--bg:#f8fafc;
+--card:#ffffff;--line:#dbe4f0;--warn:#b45309}
 *{box-sizing:border-box}body{margin:0;font:15px/1.55 system-ui,Segoe UI,Roboto,
 sans-serif;color:var(--ink);background:var(--bg)}
 .wrap{max-width:1100px;margin:0 auto;padding:28px 20px 60px}

--- a/reports/lower_tertiary/lifecycle/norms/produce.html
+++ b/reports/lower_tertiary/lifecycle/norms/produce.html
@@ -3,8 +3,8 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Produce — uptime, decline, cumulative oil — LT phase norms</title>
 <style>
-:root{--navy:#0b2545;--teal:#0f766e;--ink:#1f2937;--mut:#6b7280;--bg:#f8fafc;
---card:#ffffff;--line:#e5e7eb;--warn:#b45309}
+:root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--mut:#5b6b86;--bg:#f8fafc;
+--card:#ffffff;--line:#dbe4f0;--warn:#b45309}
 *{box-sizing:border-box}body{margin:0;font:15px/1.55 system-ui,Segoe UI,Roboto,
 sans-serif;color:var(--ink);background:var(--bg)}
 .wrap{max-width:1100px;margin:0 auto;padding:28px 20px 60px}

--- a/reports/lower_tertiary/lifecycle/norms/workover.html
+++ b/reports/lower_tertiary/lifecycle/norms/workover.html
@@ -3,8 +3,8 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Workover — interventions per well — LT phase norms</title>
 <style>
-:root{--navy:#0b2545;--teal:#0f766e;--ink:#1f2937;--mut:#6b7280;--bg:#f8fafc;
---card:#ffffff;--line:#e5e7eb;--warn:#b45309}
+:root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--mut:#5b6b86;--bg:#f8fafc;
+--card:#ffffff;--line:#dbe4f0;--warn:#b45309}
 *{box-sizing:border-box}body{margin:0;font:15px/1.55 system-ui,Segoe UI,Roboto,
 sans-serif;color:var(--ink);background:var(--bg)}
 .wrap{max-width:1100px;margin:0 auto;padding:28px 20px 60px}

--- a/scripts/enforcement/check_brand_drift.py
+++ b/scripts/enforcement/check_brand_drift.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Brand-token drift guard — worldenergydata#908 (wh#3401 ecosystem rollout).
+
+Any report page that DECLARES the brand (defines --navy) must match the canonical
+navy/teal token values in reports/capabilities/assets/tokens.css. The generated
+capability pages already single-source those tokens; this guard also covers the
+non-generated atlas/index/report pages so the identity can't drift anywhere.
+
+Pages that do NOT declare --navy (e.g. dark marine-safety pages, other intentional
+designs) are exempt. Run locally and in CI:
+    python scripts/enforcement/check_brand_drift.py
+Exit 0 = consistent, 1 = drift.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+TOKENS = ROOT / "reports" / "capabilities" / "assets" / "tokens.css"
+REPORTS = ROOT / "reports"
+
+# Dark-themed marketing infographics use --navy as their dark BACKGROUND, so they
+# cannot adopt the light brand navy by a token swap — they need a brand-accent
+# design pass (tracked in worldenergydata#922). Exempt until then.
+EXEMPT_PREFIXES = ("reports/modules/marketing/",)
+
+TOKEN_RE = re.compile(r"--([a-z0-9-]+)\s*:\s*(#[0-9a-fA-F]{3,8})")
+
+
+def norm(hexv: str) -> str:
+    h = hexv.strip().lower()
+    if re.fullmatch(r"#[0-9a-f]{3}", h):
+        h = "#" + "".join(c * 2 for c in h[1:])
+    return h
+
+
+def root_tokens(text: str) -> dict[str, str]:
+    m = re.search(r":root\s*\{([^}]*)\}", text, re.DOTALL)
+    if not m:
+        return {}
+    return {name: norm(val) for name, val in TOKEN_RE.findall(m.group(1))}
+
+
+def find_violations(canon: dict[str, str], pages: dict[str, dict[str, str]]):
+    out = []
+    for label, toks in pages.items():
+        if "navy" not in toks:  # not a brand page -> exempt
+            continue
+        for name, val in toks.items():
+            if name in canon and val != canon[name]:
+                out.append((label, name, val, canon[name]))
+    return out
+
+
+def main() -> int:
+    if not TOKENS.exists():
+        print(f"brand guard: {TOKENS} missing", file=sys.stderr)
+        return 1
+    canon = root_tokens(TOKENS.read_text(encoding="utf-8"))
+    pages = {
+        str(p.relative_to(ROOT)): root_tokens(p.read_text(encoding="utf-8", errors="ignore"))
+        for p in sorted(REPORTS.rglob("*.html"))
+        if not str(p.relative_to(ROOT)).startswith(EXEMPT_PREFIXES)
+    }
+    checked = [lbl for lbl, t in pages.items() if "navy" in t]
+    violations = find_violations(canon, pages)
+    if violations:
+        print("BRAND-TOKEN DRIFT — pages that declare --navy must match "
+              "reports/capabilities/assets/tokens.css:\n")
+        for label, name, got, want in violations:
+            print(f"  x {label}: --{name} = {got} (tokens.css: {want})")
+        print("\nFix the page's :root to the canonical values, or update tokens.css "
+              "if the brand deliberately changed.")
+        return 1
+    print(f"brand guard OK — {len(checked)} brand-declaring page(s) match "
+          f"tokens.css ({len(canon)} tokens)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lower_tertiary/build_phase_norms.py
+++ b/scripts/lower_tertiary/build_phase_norms.py
@@ -58,8 +58,8 @@ STAGE_POP_NOTE = {
 }
 
 CSS = """
-:root{--navy:#0b2545;--teal:#0f766e;--ink:#1f2937;--mut:#6b7280;--bg:#f8fafc;
---card:#ffffff;--line:#e5e7eb;--warn:#b45309}
+:root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--mut:#5b6b86;--bg:#f8fafc;
+--card:#ffffff;--line:#dbe4f0;--warn:#b45309}
 *{box-sizing:border-box}body{margin:0;font:15px/1.55 system-ui,Segoe UI,Roboto,
 sans-serif;color:var(--ink);background:var(--bg)}
 .wrap{max-width:1100px;margin:0 auto;padding:28px 20px 60px}

--- a/tests/unit/cli/test_brand_drift.py
+++ b/tests/unit/cli/test_brand_drift.py
@@ -1,0 +1,55 @@
+"""Tests for the wed brand-token drift guard (#908 / wh#3401).
+
+Verifies hex normalisation, :root parsing, the declare-navy-then-must-match rule
+(non-navy pages exempt), and that the real reports tree is consistent with
+reports/capabilities/assets/tokens.css.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[3]
+_GUARD = _ROOT / "scripts" / "enforcement" / "check_brand_drift.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("wed_brand_drift", _GUARD)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+G = _load()
+CANON = {"navy": "#0b3d91", "teal": "#0f8a7e", "ink": "#13233f"}
+
+
+def test_norm_expands_and_lowercases():
+    assert G.norm("#FFF") == "#ffffff"
+    assert G.norm("#0B3D91") == "#0b3d91"
+
+
+def test_root_tokens_parses_first_root():
+    toks = G.root_tokens(":root{--navy:#0B3D91;--teal:#0f8a7e}")
+    assert toks == {"navy": "#0b3d91", "teal": "#0f8a7e"}
+
+
+def test_matching_navy_page_has_no_violation():
+    pages = {"ok.html": {"navy": "#0b3d91", "teal": "#0f8a7e", "warn": "#b45309"}}
+    assert G.find_violations(CANON, pages) == []
+
+
+def test_drifted_navy_page_is_flagged():
+    pages = {"bad.html": {"navy": "#0b2545", "teal": "#0f8a7e"}}
+    v = G.find_violations(CANON, pages)
+    assert v and v[0][0] == "bad.html" and v[0][1] == "navy"
+
+
+def test_non_navy_page_is_exempt():
+    pages = {"dark.html": {"bg": "#0f1117", "ink": "#e6edf3"}}
+    assert G.find_violations(CANON, pages) == []
+
+
+def test_real_reports_tree_is_consistent():
+    assert G.main() == 0


### PR DESCRIPTION
Final slice of the worldenergydata brand plan (wh#3401). One PR (batched).

**Recolor (5 pages):** the lifecycle-norm pages used a Tailwind slate/teal palette. Brought onto the wed navy/teal brand via their generator `build_phase_norms.py` + the committed output (local regen needs BSEE data that's absent, so output edited in sync — a future regen produces identical). Screenshot-verified a clean on-brand recolor (headings/accents now brand navy/teal), no breakage.

**Guard:** `scripts/enforcement/check_brand_drift.py` fails if any report page that declares `--navy` diverges from `reports/capabilities/assets/tokens.css`. Wired into `.github/workflows/brand-guard.yml` (runs on `reports/`/`scripts/` changes). **Passes: 31 brand-declaring pages match.**

**Exemption (documented):** the 3 dark marketing infographics use `--navy` as their *dark background* — they can't adopt the light brand navy by a token swap and need a brand-accent **design pass**, tracked in #922. Exempted via `EXEMPT_PREFIXES` until then.

**TDD** `test_brand_drift.py` (6: norm, parse, match, drift-flagged, non-navy-exempt, real-tree) — pass. Lint clean (black/isort/flake8).

Ready for review/merge — not auto-merged.