### PR TITLE
feat: past-projects field-development registry, GoM first (#931)

### DIFF
--- a/src/worldenergydata/field_development/past_projects.py
+++ b/src/worldenergydata/field_development/past_projects.py
@@ -1,0 +1,309 @@
+# ABOUTME: Past-projects registry loader + query API (selectable historical developments).
+# ABOUTME: Issue #931 (epic #929, A2) — GoM first, derived ONLY from in-repo data sources.
+"""
+worldenergydata.field_development.past_projects
+===============================================
+
+Historical field-development projects as machine-readable, selectable lists —
+filterable by region, operator, and water-depth class. Gulf of Mexico first;
+the ``worldwide`` region is structured but deliberately empty (later slice of
+epic #929).
+
+All entries live in :data:`PAST_PROJECTS_PATH` (``past_projects.yml``, shipped
+next to this module) — **no project data is hardcoded here**.
+
+Derivation & provenance
+-----------------------
+Every catalog entry is derived from data already in this repo and lists its
+sources (repo-relative paths) under ``sources``:
+
+* ``config/fields.yml`` — the CANONICAL field-identity registry (epic #754):
+  ``project_id`` == ``canonical_id``, display name, play, BSEE area/blocks.
+  This module adds **no parallel identity mappings**.
+* ``config/ong_field_development/fields_registry.yml`` — auto-generated
+  BOEM/BSEE-backed attribute registry: operator, water depth, status,
+  first oil, development system, facility.
+* ``packages/worldenergydata-bsee/.../buckskin/buckskin_config.py`` — BSEE
+  WAR/LAB-derived Buckskin field config (the one canonical field absent from
+  the auto-generated registry).
+
+No fabrication: where a source does not state an attribute it is ``null`` in
+the catalog (with a ``notes`` explanation) and ``None`` on the record. The
+contract tests assert both provenance completeness (every entry has sources
+that exist in the repo) and coherence with the upstream registries.
+
+Water-depth classes follow the BOEM convention: ``shallow`` < 1,000 ft,
+``deepwater`` 1,000–4,999 ft, ``ultra_deepwater`` >= 5,000 ft.
+
+Usage::
+
+    from worldenergydata.field_development.past_projects import past_projects
+
+    past_projects(region="gulf_of_mexico")
+    past_projects(operator="Chevron")
+    past_projects(water_depth_class="ultra_deepwater", status="producing")
+
+This module is intentionally NOT exported from the package ``__init__`` (same
+as ``terrain``): import it directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+__all__ = [
+    "PAST_PROJECTS_PATH",
+    "REQUIRED_PROJECT_FIELDS",
+    "VALID_STATUSES",
+    "WATER_DEPTH_CLASSES",
+    "PastProject",
+    "classify_water_depth",
+    "load_past_projects",
+    "past_projects",
+    "past_project_operators",
+    "past_project_regions",
+]
+
+PAST_PROJECTS_PATH = Path(__file__).parent / "past_projects.yml"
+
+#: Keys every catalog entry must carry (nullable ones may be ``null``, but the
+#: key itself must be present so gaps are explicit, never silent).
+REQUIRED_PROJECT_FIELDS = {
+    "project_id",
+    "display_name",
+    "operator",
+    "water_depth_ft",
+    "development_system",
+    "facility",
+    "status",
+    "first_oil_year",
+    "play",
+    "bsee_area_blocks",
+    "sources",
+}
+
+#: Status vocabulary, exactly as used by the upstream attribute registry
+#: (``config/ong_field_development/fields_registry.yml``). ``None`` = unknown.
+VALID_STATUSES = {"producing", "non_producing", "pre-FID", "decommissioned"}
+
+#: BOEM water-depth convention (feet): deepwater >= 1,000 ft,
+#: ultra-deepwater >= 5,000 ft.
+WATER_DEPTH_CLASSES = ("shallow", "deepwater", "ultra_deepwater")
+_DEEPWATER_MIN_FT = 1_000
+_ULTRA_DEEPWATER_MIN_FT = 5_000
+
+
+def classify_water_depth(water_depth_ft: Optional[float]) -> Optional[str]:
+    """Classify a water depth (ft) per the BOEM convention.
+
+    Returns ``"shallow"`` (< 1,000 ft), ``"deepwater"`` (1,000–4,999 ft) or
+    ``"ultra_deepwater"`` (>= 5,000 ft); ``None`` in -> ``None`` out (unknown
+    depth is never classified).
+    """
+    if water_depth_ft is None:
+        return None
+    if water_depth_ft >= _ULTRA_DEEPWATER_MIN_FT:
+        return "ultra_deepwater"
+    if water_depth_ft >= _DEEPWATER_MIN_FT:
+        return "deepwater"
+    return "shallow"
+
+
+@dataclass(frozen=True)
+class PastProject:
+    """One historical field-development project (identity per fields.yml)."""
+
+    project_id: str
+    display_name: str
+    region: str
+    region_display_name: str
+    operator: Optional[str]
+    water_depth_ft: Optional[float]
+    development_system: Optional[str]
+    facility: Optional[str]
+    status: Optional[str]
+    first_oil_year: Optional[int]
+    play: Optional[str]
+    bsee_area_blocks: tuple[str, ...]
+    sources: tuple[str, ...]
+    notes: Optional[str] = None
+
+    @property
+    def water_depth_class(self) -> Optional[str]:
+        """BOEM water-depth class derived from ``water_depth_ft`` (or None)."""
+        return classify_water_depth(self.water_depth_ft)
+
+
+def _validate_entry(region_key: str, raw: dict[str, Any]) -> None:
+    missing = REQUIRED_PROJECT_FIELDS - raw.keys()
+    if missing:
+        raise ValueError(
+            f"past_projects.yml entry {raw.get('project_id')!r} in region "
+            f"{region_key!r} is missing required fields: {sorted(missing)}"
+        )
+    if not raw["project_id"] or not raw["display_name"]:
+        raise ValueError(
+            f"past_projects.yml entry in region {region_key!r} has an empty "
+            "project_id/display_name"
+        )
+    sources = raw["sources"]
+    if not isinstance(sources, list) or not sources:
+        raise ValueError(
+            f"past_projects.yml entry {raw['project_id']!r} has no sources — "
+            "every entry must trace to at least one in-repo data source"
+        )
+    status = raw["status"]
+    if status is not None and status not in VALID_STATUSES:
+        raise ValueError(
+            f"past_projects.yml entry {raw['project_id']!r} carries invalid "
+            f"status {status!r} (expected one of {sorted(VALID_STATUSES)} or null)"
+        )
+    depth = raw["water_depth_ft"]
+    if depth is not None and (not isinstance(depth, (int, float)) or depth <= 0):
+        raise ValueError(
+            f"past_projects.yml entry {raw['project_id']!r} carries invalid "
+            f"water_depth_ft {depth!r} (expected positive number or null)"
+        )
+
+
+def load_past_projects(path: Optional[Path] = None) -> list[PastProject]:
+    """Load and validate the past-projects catalog (all regions).
+
+    Returns records in file order. Raises :class:`ValueError` on a malformed
+    catalog: missing required keys, empty/missing ``sources``, an unknown
+    ``status``, a non-positive water depth, or a duplicate ``project_id``.
+    """
+    catalog_path = Path(path) if path is not None else PAST_PROJECTS_PATH
+    data = yaml.safe_load(catalog_path.read_text(encoding="utf-8")) or {}
+    regions = data.get("regions")
+    if not isinstance(regions, dict):
+        raise ValueError(
+            f"past-projects catalog {catalog_path} has no 'regions' mapping"
+        )
+
+    projects: list[PastProject] = []
+    seen: set[str] = set()
+    for region_key, region in regions.items():
+        region = region or {}
+        region_display = str(region.get("display_name") or region_key)
+        for raw in region.get("projects") or []:
+            _validate_entry(region_key, raw)
+            project_id = raw["project_id"]
+            if project_id in seen:
+                raise ValueError(
+                    f"Duplicate project_id in past_projects.yml: {project_id!r}"
+                )
+            seen.add(project_id)
+            projects.append(
+                PastProject(
+                    project_id=project_id,
+                    display_name=raw["display_name"],
+                    region=region_key,
+                    region_display_name=region_display,
+                    operator=raw["operator"],
+                    water_depth_ft=raw["water_depth_ft"],
+                    development_system=raw["development_system"],
+                    facility=raw["facility"],
+                    status=raw["status"],
+                    first_oil_year=raw["first_oil_year"],
+                    play=raw["play"],
+                    bsee_area_blocks=tuple(raw["bsee_area_blocks"] or ()),
+                    sources=tuple(raw["sources"]),
+                    notes=raw.get("notes"),
+                )
+            )
+    return projects
+
+
+def _norm(value: str) -> str:
+    return " ".join(value.split()).lower()
+
+
+def past_projects(
+    region: Optional[str] = None,
+    operator: Optional[str] = None,
+    water_depth_class: Optional[str] = None,
+    status: Optional[str] = None,
+    path: Optional[Path] = None,
+) -> list[PastProject]:
+    """Selectable list of past projects, optionally filtered.
+
+    Args:
+        region: Region key (``"gulf_of_mexico"``) or region display name
+            (``"US Gulf of Mexico"``); case-insensitive.
+        operator: Operator name, case-insensitive exact match. Entries whose
+            operator is unknown (``None``) never match an operator filter.
+        water_depth_class: One of :data:`WATER_DEPTH_CLASSES`; raises
+            :class:`ValueError` on anything else (fail loud on typos).
+            Entries with unknown water depth never match a class filter.
+        status: One of :data:`VALID_STATUSES` (case-insensitive); raises
+            :class:`ValueError` on anything else. Unknown status (``None``)
+            never matches.
+        path: Optional alternate catalog path (tests).
+
+    Returns:
+        Matching records in catalog order. Unknown region/operator values
+        return an empty list (fail-closed — nothing is invented).
+    """
+    if water_depth_class is not None and water_depth_class not in WATER_DEPTH_CLASSES:
+        raise ValueError(
+            f"Unknown water_depth_class {water_depth_class!r} "
+            f"(expected one of {list(WATER_DEPTH_CLASSES)})"
+        )
+    status_key: Optional[str] = None
+    if status is not None:
+        by_norm = {_norm(s): s for s in VALID_STATUSES}
+        status_key = by_norm.get(_norm(status))
+        if status_key is None:
+            raise ValueError(
+                f"Unknown status {status!r} (expected one of {sorted(VALID_STATUSES)})"
+            )
+
+    selected = []
+    for project in load_past_projects(path=path):
+        if region is not None and _norm(region) not in (
+            _norm(project.region),
+            _norm(project.region_display_name),
+        ):
+            continue
+        if operator is not None and (
+            project.operator is None or _norm(project.operator) != _norm(operator)
+        ):
+            continue
+        if (
+            water_depth_class is not None
+            and project.water_depth_class != water_depth_class
+        ):
+            continue
+        if status_key is not None and project.status != status_key:
+            continue
+        selected.append(project)
+    return selected
+
+
+def past_project_operators(
+    region: Optional[str] = None, path: Optional[Path] = None
+) -> list[str]:
+    """Sorted unique operator names (for selection UIs). Nulls are omitted."""
+    return sorted(
+        {
+            p.operator
+            for p in past_projects(region=region, path=path)
+            if p.operator is not None
+        }
+    )
+
+
+def past_project_regions(path: Optional[Path] = None) -> dict[str, str]:
+    """Region key -> display name for every region in the catalog (incl. empty)."""
+    catalog_path = Path(path) if path is not None else PAST_PROJECTS_PATH
+    data = yaml.safe_load(catalog_path.read_text(encoding="utf-8")) or {}
+    regions = data.get("regions") or {}
+    return {
+        key: str((region or {}).get("display_name") or key)
+        for key, region in regions.items()
+    }

--- a/src/worldenergydata/field_development/past_projects.yml
+++ b/src/worldenergydata/field_development/past_projects.yml
@@ -1,0 +1,220 @@
+# ABOUTME: Past-projects registry — historical field developments as selectable lists.
+# ABOUTME: Issue #931 (epic #929, workstream A2) — Gulf of Mexico first, worldwide later.
+#
+# PROVENANCE DISCIPLINE — every entry, and every attribute on it, traces to a
+# data source ALREADY IN THIS REPO (listed per-entry under `sources`, paths
+# relative to the repo root). Nothing here is fabricated: where a repo source
+# does not state an attribute (operator, status, ...) it is `null`, with the
+# gap called out in `notes`. Do not fill a null from memory or the open web —
+# extend the upstream source first, then mirror it here.
+#
+# Identity: `project_id` == `canonical_id` in config/fields.yml (the canonical
+# field-identity registry, epic #754 / issue #755). This catalog adds NO new
+# identity mappings; display names and BSEE area/blocks are mirrored from
+# fields.yml and contract-tested against it (test_past_projects.py).
+#
+# Attribute sources (Gulf of Mexico slice):
+#   config/fields.yml                                  identity, play, BSEE area/blocks
+#   config/ong_field_development/fields_registry.yml   operator, water_depth_ft, status,
+#                                                      first oil, dev system, facility
+#                                                      (auto-generated from BOEM fields +
+#                                                      BSEE lease mapping + validated
+#                                                      golden_baseline_v30 economics)
+#   packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/buckskin/buckskin_config.py
+#                                                      Buckskin attributes (BSEE WAR/LAB-
+#                                                      derived field config)
+#
+# `worldwide` is deliberately EMPTY: the structure for later slices of epic
+# #929 is in place, but entries are only added when a repo data source exists
+# to derive them from.
+#
+# Consumers: digitalmodel#1507 (field-development layout epic).
+
+regions:
+  gulf_of_mexico:
+    display_name: "US Gulf of Mexico"
+    projects:
+      - project_id: stones
+        display_name: "Stones"
+        operator: "Shell"
+        water_depth_ft: 9525
+        development_system: subsea15
+        facility: "FPSO Turritella (disconnectable turret-moored)"
+        status: producing
+        first_oil_year: 2016
+        play: "Lower Tertiary Wilcox"
+        bsee_area_blocks: [WR508]
+        sources:
+          - config/fields.yml
+          - config/ong_field_development/fields_registry.yml
+        notes: null
+
+      - project_id: cascade_chinook
+        display_name: "Cascade/Chinook"
+        operator: "Petrobras America"
+        water_depth_ft: 8200
+        development_system: subsea15
+        facility: "FPSO BW Pioneer (first US-GoM FPSO)"
+        status: producing
+        first_oil_year: 2014
+        play: "Lower Tertiary (Wilcox)"
+        bsee_area_blocks: [WR205, WR206, WR469, WR470]
+        sources:
+          - config/fields.yml
+          - config/ong_field_development/fields_registry.yml
+        notes: null
+
+      - project_id: jack_st_malo
+        display_name: "Jack/St. Malo"
+        operator: "Chevron"
+        water_depth_ft: 7240
+        development_system: subsea15
+        facility: "deep-draft semisubmersible FPU + subsea tiebacks (up to ~15 mi)"
+        status: producing
+        first_oil_year: 2014
+        play: "Lower Tertiary (Wilcox)"
+        bsee_area_blocks: [WR678, WR758, WR759]
+        sources:
+          - config/fields.yml
+          - config/ong_field_development/fields_registry.yml
+        notes: null
+
+      - project_id: julia
+        display_name: "Julia"
+        operator: "ExxonMobil"
+        water_depth_ft: 7335
+        development_system: tieback15
+        facility: "subsea tieback to Chevron Jack/St. Malo semi host (~15 mi)"
+        status: producing
+        first_oil_year: 2016
+        play: "Lower Tertiary Wilcox"
+        bsee_area_blocks: [WR627]
+        sources:
+          - config/fields.yml
+          - config/ong_field_development/fields_registry.yml
+        notes: null
+
+      - project_id: big_foot
+        display_name: "Big Foot"
+        operator: "Chevron"
+        water_depth_ft: 5190
+        development_system: dry
+        facility: "extended tension-leg platform (ETLP), 15-slot"
+        status: producing
+        first_oil_year: 2018
+        play: "Wilcox / Lower Tertiary"
+        bsee_area_blocks: [WR029]
+        sources:
+          - config/fields.yml
+          - config/ong_field_development/fields_registry.yml
+        notes: null
+
+      - project_id: anchor
+        display_name: "Anchor"
+        operator: "Chevron"
+        water_depth_ft: 5080
+        development_system: subsea20
+        facility: "semisubmersible FPU, 7-well subsea — industry-first 20,000 psi (20K)"
+        status: producing
+        first_oil_year: 2024
+        play: "Lower Tertiary Wilcox"
+        bsee_area_blocks: [GC807]
+        sources:
+          - config/fields.yml
+          - config/ong_field_development/fields_registry.yml
+        notes: null
+
+      - project_id: shenandoah
+        display_name: "Shenandoah"
+        operator: null
+        water_depth_ft: 5800
+        development_system: subsea20
+        facility: null
+        status: producing
+        first_oil_year: 2025
+        play: "Wilcox (Lower Tertiary)"
+        bsee_area_blocks: [WR051]
+        sources:
+          - config/fields.yml
+          - config/ong_field_development/fields_registry.yml
+        notes: >-
+          Operator/facility not recorded in the repo attribute source
+          (fields_registry.yml public_metadata absent) — left null.
+
+      - project_id: buckskin
+        display_name: "Buckskin"
+        operator: "LLOG Exploration"
+        water_depth_ft: 6800
+        development_system: null
+        facility: "Lucius Spar (subsea tieback host)"
+        status: null
+        first_oil_year: 2019
+        play: "Lower Tertiary / Wilcox"
+        bsee_area_blocks: [KC785, KC828, KC829, KC830, KC871, KC872]
+        sources:
+          - config/fields.yml
+          - packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/buckskin/buckskin_config.py
+        notes: >-
+          Attributes from buckskin_config.py (BSEE WAR/LAB-derived): operator =
+          development operator at sanction/first oil per operator_history (LLOG
+          2018 sanction, 2019 first oil; Harbour Energy acquisition 2026);
+          host_facility = Lucius Spar. Not in fields_registry.yml, so
+          development_system (dev-system taxonomy) and current status are not
+          stated by any repo source — left null.
+
+      - project_id: kaskida
+        display_name: "Kaskida"
+        operator: null
+        water_depth_ft: 5860
+        development_system: subsea20
+        facility: null
+        status: pre-FID
+        first_oil_year: null
+        play: "Lower Tertiary (Wilcox)"
+        bsee_area_blocks: [KC291, KC292]
+        sources:
+          - config/fields.yml
+          - config/ong_field_development/fields_registry.yml
+        notes: >-
+          pre-FID in the repo attribute source: no operator/facility/first-oil
+          recorded — left null.
+
+      - project_id: tiber
+        display_name: "Tiber"
+        operator: null
+        water_depth_ft: 4130
+        development_system: subsea20
+        facility: null
+        status: pre-FID
+        first_oil_year: null
+        play: "Wilcox (Lower Tertiary / Paleogene)"
+        bsee_area_blocks: [KC102]
+        sources:
+          - config/fields.yml
+          - config/ong_field_development/fields_registry.yml
+        notes: >-
+          pre-FID in the repo attribute source: no operator/facility/first-oil
+          recorded — left null.
+
+      - project_id: north_platte
+        display_name: "North Platte (renamed Sparta)"
+        operator: null
+        water_depth_ft: 5840
+        development_system: subsea20
+        facility: null
+        status: non_producing
+        first_oil_year: null
+        play: "Wilcox (Lower Tertiary / Paleogene)"
+        bsee_area_blocks: [GB915, GB916, GB958, GB959]
+        sources:
+          - config/fields.yml
+          - config/ong_field_development/fields_registry.yml
+        notes: >-
+          non_producing in the repo attribute source: no operator/facility/
+          first-oil recorded — left null.
+
+  # Later slice of epic #929 — structure only. Populate ONLY from repo data
+  # sources (e.g. sodir/ANP/UKCS pipeline outputs), never from memory.
+  worldwide:
+    display_name: "Worldwide (structure only — later slice of epic #929)"
+    projects: []

--- a/tests/modules/field_development/test_past_projects.py
+++ b/tests/modules/field_development/test_past_projects.py
@@ -1,0 +1,290 @@
+# ABOUTME: Tests for the past-projects registry catalog + query API (issue #931).
+# ABOUTME: Offline only — loader, filters, provenance completeness, null handling.
+"""Tests for ``worldenergydata.field_development.past_projects``."""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pytest
+import yaml
+
+from worldenergydata.field_development.past_projects import (
+    PAST_PROJECTS_PATH,
+    REQUIRED_PROJECT_FIELDS,
+    VALID_STATUSES,
+    WATER_DEPTH_CLASSES,
+    classify_water_depth,
+    load_past_projects,
+    past_project_operators,
+    past_project_regions,
+    past_projects,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIELDS_YML = REPO_ROOT / "config" / "fields.yml"
+ATTR_REGISTRY_YML = (
+    REPO_ROOT / "config" / "ong_field_development" / "fields_registry.yml"
+)
+
+
+def _raw_catalog() -> dict:
+    return yaml.safe_load(PAST_PROJECTS_PATH.read_text(encoding="utf-8"))
+
+
+def _write(tmp_path: Path, catalog: dict) -> Path:
+    p = tmp_path / "catalog.yml"
+    p.write_text(yaml.safe_dump(catalog), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Catalog contract
+# ---------------------------------------------------------------------------
+
+
+class TestCatalog:
+    def test_catalog_ships_next_to_module(self):
+        assert PAST_PROJECTS_PATH.is_file()
+
+    def test_loads_and_is_nonempty(self):
+        projects = load_past_projects()
+        assert projects, "catalog must not be empty"
+
+    def test_every_entry_carries_required_fields(self):
+        for region in _raw_catalog()["regions"].values():
+            for raw in region.get("projects") or []:
+                assert REQUIRED_PROJECT_FIELDS.issubset(raw), raw.get("project_id")
+
+    def test_gom_region_present_and_populated(self):
+        gom = past_projects(region="gulf_of_mexico")
+        assert len(gom) >= 10
+        assert {p.project_id for p in gom} == {
+            p.project_id for p in load_past_projects()
+        }, "GoM is currently the only populated region"
+
+    def test_worldwide_region_structured_but_empty(self):
+        regions = past_project_regions()
+        assert "worldwide" in regions, "worldwide slice must be structured for later"
+        assert past_projects(region="worldwide") == []
+
+
+# ---------------------------------------------------------------------------
+# Provenance discipline
+# ---------------------------------------------------------------------------
+
+
+class TestProvenance:
+    def test_every_entry_has_at_least_one_source(self):
+        for p in load_past_projects():
+            assert p.sources, f"{p.project_id} has no provenance sources"
+
+    def test_every_source_path_exists_in_repo(self):
+        for p in load_past_projects():
+            for source in p.sources:
+                assert (REPO_ROOT / source).is_file(), (
+                    f"{p.project_id} cites a source that does not exist in the "
+                    f"repo: {source}"
+                )
+
+    def test_every_project_resolves_in_canonical_fields_yml(self):
+        """project_id == canonical_id in fields.yml — no parallel identities."""
+        canonical = {
+            f["canonical_id"]: f
+            for f in yaml.safe_load(FIELDS_YML.read_text(encoding="utf-8"))["fields"]
+        }
+        for p in load_past_projects():
+            assert (
+                p.project_id in canonical
+            ), f"{p.project_id} is not a canonical_id in config/fields.yml"
+            field = canonical[p.project_id]
+            assert p.display_name == field["display_name"], p.project_id
+            assert set(p.bsee_area_blocks) == set(
+                field["bsee"]["area_blocks"]
+            ), p.project_id
+            assert p.play == field["play"], p.project_id
+
+    def test_attributes_cohere_with_upstream_registry(self):
+        """Where an entry cites fields_registry.yml, its attributes match it."""
+        upstream = yaml.safe_load(ATTR_REGISTRY_YML.read_text(encoding="utf-8"))[
+            "fields"
+        ]
+        checked = 0
+        for p in load_past_projects():
+            if "config/ong_field_development/fields_registry.yml" not in p.sources:
+                continue
+            src = upstream[p.project_id]
+            assert p.water_depth_ft == src["water_depth_ft"], p.project_id
+            assert p.status == src.get("status"), p.project_id
+            assert p.operator == src.get("public_metadata", {}).get(
+                "operator"
+            ), p.project_id
+            first_oil = src.get("first_oil")
+            expected_year = int(str(first_oil)[:4]) if first_oil else None
+            assert p.first_oil_year == expected_year, p.project_id
+            assert p.development_system == src.get("dev_system"), p.project_id
+            checked += 1
+        assert checked >= 10, "expected the whole GoM slice to be cross-checked"
+
+    def test_null_attributes_carry_an_explanatory_note(self):
+        nullable = (
+            "operator",
+            "facility",
+            "status",
+            "first_oil_year",
+            "development_system",
+        )
+        for p in load_past_projects():
+            if any(getattr(p, attr) is None for attr in nullable):
+                assert (
+                    p.notes
+                ), f"{p.project_id} has null attributes but no provenance note"
+
+
+# ---------------------------------------------------------------------------
+# Water-depth classification
+# ---------------------------------------------------------------------------
+
+
+class TestWaterDepthClass:
+    def test_boem_thresholds(self):
+        assert classify_water_depth(400) == "shallow"
+        assert classify_water_depth(999) == "shallow"
+        assert classify_water_depth(1000) == "deepwater"
+        assert classify_water_depth(4999) == "deepwater"
+        assert classify_water_depth(5000) == "ultra_deepwater"
+        assert classify_water_depth(9525) == "ultra_deepwater"
+
+    def test_none_depth_is_never_classified(self):
+        assert classify_water_depth(None) is None
+
+    def test_every_class_is_in_the_declared_vocabulary(self):
+        for p in load_past_projects():
+            assert p.water_depth_class in WATER_DEPTH_CLASSES or (
+                p.water_depth_class is None and p.water_depth_ft is None
+            )
+
+
+# ---------------------------------------------------------------------------
+# Query API / filters
+# ---------------------------------------------------------------------------
+
+
+class TestFilters:
+    def test_no_filters_returns_everything(self):
+        assert len(past_projects()) == len(load_past_projects())
+
+    def test_region_accepts_key_and_display_name(self):
+        by_key = past_projects(region="gulf_of_mexico")
+        by_name = past_projects(region="US Gulf of Mexico")
+        by_case = past_projects(region="Gulf_Of_Mexico")
+        assert by_key and by_key == by_name == by_case
+
+    def test_unknown_region_fails_closed(self):
+        assert past_projects(region="atlantis_basin") == []
+
+    def test_operator_filter_case_insensitive(self):
+        chevron = past_projects(operator="chevron")
+        assert {p.project_id for p in chevron} == {
+            "anchor",
+            "jack_st_malo",
+            "big_foot",
+        }
+
+    def test_operator_filter_never_matches_null_operators(self):
+        assert past_projects(operator="Chevron") == [
+            p for p in past_projects(operator="Chevron") if p.operator is not None
+        ]
+        assert past_projects(operator="Unknown Operator LLC") == []
+
+    def test_water_depth_class_filter(self):
+        deep = past_projects(water_depth_class="deepwater")
+        ultra = past_projects(water_depth_class="ultra_deepwater")
+        assert {p.project_id for p in deep} == {"tiber"}
+        assert all(p.water_depth_ft >= 5000 for p in ultra)
+        assert past_projects(water_depth_class="shallow") == []
+
+    def test_invalid_water_depth_class_raises(self):
+        with pytest.raises(ValueError, match="water_depth_class"):
+            past_projects(water_depth_class="abyssal")
+
+    def test_status_filter_case_insensitive_and_validated(self):
+        producing = past_projects(status="producing")
+        assert {p.project_id for p in past_projects(status="pre-fid")} == {
+            "kaskida",
+            "tiber",
+        }
+        assert all(p.status == "producing" for p in producing)
+        with pytest.raises(ValueError, match="status"):
+            past_projects(status="abandoned-maybe")
+
+    def test_filters_compose(self):
+        rows = past_projects(
+            region="gulf_of_mexico",
+            operator="Chevron",
+            water_depth_class="ultra_deepwater",
+            status="producing",
+        )
+        assert {p.project_id for p in rows} == {"anchor", "jack_st_malo", "big_foot"}
+
+    def test_operator_selectable_list(self):
+        operators = past_project_operators(region="gulf_of_mexico")
+        assert operators == sorted(operators)
+        assert "Chevron" in operators
+        assert None not in operators
+
+
+# ---------------------------------------------------------------------------
+# Loader validation (malformed catalogs are rejected loudly)
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_missing_required_field_rejected(self, tmp_path: Path):
+        catalog = copy.deepcopy(_raw_catalog())
+        gom = catalog["regions"]["gulf_of_mexico"]["projects"]
+        del gom[0]["water_depth_ft"]
+        with pytest.raises(ValueError, match="missing required fields"):
+            load_past_projects(_write(tmp_path, catalog))
+
+    def test_empty_sources_rejected(self, tmp_path: Path):
+        catalog = copy.deepcopy(_raw_catalog())
+        catalog["regions"]["gulf_of_mexico"]["projects"][0]["sources"] = []
+        with pytest.raises(ValueError, match="no sources"):
+            load_past_projects(_write(tmp_path, catalog))
+
+    def test_invalid_status_rejected(self, tmp_path: Path):
+        catalog = copy.deepcopy(_raw_catalog())
+        catalog["regions"]["gulf_of_mexico"]["projects"][0]["status"] = "maybe"
+        with pytest.raises(ValueError, match="invalid status"):
+            load_past_projects(_write(tmp_path, catalog))
+        assert "maybe" not in VALID_STATUSES
+
+    def test_duplicate_project_id_rejected(self, tmp_path: Path):
+        catalog = copy.deepcopy(_raw_catalog())
+        gom = catalog["regions"]["gulf_of_mexico"]["projects"]
+        gom.append(copy.deepcopy(gom[0]))
+        with pytest.raises(ValueError, match="Duplicate project_id"):
+            load_past_projects(_write(tmp_path, catalog))
+
+    def test_negative_water_depth_rejected(self, tmp_path: Path):
+        catalog = copy.deepcopy(_raw_catalog())
+        catalog["regions"]["gulf_of_mexico"]["projects"][0]["water_depth_ft"] = -10
+        with pytest.raises(ValueError, match="water_depth_ft"):
+            load_past_projects(_write(tmp_path, catalog))
+
+    def test_missing_regions_mapping_rejected(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="regions"):
+            load_past_projects(_write(tmp_path, {"projects": []}))
+
+    def test_null_handling_round_trips(self):
+        by_id = {p.project_id: p for p in load_past_projects()}
+        kaskida = by_id["kaskida"]
+        assert kaskida.operator is None
+        assert kaskida.first_oil_year is None
+        assert kaskida.water_depth_class == "ultra_deepwater"
+        buckskin = by_id["buckskin"]
+        assert buckskin.status is None
+        assert buckskin.development_system is None
+        assert buckskin.first_oil_year == 2019


### PR DESCRIPTION
Closes #931. Part of epic #929 (workstream A2). Consumer: digitalmodel#1507.

## What

Historical field-development projects as machine-readable, **selectable lists** — filterable by region, operator, water-depth class, and status. Gulf of Mexico first; a `worldwide` region is structured but deliberately empty (later slice of #929).

- `src/worldenergydata/field_development/past_projects.yml` — the catalog (ships next to the module, same pattern as `terrain_sources.yml` from #930). **11 US GoM projects.**
- `src/worldenergydata/field_development/past_projects.py` — loader + query API:
  - `past_projects(region=..., operator=..., water_depth_class=..., status=...) -> list[PastProject]` (frozen dataclass record; fail-closed on unknown values, fail-loud `ValueError` on invalid filter vocabulary)
  - `past_project_operators()` / `past_project_regions()` — selectable-list helpers for UIs
  - `classify_water_depth()` — BOEM convention (shallow < 1,000 ft, deepwater 1,000–4,999 ft, ultra-deepwater >= 5,000 ft), derived from `water_depth_ft` (never stored, never guessed)
  - Deliberately **not** exported from the package `__init__` (same as `terrain`).
- `tests/modules/field_development/test_past_projects.py` — 30 offline tests (no network).

## Provenance discipline (no fabrication)

Every entry, and every attribute on it, traces to a data source **already in this repo**, listed per-entry under `sources`:

| Source | Contributes | Projects |
|---|---|---|
| `config/fields.yml` (canonical identity registry, #755) | `project_id` == `canonical_id`, display name, play, BSEE area/blocks | all 11 |
| `config/ong_field_development/fields_registry.yml` (auto-generated BOEM/BSEE + validated-economics registry) | operator, water_depth_ft, status, first oil, dev system, facility | 10 |
| `packages/worldenergydata-bsee/.../buckskin/buckskin_config.py` (BSEE WAR/LAB-derived) | Buckskin attributes | 1 |

Where a source does not state an attribute it is `null` with an explanatory `notes` entry (e.g. Shenandoah/Kaskida/Tiber/North Platte operator; Buckskin current status + dev-system taxonomy). Nothing was filled from memory or the open web.

**No parallel registry format**: this catalog adds zero identity mappings — contract tests assert every `project_id` resolves in `config/fields.yml` (display name, blocks, play match) and that every attribute matches `fields_registry.yml` where cited, so drift from the upstream registries fails CI.

## Tests

`tests/modules/field_development/test_past_projects.py` — 30 passed (plus sibling `test_terrain.py` re-run green):
- catalog contract (required keys, GoM populated, worldwide structured-but-empty)
- provenance completeness (every entry has sources; every cited source path exists in the repo; canonical-identity + attribute coherence)
- water-depth classification thresholds + None handling
- filters (region key/display-name, case-insensitive operator, water-depth class, status; composition; fail-closed unknowns; fail-loud invalid vocabulary)
- malformed-catalog rejection (missing keys, empty sources, invalid status, duplicate ids, negative depth)

Lint run with the repo's exact toolchain (black 25.9.0, isort 8.0.1, flake8 7.3.0 per `uv.lock`, CI flags) — clean.