### PR TITLE
feat: analogs query layer over past-projects registry (#932)

### DIFF
--- a/src/worldenergydata/field_development/analogs.py
+++ b/src/worldenergydata/field_development/analogs.py
@@ -1,0 +1,538 @@
+# ABOUTME: Analogs query layer over the past-projects registry (ranked, explained).
+# ABOUTME: Issue #932 (epic #929, A3) — region/water-depth/asset-type analog screening.
+"""
+worldenergydata.field_development.analogs
+=========================================
+
+Analog past projects for a screening run: given a region, a water depth and/or
+an asset type (development system), rank the projects in the past-projects
+registry (:mod:`~worldenergydata.field_development.past_projects`, issue #931)
+by similarity — with an **explicit match rationale** per project, so a
+screening consumer can see *why* something is (or is not) an analog.
+
+Scoring
+-------
+Every supplied criterion (``region``, water depth, ``development_system``,
+``status``) is assessed per project as **matched** (credit 1.0), **near_miss**
+(partial credit), **missed** (credit 0.0) or **unknown** (credit 0.0 — the
+registry attribute is ``null``; nulls NEVER silently count as matches). The
+score is the weight-normalised sum of credits over the criteria actually
+supplied, so it is always in ``[0, 1]`` regardless of how many criteria the
+caller passed. All weights and near-miss credits live in
+:data:`ANALOG_WEIGHTS_PATH` (``analogs_weights.yml``, shipped next to this
+module) — **no scoring numbers are hardcoded here**.
+
+Ranking is deterministic: score (desc), then absolute water-depth distance
+(asc, when both the query and the project depth are known), then
+``project_id`` (asc) as the stable tie-break.
+
+Candidates with at least one matched/near-missed criterion are returned;
+projects that *miss* every supplied criterion are excluded. A project whose
+relevant attributes are all ``null`` (nothing matched, nothing missed) is kept
+at score 0.0 with an all-``unknown`` rationale — it cannot be ruled out, and
+silently dropping it would turn "unknown" into a hidden "no".
+
+This module only **queries** the registry — it adds no project data. It is
+intentionally NOT exported from the package ``__init__`` (same as ``terrain``
+and ``past_projects``): import it directly.
+
+Usage::
+
+    from worldenergydata.field_development.analogs import find_analogs, to_records
+
+    matches = find_analogs(
+        region="gulf_of_mexico",
+        water_depth_m=1580.0,
+        development_system="subsea20",
+    )
+    to_records(matches)  # plain JSON-serialisable dicts for the API consumer
+
+Consumers: digitalmodel#1507 (field-development layout epic) via the
+``analogs`` API endpoint (digitalmodel#1512).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+from worldenergydata.field_development.past_projects import (
+    VALID_STATUSES,
+    WATER_DEPTH_CLASSES,
+    PastProject,
+    classify_water_depth,
+    load_past_projects,
+)
+
+__all__ = [
+    "ANALOG_WEIGHTS_PATH",
+    "CRITERIA",
+    "FT_PER_M",
+    "AnalogMatch",
+    "CriterionAssessment",
+    "find_analogs",
+    "load_analog_weights",
+    "to_records",
+]
+
+ANALOG_WEIGHTS_PATH = Path(__file__).parent / "analogs_weights.yml"
+
+#: The criteria the query layer scores, in rationale order. The weights file
+#: must cover exactly this set.
+CRITERIA = ("region", "water_depth", "development_system", "status")
+
+#: Near-miss credit keys the weights file must define (see analogs_weights.yml).
+NEAR_MISS_CREDIT_KEYS = (
+    "water_depth_adjacent_class",
+    "development_system_same_family",
+)
+
+#: Exact unit conversion (1 ft == 0.3048 m by definition). The registry stores
+#: depths in feet (BOEM convention); the query accepts metres for the
+#: digitalmodel consumer.
+FT_PER_M = 1.0 / 0.3048
+
+#: Assessment statuses, from best to worst.
+MATCHED = "matched"
+NEAR_MISS = "near_miss"
+MISSED = "missed"
+UNKNOWN = "unknown"
+
+#: Full credit for a matched criterion (definitional — not a tunable weight).
+_FULL_CREDIT = 1.0
+_NO_CREDIT = 0.0
+
+
+@dataclass(frozen=True)
+class CriterionAssessment:
+    """How one query criterion fared against one project (match rationale)."""
+
+    criterion: str
+    status: str  # matched | near_miss | missed | unknown
+    weight: float
+    credit: float  # 0..1 credit earned for this criterion
+    detail: str
+
+    def to_record(self) -> dict[str, Any]:
+        """Plain JSON-serialisable dict form."""
+        return {
+            "criterion": self.criterion,
+            "status": self.status,
+            "weight": self.weight,
+            "credit": self.credit,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class AnalogMatch:
+    """One ranked analog candidate: project + score + explicit rationale."""
+
+    project: PastProject
+    score: float
+    rationale: tuple[CriterionAssessment, ...]
+    #: |query depth - project depth| in ft; None unless BOTH are known.
+    water_depth_distance_ft: Optional[float]
+
+    def to_record(self) -> dict[str, Any]:
+        """Plain JSON-serialisable dict form (for the digitalmodel consumer)."""
+        p = self.project
+        return {
+            "project_id": p.project_id,
+            "display_name": p.display_name,
+            "region": p.region,
+            "region_display_name": p.region_display_name,
+            "operator": p.operator,
+            "water_depth_ft": p.water_depth_ft,
+            "water_depth_class": p.water_depth_class,
+            "development_system": p.development_system,
+            "facility": p.facility,
+            "status": p.status,
+            "first_oil_year": p.first_oil_year,
+            "play": p.play,
+            "bsee_area_blocks": list(p.bsee_area_blocks),
+            "sources": list(p.sources),
+            "notes": p.notes,
+            "score": self.score,
+            "water_depth_distance_ft": self.water_depth_distance_ft,
+            "rationale": [a.to_record() for a in self.rationale],
+        }
+
+
+def to_records(matches: list[AnalogMatch]) -> list[dict[str, Any]]:
+    """Ranked matches as plain JSON-serialisable dicts (screening-run form)."""
+    return [m.to_record() for m in matches]
+
+
+def load_analog_weights(path: Optional[Path] = None) -> dict[str, dict[str, float]]:
+    """Load and validate the scoring-weights file.
+
+    Contract (fail loud on violation): ``criteria_weights`` covers exactly
+    :data:`CRITERIA`, every weight is a positive number, the weights sum to
+    1.0, and every :data:`NEAR_MISS_CREDIT_KEYS` credit is a number in
+    ``[0, 1)`` (a near-miss must never earn as much as a real match).
+    """
+    weights_path = Path(path) if path is not None else ANALOG_WEIGHTS_PATH
+    data = yaml.safe_load(weights_path.read_text(encoding="utf-8")) or {}
+
+    weights = data.get("criteria_weights")
+    if not isinstance(weights, dict):
+        raise ValueError(f"{weights_path} has no 'criteria_weights' mapping")
+    if set(weights) != set(CRITERIA):
+        raise ValueError(
+            f"{weights_path} criteria_weights keys {sorted(weights)} != "
+            f"expected criteria {sorted(CRITERIA)}"
+        )
+    for criterion, weight in weights.items():
+        if not isinstance(weight, (int, float)) or weight <= 0:
+            raise ValueError(
+                f"{weights_path} weight for {criterion!r} must be a positive "
+                f"number, got {weight!r}"
+            )
+    total = sum(weights.values())
+    if not math.isclose(total, 1.0, rel_tol=0, abs_tol=1e-9):
+        raise ValueError(
+            f"{weights_path} criteria_weights must sum to 1.0, got {total!r}"
+        )
+
+    credits = data.get("near_miss_credits")
+    if not isinstance(credits, dict):
+        raise ValueError(f"{weights_path} has no 'near_miss_credits' mapping")
+    if set(credits) != set(NEAR_MISS_CREDIT_KEYS):
+        raise ValueError(
+            f"{weights_path} near_miss_credits keys {sorted(credits)} != "
+            f"expected {sorted(NEAR_MISS_CREDIT_KEYS)}"
+        )
+    for key, credit in credits.items():
+        if not isinstance(credit, (int, float)) or not 0 <= credit < 1:
+            raise ValueError(
+                f"{weights_path} near-miss credit {key!r} must be a number in "
+                f"[0, 1), got {credit!r}"
+            )
+
+    return {
+        "criteria_weights": {k: float(v) for k, v in weights.items()},
+        "near_miss_credits": {k: float(v) for k, v in credits.items()},
+    }
+
+
+def _norm(value: str) -> str:
+    return " ".join(value.split()).lower()
+
+
+def _dev_system_family(dev_system: str) -> str:
+    """Taxonomy family = the token with trailing digits stripped.
+
+    ``subsea15``/``subsea20`` -> ``subsea``; ``tieback15`` -> ``tieback``;
+    ``dry`` -> ``dry``.
+    """
+    return _norm(dev_system).rstrip("0123456789")
+
+
+def _assess_region(
+    query: str, project: PastProject, weight: float
+) -> CriterionAssessment:
+    if _norm(query) in (_norm(project.region), _norm(project.region_display_name)):
+        return CriterionAssessment(
+            "region",
+            MATCHED,
+            weight,
+            _FULL_CREDIT,
+            f"project region {project.region!r} matches query {query!r}",
+        )
+    return CriterionAssessment(
+        "region",
+        MISSED,
+        weight,
+        _NO_CREDIT,
+        f"project region {project.region!r} != query {query!r}",
+    )
+
+
+def _adjacent_classes(class_a: str, class_b: str) -> bool:
+    order = list(WATER_DEPTH_CLASSES)
+    return abs(order.index(class_a) - order.index(class_b)) == 1
+
+
+def _assess_water_depth(
+    query_class: str,
+    query_depth_ft: Optional[float],
+    project: PastProject,
+    weight: float,
+    adjacent_credit: float,
+) -> tuple[CriterionAssessment, Optional[float]]:
+    if project.water_depth_ft is None:
+        return (
+            CriterionAssessment(
+                "water_depth",
+                UNKNOWN,
+                weight,
+                _NO_CREDIT,
+                "water depth not stated in the registry (null) — cannot "
+                f"compare with query class {query_class!r}",
+            ),
+            None,
+        )
+    project_class = project.water_depth_class
+    distance = (
+        abs(query_depth_ft - project.water_depth_ft)
+        if query_depth_ft is not None
+        else None
+    )
+    depth_note = f"; |depth distance| = {distance:g} ft" if distance is not None else ""
+    if project_class == query_class:
+        return (
+            CriterionAssessment(
+                "water_depth",
+                MATCHED,
+                weight,
+                _FULL_CREDIT,
+                f"project depth {project.water_depth_ft:g} ft is "
+                f"{project_class!r} == query class{depth_note}",
+            ),
+            distance,
+        )
+    if _adjacent_classes(project_class, query_class):
+        return (
+            CriterionAssessment(
+                "water_depth",
+                NEAR_MISS,
+                weight,
+                adjacent_credit,
+                f"project class {project_class!r} is adjacent to query class "
+                f"{query_class!r}{depth_note}",
+            ),
+            distance,
+        )
+    return (
+        CriterionAssessment(
+            "water_depth",
+            MISSED,
+            weight,
+            _NO_CREDIT,
+            f"project class {project_class!r} is not adjacent to query class "
+            f"{query_class!r}{depth_note}",
+        ),
+        distance,
+    )
+
+
+def _assess_development_system(
+    query: str, project: PastProject, weight: float, family_credit: float
+) -> CriterionAssessment:
+    if project.development_system is None:
+        return CriterionAssessment(
+            "development_system",
+            UNKNOWN,
+            weight,
+            _NO_CREDIT,
+            "development_system not stated in the registry (null) — cannot "
+            f"match query {query!r}",
+        )
+    if _norm(project.development_system) == _norm(query):
+        return CriterionAssessment(
+            "development_system",
+            MATCHED,
+            weight,
+            _FULL_CREDIT,
+            f"development_system {project.development_system!r} matches "
+            f"query {query!r}",
+        )
+    if _dev_system_family(project.development_system) == _dev_system_family(query):
+        return CriterionAssessment(
+            "development_system",
+            NEAR_MISS,
+            weight,
+            family_credit,
+            f"development_system {project.development_system!r} is in the "
+            f"same family as query {query!r}",
+        )
+    return CriterionAssessment(
+        "development_system",
+        MISSED,
+        weight,
+        _NO_CREDIT,
+        f"development_system {project.development_system!r} != query {query!r}",
+    )
+
+
+def _assess_status(
+    query: str, project: PastProject, weight: float
+) -> CriterionAssessment:
+    if project.status is None:
+        return CriterionAssessment(
+            "status",
+            UNKNOWN,
+            weight,
+            _NO_CREDIT,
+            f"status not stated in the registry (null) — cannot match query {query!r}",
+        )
+    if project.status == query:
+        return CriterionAssessment(
+            "status",
+            MATCHED,
+            weight,
+            _FULL_CREDIT,
+            f"status {project.status!r} matches query",
+        )
+    return CriterionAssessment(
+        "status",
+        MISSED,
+        weight,
+        _NO_CREDIT,
+        f"status {project.status!r} != query {query!r}",
+    )
+
+
+def find_analogs(
+    region: Optional[str] = None,
+    water_depth_m: Optional[float] = None,
+    water_depth_class: Optional[str] = None,
+    development_system: Optional[str] = None,
+    status: Optional[str] = None,
+    limit: Optional[int] = None,
+    path: Optional[Path] = None,
+    weights_path: Optional[Path] = None,
+) -> list[AnalogMatch]:
+    """Ranked analog past projects for a screening run.
+
+    Args:
+        region: Region key (``"gulf_of_mexico"``) or display name
+            (``"US Gulf of Mexico"``); case-insensitive.
+        water_depth_m: Site water depth in **metres**; classified via
+            :func:`classify_water_depth` (BOEM convention, ft) and also used
+            to rank by absolute depth distance where project depths are known.
+            Mutually exclusive with ``water_depth_class``.
+        water_depth_class: One of the BOEM classes (``shallow`` /
+            ``deepwater`` / ``ultra_deepwater``) when the caller already has a
+            class instead of a depth.
+        development_system: Asset type — the registry's ``development_system``
+            taxonomy (e.g. ``subsea15``, ``subsea20``, ``tieback15``, ``dry``);
+            case-insensitive. Same-family variants score a near-miss.
+        status: One of the registry statuses (case-insensitive); validated,
+            fail-loud on typos.
+        limit: Keep only the top-``limit`` matches after ranking.
+        path: Optional alternate past-projects catalog path (tests).
+        weights_path: Optional alternate scoring-weights path (tests).
+
+    Returns:
+        :class:`AnalogMatch` list, best first. Deterministic order: score
+        (desc), then absolute depth distance (asc, known distances before
+        unknown), then ``project_id`` (asc). Projects that miss every
+        supplied criterion are excluded; all-``unknown`` candidates are kept
+        at score 0.0 (they cannot be ruled out).
+
+    Raises:
+        ValueError: No criterion supplied, both ``water_depth_m`` and
+            ``water_depth_class`` supplied, non-positive ``water_depth_m``,
+            unknown ``water_depth_class``/``status``, non-positive ``limit``,
+            or an invalid weights file.
+    """
+    if all(
+        arg is None
+        for arg in (
+            region,
+            water_depth_m,
+            water_depth_class,
+            development_system,
+            status,
+        )
+    ):
+        raise ValueError(
+            "find_analogs() needs at least one criterion (region, water_depth_m, "
+            "water_depth_class, development_system, status)"
+        )
+    if water_depth_m is not None and water_depth_class is not None:
+        raise ValueError(
+            "Pass either water_depth_m or water_depth_class, not both "
+            "(the class is derived from the depth)"
+        )
+    query_depth_ft: Optional[float] = None
+    query_class: Optional[str] = water_depth_class
+    if water_depth_m is not None:
+        if not isinstance(water_depth_m, (int, float)) or water_depth_m <= 0:
+            raise ValueError(
+                f"water_depth_m must be a positive number, got {water_depth_m!r}"
+            )
+        # Round the converted depth so an exact metric equivalent of a BOEM
+        # threshold (e.g. 304.8 m == 1,000 ft) can never fall on the wrong
+        # side of the class boundary through float error.
+        query_depth_ft = round(water_depth_m * FT_PER_M, 6)
+        query_class = classify_water_depth(query_depth_ft)
+    if query_class is not None and query_class not in WATER_DEPTH_CLASSES:
+        raise ValueError(
+            f"Unknown water_depth_class {query_class!r} "
+            f"(expected one of {list(WATER_DEPTH_CLASSES)})"
+        )
+    status_key: Optional[str] = None
+    if status is not None:
+        by_norm = {_norm(s): s for s in VALID_STATUSES}
+        status_key = by_norm.get(_norm(status))
+        if status_key is None:
+            raise ValueError(
+                f"Unknown status {status!r} (expected one of {sorted(VALID_STATUSES)})"
+            )
+    if limit is not None and limit <= 0:
+        raise ValueError(f"limit must be a positive integer, got {limit!r}")
+
+    weights_cfg = load_analog_weights(path=weights_path)
+    weights = weights_cfg["criteria_weights"]
+    credits = weights_cfg["near_miss_credits"]
+
+    matches: list[AnalogMatch] = []
+    for project in load_past_projects(path=path):
+        rationale: list[CriterionAssessment] = []
+        distance: Optional[float] = None
+        if region is not None:
+            rationale.append(_assess_region(region, project, weights["region"]))
+        if query_class is not None:
+            assessment, distance = _assess_water_depth(
+                query_class,
+                query_depth_ft,
+                project,
+                weights["water_depth"],
+                credits["water_depth_adjacent_class"],
+            )
+            rationale.append(assessment)
+        if development_system is not None:
+            rationale.append(
+                _assess_development_system(
+                    development_system,
+                    project,
+                    weights["development_system"],
+                    credits["development_system_same_family"],
+                )
+            )
+        if status_key is not None:
+            rationale.append(_assess_status(status_key, project, weights["status"]))
+
+        earned = sum(a.weight * a.credit for a in rationale)
+        applicable = sum(a.weight for a in rationale)
+        score = round(earned / applicable, 6)
+        if score <= 0 and any(a.status == MISSED for a in rationale):
+            # Definitively not an analog on every supplied axis it answers.
+            continue
+        matches.append(
+            AnalogMatch(
+                project=project,
+                score=score,
+                rationale=tuple(rationale),
+                water_depth_distance_ft=distance,
+            )
+        )
+
+    matches.sort(
+        key=lambda m: (
+            -m.score,
+            m.water_depth_distance_ft is None,
+            m.water_depth_distance_ft or 0.0,
+            m.project.project_id,
+        )
+    )
+    if limit is not None:
+        matches = matches[:limit]
+    return matches

--- a/src/worldenergydata/field_development/analogs_weights.yml
+++ b/src/worldenergydata/field_development/analogs_weights.yml
@@ -1,0 +1,36 @@
+# ABOUTME: Scoring weights + near-miss credits for the analogs query layer.
+# ABOUTME: Issue #932 (epic #929, A3) — ALL scoring numbers live here, none in code.
+#
+# SCORING CONTRACT (see analogs.py):
+#   * `criteria_weights` must list EXACTLY the criteria the query layer knows
+#     (region, water_depth, development_system, status), every weight > 0,
+#     and the weights must sum to 1.0. The loader fails loudly otherwise.
+#   * A fully matched criterion earns credit 1.0 (definitional, not tunable).
+#   * `near_miss_credits` are the partial credits (0 <= credit < 1) awarded
+#     for a near-miss; a near-miss must never earn as much as a real match.
+#   * An attribute that is null in the past-projects registry earns credit
+#     0.0 and surfaces as "unknown" in the match rationale — nulls NEVER
+#     silently count as matches.
+#
+# Rationale for the defaults:
+#   water_depth (0.35) and region (0.30) dominate because they drive the
+#   development concept (host type, riser/mooring class, export route);
+#   development_system (0.25) is the asset-type axis itself; status (0.10)
+#   only nudges ranking toward proven producers.
+#
+# Consumers: digitalmodel#1507 (field-development layout epic) via the
+# `analogs` API endpoint (digitalmodel#1512).
+
+criteria_weights:
+  region: 0.30
+  water_depth: 0.35
+  development_system: 0.25
+  status: 0.10
+
+near_miss_credits:
+  # Project depth class is adjacent to the queried class (shallow<->deepwater
+  # or deepwater<->ultra_deepwater; shallow vs ultra_deepwater is a miss).
+  water_depth_adjacent_class: 0.5
+  # Same development-system family, different variant — e.g. subsea15 vs
+  # subsea20 (family = the taxonomy token with trailing digits stripped).
+  development_system_same_family: 0.5

--- a/tests/modules/field_development/test_analogs.py
+++ b/tests/modules/field_development/test_analogs.py
@@ -1,0 +1,434 @@
+# ABOUTME: Tests for the analogs query layer over the past-projects registry (#932).
+# ABOUTME: Offline only — filters, boundaries, ranking determinism, nulls, weights.
+"""Tests for ``worldenergydata.field_development.analogs``.
+
+Registry snapshot the hand-anchored expectations below rely on (from
+``past_projects.yml``, issue #931 — 11 GoM projects):
+
+    project_id       depth_ft  class          dev_system  status
+    stones           9525      ultra_deep     subsea15    producing
+    cascade_chinook  8200      ultra_deep     subsea15    producing
+    jack_st_malo     7240      ultra_deep     subsea15    producing
+    julia            7335      ultra_deep     tieback15   producing
+    big_foot         5190      ultra_deep     dry         producing
+    anchor           5080      ultra_deep     subsea20    producing
+    shenandoah       5800      ultra_deep     subsea20    producing
+    buckskin         6800      ultra_deep     null        null
+    kaskida          5860      ultra_deep     subsea20    pre-FID
+    tiber            4130      deepwater      subsea20    pre-FID
+    north_platte     5840      ultra_deep     subsea20    non_producing
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from worldenergydata.field_development.analogs import (
+    ANALOG_WEIGHTS_PATH,
+    CRITERIA,
+    FT_PER_M,
+    AnalogMatch,
+    find_analogs,
+    load_analog_weights,
+    to_records,
+)
+
+#: Exact metric equivalents of the BOEM class-boundary depths (ft * 0.3048).
+M_999_FT = 999 * 0.3048
+M_1000_FT = 1000 * 0.3048
+M_4999_FT = 4999 * 0.3048
+M_5000_FT = 5000 * 0.3048
+
+
+def _ids(matches: list[AnalogMatch]) -> list[str]:
+    return [m.project.project_id for m in matches]
+
+
+def _rationale_by_criterion(match: AnalogMatch) -> dict[str, str]:
+    return {a.criterion: a.status for a in match.rationale}
+
+
+# ---------------------------------------------------------------------------
+# Exact-filter behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestFilters:
+    def test_region_accepts_key_and_display_name_case_insensitive(self):
+        by_key = _ids(find_analogs(region="gulf_of_mexico"))
+        by_name = _ids(find_analogs(region="US Gulf of Mexico"))
+        by_case = _ids(find_analogs(region="Gulf_Of_Mexico"))
+        assert by_key and by_key == by_name == by_case
+        # Region-only query, everything matches -> tie on score, stable by id.
+        assert by_key == sorted(by_key)
+
+    def test_unmatched_region_fails_closed(self):
+        # 'worldwide' exists in the catalog but has no projects; a region-only
+        # query where every project misses returns nothing (nothing invented).
+        assert find_analogs(region="worldwide") == []
+        assert find_analogs(region="atlantis_basin") == []
+
+    def test_development_system_exact_near_and_excluded(self):
+        matches = find_analogs(development_system="subsea15")
+        # Hand-anchored: subsea15 matches (score 1.0, tie -> id order):
+        #   cascade_chinook, jack_st_malo, stones
+        # subsea20 = same 'subsea' family -> near-miss (credit 0.5):
+        #   anchor, kaskida, north_platte, shenandoah, tiber
+        # julia (tieback15) and big_foot (dry) miss -> EXCLUDED
+        # buckskin (dev_system null) -> unknown, kept last at score 0.0
+        assert _ids(matches) == [
+            "cascade_chinook",
+            "jack_st_malo",
+            "stones",
+            "anchor",
+            "kaskida",
+            "north_platte",
+            "shenandoah",
+            "tiber",
+            "buckskin",
+        ]
+        assert matches[0].score == 1.0
+        assert matches[3].score == 0.5
+        assert matches[-1].score == 0.0
+
+    def test_status_filter_validated_and_null_never_matches(self):
+        matches = find_analogs(status="producing")
+        producing = {
+            "stones",
+            "cascade_chinook",
+            "jack_st_malo",
+            "julia",
+            "big_foot",
+            "anchor",
+            "shenandoah",
+        }
+        # pre-FID / non_producing projects MISS and are excluded; buckskin
+        # (status null) is unknown -> kept at score 0.0, never a match.
+        assert set(_ids(matches)) == producing | {"buckskin"}
+        assert _ids(matches)[-1] == "buckskin"
+        assert matches[-1].score == 0.0
+        with pytest.raises(ValueError, match="status"):
+            find_analogs(status="abandoned-maybe")
+
+    def test_water_depth_class_param_filters_by_class(self):
+        matches = find_analogs(water_depth_class="deepwater")
+        # tiber is the only deepwater project (matched); all ultra projects
+        # are adjacent-class near-misses; no distances (no query depth).
+        assert _ids(matches)[0] == "tiber"
+        assert matches[0].score == 1.0
+        assert all(m.score == 0.5 for m in matches[1:])
+        assert all(m.water_depth_distance_ft is None for m in matches)
+
+    def test_invalid_water_depth_class_raises(self):
+        with pytest.raises(ValueError, match="water_depth_class"):
+            find_analogs(water_depth_class="abyssal")
+
+
+# ---------------------------------------------------------------------------
+# Depth-class boundaries (BOEM: 999/1000 ft and 4999/5000 ft, queried in m)
+# ---------------------------------------------------------------------------
+
+
+class TestDepthClassBoundaries:
+    def test_999_ft_is_shallow(self):
+        # shallow: no shallow projects; tiber (deepwater) is adjacent ->
+        # the ONLY candidate; ultra projects are two classes away -> excluded.
+        matches = find_analogs(water_depth_m=M_999_FT)
+        assert _ids(matches) == ["tiber"]
+        assert matches[0].rationale[0].status == "near_miss"
+
+    def test_1000_ft_is_deepwater(self):
+        matches = find_analogs(water_depth_m=M_1000_FT)
+        assert _ids(matches)[0] == "tiber"
+        assert matches[0].score == 1.0  # tiber matched
+        assert all(m.score == 0.5 for m in matches[1:])  # ultra = adjacent
+
+    def test_4999_ft_is_still_deepwater(self):
+        matches = find_analogs(water_depth_m=M_4999_FT)
+        assert _ids(matches)[0] == "tiber"
+        assert matches[0].score == 1.0
+
+    def test_5000_ft_is_ultra_deepwater(self):
+        matches = find_analogs(water_depth_m=M_5000_FT)
+        # Now the ultra projects match and tiber is the near-miss; nearest
+        # ultra depth to 5000 ft is anchor (5080 ft).
+        assert _ids(matches)[0] == "anchor"
+        assert matches[0].score == 1.0
+        tiber = next(m for m in matches if m.project.project_id == "tiber")
+        assert tiber.score == 0.5
+        assert tiber.rationale[0].status == "near_miss"
+
+    def test_non_positive_depth_rejected(self):
+        with pytest.raises(ValueError, match="water_depth_m"):
+            find_analogs(water_depth_m=0)
+        with pytest.raises(ValueError, match="water_depth_m"):
+            find_analogs(water_depth_m=-100)
+
+
+# ---------------------------------------------------------------------------
+# Ranking determinism
+# ---------------------------------------------------------------------------
+
+
+class TestRanking:
+    def test_depth_distance_ranks_within_equal_scores(self):
+        # 5,850 ft (queried in m). Every project has a known depth; all ultra
+        # projects match (1.0) and rank by |depth - 5850| ft:
+        #   kaskida 10, north_platte 10, shenandoah 50, big_foot 660,
+        #   anchor 770, buckskin 950, jack_st_malo 1390, julia 1485,
+        #   cascade_chinook 2350, stones 3675; then tiber (near-miss, 0.5).
+        # kaskida/north_platte tie at 10 ft -> broken by project_id.
+        matches = find_analogs(water_depth_m=5850 * 0.3048)
+        assert _ids(matches) == [
+            "kaskida",
+            "north_platte",
+            "shenandoah",
+            "big_foot",
+            "anchor",
+            "buckskin",
+            "jack_st_malo",
+            "julia",
+            "cascade_chinook",
+            "stones",
+            "tiber",
+        ]
+        assert matches[0].water_depth_distance_ft == pytest.approx(10.0)
+        assert matches[1].water_depth_distance_ft == pytest.approx(10.0)
+
+    def test_composite_query_hand_anchored_ranking(self):
+        # region GoM + 1,580 m (= 5,183.727 ft, ultra) + subsea20 + producing.
+        # Weights: region .30, water_depth .35, development_system .25,
+        # status .10; near-miss credit 0.5 on depth-class and dev-family.
+        #   anchor       1.0    (all matched), dist 103.7 ft
+        #   shenandoah   1.0    (all matched), dist 616.3 ft
+        #   north_platte 0.90   (status non_producing missed), dist 656.3
+        #   kaskida      0.90   (status pre-FID missed), dist 676.3
+        #   jack_st_malo 0.875  (subsea15 = family near-miss), dist 2056.3
+        #   cascade      0.875  dist 3016.3
+        #   stones       0.875  dist 4341.3
+        #   big_foot     0.75   (dry missed dev), dist 6.3
+        #   julia        0.75   (tieback family missed dev), dist 2151.3
+        #   tiber        0.725  (deepwater adjacent .175 + dev 1.0*.25 ...)
+        #   buckskin     0.65   (dev + status unknown -> zero credit)
+        matches = find_analogs(
+            region="gulf_of_mexico",
+            water_depth_m=1580.0,
+            development_system="subsea20",
+            status="producing",
+        )
+        assert _ids(matches) == [
+            "anchor",
+            "shenandoah",
+            "north_platte",
+            "kaskida",
+            "jack_st_malo",
+            "cascade_chinook",
+            "stones",
+            "big_foot",
+            "julia",
+            "tiber",
+            "buckskin",
+        ]
+        by_id = {m.project.project_id: m for m in matches}
+        assert by_id["anchor"].score == 1.0
+        assert by_id["north_platte"].score == pytest.approx(0.90)
+        assert by_id["jack_st_malo"].score == pytest.approx(0.875)
+        assert by_id["buckskin"].score == pytest.approx(0.65)
+
+    def test_ranking_is_deterministic_across_calls(self):
+        kwargs = dict(water_depth_m=1580.0, development_system="subsea20")
+        first = find_analogs(**kwargs)
+        second = find_analogs(**kwargs)
+        assert _ids(first) == _ids(second)
+        assert [m.score for m in first] == [m.score for m in second]
+
+    def test_limit_truncates_after_ranking(self):
+        top3 = find_analogs(
+            region="gulf_of_mexico",
+            water_depth_m=1580.0,
+            development_system="subsea20",
+            status="producing",
+            limit=3,
+        )
+        assert _ids(top3) == ["anchor", "shenandoah", "north_platte"]
+        with pytest.raises(ValueError, match="limit"):
+            find_analogs(region="gulf_of_mexico", limit=0)
+
+
+# ---------------------------------------------------------------------------
+# Null handling — unknowns surface in the rationale, never silent matches
+# ---------------------------------------------------------------------------
+
+
+class TestNullHandling:
+    def test_null_attribute_is_unknown_not_matched(self):
+        matches = find_analogs(development_system="subsea15")
+        buckskin = next(m for m in matches if m.project.project_id == "buckskin")
+        assert _rationale_by_criterion(buckskin) == {"development_system": "unknown"}
+        assert buckskin.score == 0.0
+
+    def test_all_unknown_candidate_is_kept_not_dropped(self):
+        # buckskin has null dev_system AND null status: with both criteria
+        # supplied it earns nothing but misses nothing -> kept, ranked last.
+        matches = find_analogs(development_system="subsea20", status="producing")
+        assert "buckskin" in _ids(matches)
+        buckskin = next(m for m in matches if m.project.project_id == "buckskin")
+        assert set(_rationale_by_criterion(buckskin).values()) == {"unknown"}
+
+    def test_miss_plus_unknown_is_excluded(self):
+        # buckskin misses the (empty) 'worldwide' region and is unknown on
+        # dev_system: a hard miss with zero earned credit -> excluded, unlike
+        # the all-unknown case above. (Everything else also misses region and
+        # earns nothing on a tieback15 query except julia, which matches it.)
+        matches = find_analogs(region="worldwide", development_system="tieback15")
+        assert "buckskin" not in _ids(matches)
+        assert _ids(matches) == ["julia"]
+
+    def test_partial_match_beats_exclusion(self):
+        # julia misses a subsea20 query on dev-system but still matches
+        # status=producing -> partial score, ranked below full matches but
+        # NOT excluded (only projects that earn nothing and miss are dropped).
+        matches = find_analogs(development_system="subsea20", status="producing")
+        ids = _ids(matches)
+        assert "julia" in ids
+        assert ids.index("julia") > ids.index("anchor")
+
+    def test_every_rationale_status_is_in_vocabulary(self):
+        for m in find_analogs(
+            region="gulf_of_mexico", water_depth_m=1580.0, status="producing"
+        ):
+            for a in m.rationale:
+                assert a.status in {"matched", "near_miss", "missed", "unknown"}
+                assert 0.0 <= a.credit <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Screening-run consumability (JSON-serialisable records)
+# ---------------------------------------------------------------------------
+
+
+class TestRecords:
+    def test_records_round_trip_through_json(self):
+        matches = find_analogs(
+            region="gulf_of_mexico", water_depth_m=1580.0, status="producing"
+        )
+        records = to_records(matches)
+        assert json.loads(json.dumps(records)) == records
+
+    def test_records_carry_score_rationale_and_plain_types(self):
+        def only_plain(value) -> bool:
+            if isinstance(value, dict):
+                return all(
+                    isinstance(k, str) and only_plain(v) for k, v in value.items()
+                )
+            if isinstance(value, list):
+                return all(only_plain(v) for v in value)
+            return value is None or isinstance(value, (str, int, float, bool))
+
+        records = to_records(find_analogs(development_system="subsea20"))
+        assert records
+        for record in records:
+            assert only_plain(record), record["project_id"]
+            assert {"project_id", "score", "rationale", "water_depth_class"} <= set(
+                record
+            )
+            assert isinstance(record["bsee_area_blocks"], list)
+            assert isinstance(record["sources"], list)
+            for entry in record["rationale"]:
+                assert {"criterion", "status", "weight", "credit", "detail"} == set(
+                    entry
+                )
+
+
+# ---------------------------------------------------------------------------
+# Weights file (externalized scoring — validated loudly)
+# ---------------------------------------------------------------------------
+
+
+def _write_weights(tmp_path: Path, cfg: dict) -> Path:
+    p = tmp_path / "weights.yml"
+    p.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    return p
+
+
+class TestWeightsFile:
+    def test_shipped_weights_load_and_cover_all_criteria(self):
+        assert ANALOG_WEIGHTS_PATH.is_file()
+        cfg = load_analog_weights()
+        assert set(cfg["criteria_weights"]) == set(CRITERIA)
+        assert sum(cfg["criteria_weights"].values()) == pytest.approx(1.0)
+        for credit in cfg["near_miss_credits"].values():
+            assert 0.0 <= credit < 1.0
+
+    def test_missing_criterion_rejected(self, tmp_path: Path):
+        cfg = copy.deepcopy(yaml.safe_load(ANALOG_WEIGHTS_PATH.read_text()))
+        del cfg["criteria_weights"]["status"]
+        with pytest.raises(ValueError, match="criteria_weights"):
+            load_analog_weights(_write_weights(tmp_path, cfg))
+
+    def test_weights_must_sum_to_one(self, tmp_path: Path):
+        cfg = copy.deepcopy(yaml.safe_load(ANALOG_WEIGHTS_PATH.read_text()))
+        cfg["criteria_weights"]["region"] = 0.9
+        with pytest.raises(ValueError, match="sum to 1.0"):
+            load_analog_weights(_write_weights(tmp_path, cfg))
+
+    def test_non_positive_weight_rejected(self, tmp_path: Path):
+        cfg = copy.deepcopy(yaml.safe_load(ANALOG_WEIGHTS_PATH.read_text()))
+        cfg["criteria_weights"]["region"] = 0
+        with pytest.raises(ValueError, match="positive"):
+            load_analog_weights(_write_weights(tmp_path, cfg))
+
+    def test_near_miss_credit_must_stay_below_full_match(self, tmp_path: Path):
+        cfg = copy.deepcopy(yaml.safe_load(ANALOG_WEIGHTS_PATH.read_text()))
+        cfg["near_miss_credits"]["water_depth_adjacent_class"] = 1.0
+        with pytest.raises(ValueError, match="near-miss credit"):
+            load_analog_weights(_write_weights(tmp_path, cfg))
+
+    def test_unknown_near_miss_key_rejected(self, tmp_path: Path):
+        cfg = copy.deepcopy(yaml.safe_load(ANALOG_WEIGHTS_PATH.read_text()))
+        cfg["near_miss_credits"]["bonus_for_vibes"] = 0.2
+        with pytest.raises(ValueError, match="near_miss_credits"):
+            load_analog_weights(_write_weights(tmp_path, cfg))
+
+    def test_alternate_weights_change_scores(self, tmp_path: Path):
+        cfg = copy.deepcopy(yaml.safe_load(ANALOG_WEIGHTS_PATH.read_text()))
+        cfg["criteria_weights"] = {
+            "region": 0.7,
+            "water_depth": 0.1,
+            "development_system": 0.1,
+            "status": 0.1,
+        }
+        weights = _write_weights(tmp_path, cfg)
+        default = find_analogs(region="gulf_of_mexico", status="pre-FID")
+        reweighted = find_analogs(
+            region="gulf_of_mexico", status="pre-FID", weights_path=weights
+        )
+        # region .7 / (.7+.1) = .875 vs default .30/.40 = .75 for a
+        # region-match + status-miss project (e.g. anchor).
+        d = {m.project.project_id: m.score for m in default}
+        r = {m.project.project_id: m.score for m in reweighted}
+        assert d["anchor"] == pytest.approx(0.75)
+        assert r["anchor"] == pytest.approx(0.875)
+
+
+# ---------------------------------------------------------------------------
+# Query validation
+# ---------------------------------------------------------------------------
+
+
+class TestQueryValidation:
+    def test_at_least_one_criterion_required(self):
+        with pytest.raises(ValueError, match="at least one criterion"):
+            find_analogs()
+
+    def test_depth_m_and_class_are_mutually_exclusive(self):
+        with pytest.raises(ValueError, match="not both"):
+            find_analogs(water_depth_m=1500.0, water_depth_class="ultra_deepwater")
+
+    def test_metric_conversion_constant_is_exact(self):
+        assert FT_PER_M == pytest.approx(1 / 0.3048)


### PR DESCRIPTION
Closes #932 (epic #929, workstream A3).

## What
New module `src/worldenergydata/field_development/analogs.py`: given region / water depth / asset type (development system) / status, return **ranked analog past projects** for a screening run, querying the #931 past-projects registry (no registry data added or edited).

- `find_analogs(region=, water_depth_m=, water_depth_class=, development_system=, status=, limit=)` -> `list[AnalogMatch]`
- **Explicit match rationale**: each criterion is assessed `matched` / `near_miss` / `missed` / `unknown` per project. Registry nulls NEVER silently count as matches — they surface as `unknown` in the rationale, and an all-unknown candidate is kept at score 0.0 rather than silently dropped.
- **Deterministic scoring, no magic numbers in code**: weights + near-miss credits live in `analogs_weights.yml` (region 0.30 / water_depth 0.35 / development_system 0.25 / status 0.10; adjacent-depth-class and same-dev-system-family near-misses at 0.5). Loader fails loudly on missing criteria, non-positive weights, sum != 1.0, or a near-miss credit >= a full match.
- **Ranking**: score desc -> absolute water-depth distance asc (when both depths known) -> `project_id` asc (stable tie-break). `water_depth_m` is metres (for the digitalmodel consumer), converted exactly (1 ft = 0.3048 m) and classified via the BOEM `classify_water_depth`.
- **Screening-run consumability**: `AnalogMatch.to_record()` / `to_records()` emit plain JSON-serialisable dicts for the digitalmodel `analogs` API endpoint (digitalmodel#1512, consumer epic digitalmodel#1507).
- Follows the module-family conventions from #930/#931: YAML shipped next to the module, not exported from the package `__init__`, offline tests only.

## Tests
`tests/modules/field_development/test_analogs.py` — offline tests: exact-filter behaviour, BOEM depth-class boundaries (999/1000/4999/5000 ft queried in metres), hand-anchored composite ranking + tie-breaks, null-handling rationale, JSON round-trip, weights-file validation, query validation. Existing `test_past_projects.py` still green (62 passed combined).

## Notes for review
- Local runs used a scratchpad venv pinned from `uv.lock` (pytest 8.4.2, black 25.9.0, isort 8.0.1, flake8 7.3.0 — all three lint tools pass on the new files with the CI flags); **CI is authoritative**.
- Known pre-existing CI flake: the test-performance tracker can throw `sqlite3.OperationalError: database is locked` under xdist — unrelated to this change.