### PR TITLE
feat: terrain & bathymetry public source catalog + 3DEP fetch helper (#930)

### DIFF
--- a/data/catalog/source-registry.yml
+++ b/data/catalog/source-registry.yml
@@ -212,3 +212,27 @@ modules:
       blm:
         source_url: https://reports.blm.gov/
         update_frequency: monthly
+
+  terrain:
+    # Terrain & bathymetry for field-development layout/screening (#930,
+    # epic #929 A1). Verified 2026-07-10; endpoints + evidence live in
+    # src/worldenergydata/field_development/terrain_sources.yml. Rasters are
+    # fetch-on-demand only (hundreds of MB to GB) — never committed.
+    license: "US Government Public Domain / GEBCO Public Domain"
+    default_update_frequency: annual
+    datasets:
+      usgs_3dep_dem:
+        source_url: https://elevation.nationalmap.gov/arcgis/rest/services/3DEPElevation/ImageServer
+        update_frequency: continual
+      usgs_3dep_staged_tiles:
+        source_url: https://prd-tnm.s3.amazonaws.com/StagedProducts/Elevation/13/TIFF/current/
+        update_frequency: continual
+      gebco_global_bathymetry:
+        source_url: https://www.bodc.ac.uk/data/open_download/gebco/gebco_2024/zip/
+        update_frequency: annual
+      noaa_ncei_coastal_relief:
+        source_url: https://www.ngdc.noaa.gov/thredds/catalog/crm/catalog.xml
+        update_frequency: static
+      boem_gom_bathymetry:
+        source_url: https://www.boem.gov/oil-gas-energy/mapping-and-data/map-gallery/northern-gom-deepwater-bathymetry-grid-3d-seismic
+        update_frequency: static

--- a/docs/data-sources/terrain/source-catalog.md
+++ b/docs/data-sources/terrain/source-catalog.md
@@ -1,0 +1,66 @@
+# Terrain & Bathymetry Public Source Catalog
+
+Issue [#930](https://github.com/vamseeachanta/worldenergydata/issues/930)
+(epic [#929](https://github.com/vamseeachanta/worldenergydata/issues/929),
+workstream A1). Machine-readable twin:
+[`src/worldenergydata/field_development/terrain_sources.yml`](../../../src/worldenergydata/field_development/terrain_sources.yml)
+(loaded and validated by `worldenergydata.field_development.terrain`).
+
+Consumers: the field-development layout/screening epic (digitalmodel#1507) and
+the onshore tracer (digitalmodel#1508 — needs the USGS 3DEP DEM path first).
+
+Every source below was verified live on **2026-07-10** (curl HEAD or a tiny
+sample download against the real endpoint — not documentation pages).
+
+## Verified sources
+
+| Source | Provider | Access | Format | Resolution | Coverage | License |
+|---|---|---|---|---|---|---|
+| USGS 3DEP seamless DEM (dynamic image service) | USGS | ArcGIS ImageServer `exportImage` (bbox → clipped raster) | GeoTIFF | best-available seamless (1/3 arc-sec ~10 m baseline; 1 m where lidar published) | Onshore US | US public domain |
+| USGS 3DEP staged tiles + TNM Access API | USGS | TNM products API + static S3 tiles | GeoTIFF | 1/3 arc-sec, 1°x1° tiles (~490 MB each) | Onshore US | US public domain |
+| GEBCO 2024 global grid | GEBCO / BODC | Static download (release-pinned URL) | netCDF | 15 arc-sec (~450 m) | Global | Public domain (attribution requested) |
+| NOAA NCEI Coastal Relief Model | NOAA NCEI | THREDDS (HTTPServer / OpenDAP / WCS / WMS) | netCDF | 3 arc-sec (~90 m) per coastal volume | US coastal zone incl. GoM | US public domain |
+| BOEM northern GoM deepwater bathymetry | BOEM | Static download (west/east GeoTIFF zips) | GeoTIFF | 40 x 40 ft (~12.2 m) | Northern GoM deepwater | US public domain |
+
+## Verification evidence (2026-07-10)
+
+- **USGS 3DEP dynamic service** — `exportImage` with
+  `bbox=-95.40,29.70,-95.30,29.80&bboxSR=4326&size=64,64&format=tiff&pixelType=F32&f=image`
+  returned HTTP 200 with a valid 64x64 float32 GeoTIFF (66,342 bytes).
+  Service metadata (`?f=json`) reports 3DEP DEM data published as of
+  2026-06-23.
+- **USGS 3DEP staged tiles** — TNM products API returned HTTP 200 JSON
+  (4 products for the test bbox); HEAD of tile `USGS_13_n30w096.tif` returned
+  HTTP 200, `image/tiff`, 487,781,914 bytes, Last-Modified 2026-06-24.
+- **GEBCO 2024** — HEAD of the BODC zip endpoint returned HTTP 200,
+  `application/zip`, `gebco_2024.zip`, 4,267,373,073 bytes. (A `gebco_2025`
+  path returned 404 on the verification date — 2024 is the latest release at
+  this endpoint; bump the release-pinned URL on new annual grids.)
+- **NOAA NCEI CRM** — THREDDS catalog XML returned HTTP 200 (HTTPServer /
+  OpenDAP / WCS / WMS services); a byte-range request on `crm_vol3.nc`
+  (Florida & eastern GoM) returned HTTP 206,
+  `Content-Range: bytes 0-0/570529124`, `application/x-netcdf`.
+- **BOEM GoM bathymetry** — HEAD of
+  `BOEM_Bathymetry_West_meters_tiff.zip` returned HTTP 200, 513,392,333 bytes;
+  `BOEM_Bathymetry_East_meters_tiff.zip` HTTP 200, 509,191,783 bytes (both
+  Last-Modified 2024-09-25).
+
+## Fetch helper
+
+```python
+from worldenergydata.field_development.terrain import fetch_dem
+
+# Clipped onshore-US DEM (WGS84 bbox) -> small GeoTIFF, no bulk tile download
+path = fetch_dem((-95.40, 29.70, -95.30, 29.80), size=(256, 256))
+```
+
+Endpoints are config-externalized in `terrain_sources.yml`; `fetch_dem`
+refuses unverified sources, sniffs the GeoTIFF magic (the ArcGIS service
+reports errors as HTTP-200 JSON), and defaults its output to the system temp
+directory. **Rasters are fetch-on-demand only — never commit them to git**
+(staged tiles ~490 MB, GEBCO ~4.3 GB, CRM volumes ~570 MB, BOEM halves
+~510 MB).
+
+Tests: `tests/modules/field_development/test_terrain.py` (offline by default;
+the live smoke test is opt-in via `WED_LIVE_NETWORK_TESTS=1` and the
+`network` marker).

--- a/src/worldenergydata/field_development/terrain.py
+++ b/src/worldenergydata/field_development/terrain.py
@@ -1,0 +1,226 @@
+# ABOUTME: Terrain/bathymetry public-source catalog loader + USGS 3DEP DEM fetch helper.
+# ABOUTME: Issue #930 (epic #929, A1) — public DEM path for the onshore tracer (digitalmodel#1508).
+"""
+worldenergydata.field_development.terrain
+=========================================
+
+Verified public terrain & bathymetry sources for field-development layout and
+screening, plus a small fetch helper for onshore US DEMs.
+
+All endpoints live in :data:`TERRAIN_SOURCES_PATH` (``terrain_sources.yml``,
+shipped next to this module) — **no URLs are hardcoded here**. Every catalog
+entry records the license, format, resolution and the live-verification
+evidence (``verified_on`` / ``verification``) for that source.
+
+The one network helper, :func:`fetch_dem`, clips an arbitrary bounding box
+from the USGS 3DEP dynamic image service and writes a small GeoTIFF — the
+public-DEM path the onshore tracer (digitalmodel#1508) needs. Bulk products
+(3DEP staged tiles, GEBCO, NOAA CRM, BOEM bathymetry) are catalogued for
+fetch-on-demand use; they are hundreds of MB to GB and must never be
+committed to git.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any, Optional
+
+import requests
+import yaml
+
+__all__ = [
+    "TERRAIN_SOURCES_PATH",
+    "TerrainFetchError",
+    "load_terrain_sources",
+    "fetch_dem",
+]
+
+TERRAIN_SOURCES_PATH = Path(__file__).parent / "terrain_sources.yml"
+
+#: Fields every catalog entry must carry (mirrors the texas_rrc source-catalog
+#: convention, PR #667, adapted to remote-endpoint sources).
+REQUIRED_SOURCE_FIELDS = {
+    "name",
+    "provider",
+    "canonical_url",
+    "access_method",
+    "endpoints",
+    "format",
+    "resolution",
+    "coverage",
+    "license",
+    "status",
+    "verified_on",
+    "verification",
+    "consumers",
+}
+
+VALID_STATUSES = {"verified", "not_verified"}
+
+#: GeoTIFF magic prefixes (little/big endian). The ArcGIS image service
+#: reports errors as HTTP-200 JSON bodies, so content sniffing is required.
+_TIFF_MAGICS = (b"II*\x00", b"MM\x00*")
+
+_DEFAULT_DEM_SOURCE = "usgs_3dep_dem"
+_DEFAULT_SIZE = (256, 256)
+_DEFAULT_TIMEOUT_S = 120.0
+
+
+class TerrainFetchError(RuntimeError):
+    """A terrain/bathymetry endpoint returned something other than the data."""
+
+
+def load_terrain_sources(
+    path: Optional[Path] = None,
+) -> dict[str, dict[str, Any]]:
+    """Load and validate the terrain/bathymetry source catalog.
+
+    Returns the ``sources`` mapping from ``terrain_sources.yml``. Raises
+    :class:`ValueError` if any entry is missing required fields or carries an
+    invalid status.
+    """
+    catalog_path = path or TERRAIN_SOURCES_PATH
+    with catalog_path.open("r", encoding="utf-8") as stream:
+        payload = yaml.safe_load(stream) or {}
+
+    sources = payload.get("sources", {})
+    if not isinstance(sources, dict) or not sources:
+        raise ValueError("terrain source catalog must contain a 'sources' mapping")
+    validate_terrain_sources(sources)
+    return sources
+
+
+def validate_terrain_sources(sources: dict[str, dict[str, Any]]) -> None:
+    """Validate catalog shape: required fields, status vocabulary, https URLs."""
+    for source_id, entry in sources.items():
+        if not isinstance(entry, dict):
+            raise ValueError(f"catalog entry '{source_id}' must be a mapping")
+
+        missing = REQUIRED_SOURCE_FIELDS.difference(entry)
+        if missing:
+            fields = ", ".join(sorted(missing))
+            raise ValueError(f"catalog entry '{source_id}' is missing: {fields}")
+
+        status = entry["status"]
+        if status not in VALID_STATUSES:
+            raise ValueError(
+                f"catalog entry '{source_id}' has invalid status: {status!r}"
+            )
+        if status == "verified" and not str(entry["verification"]).strip():
+            raise ValueError(
+                f"catalog entry '{source_id}' is 'verified' but records no "
+                "verification evidence"
+            )
+
+        endpoints = entry["endpoints"]
+        if not isinstance(endpoints, dict) or not endpoints:
+            raise ValueError(
+                f"catalog entry '{source_id}' must define an 'endpoints' mapping"
+            )
+        for key, url in endpoints.items():
+            if not str(url).startswith("https://"):
+                raise ValueError(
+                    f"catalog entry '{source_id}' endpoint '{key}' must be https"
+                )
+
+
+def _validate_bbox(bbox: tuple[float, float, float, float]) -> None:
+    if len(bbox) != 4:
+        raise ValueError("bbox must be (min_lon, min_lat, max_lon, max_lat)")
+    min_lon, min_lat, max_lon, max_lat = bbox
+    if not (-180.0 <= min_lon < max_lon <= 180.0):
+        raise ValueError(f"bbox longitudes invalid: {min_lon}..{max_lon}")
+    if not (-90.0 <= min_lat < max_lat <= 90.0):
+        raise ValueError(f"bbox latitudes invalid: {min_lat}..{max_lat}")
+
+
+def fetch_dem(
+    bbox: tuple[float, float, float, float],
+    out_path: Optional[Path] = None,
+    *,
+    size: tuple[int, int] = _DEFAULT_SIZE,
+    source_id: str = _DEFAULT_DEM_SOURCE,
+    catalog_path: Optional[Path] = None,
+    timeout: float = _DEFAULT_TIMEOUT_S,
+    session: Optional[requests.Session] = None,
+) -> Path:
+    """Fetch a clipped onshore-US DEM GeoTIFF for ``bbox`` (WGS84 degrees).
+
+    Parameters
+    ----------
+    bbox:
+        ``(min_lon, min_lat, max_lon, max_lat)`` in EPSG:4326.
+    out_path:
+        Destination file. Defaults to a deterministic name in the system
+        temp directory — DEM rasters are fetch-on-demand artifacts and must
+        not be committed to the repository.
+    size:
+        Output raster size ``(width, height)`` in pixels; the service clips
+        and resamples, so small sizes stay small on disk.
+    source_id:
+        Catalog entry to use; must be ``status: verified`` and expose an
+        ``export_image`` endpoint (default: USGS 3DEP dynamic image service).
+    catalog_path:
+        Override for the catalog YAML (tests use a tmp copy).
+    session:
+        Injectable ``requests.Session``-alike (anything with ``.get``) so
+        unit tests never touch the network.
+
+    Returns
+    -------
+    Path
+        Path of the written GeoTIFF.
+    """
+    _validate_bbox(bbox)
+    width, height = size
+    if width <= 0 or height <= 0:
+        raise ValueError(f"size must be positive pixels, got {size}")
+
+    sources = load_terrain_sources(catalog_path)
+    entry = sources.get(source_id)
+    if entry is None:
+        raise KeyError(f"unknown terrain source '{source_id}'")
+    if entry["status"] != "verified":
+        raise TerrainFetchError(
+            f"terrain source '{source_id}' is not verified; refusing to fetch"
+        )
+    export_url = entry["endpoints"].get("export_image")
+    if not export_url:
+        raise TerrainFetchError(
+            f"terrain source '{source_id}' has no 'export_image' endpoint"
+        )
+
+    if out_path is None:
+        min_lon, min_lat, max_lon, max_lat = bbox
+        stem = (
+            f"{source_id}_{min_lon:+08.3f}_{min_lat:+07.3f}"
+            f"_{max_lon:+08.3f}_{max_lat:+07.3f}_{width}x{height}"
+        ).replace(".", "p")
+        out_path = Path(tempfile.gettempdir()) / f"{stem}.tif"
+    out_path = Path(out_path)
+
+    params = {
+        "bbox": ",".join(f"{v:.6f}" for v in bbox),
+        "bboxSR": "4326",
+        "imageSR": "4326",
+        "size": f"{width},{height}",
+        "format": "tiff",
+        "pixelType": "F32",
+        "f": "image",
+    }
+    http = session or requests
+    response = http.get(export_url, params=params, timeout=timeout)
+    response.raise_for_status()
+
+    content = response.content
+    if not content.startswith(_TIFF_MAGICS):
+        excerpt = content[:200].decode("utf-8", errors="replace")
+        raise TerrainFetchError(
+            f"terrain source '{source_id}' did not return a GeoTIFF "
+            f"(the service reports errors as HTTP-200 JSON): {excerpt}"
+        )
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_bytes(content)
+    return out_path

--- a/src/worldenergydata/field_development/terrain_sources.yml
+++ b/src/worldenergydata/field_development/terrain_sources.yml
@@ -1,0 +1,140 @@
+# ABOUTME: Machine-readable catalog of VERIFIED public terrain/bathymetry sources.
+# ABOUTME: Issue #930 (epic #929, workstream A1) — endpoints for fetch helpers live here, not in code.
+#
+# Every entry with status: verified was checked live against the real endpoint
+# (curl HEAD / tiny sample download) on the date in verified_on. Do not add a
+# source here without re-running the verification and recording the evidence.
+#
+# Consumers: digitalmodel#1507 (field-development layout epic) and
+# digitalmodel#1508 (onshore tracer — needs usgs_3dep_dem first).
+
+sources:
+  usgs_3dep_dem:
+    name: "USGS 3DEP seamless DEM (dynamic image service)"
+    provider: "USGS 3D Elevation Program (3DEP)"
+    canonical_url: "https://elevation.nationalmap.gov/arcgis/rest/services/3DEPElevation/ImageServer"
+    access_method: "api_arcgis_image_server"
+    endpoints:
+      metadata: "https://elevation.nationalmap.gov/arcgis/rest/services/3DEPElevation/ImageServer?f=json"
+      export_image: "https://elevation.nationalmap.gov/arcgis/rest/services/3DEPElevation/ImageServer/exportImage"
+    format: "geotiff"
+    resolution: "Seamless best-available bare-earth DEM (1/3 arc-second ~10 m CONUS baseline; 1 m where lidar is published)"
+    coverage: "Onshore US — CONUS, Alaska, Hawaii, territories (partial Mexico/Canada border coverage)"
+    license: "US Government public domain (USGS 3DEP)"
+    status: "verified"
+    verified_on: "2026-07-10"
+    verification: >-
+      exportImage with bbox=-95.40,29.70,-95.30,29.80&bboxSR=4326&size=64,64
+      &format=tiff&pixelType=F32&f=image returned HTTP 200 with a valid 64x64
+      float32 little-endian GeoTIFF (66,342 bytes). Service metadata (f=json)
+      returned HTTP 200 and reports 3DEP DEM data published as of 2026-06-23.
+    consumers:
+      - "digitalmodel#1508"
+      - "digitalmodel#1507"
+    notes: >-
+      Preferred path for the onshore tracer: arbitrary bbox in, small clipped
+      GeoTIFF out — no 400+ MB tile downloads. WMS/WCS interfaces are also
+      enabled on the same service.
+
+  usgs_3dep_staged_tiles:
+    name: "USGS 3DEP staged 1-degree GeoTIFF tiles (1/3 arc-second) + TNM Access API"
+    provider: "USGS The National Map"
+    canonical_url: "https://prd-tnm.s3.amazonaws.com/StagedProducts/Elevation/13/TIFF/current/"
+    access_method: "api_tnm_products_plus_static_s3"
+    endpoints:
+      tnm_products_api: "https://tnmaccess.nationalmap.gov/api/v1/products"
+      staged_tile_template: "https://prd-tnm.s3.amazonaws.com/StagedProducts/Elevation/13/TIFF/current/{tile}/USGS_13_{tile}.tif"
+    format: "geotiff"
+    resolution: "1/3 arc-second (~10 m); 1x1 degree tiles"
+    coverage: "Onshore US — CONUS, Alaska, Hawaii, territories"
+    license: "US Government public domain (USGS 3DEP)"
+    status: "verified"
+    verified_on: "2026-07-10"
+    verification: >-
+      TNM products API query (datasets=National Elevation Dataset (NED) 1/3
+      arc-second, bbox=-95.40,29.70,-95.30,29.80) returned HTTP 200 JSON with
+      4 products. HEAD of staged tile n30w096 (USGS_13_n30w096.tif) returned
+      HTTP 200, Content-Type image/tiff, Content-Length 487,781,914 bytes,
+      Last-Modified 2026-06-24.
+    consumers:
+      - "digitalmodel#1508"
+      - "digitalmodel#1507"
+    notes: >-
+      Bulk path — full tiles are ~490 MB each; fetch on demand only, never
+      commit to git. Use usgs_3dep_dem (exportImage) for small clips.
+
+  gebco_global_bathymetry:
+    name: "GEBCO 2024 global bathymetry/topography grid"
+    provider: "GEBCO / British Oceanographic Data Centre (BODC)"
+    canonical_url: "https://www.gebco.net/data_and_products/gridded_bathymetry_data/"
+    access_method: "static_download"
+    endpoints:
+      global_grid_zip: "https://www.bodc.ac.uk/data/open_download/gebco/gebco_2024/zip/"
+    format: "netcdf"
+    resolution: "15 arc-second (~450 m) global grid"
+    coverage: "Global (ocean bathymetry + land topography)"
+    license: "Public domain (GEBCO grid is placed in the public domain; attribution requested)"
+    status: "verified"
+    verified_on: "2026-07-10"
+    verification: >-
+      HEAD of the BODC download endpoint returned HTTP 200, Content-Type
+      application/zip, Content-Disposition gebco_2024.zip, Content-Length
+      4,267,373,073 bytes (~4.3 GB).
+    consumers:
+      - "digitalmodel#1507"
+    notes: >-
+      Release-pinned URL (gebco_2024); bump the path when GEBCO publishes a
+      new annual grid (gebco_2025 path returned 404 on 2026-07-10 — 2024 is
+      the latest at this endpoint). ~4.3 GB: fetch on demand only.
+
+  noaa_ncei_coastal_relief:
+    name: "NOAA NCEI Coastal Relief Model (CRM)"
+    provider: "NOAA National Centers for Environmental Information (NCEI)"
+    canonical_url: "https://www.ngdc.noaa.gov/mgg/coastal/crm.html"
+    access_method: "api_thredds"
+    endpoints:
+      thredds_catalog: "https://www.ngdc.noaa.gov/thredds/catalog/crm/catalog.xml"
+      http_file_template: "https://www.ngdc.noaa.gov/thredds/fileServer/crm/{volume}.nc"
+      opendap_template: "https://www.ngdc.noaa.gov/thredds/dodsC/crm/{volume}.nc"
+    format: "netcdf"
+    resolution: "3 arc-second (~90 m), by coastal volume"
+    coverage: "US coastal zone (land-sea merged), incl. Gulf of Mexico volumes"
+    license: "US Government public domain (NOAA NCEI)"
+    status: "verified"
+    verified_on: "2026-07-10"
+    verification: >-
+      THREDDS catalog XML returned HTTP 200 listing HTTPServer/OpenDAP/WCS/WMS
+      services for "Coastal Relief Model by Volume". Range request (bytes 0-0)
+      on crm_vol3.nc (Florida & eastern Gulf of Mexico) returned HTTP 206 with
+      Content-Range bytes 0-0/570,529,124 and Content-Type application/x-netcdf.
+    consumers:
+      - "digitalmodel#1507"
+    notes: >-
+      OpenDAP/WCS on the same THREDDS server allow subsetting without pulling
+      the ~570 MB volume files. Volumes 3-5 cover the Gulf of Mexico coast.
+
+  boem_gom_bathymetry:
+    name: "BOEM northern Gulf of Mexico deepwater bathymetry grid (from 3D seismic)"
+    provider: "Bureau of Ocean Energy Management (BOEM)"
+    canonical_url: "https://www.boem.gov/oil-gas-energy/mapping-and-data/map-gallery/northern-gom-deepwater-bathymetry-grid-3d-seismic"
+    access_method: "static_download"
+    endpoints:
+      west_meters_geotiff_zip: "https://www.boem.gov/sites/default/files/Bathymetry/BOEM_Bathymetry_West_meters_tiff.zip"
+      east_meters_geotiff_zip: "https://www.boem.gov/sites/default/files/Bathymetry/BOEM_Bathymetry_East_meters_tiff.zip"
+    format: "geotiff"
+    resolution: "40 x 40 ft (~12.2 m) cells, from proprietary-derived 3D seismic (published grid is public)"
+    coverage: "Northern Gulf of Mexico deepwater (west + east halves)"
+    license: "US Government public domain (BOEM)"
+    status: "verified"
+    verified_on: "2026-07-10"
+    verification: >-
+      HEAD of BOEM_Bathymetry_West_meters_tiff.zip returned HTTP 200,
+      application/zip, 513,392,333 bytes; BOEM_Bathymetry_East_meters_tiff.zip
+      returned HTTP 200, application/zip, 509,191,783 bytes (both
+      Last-Modified 2024-09-25).
+    consumers:
+      - "digitalmodel#1507"
+    notes: >-
+      Highest-resolution public bathymetry for GoM deepwater field layout.
+      ~510 MB per half: fetch on demand only. Feet-unit and hillshade
+      variants exist at the same path prefix.

--- a/tests/modules/field_development/test_terrain.py
+++ b/tests/modules/field_development/test_terrain.py
@@ -1,0 +1,196 @@
+# ABOUTME: Tests for the terrain/bathymetry source catalog + fetch_dem helper (issue #930).
+# ABOUTME: Offline by default — network use is faked; one live smoke test is opt-in via marker.
+"""Tests for ``worldenergydata.field_development.terrain``."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from worldenergydata.field_development.terrain import (
+    REQUIRED_SOURCE_FIELDS,
+    TERRAIN_SOURCES_PATH,
+    TerrainFetchError,
+    fetch_dem,
+    load_terrain_sources,
+)
+
+HOUSTON_BBOX = (-95.40, 29.70, -95.30, 29.80)
+
+# ---------------------------------------------------------------------------
+# Catalog contract
+# ---------------------------------------------------------------------------
+
+
+class TestCatalog:
+    def test_catalog_ships_next_to_module(self):
+        assert TERRAIN_SOURCES_PATH.is_file()
+
+    def test_loads_and_validates(self):
+        sources = load_terrain_sources()
+        assert sources, "catalog must not be empty"
+        for entry in sources.values():
+            assert REQUIRED_SOURCE_FIELDS.issubset(entry)
+
+    def test_expected_source_families_present(self):
+        sources = load_terrain_sources()
+        for source_id in (
+            "usgs_3dep_dem",
+            "usgs_3dep_staged_tiles",
+            "gebco_global_bathymetry",
+            "noaa_ncei_coastal_relief",
+            "boem_gom_bathymetry",
+        ):
+            assert source_id in sources, f"missing source family: {source_id}"
+
+    def test_verified_entries_carry_evidence_and_date(self):
+        for source_id, entry in load_terrain_sources().items():
+            assert entry["status"] == "verified", source_id
+            assert str(entry["verification"]).strip(), source_id
+            assert str(entry["verified_on"]), source_id
+            assert str(entry["license"]).strip(), source_id
+
+    def test_all_endpoints_https(self):
+        for entry in load_terrain_sources().values():
+            for url in entry["endpoints"].values():
+                assert str(url).startswith("https://")
+
+    def test_dem_source_has_export_endpoint(self):
+        entry = load_terrain_sources()["usgs_3dep_dem"]
+        assert "export_image" in entry["endpoints"]
+
+    def test_missing_field_rejected(self, tmp_path: Path):
+        sources = load_terrain_sources()
+        broken = {"sources": {"bad": {"name": "incomplete"}}}
+        assert sources  # sanity: the real catalog loaded before we break a copy
+        bad_path = tmp_path / "broken.yml"
+        bad_path.write_text(yaml.safe_dump(broken), encoding="utf-8")
+        with pytest.raises(ValueError, match="is missing"):
+            load_terrain_sources(bad_path)
+
+    def test_invalid_status_rejected(self, tmp_path: Path):
+        catalog = yaml.safe_load(TERRAIN_SOURCES_PATH.read_text(encoding="utf-8"))
+        entry = catalog["sources"]["usgs_3dep_dem"]
+        entry["status"] = "maybe"
+        bad_path = tmp_path / "bad_status.yml"
+        bad_path.write_text(yaml.safe_dump({"sources": {"x": entry}}), encoding="utf-8")
+        with pytest.raises(ValueError, match="invalid status"):
+            load_terrain_sources(bad_path)
+
+
+# ---------------------------------------------------------------------------
+# fetch_dem — offline, via injected fake session
+# ---------------------------------------------------------------------------
+
+
+class FakeResponse:
+    def __init__(self, content: bytes, status_code: int = 200):
+        self.content = content
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class FakeSession:
+    """Duck-typed requests.Session capturing the outgoing call."""
+
+    def __init__(self, response: FakeResponse):
+        self._response = response
+        self.calls: list[tuple[str, dict]] = []
+
+    def get(self, url: str, params: dict, timeout: float) -> FakeResponse:
+        self.calls.append((url, params))
+        return self._response
+
+    def head(self, *a, **k):  # pragma: no cover - not used by fetch_dem
+        raise AssertionError("fetch_dem must not HEAD")
+
+
+TIFF_BYTES = b"II*\x00" + b"\x00" * 64
+
+
+class TestFetchDem:
+    def test_writes_geotiff_and_builds_request_from_catalog(self, tmp_path: Path):
+        session = FakeSession(FakeResponse(TIFF_BYTES))
+        out = tmp_path / "dem.tif"
+        result = fetch_dem(HOUSTON_BBOX, out, size=(64, 64), session=session)
+
+        assert result == out
+        assert out.read_bytes() == TIFF_BYTES
+
+        ((url, params),) = session.calls
+        catalog_url = load_terrain_sources()["usgs_3dep_dem"]["endpoints"][
+            "export_image"
+        ]
+        assert url == catalog_url  # endpoint comes from YAML, not code
+        assert params["bbox"] == "-95.400000,29.700000,-95.300000,29.800000"
+        assert params["size"] == "64,64"
+        assert params["format"] == "tiff"
+        assert params["f"] == "image"
+
+    def test_default_out_path_lands_in_tmp(self, tmp_path: Path):
+        session = FakeSession(FakeResponse(TIFF_BYTES))
+        result = fetch_dem(HOUSTON_BBOX, size=(32, 32), session=session)
+        try:
+            assert result.is_file()
+            assert result.suffix == ".tif"
+            assert "usgs_3dep_dem" in result.name
+        finally:
+            result.unlink(missing_ok=True)
+
+    def test_non_tiff_response_raises(self, tmp_path: Path):
+        session = FakeSession(FakeResponse(b'{"error": {"code": 400}}'))
+        with pytest.raises(TerrainFetchError, match="did not return a GeoTIFF"):
+            fetch_dem(HOUSTON_BBOX, tmp_path / "dem.tif", session=session)
+        assert not (tmp_path / "dem.tif").exists()
+
+    @pytest.mark.parametrize(
+        "bbox",
+        [
+            (-95.3, 29.7, -95.4, 29.8),  # min_lon > max_lon
+            (-95.4, 29.8, -95.3, 29.7),  # min_lat > max_lat
+            (-195.0, 29.7, -95.3, 29.8),  # lon out of range
+            (-95.4, 29.7, -95.3, 99.0),  # lat out of range
+        ],
+    )
+    def test_invalid_bbox_rejected(self, bbox):
+        with pytest.raises(ValueError):
+            fetch_dem(bbox, session=FakeSession(FakeResponse(TIFF_BYTES)))
+
+    def test_zero_size_rejected(self):
+        with pytest.raises(ValueError, match="size"):
+            fetch_dem(
+                HOUSTON_BBOX,
+                size=(0, 64),
+                session=FakeSession(FakeResponse(TIFF_BYTES)),
+            )
+
+    def test_unknown_source_rejected(self):
+        with pytest.raises(KeyError):
+            fetch_dem(
+                HOUSTON_BBOX,
+                source_id="nonexistent",
+                session=FakeSession(FakeResponse(TIFF_BYTES)),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Live smoke test — opt-in only (network marker + env gate)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.network
+@pytest.mark.skipif(
+    not os.environ.get("WED_LIVE_NETWORK_TESTS"),
+    reason="live endpoint check; set WED_LIVE_NETWORK_TESTS=1 to run",
+)
+def test_fetch_dem_live_smoke(tmp_path: Path):
+    out = fetch_dem(HOUSTON_BBOX, tmp_path / "live_dem.tif", size=(32, 32))
+    data = out.read_bytes()
+    assert data[:4] in (b"II*\x00", b"MM\x00*")
+    assert len(data) > 1000


### PR DESCRIPTION
## Summary
- Adds a machine-readable terrain/bathymetry source catalog (`src/worldenergydata/field_development/terrain_sources.yml`) with 5 live-verified public sources, each recording canonical URL, access method, format, resolution, license, and verification evidence dated 2026-07-10.
- Adds `worldenergydata.field_development.terrain`: catalog loader/validator + `fetch_dem(bbox) -> Path` against the USGS 3DEP dynamic image service (arbitrary bbox in, small clipped GeoTIFF out — the public-DEM path digitalmodel#1508 needs). Endpoints are config-externalized in the YAML; no URLs in code; GeoTIFF magic sniffing catches the service's HTTP-200 JSON errors.
- Human-readable twin at `docs/data-sources/terrain/source-catalog.md`; `terrain` module entry added to `data/catalog/source-registry.yml`.
- No rasters committed — all sources are fetch-on-demand (staged tiles ~490 MB, GEBCO ~4.3 GB, CRM ~570 MB/volume, BOEM ~510 MB/half).

Closes #930. Part of epic #929 (workstream A1). Unblocks digitalmodel#1508 / digitalmodel#1507.

## Verified sources (all endpoints hit live on 2026-07-10)
| Source | Endpoint verified | Evidence |
|---|---|---|
| USGS 3DEP dynamic image service | `exportImage` bbox clip | HTTP 200, valid 64x64 float32 GeoTIFF, 66,342 bytes; service metadata reports DEM data published 2026-06-23 |
| USGS 3DEP staged tiles + TNM API | products API + S3 tile HEAD | API HTTP 200 JSON (4 products); tile USGS_13_n30w096.tif HTTP 200, image/tiff, 487,781,914 B, Last-Modified 2026-06-24 |
| GEBCO 2024 global grid | BODC zip HEAD | HTTP 200, application/zip, gebco_2024.zip, 4,267,373,073 B (gebco_2025 path 404 — 2024 is latest) |
| NOAA NCEI Coastal Relief Model | THREDDS catalog + byte-range | catalog XML HTTP 200; crm_vol3.nc HTTP 206, bytes 0-0/570,529,124, application/x-netcdf |
| BOEM GoM deepwater bathymetry | west/east zip HEAD | HTTP 200, 513,392,333 B (west) / 509,191,783 B (east), Last-Modified 2024-09-25 |

Per the data-source flywheel, each family is filed as its own cat:data issue: #933 (USGS 3DEP), #934 (GEBCO), #935 (NOAA CRM), #936 (BOEM).

## Validation
- `PYTHONPATH='packages/worldenergydata-core/src:src' PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -o addopts='' --noconftest tests/modules/field_development/test_terrain.py -q` -> 17 passed, 1 skipped (opt-in live test)
- Live smoke (`WED_LIVE_NETWORK_TESTS=1`, network marker): passed — real 32x32 GeoTIFF fetched via `fetch_dem` (first attempt hit a transient USGS HTTP error; service is known to throttle)
- `black --check` / `isort --check-only` / `flake8 --max-line-length=100 --extend-ignore=E203,W503` on the new files -> clean