### PR TITLE
feat(explorer): one-page shell tracer on /field-atlas/

### DIFF
--- a/config/repo_structure.yml
+++ b/config/repo_structure.yml
@@ -347,6 +347,7 @@ temporary_exceptions:
       - reports/lower_tertiary/jack_st_malo_npv_stackup.html
       - reports/lower_tertiary/julia_fdp.html
       - reports/lower_tertiary/julia_npv_stackup.html
+      - reports/lower_tertiary/lifecycle/_explorer.json
       - reports/lower_tertiary/lifecycle/_facts.json
       - reports/lower_tertiary/lifecycle/_norms.json
       - reports/lower_tertiary/lifecycle/_performance.json
@@ -423,6 +424,7 @@ temporary_exceptions:
       - reports/lower_tertiary/drilling_insights.html
       - reports/lower_tertiary/lt_drilling_insights.csv
       - reports/field-atlas/_roster.json
+      - reports/field-atlas/atlas_template.html
       - reports/field-atlas/index.html
       - reports/pressure-atlas/_pressure.json
       - reports/pressure-atlas/index.html

--- a/reports/field-atlas/atlas_template.html
+++ b/reports/field-atlas/atlas_template.html
@@ -1,0 +1,339 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>GoM Field Atlas — worldenergydata</title>
+<!-- Template consumed by scripts/field_atlas/build_field_atlas.py (__ROSTER_JSON__
+     is substituted at build time). The Explorer shell (issue #946) fetches
+     ../lifecycle/_explorer.json at runtime — local preview therefore needs an
+     HTTP server: run `python3 -m http.server` from public/ (fetch() fails on
+     file://; the funnel itself still works without it). -->
+<style>
+  :root{--navy:#0B3D91;--teal:#0f8a7e;--bg:#eef3fa;--panel:#fff;--ink:#13233f;--muted:#5b6b86;
+        --line:#dbe4f0;--soft:#f4f8fc;--rich:#1f9d57;--sample:#b7791f;--roadmap:#8a97ab}
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;background:var(--bg);color:var(--ink);line-height:1.5}
+  a{color:inherit;text-decoration:none}
+  .wrap{max-width:1180px;margin:0 auto;padding:36px 22px 80px}
+  .eyebrow{font-family:ui-monospace,monospace;font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:var(--muted)}
+  h1{font-size:30px;font-weight:800;letter-spacing:-.4px;color:var(--navy);margin:6px 0 8px}
+  .lede{color:var(--muted);font-size:16px;max-width:760px}
+  .story{display:inline-block;margin-top:14px;background:#fff;border:1px solid var(--line);border-left:4px solid var(--teal);
+         border-radius:10px;padding:10px 16px;font-size:14px}
+  .story b{color:var(--navy)}
+  .funnel{display:flex;flex-wrap:wrap;gap:10px;align-items:center;margin:26px 0 6px;
+          background:#fff;border:1px solid var(--line);border-radius:14px;padding:14px 16px}
+  .funnel label{font-family:ui-monospace,monospace;font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);display:block;margin-bottom:3px}
+  .funnel select,.funnel input{font:inherit;font-size:14px;padding:7px 10px;border:1px solid var(--line);border-radius:9px;background:var(--soft);color:var(--ink)}
+  .funnel .grp{display:flex;flex-direction:column}
+  .funnel .arrow{color:var(--muted);align-self:end;padding-bottom:8px}
+  .funnel input[type=search]{min-width:190px}
+  .tiers{display:flex;gap:8px;margin:14px 0 4px;flex-wrap:wrap}
+  .tierbtn{font-family:ui-monospace,monospace;font-size:12px;font-weight:700;padding:6px 12px;border-radius:20px;border:1px solid var(--line);background:#fff;color:var(--muted);cursor:pointer}
+  .tierbtn.on{background:var(--navy);color:#fff;border-color:var(--navy)}
+  .count{font-family:ui-monospace,monospace;font-size:13px;color:var(--muted);margin:10px 2px}
+  .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:14px}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:15px 17px;display:flex;flex-direction:column;
+        box-shadow:0 1px 2px rgba(16,40,80,.04);transition:transform .12s,border-color .12s,box-shadow .12s}
+  .card:hover{transform:translateY(-2px);border-color:#b9cbe6;box-shadow:0 8px 20px rgba(16,40,80,.09)}
+  .card[data-fid]{cursor:pointer}
+  .card h3{font-size:15.5px;font-weight:700;color:var(--ink);display:flex;align-items:center;gap:8px;justify-content:space-between}
+  .badge{font-family:ui-monospace,monospace;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;padding:3px 8px;border-radius:20px;white-space:nowrap}
+  .badge.rich{color:var(--rich);background:color-mix(in srgb,var(--rich) 12%,#fff);border:1px solid color-mix(in srgb,var(--rich) 35%,#fff)}
+  .badge.sample{color:var(--sample);background:color-mix(in srgb,var(--sample) 12%,#fff);border:1px solid color-mix(in srgb,var(--sample) 35%,#fff)}
+  .badge.roadmap{color:var(--roadmap);background:#f2f5f9;border:1px solid var(--line)}
+  .card .meta{font-size:12.5px;color:var(--muted);margin-top:5px}
+  .card .meta b{color:var(--ink);font-weight:600}
+  .card .concept{font-size:12.5px;color:var(--teal);font-weight:600;margin-top:6px}
+  .card .go{margin-top:12px}
+  .card .go a{font-size:13px;font-weight:700;color:#fff;background:linear-gradient(135deg,var(--teal),var(--navy));padding:6px 12px;border-radius:9px;display:inline-block}
+  .card .go span{font-size:12px;color:var(--muted);font-family:ui-monospace,monospace}
+  .note{margin-top:26px;font-size:13px;color:var(--muted);background:#fff;border:1px solid var(--line);border-radius:12px;padding:14px 18px}
+  .note b{color:var(--navy)}
+  /* ---- Explorer panel (issue #946) ---- */
+  #x-panel{margin-top:26px;background:var(--panel);border:1px solid var(--line);border-left:4px solid var(--navy);
+           border-radius:14px;padding:18px 22px;box-shadow:0 8px 24px rgba(16,40,80,.08)}
+  .xcrumb{font-family:ui-monospace,monospace;font-size:12.5px;color:var(--muted);margin-bottom:12px}
+  .xcrumb a{color:var(--teal);font-weight:700}
+  .xtitle{font-size:22px;font-weight:800;color:var(--navy);display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+  .xtitle .badge{font-size:11px}
+  .xsub{font-size:13px;color:var(--muted);margin:2px 0 12px}
+  .xstrip{display:flex;gap:6px;flex-wrap:wrap;margin:10px 0 4px}
+  .xph{font-family:ui-monospace,monospace;font-size:11px;text-transform:uppercase;letter-spacing:.05em;
+       padding:4px 10px;border-radius:20px;border:1px solid var(--line);color:var(--muted);background:var(--soft)}
+  .xph.on{background:var(--navy);color:#fff;border-color:var(--navy);font-weight:700}
+  .xgates{font-family:ui-monospace,monospace;font-size:12px;color:var(--muted);margin:6px 0 12px}
+  .xmets{display:flex;gap:12px;flex-wrap:wrap;margin:10px 0}
+  .xmet{background:var(--soft);border:1px solid var(--line);border-radius:10px;padding:8px 14px;min-width:110px}
+  .xmet b{font-size:17px;color:var(--ink)}
+  .xmet i{font-style:normal;font-size:11px;color:var(--muted);margin-left:3px}
+  .xmet s{text-decoration:none;display:block;font-family:ui-monospace,monospace;font-size:10.5px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}
+  .xcols{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:14px;margin-top:8px}
+  .xcardlet{background:var(--soft);border:1px solid var(--line);border-radius:10px;padding:12px 14px}
+  .xcardlet .xh{font-family:ui-monospace,monospace;font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin-bottom:8px}
+  .xcardlet table{width:100%;border-collapse:collapse;font-size:13px}
+  .xcardlet td{padding:3px 0;vertical-align:top}
+  .xcardlet td:first-child{color:var(--muted);padding-right:12px;white-space:nowrap}
+  .xacts{display:flex;gap:10px;flex-wrap:wrap;margin-top:16px}
+  .xact{font-size:13px;font-weight:700;color:#fff;background:linear-gradient(135deg,var(--teal),var(--navy));padding:7px 13px;border-radius:9px;display:inline-block}
+  .xnote{margin-top:12px;font-size:13px;color:var(--muted);background:var(--soft);border:1px dashed var(--line);border-radius:9px;padding:9px 13px}
+  .xnote a{color:var(--teal);font-weight:700}
+  .xerr{font-size:14px;color:#a33;background:#fff4f4;border:1px solid #ecc;border-radius:9px;padding:10px 14px}
+  .xwells{width:100%;border-collapse:collapse;font-size:13px;margin-top:8px}
+  .xwells th{font-family:ui-monospace,monospace;font-size:10.5px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);text-align:left;padding:6px 10px;border-bottom:1px solid var(--line)}
+  .xwells td{padding:7px 10px;border-bottom:1px solid var(--line)}
+  .xwells a{color:var(--teal);font-weight:700}
+  .xstages{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:10px;margin-top:10px}
+  .xstage{background:var(--soft);border:1px solid var(--line);border-radius:10px;padding:10px 12px}
+  .xstage .xh{font-family:ui-monospace,monospace;font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--teal);margin-bottom:4px;font-weight:700}
+  .xstage p{font-size:13px}
+  .xprov{margin-top:14px;font-size:11.5px;color:var(--muted);font-family:ui-monospace,monospace}
+  @media (prefers-color-scheme:dark){
+    :root{--bg:#0a141f;--panel:#10202f;--ink:#e8eef4;--muted:#8ca0b3;--line:#24384b;--soft:#0d1b28;--navy:#5b9de0;--teal:#3fb99b}
+    .badge.roadmap{background:#182636}.card .go a{color:#08131f}
+    .xact{color:#08131f}.xerr{background:#2a1518;border-color:#5c2a30;color:#f0a9a9}
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <p class="eyebrow">worldenergydata · browse the field atlas</p>
+  <h1>Gulf of Mexico Field Atlas</h1>
+  <p class="lede">Browse deepwater fields top-down — Country → onshore/offshore → Region → geological play → field.
+     Fields with a full life-cycle analysis open right here — and link through to their stage-gate hub.</p>
+  <div class="story">The <b>Lower Tertiary (Wilcox)</b> play is ~8% of GoM fields but holds <b>~36% of the oil</b> — start there.</div>
+
+  <div class="funnel">
+    <div class="grp"><label>Country</label><select id="f-country"></select></div>
+    <span class="arrow">→</span>
+    <div class="grp"><label>Domain</label><select id="f-domain"></select></div>
+    <span class="arrow">→</span>
+    <div class="grp"><label>Region</label><select id="f-region"></select></div>
+    <span class="arrow">→</span>
+    <div class="grp"><label>Play</label><select id="f-play"></select></div>
+    <div class="grp" style="margin-left:auto"><label>Search</label><input id="f-search" type="search" placeholder="field or block…"></div>
+  </div>
+  <div class="tiers" id="f-tiers"></div>
+  <div class="count" id="f-count"></div>
+  <div class="grid" id="f-grid"></div>
+
+  <section id="x-panel" hidden>
+    <nav class="xcrumb" id="x-crumb"></nav>
+    <div id="x-body"></div>
+  </section>
+
+  <div class="note">Showing the <b>120 concept-matched</b> Gulf of Mexico fields. The full GoM atlas holds
+     <b>1,390 fields</b> (Lower Tertiary = 111 fields, ~36% of GoM oil); the long tail is a searchable catalog, not shown here.
+     Density: <b style="color:var(--rich)">rich</b> = life-cycle hub + economics · <b style="color:var(--sample)">sample</b> = concept data · <b style="color:var(--roadmap)">roadmap</b> = name/block only.</div>
+</div>
+
+<script>
+const ROSTER = __ROSTER_JSON__;
+const TIER_ORDER = {rich:0, sample:1, roadmap:2};
+const $ = id => document.getElementById(id);
+let tierFilter = "all";
+
+function uniq(key){ return [...new Set(ROSTER.map(f=>f[key]).filter(Boolean))].sort(); }
+function fillSelect(el, vals, allLabel){
+  el.innerHTML = `<option value="">${allLabel}</option>` + vals.map(v=>`<option>${v}</option>`).join("");
+}
+fillSelect($("f-country"), uniq("country"), "All countries");
+fillSelect($("f-domain"), uniq("domain"), "All");
+fillSelect($("f-region"), uniq("region"), "All regions");
+fillSelect($("f-play"), uniq("play"), "All plays");
+// sensible defaults: US · offshore · GoM
+$("f-country").value = "USA"; $("f-domain").value = "offshore"; $("f-region").value = "US Gulf of Mexico";
+
+const tiers = ["all","rich","sample","roadmap"];
+$("f-tiers").innerHTML = tiers.map(t=>`<button class="tierbtn${t==="all"?" on":""}" data-t="${t}">${t==="all"?"All tiers":t}</button>`).join("");
+$("f-tiers").onclick = e => { if(!e.target.dataset.t) return;
+  tierFilter = e.target.dataset.t;
+  [...$("f-tiers").children].forEach(b=>b.classList.toggle("on", b.dataset.t===tierFilter));
+  render(); };
+
+["f-country","f-domain","f-region","f-play","f-search"].forEach(id=>$(id).addEventListener("input", render));
+
+function render(){
+  const c=$("f-country").value, d=$("f-domain").value, r=$("f-region").value, p=$("f-play").value,
+        q=$("f-search").value.trim().toLowerCase();
+  let rows = ROSTER.filter(f =>
+    (!c||f.country===c) && (!d||f.domain===d) && (!r||f.region===r) && (!p||f.play===p) &&
+    (tierFilter==="all"||f.density_tier===tierFilter) &&
+    (!q || (f.name+" "+(f.block||"")+" "+(f.operator||"")).toLowerCase().includes(q)));
+  rows.sort((a,b)=> (TIER_ORDER[a.density_tier]-TIER_ORDER[b.density_tier]) || a.name.localeCompare(b.name));
+  $("f-count").textContent = `${rows.length} field${rows.length===1?"":"s"}`;
+  $("f-grid").innerHTML = rows.map(f=>{
+    const go = f.lifecycle_id
+      ? `<div class="go"><a href="../lifecycle/${f.lifecycle_id}_lifecycle.html">Life-cycle →</a></div>`
+      : (f.concept ? `<div class="go"><span>concept: ${f.concept}</span></div>` : "");
+    const meta = [f.operator, f.block].filter(Boolean).map(x=>`<b>${x}</b>`).join(" · ");
+    const play = f.play ? `<div class="concept">${f.play}</div>` : "";
+    const fid = f.lifecycle_id ? ` data-fid="${f.lifecycle_id}"` : "";
+    return `<div class="card"${fid}><h3>${f.name}<span class="badge ${f.density_tier}">${f.density_tier}</span></h3>
+      ${meta?`<div class="meta">${meta}</div>`:""}${play}${go}</div>`;
+  }).join("");
+}
+render();
+
+/* ---- Explorer shell (issue #946): in-place drill-down for rich fields. ----
+   Data contract: ../lifecycle/_explorer.json (post-enrichment poster payloads
+   keyed by id + the wells contract). All payload hrefs are lifecycle-relative
+   by contract — EVERY href is rebased through rb() before it reaches the DOM.
+   Router links are always bare "#/..." (never "index.html#/..."). Rich-only:
+   cards without a lifecycle_id keep plain funnel behavior (#947 owns ids). */
+const LIFE_BASE = new URL("../lifecycle/", document.baseURI);
+const rb = h => new URL(h, LIFE_BASE).href;
+const esc = s => String(s).replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
+const PHASES = ["explore","appraise","define","execute","operate","decommission"];
+let XP = null;
+async function explorer(){
+  if (XP) return XP;
+  const res = await fetch(rb("_explorer.json"));
+  if (!res.ok) throw new Error("HTTP " + res.status);
+  XP = await res.json();
+  return XP;
+}
+
+function crumb(items){
+  // items: [label, "#/..."] pairs; the last item renders as the current leaf.
+  $("x-crumb").innerHTML = items.map(([lab, h], i) =>
+    i < items.length - 1 ? `<a href="${h}">${esc(lab)}</a>` : `<span>${esc(lab)}</span>`
+  ).join(" ▸ ");
+}
+function show(html){ $("x-body").innerHTML = html; }
+
+function renderField(x, f){
+  crumb([["Atlas", "#"], [f.name, `#/field/${f.id}`]]);
+  const strip = PHASES.map(p=>`<span class="xph${p===f.currentPhase?" on":""}">${esc(p)}</span>`).join("");
+  const gates = (f.gates||[]).filter(g=>g.kind==="primary")
+    .map(g=>`${esc(g.lab)} ${esc(g.dt)}`).join(" · ");
+  const mets = (f.metrics||[]).map(m=>
+    `<div class="xmet"><b>${esc(m.v)}</b><i>${esc(m.u||"")}</i><s>${esc(m.k)}</s></div>`).join("");
+  const facts = (f.hostFacts||[]).map(([k,v])=>`<tr><td>${esc(k)}</td><td>${esc(v)}</td></tr>`).join("");
+  let perf = "";
+  if (f.performance){
+    const P = f.performance, row = (k,v)=> v==null?"":`<tr><td>${esc(k)}</td><td>${esc(v)}</td></tr>`;
+    perf = `<div class="xcardlet"><div class="xh">Field performance · BSEE life-to-date</div><table>` +
+      row("Wells", P.wells) + row("Cum oil", P.cum_oil_mmbbl==null?null:P.cum_oil_mmbbl+" MMbbl") +
+      row("EUR", P.eur_mmbbl==null?null:P.eur_mmbbl+" MMbbl") +
+      row("Avg uptime", P.avg_uptime_pct==null?null:P.avg_uptime_pct+"%") +
+      row("Avg decline", P.avg_decline_pct_yr==null?null:P.avg_decline_pct_yr+"%/yr") +
+      row("Breakeven WTI", P.breakeven_wti==null?null:"$"+P.breakeven_wti+"/bbl") +
+      row("NPV", P.npv_mm==null?null:"$"+P.npv_mm+"MM") +
+      row("Interventions", P.interventions) + `</table></div>`;
+  }
+  let resv = "";
+  if (f.reservoir){
+    const R = f.reservoir, row = (k,v)=> v==null||v===""?"":`<tr><td>${esc(k)}</td><td>${esc(v)}</td></tr>`;
+    const body = row("Formation", R.formation) +
+      row("Pressure", R.pressure_psi==null?null:R.pressure_psi.toLocaleString()+" psi "+(R.pressure_qual||"")) +
+      row("Equip. rating", R.equip_rating_psi==null?null:R.equip_rating_psi.toLocaleString()+" psi") +
+      row("Temp", R.temp_f==null?null:R.temp_f+" °F") + row("TVD", R.tvd_ft==null?null:R.tvd_ft.toLocaleString()+" ft") +
+      row("Fluid", R.fluid) + row("HPHT class", R.hpht_class);
+    if (body) resv = `<div class="xcardlet"><div class="xh">Reservoir</div><table>${body}</table></div>`;
+  }
+  const acts = [`<a class="xact" href="${rb(f.id + "_lifecycle.html")}">Full life-cycle poster →</a>`];
+  if (f.economics_href) acts.push(`<a class="xact" href="${rb(f.economics_href)}">Economics →</a>`);
+  if (f.benchmark_href) acts.push(`<a class="xact" href="${rb(f.benchmark_href)}">Benchmark →</a>`);
+  if (f.wellsHref && f.wellsCount) acts.push(`<a class="xact" href="#/field/${f.id}/wells">Wells (${f.wellsCount}) →</a>`);
+  if (f.assetsHref) acts.push(`<a class="xact" href="${rb(f.assetsHref)}">Assets →</a>`);
+  const wellsNote = f.wellsHref ? "" :
+    `<p class="xnote">Well-level timelines: Big Foot only today — rollout tracked in
+     <a href="https://github.com/vamseeachanta/worldenergydata/issues/948">#948</a>.</p>`;
+  show(`
+    <div class="xtitle">${esc(f.name)}
+      <span class="badge rich">${esc(f.statusLabel)}</span>
+      ${f.treeLabel?`<span class="badge sample">${esc(f.treeLabel)}</span>`:""}</div>
+    <p class="xsub">${esc(f.operator)} · ${esc(f.region)}</p>
+    <div class="xstrip">${strip}</div>
+    ${gates?`<div class="xgates">${gates}</div>`:""}
+    <div class="xmets">${mets}</div>
+    <div class="xcols">
+      <div class="xcardlet"><div class="xh">Host &amp; field facts</div><table>${facts}</table></div>
+      ${perf}${resv}
+    </div>
+    <div class="xacts">${acts.join("")}</div>
+    ${wellsNote}
+    <p class="xprov">${esc(f.provenance||"")}</p>`);
+}
+
+function renderWells(x, f){
+  crumb([["Atlas", "#"], [f.name, `#/field/${f.id}`], ["Wells", `#/field/${f.id}/wells`]]);
+  const rows = (x.wells.wells||[]).filter(w=>w.field_id===f.id);
+  if (!rows.length){
+    show(`<div class="xtitle">${esc(f.name)} · wells</div>
+      <p class="xnote">No well records for this field yet — rollout tracked in
+      <a href="https://github.com/vamseeachanta/worldenergydata/issues/948">#948</a>.</p>`);
+    return;
+  }
+  const tr = rows.map(w=>`<tr>
+    <td><a href="#/field/${f.id}/wells/${esc(w.slot)}">${esc(w.slot)}</a></td>
+    <td>${esc(w.spud_date||"—")}</td><td>${w.drilling_rig_days??"—"}</td>
+    <td>${w.completion_rig_days??"—"}</td><td>${w.max_tvd_ft?w.max_tvd_ft.toLocaleString():"—"}</td>
+    <td>${esc(w.first_oil||"—")}</td><td>${w.cum_oil_mmbbl??"—"}</td>
+    <td>${w.uptime_pct??"—"}</td><td>${esc(w.status||"—")}</td></tr>`).join("");
+  show(`<div class="xtitle">${esc(f.name)} · wells</div>
+    <table class="xwells"><thead><tr><th>Slot</th><th>Spud</th><th>Drill rig-days</th><th>Compl. rig-days</th>
+    <th>TVD ft</th><th>First oil</th><th>Cum oil MMbbl</th><th>Uptime %</th><th>Status</th></tr></thead>
+    <tbody>${tr}</tbody></table>
+    <div class="xacts"><a class="xact" href="${rb("wells/")}">All well timelines →</a></div>`);
+}
+
+function renderWell(x, f, slot){
+  const w = (x.wells.wells||[]).find(v=>v.field_id===f.id && v.slot===slot);
+  crumb([["Atlas", "#"], [f.name, `#/field/${f.id}`], ["Wells", `#/field/${f.id}/wells`], [slot, ""]]);
+  if (!w){
+    show(`<p class="xerr">Unknown well “${esc(slot)}” for ${esc(f.name)}.</p>`);
+    return;
+  }
+  const wo = (w.workovers||[]).map(v=>`${esc(v.date)} (${esc(v.type)})`).join(", ") || "none recorded";
+  const stage = (h, body) => `<div class="xstage"><div class="xh">${h}</div><p>${body}</p></div>`;
+  show(`<div class="xtitle">${esc(f.name)} · well ${esc(w.slot)}</div>
+    <p class="xsub">API ${esc(w.api)} · ${esc(w.status||"")}</p>
+    <div class="xstages">
+      ${stage("Spud", esc(w.spud_date||"—"))}
+      ${stage("Drill", `${w.drilling_rig_days??"—"} rig-days → TD ${esc(w.td_date||"—")}` +
+        (w.max_tvd_ft?`<br>TVD ${w.max_tvd_ft.toLocaleString()} ft`:"") +
+        (w.mud_weight_ppg?` · ${w.mud_weight_ppg} ppg`:""))}
+      ${stage("Complete", `${w.completion_rig_days??"—"} rig-days`)}
+      ${stage("First oil", esc(w.first_oil||"—"))}
+      ${stage("Workover", wo)}
+      ${stage("Produce", `${w.cum_oil_mmbbl??"—"} MMbbl cum` + (w.uptime_pct?` · ${w.uptime_pct}% uptime`:""))}
+    </div>
+    <div class="xacts"><a class="xact" href="${rb(`wells/${f.id}_${w.slot}_well.html`)}">Full well timeline →</a></div>`);
+}
+
+const ROUTE = /^#\/field\/([a-z0-9_]+)(?:\/(wells)(?:\/([A-Za-z0-9-]+))?)?$/;
+async function onHash(){
+  const m = ROUTE.exec(location.hash);
+  const panel = $("x-panel");
+  if (!m){ panel.hidden = true; return; }
+  panel.hidden = false;
+  const fid = m[1], wells = !!m[2], slot = m[3];
+  try {
+    const x = await explorer();
+    const f = x.fields[fid];
+    if (!f){
+      crumb([["Atlas", "#"], [fid, ""]]);
+      show(`<p class="xerr">Unknown field id “${esc(fid)}”. Pick a rich-tier field above.</p>`);
+    }
+    else if (!wells) renderField(x, f);
+    else if (!slot) renderWells(x, f);
+    else renderWell(x, f, slot);
+  } catch (e){
+    crumb([["Atlas", "#"], ["error", ""]]);
+    show(`<p class="xerr">Could not load field data (${esc(e.message)}). The Life-cycle links on each card still work.</p>`);
+  }
+  panel.scrollIntoView({behavior:"smooth", block:"start"});
+}
+$("f-grid").addEventListener("click", e => {
+  if (e.target.closest("a")) return;               // real links keep navigating
+  const card = e.target.closest(".card[data-fid]");
+  if (card) location.hash = "#/field/" + card.dataset.fid;
+});
+window.addEventListener("hashchange", onHash);
+onHash();
+</script>
+</body>
+</html>

--- a/reports/field-atlas/index.html
+++ b/reports/field-atlas/index.html
@@ -4,6 +4,11 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>GoM Field Atlas — worldenergydata</title>
+<!-- Template consumed by scripts/field_atlas/build_field_atlas.py ([{"name": "Aconcagua", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC305", "operator": "ATP Oil & Gas (defunct; orig. TotalFinaElf)", "play": "Deepwater Pliocene/Miocene gas", "concept": "Canyon Express system to Canyon Station platform", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Allegheny", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC254", "operator": null, "play": null, "concept": "tlp", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Amethyst", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC26", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Anduin", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC755", "operator": null, "play": null, "concept": "semisub_fps", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Angelica", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "EC115", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Angus", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC112", "operator": null, "play": null, "concept": "subsea_tieback", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Ariel", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC429", "operator": null, "play": null, "concept": "semisub_fps", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Armstrong", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC162", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Arnold", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "EW963", "operator": null, "play": null, "concept": "subsea_tieback", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Aspen", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC243", "operator": null, "play": null, "concept": "subsea_tieback", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Atlantis North", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC743", "operator": null, "play": null, "concept": "semisub_fps", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Atlas NW", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "LL5", "operator": null, "play": null, "concept": "semisub_fps", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Auger", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GB426", "operator": null, "play": null, "concept": "tlp", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Baccarat", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC178", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Balboa", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "EB597", "operator": null, "play": null, "concept": "subsea_tieback", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Big Bend (Noble)", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC698", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Big Foot", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "WR29", "operator": "Chevron", "play": "Lower Tertiary / Wilcox", "concept": "Extended Tension-Leg Platform (eTLP)", "density_tier": "rich", "has_lifecycle": true, "lifecycle_id": "big_foot"}, {"name": "Boris", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC282", "operator": null, "play": null, "concept": "semisub_fps", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Brutus", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC158", "operator": null, "play": null, "concept": "tlp", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Buckskin", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "KC872", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Bullwinkle", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC65", "operator": null, "play": null, "concept": "subsea_tieback", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Bushwood (Geauxpher)", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GB462", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Callisto", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC876", "operator": null, "play": null, "concept": "semisub_fps", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Camden Hills", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC348", "operator": "Marathon (orig.); ATP (defunct)", "play": "Miocene deepwater gas sands", "concept": "Canyon Express to Williams Canyon Station / Virgo", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Cardona", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC29", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Cardona South", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC29", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Cheyenne", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "LL399", "operator": "Occidental (via Anadarko, 2019)", "play": "Miocene deepwater gas sands", "concept": "Independence Hub semisubmersible", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Cascade/Chinook", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "WR469", "operator": "MP Gulf of Mexico LLC (Murphy EXPRO)", "play": "Lower Tertiary / Wilcox", "concept": "FPSO (BW Pioneer) with subsea tieback", "density_tier": "rich", "has_lifecycle": true, "lifecycle_id": "cascade_chinook"}, {"name": "Clipper", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC299", "operator": null, "play": null, "concept": "subsea_tieback", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Constitution", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC680", "operator": null, "play": null, "concept": "spar", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Cottonwood", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GB244", "operator": null, "play": null, "concept": "fixed_jacket", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Coulomb", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC657", "operator": "BP (Na Kika host); wells orig. Shell", "play": "Deepwater Miocene", "concept": "Na Kika semisubmersible FPS", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Dalmatian North", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "DC4", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Dalmatian South", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "DC134", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Daniel Boone", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC646", "operator": null, "play": null, "concept": "subsea_tieback", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Deep Blue", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC723", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Devils Tower", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC773", "operator": null, "play": null, "concept": "spar", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Diana", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "EB945", "operator": null, "play": null, "concept": "subsea_tieback", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Dorado", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "VK915", "operator": null, "play": null, "concept": "tlp", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Droshky", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC244", "operator": null, "play": null, "concept": "subsea_tieback", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Dulcimer", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GB367", "operator": null, "play": null, "concept": "fixed_jacket", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "East Anstey", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC607", "operator": null, "play": null, "concept": "semisub_fps", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "EW 998", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "EW998", "operator": null, "play": null, "concept": "fixed_jacket", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Falcon", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "EB579", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Fastball", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "VK1003", "operator": null, "play": null, "concept": "fixed_jacket", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Fiji", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC427", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Flintcreek", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GB171", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Flying Dutchman", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC511", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Fourier", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC522", "operator": null, "play": null, "concept": "semisub_fps", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Friesian", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC599", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Front Runner South", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC339", "operator": null, "play": null, "concept": "spar", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Gladden", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC800", "operator": null, "play": null, "concept": "semisub_fps", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Great White", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "AC857", "operator": "Shell", "play": "Lower Tertiary / Wilcox", "concept": "Perdido spar", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Guadalupe", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC555", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Gunflint (Freedom)", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC948", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Hadrian South", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "KC964", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Harrier", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "EB759", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Hartebeest", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC166", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Heidelberg", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC859", "operator": null, "play": null, "concept": "spar", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Hoover", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "AC25", "operator": null, "play": null, "concept": "spar", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Jaguar (Buccaneer)", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "EI147", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Kakuna", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC416", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Kepler", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC383", "operator": null, "play": null, "concept": "semisub_fps", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "King", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC84", "operator": "Occidental (chain BP-Plains-FCX-Anadarko-Oxy)", "play": "Miocene", "concept": "Marlin TLP (Viosca Knoll 915)", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Lafitte", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "EI223", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Leon", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "KC642", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Longhorn (aka Leo)", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC546", "operator": null, "play": null, "concept": "fixed_jacket", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Macaroni", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GB602", "operator": null, "play": null, "concept": "tlp", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Macondo", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC252", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Madison", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "AC24", "operator": null, "play": null, "concept": "subsea_tieback", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Magnolia", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GB783", "operator": null, "play": null, "concept": "tlp", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Mahogany", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "SS349", "operator": null, "play": null, "concept": "fixed_jacket", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Main Pass 108", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MP107", "operator": null, "play": null, "concept": "fixed_jacket", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Main Pass 98", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MP98", "operator": null, "play": null, "concept": "fixed_jacket", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Marco Polo", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC608", "operator": null, "play": null, "concept": "subsea_tieback", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Matterhorn", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC243", "operator": null, "play": null, "concept": "tlp", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Mica Deep", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC211", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Moccasin", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "KC736", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Mondo NW", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "LL1", "operator": null, "play": null, "concept": "semisub_fps", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Morpeth", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "EW921", "operator": null, "play": null, "concept": "tlp", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Nautilus (GOM)", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "SS263", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Nile", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "VK914", "operator": null, "play": null, "concept": "tlp", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "North Boomvang", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "EB643", "operator": null, "play": null, "concept": "spar", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Northwood", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC944", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Parmer", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC823", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Pegasus", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC385", "operator": null, "play": null, "concept": "tlp", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Petronius", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "VK786", "operator": null, "play": null, "concept": "compliant_tower", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Phobos", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "SE39", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Phoenix", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC236", "operator": null, "play": null, "concept": "semisub_fps", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Pony", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC468", "operator": null, "play": null, "concept": "semisub_fps", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Prince", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "EW958", "operator": null, "play": null, "concept": "tlp", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Pyrenees", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GB293", "operator": null, "play": null, "concept": "fixed_jacket", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Q", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC961", "operator": null, "play": null, "concept": "semisub_fps", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Raptor", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "EB668", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Red Hawk", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GB877", "operator": null, "play": null, "concept": "spar", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Samurai", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC432", "operator": null, "play": null, "concept": "subsea_tieback", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "San Jacinto", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "DC618", "operator": null, "play": null, "concept": "semisub_fps", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "SOB 2", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC387", "operator": null, "play": null, "concept": "semisub_fps", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Jack/St. Malo", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "WR678", "operator": "Chevron", "play": "Lower Tertiary / Wilcox", "concept": "Semisubmersible FPU", "density_tier": "rich", "has_lifecycle": true, "lifecycle_id": "jack_st_malo"}, {"name": "Stones", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "WR508", "operator": "Shell", "play": "Lower Tertiary / Wilcox", "concept": "FPSO (Turritella / Stones FPSO, disconnectable)", "density_tier": "rich", "has_lifecycle": true, "lifecycle_id": "stones"}, {"name": "Swordfish", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "VK917", "operator": null, "play": null, "concept": "subsea_tieback", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Taggart", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC816", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Tahiti", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC640", "operator": null, "play": null, "concept": "spar", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Tahoe", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "VK783", "operator": null, "play": null, "concept": "fixed_jacket", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Telemark", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "AT63", "operator": null, "play": null, "concept": "subsea_tieback", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Tiber", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "KC102", "operator": "BP", "play": "Lower Tertiary / Wilcox", "concept": "Semisubmersible FPU", "density_tier": "rich", "has_lifecycle": true, "lifecycle_id": "tiber"}, {"name": "Ticonderoga", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC768", "operator": null, "play": null, "concept": "subsea_tieback", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Tobago", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "AC859", "operator": "Shell (32.5%); Chevron 57.5%, CNOOC 10%", "play": "Lower Tertiary / Paleogene (Perdido Fold Belt)", "concept": "Perdido spar (subsea tieback)", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Toddy", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "ST221", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Trident", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "AC903", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Troubadour", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC699", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "West Boomvang", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "EB642", "operator": null, "play": null, "concept": "spar", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Who Dat", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC503", "operator": null, "play": null, "concept": "semisub_fps", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Wide Berth", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC490", "operator": null, "play": null, "concept": null, "density_tier": "roadmap", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Wrigley", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "MC506", "operator": null, "play": null, "concept": "fixed_jacket", "density_tier": "sample", "has_lifecycle": false, "lifecycle_id": null}, {"name": "Anchor", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GC807", "operator": "Chevron", "play": "Lower Tertiary / Wilcox", "concept": "Semisubmersible FPU", "density_tier": "rich", "has_lifecycle": true, "lifecycle_id": "anchor"}, {"name": "Julia", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "WR627", "operator": "ExxonMobil", "play": "Lower Tertiary / Wilcox", "concept": "Subsea tieback to Jack/St. Malo FPU", "density_tier": "rich", "has_lifecycle": true, "lifecycle_id": "julia"}, {"name": "Kaskida", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "KC292", "operator": "BP", "play": "Lower Tertiary / Wilcox", "concept": "Semisubmersible FPU (20,000 psi)", "density_tier": "rich", "has_lifecycle": true, "lifecycle_id": "kaskida"}, {"name": "North Platte (Sparta)", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "GB959", "operator": "Shell", "play": "Lower Tertiary / Wilcox", "concept": "Newbuild Semisubmersible FPU", "density_tier": "rich", "has_lifecycle": true, "lifecycle_id": "north_platte"}, {"name": "Shenandoah", "country": "USA", "domain": "offshore", "region": "US Gulf of Mexico", "block": "WR52", "operator": "Beacon Offshore Energy", "play": "Lower Tertiary / Wilcox", "concept": "Semisubmersible FPU (20,000-psi)", "density_tier": "rich", "has_lifecycle": true, "lifecycle_id": "shenandoah"}]
+     is substituted at build time). The Explorer shell (issue #946) fetches
+     ../lifecycle/_explorer.json at runtime — local preview therefore needs an
+     HTTP server: run `python3 -m http.server` from public/ (fetch() fails on
+     file://; the funnel itself still works without it). -->
 <style>
   :root{--navy:#0B3D91;--teal:#0f8a7e;--bg:#eef3fa;--panel:#fff;--ink:#13233f;--muted:#5b6b86;
         --line:#dbe4f0;--soft:#f4f8fc;--rich:#1f9d57;--sample:#b7791f;--roadmap:#8a97ab}
@@ -32,6 +37,7 @@
   .card{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:15px 17px;display:flex;flex-direction:column;
         box-shadow:0 1px 2px rgba(16,40,80,.04);transition:transform .12s,border-color .12s,box-shadow .12s}
   .card:hover{transform:translateY(-2px);border-color:#b9cbe6;box-shadow:0 8px 20px rgba(16,40,80,.09)}
+  .card[data-fid]{cursor:pointer}
   .card h3{font-size:15.5px;font-weight:700;color:var(--ink);display:flex;align-items:center;gap:8px;justify-content:space-between}
   .badge{font-family:ui-monospace,monospace;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;padding:3px 8px;border-radius:20px;white-space:nowrap}
   .badge.rich{color:var(--rich);background:color-mix(in srgb,var(--rich) 12%,#fff);border:1px solid color-mix(in srgb,var(--rich) 35%,#fff)}
@@ -45,9 +51,48 @@
   .card .go span{font-size:12px;color:var(--muted);font-family:ui-monospace,monospace}
   .note{margin-top:26px;font-size:13px;color:var(--muted);background:#fff;border:1px solid var(--line);border-radius:12px;padding:14px 18px}
   .note b{color:var(--navy)}
+  /* ---- Explorer panel (issue #946) ---- */
+  #x-panel{margin-top:26px;background:var(--panel);border:1px solid var(--line);border-left:4px solid var(--navy);
+           border-radius:14px;padding:18px 22px;box-shadow:0 8px 24px rgba(16,40,80,.08)}
+  .xcrumb{font-family:ui-monospace,monospace;font-size:12.5px;color:var(--muted);margin-bottom:12px}
+  .xcrumb a{color:var(--teal);font-weight:700}
+  .xtitle{font-size:22px;font-weight:800;color:var(--navy);display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+  .xtitle .badge{font-size:11px}
+  .xsub{font-size:13px;color:var(--muted);margin:2px 0 12px}
+  .xstrip{display:flex;gap:6px;flex-wrap:wrap;margin:10px 0 4px}
+  .xph{font-family:ui-monospace,monospace;font-size:11px;text-transform:uppercase;letter-spacing:.05em;
+       padding:4px 10px;border-radius:20px;border:1px solid var(--line);color:var(--muted);background:var(--soft)}
+  .xph.on{background:var(--navy);color:#fff;border-color:var(--navy);font-weight:700}
+  .xgates{font-family:ui-monospace,monospace;font-size:12px;color:var(--muted);margin:6px 0 12px}
+  .xmets{display:flex;gap:12px;flex-wrap:wrap;margin:10px 0}
+  .xmet{background:var(--soft);border:1px solid var(--line);border-radius:10px;padding:8px 14px;min-width:110px}
+  .xmet b{font-size:17px;color:var(--ink)}
+  .xmet i{font-style:normal;font-size:11px;color:var(--muted);margin-left:3px}
+  .xmet s{text-decoration:none;display:block;font-family:ui-monospace,monospace;font-size:10.5px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}
+  .xcols{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:14px;margin-top:8px}
+  .xcardlet{background:var(--soft);border:1px solid var(--line);border-radius:10px;padding:12px 14px}
+  .xcardlet .xh{font-family:ui-monospace,monospace;font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin-bottom:8px}
+  .xcardlet table{width:100%;border-collapse:collapse;font-size:13px}
+  .xcardlet td{padding:3px 0;vertical-align:top}
+  .xcardlet td:first-child{color:var(--muted);padding-right:12px;white-space:nowrap}
+  .xacts{display:flex;gap:10px;flex-wrap:wrap;margin-top:16px}
+  .xact{font-size:13px;font-weight:700;color:#fff;background:linear-gradient(135deg,var(--teal),var(--navy));padding:7px 13px;border-radius:9px;display:inline-block}
+  .xnote{margin-top:12px;font-size:13px;color:var(--muted);background:var(--soft);border:1px dashed var(--line);border-radius:9px;padding:9px 13px}
+  .xnote a{color:var(--teal);font-weight:700}
+  .xerr{font-size:14px;color:#a33;background:#fff4f4;border:1px solid #ecc;border-radius:9px;padding:10px 14px}
+  .xwells{width:100%;border-collapse:collapse;font-size:13px;margin-top:8px}
+  .xwells th{font-family:ui-monospace,monospace;font-size:10.5px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);text-align:left;padding:6px 10px;border-bottom:1px solid var(--line)}
+  .xwells td{padding:7px 10px;border-bottom:1px solid var(--line)}
+  .xwells a{color:var(--teal);font-weight:700}
+  .xstages{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:10px;margin-top:10px}
+  .xstage{background:var(--soft);border:1px solid var(--line);border-radius:10px;padding:10px 12px}
+  .xstage .xh{font-family:ui-monospace,monospace;font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--teal);margin-bottom:4px;font-weight:700}
+  .xstage p{font-size:13px}
+  .xprov{margin-top:14px;font-size:11.5px;color:var(--muted);font-family:ui-monospace,monospace}
   @media (prefers-color-scheme:dark){
     :root{--bg:#0a141f;--panel:#10202f;--ink:#e8eef4;--muted:#8ca0b3;--line:#24384b;--soft:#0d1b28;--navy:#5b9de0;--teal:#3fb99b}
     .badge.roadmap{background:#182636}.card .go a{color:#08131f}
+    .xact{color:#08131f}.xerr{background:#2a1518;border-color:#5c2a30;color:#f0a9a9}
   }
 </style>
 </head>
@@ -57,7 +102,7 @@
   <!-- nav-spine --><div class="nav-spine" style="font:12px/1.6 ui-monospace,SFMono-Regular,Menlo,monospace;margin:0 0 10px;opacity:.75"><a href="../index.html">worldenergydata</a> ▸ <a href="../capabilities/index.html">Capabilities</a> ▸ <span>Field atlas</span></div>
 <h1>Gulf of Mexico Field Atlas</h1>
   <p class="lede">Browse deepwater fields top-down — Country → onshore/offshore → Region → geological play → field.
-     Fields with a full life-cycle analysis link straight to their stage-gate hub.</p>
+     Fields with a full life-cycle analysis open right here — and link through to their stage-gate hub.</p>
   <div class="story">The <b>Lower Tertiary (Wilcox)</b> play is ~8% of GoM fields but holds <b>~36% of the oil</b> — start there.</div>
 
   <div class="funnel">
@@ -73,6 +118,11 @@
   <div class="tiers" id="f-tiers"></div>
   <div class="count" id="f-count"></div>
   <div class="grid" id="f-grid"></div>
+
+  <section id="x-panel" hidden>
+    <nav class="xcrumb" id="x-crumb"></nav>
+    <div id="x-body"></div>
+  </section>
 
   <div class="note">Showing the <b>120 concept-matched</b> Gulf of Mexico fields. The full GoM atlas holds
      <b>1,390 fields</b> (Lower Tertiary = 111 fields, ~36% of GoM oil); the long tail is a searchable catalog, not shown here.
@@ -120,11 +170,171 @@ function render(){
       : (f.concept ? `<div class="go"><span>concept: ${f.concept}</span></div>` : "");
     const meta = [f.operator, f.block].filter(Boolean).map(x=>`<b>${x}</b>`).join(" · ");
     const play = f.play ? `<div class="concept">${f.play}</div>` : "";
-    return `<div class="card"><h3>${f.name}<span class="badge ${f.density_tier}">${f.density_tier}</span></h3>
+    const fid = f.lifecycle_id ? ` data-fid="${f.lifecycle_id}"` : "";
+    return `<div class="card"${fid}><h3>${f.name}<span class="badge ${f.density_tier}">${f.density_tier}</span></h3>
       ${meta?`<div class="meta">${meta}</div>`:""}${play}${go}</div>`;
   }).join("");
 }
 render();
+
+/* ---- Explorer shell (issue #946): in-place drill-down for rich fields. ----
+   Data contract: ../lifecycle/_explorer.json (post-enrichment poster payloads
+   keyed by id + the wells contract). All payload hrefs are lifecycle-relative
+   by contract — EVERY href is rebased through rb() before it reaches the DOM.
+   Router links are always bare "#/..." (never "index.html#/..."). Rich-only:
+   cards without a lifecycle_id keep plain funnel behavior (#947 owns ids). */
+const LIFE_BASE = new URL("../lifecycle/", document.baseURI);
+const rb = h => new URL(h, LIFE_BASE).href;
+const esc = s => String(s).replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
+const PHASES = ["explore","appraise","define","execute","operate","decommission"];
+let XP = null;
+async function explorer(){
+  if (XP) return XP;
+  const res = await fetch(rb("_explorer.json"));
+  if (!res.ok) throw new Error("HTTP " + res.status);
+  XP = await res.json();
+  return XP;
+}
+
+function crumb(items){
+  // items: [label, "#/..."] pairs; the last item renders as the current leaf.
+  $("x-crumb").innerHTML = items.map(([lab, h], i) =>
+    i < items.length - 1 ? `<a href="${h}">${esc(lab)}</a>` : `<span>${esc(lab)}</span>`
+  ).join(" ▸ ");
+}
+function show(html){ $("x-body").innerHTML = html; }
+
+function renderField(x, f){
+  crumb([["Atlas", "#"], [f.name, `#/field/${f.id}`]]);
+  const strip = PHASES.map(p=>`<span class="xph${p===f.currentPhase?" on":""}">${esc(p)}</span>`).join("");
+  const gates = (f.gates||[]).filter(g=>g.kind==="primary")
+    .map(g=>`${esc(g.lab)} ${esc(g.dt)}`).join(" · ");
+  const mets = (f.metrics||[]).map(m=>
+    `<div class="xmet"><b>${esc(m.v)}</b><i>${esc(m.u||"")}</i><s>${esc(m.k)}</s></div>`).join("");
+  const facts = (f.hostFacts||[]).map(([k,v])=>`<tr><td>${esc(k)}</td><td>${esc(v)}</td></tr>`).join("");
+  let perf = "";
+  if (f.performance){
+    const P = f.performance, row = (k,v)=> v==null?"":`<tr><td>${esc(k)}</td><td>${esc(v)}</td></tr>`;
+    perf = `<div class="xcardlet"><div class="xh">Field performance · BSEE life-to-date</div><table>` +
+      row("Wells", P.wells) + row("Cum oil", P.cum_oil_mmbbl==null?null:P.cum_oil_mmbbl+" MMbbl") +
+      row("EUR", P.eur_mmbbl==null?null:P.eur_mmbbl+" MMbbl") +
+      row("Avg uptime", P.avg_uptime_pct==null?null:P.avg_uptime_pct+"%") +
+      row("Avg decline", P.avg_decline_pct_yr==null?null:P.avg_decline_pct_yr+"%/yr") +
+      row("Breakeven WTI", P.breakeven_wti==null?null:"$"+P.breakeven_wti+"/bbl") +
+      row("NPV", P.npv_mm==null?null:"$"+P.npv_mm+"MM") +
+      row("Interventions", P.interventions) + `</table></div>`;
+  }
+  let resv = "";
+  if (f.reservoir){
+    const R = f.reservoir, row = (k,v)=> v==null||v===""?"":`<tr><td>${esc(k)}</td><td>${esc(v)}</td></tr>`;
+    const body = row("Formation", R.formation) +
+      row("Pressure", R.pressure_psi==null?null:R.pressure_psi.toLocaleString()+" psi "+(R.pressure_qual||"")) +
+      row("Equip. rating", R.equip_rating_psi==null?null:R.equip_rating_psi.toLocaleString()+" psi") +
+      row("Temp", R.temp_f==null?null:R.temp_f+" °F") + row("TVD", R.tvd_ft==null?null:R.tvd_ft.toLocaleString()+" ft") +
+      row("Fluid", R.fluid) + row("HPHT class", R.hpht_class);
+    if (body) resv = `<div class="xcardlet"><div class="xh">Reservoir</div><table>${body}</table></div>`;
+  }
+  const acts = [`<a class="xact" href="${rb(f.id + "_lifecycle.html")}">Full life-cycle poster →</a>`];
+  if (f.economics_href) acts.push(`<a class="xact" href="${rb(f.economics_href)}">Economics →</a>`);
+  if (f.benchmark_href) acts.push(`<a class="xact" href="${rb(f.benchmark_href)}">Benchmark →</a>`);
+  if (f.wellsHref && f.wellsCount) acts.push(`<a class="xact" href="#/field/${f.id}/wells">Wells (${f.wellsCount}) →</a>`);
+  if (f.assetsHref) acts.push(`<a class="xact" href="${rb(f.assetsHref)}">Assets →</a>`);
+  const wellsNote = f.wellsHref ? "" :
+    `<p class="xnote">Well-level timelines: Big Foot only today — rollout tracked in
+     <a href="https://github.com/vamseeachanta/worldenergydata/issues/948">#948</a>.</p>`;
+  show(`
+    <div class="xtitle">${esc(f.name)}
+      <span class="badge rich">${esc(f.statusLabel)}</span>
+      ${f.treeLabel?`<span class="badge sample">${esc(f.treeLabel)}</span>`:""}</div>
+    <p class="xsub">${esc(f.operator)} · ${esc(f.region)}</p>
+    <div class="xstrip">${strip}</div>
+    ${gates?`<div class="xgates">${gates}</div>`:""}
+    <div class="xmets">${mets}</div>
+    <div class="xcols">
+      <div class="xcardlet"><div class="xh">Host &amp; field facts</div><table>${facts}</table></div>
+      ${perf}${resv}
+    </div>
+    <div class="xacts">${acts.join("")}</div>
+    ${wellsNote}
+    <p class="xprov">${esc(f.provenance||"")}</p>`);
+}
+
+function renderWells(x, f){
+  crumb([["Atlas", "#"], [f.name, `#/field/${f.id}`], ["Wells", `#/field/${f.id}/wells`]]);
+  const rows = (x.wells.wells||[]).filter(w=>w.field_id===f.id);
+  if (!rows.length){
+    show(`<div class="xtitle">${esc(f.name)} · wells</div>
+      <p class="xnote">No well records for this field yet — rollout tracked in
+      <a href="https://github.com/vamseeachanta/worldenergydata/issues/948">#948</a>.</p>`);
+    return;
+  }
+  const tr = rows.map(w=>`<tr>
+    <td><a href="#/field/${f.id}/wells/${esc(w.slot)}">${esc(w.slot)}</a></td>
+    <td>${esc(w.spud_date||"—")}</td><td>${w.drilling_rig_days??"—"}</td>
+    <td>${w.completion_rig_days??"—"}</td><td>${w.max_tvd_ft?w.max_tvd_ft.toLocaleString():"—"}</td>
+    <td>${esc(w.first_oil||"—")}</td><td>${w.cum_oil_mmbbl??"—"}</td>
+    <td>${w.uptime_pct??"—"}</td><td>${esc(w.status||"—")}</td></tr>`).join("");
+  show(`<div class="xtitle">${esc(f.name)} · wells</div>
+    <table class="xwells"><thead><tr><th>Slot</th><th>Spud</th><th>Drill rig-days</th><th>Compl. rig-days</th>
+    <th>TVD ft</th><th>First oil</th><th>Cum oil MMbbl</th><th>Uptime %</th><th>Status</th></tr></thead>
+    <tbody>${tr}</tbody></table>
+    <div class="xacts"><a class="xact" href="${rb("wells/")}">All well timelines →</a></div>`);
+}
+
+function renderWell(x, f, slot){
+  const w = (x.wells.wells||[]).find(v=>v.field_id===f.id && v.slot===slot);
+  crumb([["Atlas", "#"], [f.name, `#/field/${f.id}`], ["Wells", `#/field/${f.id}/wells`], [slot, ""]]);
+  if (!w){
+    show(`<p class="xerr">Unknown well “${esc(slot)}” for ${esc(f.name)}.</p>`);
+    return;
+  }
+  const wo = (w.workovers||[]).map(v=>`${esc(v.date)} (${esc(v.type)})`).join(", ") || "none recorded";
+  const stage = (h, body) => `<div class="xstage"><div class="xh">${h}</div><p>${body}</p></div>`;
+  show(`<div class="xtitle">${esc(f.name)} · well ${esc(w.slot)}</div>
+    <p class="xsub">API ${esc(w.api)} · ${esc(w.status||"")}</p>
+    <div class="xstages">
+      ${stage("Spud", esc(w.spud_date||"—"))}
+      ${stage("Drill", `${w.drilling_rig_days??"—"} rig-days → TD ${esc(w.td_date||"—")}` +
+        (w.max_tvd_ft?`<br>TVD ${w.max_tvd_ft.toLocaleString()} ft`:"") +
+        (w.mud_weight_ppg?` · ${w.mud_weight_ppg} ppg`:""))}
+      ${stage("Complete", `${w.completion_rig_days??"—"} rig-days`)}
+      ${stage("First oil", esc(w.first_oil||"—"))}
+      ${stage("Workover", wo)}
+      ${stage("Produce", `${w.cum_oil_mmbbl??"—"} MMbbl cum` + (w.uptime_pct?` · ${w.uptime_pct}% uptime`:""))}
+    </div>
+    <div class="xacts"><a class="xact" href="${rb(`wells/${f.id}_${w.slot}_well.html`)}">Full well timeline →</a></div>`);
+}
+
+const ROUTE = /^#\/field\/([a-z0-9_]+)(?:\/(wells)(?:\/([A-Za-z0-9-]+))?)?$/;
+async function onHash(){
+  const m = ROUTE.exec(location.hash);
+  const panel = $("x-panel");
+  if (!m){ panel.hidden = true; return; }
+  panel.hidden = false;
+  const fid = m[1], wells = !!m[2], slot = m[3];
+  try {
+    const x = await explorer();
+    const f = x.fields[fid];
+    if (!f){
+      crumb([["Atlas", "#"], [fid, ""]]);
+      show(`<p class="xerr">Unknown field id “${esc(fid)}”. Pick a rich-tier field above.</p>`);
+    }
+    else if (!wells) renderField(x, f);
+    else if (!slot) renderWells(x, f);
+    else renderWell(x, f, slot);
+  } catch (e){
+    crumb([["Atlas", "#"], ["error", ""]]);
+    show(`<p class="xerr">Could not load field data (${esc(e.message)}). The Life-cycle links on each card still work.</p>`);
+  }
+  panel.scrollIntoView({behavior:"smooth", block:"start"});
+}
+$("f-grid").addEventListener("click", e => {
+  if (e.target.closest("a")) return;               // real links keep navigating
+  const card = e.target.closest(".card[data-fid]");
+  if (card) location.hash = "#/field/" + card.dataset.fid;
+});
+window.addEventListener("hashchange", onHash);
+onHash();
 </script>
 </body>
 </html>

--- a/reports/lower_tertiary/lifecycle/_explorer.json
+++ b/reports/lower_tertiary/lifecycle/_explorer.json
@@ -1,0 +1,2088 @@
+{
+  "meta": {
+    "generated_by": "scripts/lower_tertiary/build_lifecycle_posters.py",
+    "issue": 946
+  },
+  "fields": {
+    "big_foot": {
+      "id": "big_foot",
+      "wellsHref": "wells/",
+      "wellsCount": 5,
+      "assetsHref": null,
+      "economics_href": "../economics-big_foot.html",
+      "benchmark_href": "../benchmark.html",
+      "name": "Big Foot",
+      "operator": "Chevron",
+      "region": "Walker Ridge 29 (G16942) · US Gulf of Mexico",
+      "host": "Extended Tension-Leg Platform (eTLP)",
+      "statusLabel": "Producing",
+      "statusHue": "var(--good)",
+      "treeType": "dry",
+      "treeLabel": "Dry tree · eTLP",
+      "currentPhase": "operate",
+      "metrics": [
+        {
+          "k": "Water depth",
+          "v": "5,200",
+          "u": "ft"
+        },
+        {
+          "k": "Gross CAPEX",
+          "v": "$5.2",
+          "u": "B"
+        },
+        {
+          "k": "Plateau rate",
+          "v": "75",
+          "u": "mbopd"
+        },
+        {
+          "k": "GOR",
+          "v": "1,100",
+          "u": "scf/bbl"
+        },
+        {
+          "k": "OPEX",
+          "v": "$15",
+          "u": "/boe"
+        },
+        {
+          "k": "Operator WI",
+          "v": "60",
+          "u": "%"
+        }
+      ],
+      "axis": {
+        "start": 2000,
+        "end": 2040,
+        "ticks": [
+          2000,
+          2005,
+          2010,
+          2015,
+          2020,
+          2025,
+          2030,
+          2035,
+          2040
+        ]
+      },
+      "gates": [
+        {
+          "year": 2006.0,
+          "phase": "explore",
+          "lab": "Discovery",
+          "dt": "2006",
+          "kind": "primary"
+        },
+        {
+          "year": 2010.0,
+          "phase": "define",
+          "lab": "FID / Sanction",
+          "dt": "2010",
+          "kind": "primary"
+        },
+        {
+          "year": 2015.0,
+          "phase": "execute",
+          "lab": "Tendon incident",
+          "dt": "2015",
+          "kind": "sec"
+        },
+        {
+          "year": 2018.875,
+          "phase": "operate",
+          "lab": "First oil",
+          "dt": "Nov 2018",
+          "kind": "now"
+        },
+        {
+          "year": 2026.5,
+          "phase": "operate",
+          "lab": "Today",
+          "dt": "2026",
+          "kind": "nowmark"
+        }
+      ],
+      "spans": [
+        {
+          "from": 2006.0,
+          "to": 2010.0,
+          "txt": "Discovery→FID ~4 yr"
+        },
+        {
+          "from": 2010.0,
+          "to": 2018.875,
+          "txt": "FID→first oil ~9 yr (incl. delay)"
+        },
+        {
+          "from": 2018.875,
+          "to": 2038.0,
+          "txt": "Operating life ~19 yr proj."
+        }
+      ],
+      "workingInterest": [
+        {
+          "name": "Chevron",
+          "wi": 60,
+          "lead": true
+        },
+        {
+          "name": "Equinor",
+          "wi": 27.5
+        },
+        {
+          "name": "Marubeni Oil & Gas",
+          "wi": 12.5
+        }
+      ],
+      "hostFacts": [
+        [
+          "Host type",
+          "Extended Tension-Leg Platform (eTLP)"
+        ],
+        [
+          "Water depth",
+          "5,200 ft (1,585 m)"
+        ],
+        [
+          "Play",
+          "Wilcox / Lower Tertiary"
+        ],
+        [
+          "First oil",
+          "Nov 2018"
+        ],
+        [
+          "Data through",
+          "Dec 2024"
+        ]
+      ],
+      "reservoir": {
+        "formation": "Wilcox / Paleogene (Lower Tertiary)",
+        "hpht_class": null,
+        "pressure_psi": null,
+        "pressure_qual": "",
+        "equip_rating_psi": null,
+        "temp_f": null,
+        "tvd_ft": null,
+        "fluid": "black oil",
+        "api": null,
+        "source_note": "Wilcox oil field (Offshore Technology; Chevron). Field-specific reservoir pressure/temperature not publicly disclosed — shown as — rather than borrowed from neighbouring fields."
+      },
+      "provenance": "Data: big_foot.yml + Chevron public disclosures + BSEE (dates to be reconciled in #375)",
+      "norms": [
+        {
+          "delta_play_pct": -22.3,
+          "href": "norms/drill.html#big_foot",
+          "n": 24,
+          "play_n": 160,
+          "stage": "drill",
+          "state": "ok",
+          "unit": "days",
+          "value": 36.5
+        },
+        {
+          "delta_play_pct": 12.1,
+          "href": "norms/complete.html#big_foot",
+          "n": 25,
+          "play_n": 161,
+          "stage": "complete",
+          "state": "ok",
+          "unit": "days",
+          "value": 37.0
+        },
+        {
+          "delta_play_pct": -1.8,
+          "href": "norms/produce.html#big_foot",
+          "n": 8,
+          "play_n": 48,
+          "stage": "produce",
+          "state": "ok",
+          "unit": "%",
+          "value": 93.05
+        },
+        {
+          "delta_play_pct": 257.1,
+          "href": "norms/workover.html#big_foot",
+          "n": 8,
+          "play_n": 48,
+          "stage": "workover",
+          "state": "ok",
+          "unit": "per well",
+          "value": 0.75
+        },
+        {
+          "href": "norms/abandon.html#big_foot",
+          "stage": "abandon",
+          "state": "unavailable"
+        }
+      ],
+      "performance": {
+        "avg_decline_pct_yr": 17.2,
+        "avg_uptime_pct": 88.2,
+        "breakeven_wti": 153.0,
+        "cum_oil_mmbbl": 78.7,
+        "display": "Big Foot",
+        "eur_mmbbl": 1324,
+        "interventions": 6,
+        "npv_mm": -989.0,
+        "sens_mm_per_dollar": 12.1,
+        "wells": 8
+      }
+    },
+    "anchor": {
+      "id": "anchor",
+      "wellsHref": null,
+      "wellsCount": 0,
+      "assetsHref": null,
+      "economics_href": "../economics-anchor.html",
+      "benchmark_href": "../benchmark.html",
+      "name": "Anchor",
+      "operator": "Chevron",
+      "region": "Green Canyon 807 · US Gulf of Mexico",
+      "host": "Semisubmersible FPU",
+      "statusLabel": "Producing",
+      "statusHue": "var(--good)",
+      "treeType": "wet",
+      "treeLabel": "Wet tree · Semisub FPU",
+      "currentPhase": "operate",
+      "metrics": [
+        {
+          "k": "Water depth",
+          "v": "5,180",
+          "u": "ft"
+        },
+        {
+          "k": "Gross CAPEX",
+          "v": "$5.6",
+          "u": "B"
+        },
+        {
+          "k": "Plateau rate",
+          "v": "75",
+          "u": "mbopd"
+        },
+        {
+          "k": "GOR",
+          "v": "1,100",
+          "u": "scf/bbl"
+        },
+        {
+          "k": "OPEX",
+          "v": "$15",
+          "u": "/boe"
+        },
+        {
+          "k": "Operator WI",
+          "v": "62.5",
+          "u": "%"
+        }
+      ],
+      "axis": {
+        "start": 2010,
+        "end": 2045,
+        "ticks": [
+          2010,
+          2015,
+          2020,
+          2025,
+          2030,
+          2035,
+          2040,
+          2045
+        ]
+      },
+      "gates": [
+        {
+          "year": 2014.0,
+          "phase": "explore",
+          "lab": "Discovery",
+          "dt": "2014",
+          "kind": "primary"
+        },
+        {
+          "year": 2019.0,
+          "phase": "define",
+          "lab": "FID / Sanction",
+          "dt": "2019",
+          "kind": "primary"
+        },
+        {
+          "year": 2024.625,
+          "phase": "operate",
+          "lab": "First oil",
+          "dt": "Aug 2024",
+          "kind": "now"
+        },
+        {
+          "year": 2026.5,
+          "phase": "operate",
+          "lab": "Today",
+          "dt": "2026",
+          "kind": "nowmark"
+        }
+      ],
+      "spans": [
+        {
+          "from": 2014.0,
+          "to": 2019.0,
+          "txt": "Discovery→FID ~5 yr"
+        },
+        {
+          "from": 2019.0,
+          "to": 2024.625,
+          "txt": "FID→first oil ~6 yr"
+        }
+      ],
+      "workingInterest": [
+        {
+          "name": "Chevron",
+          "wi": 62.5,
+          "lead": true
+        },
+        {
+          "name": "Equinor",
+          "wi": 25
+        },
+        {
+          "name": "TotalEnergies",
+          "wi": 12.5
+        }
+      ],
+      "hostFacts": [
+        [
+          "Host type",
+          "Semisubmersible FPU"
+        ],
+        [
+          "Water depth",
+          "5,180 ft (1,579 m)"
+        ],
+        [
+          "Play",
+          "Lower Tertiary Wilcox"
+        ],
+        [
+          "First oil",
+          "Aug 2024"
+        ],
+        [
+          "Data through",
+          "Dec 2024"
+        ]
+      ],
+      "reservoir": {
+        "formation": "Paleocene Wilcox (Wilcox 1–4)",
+        "hpht_class": "ultra-HPHT",
+        "pressure_psi": 25000,
+        "pressure_qual": "",
+        "equip_rating_psi": 20000,
+        "temp_f": 275,
+        "tvd_ft": 30000,
+        "fluid": "black oil",
+        "api": null,
+        "source_note": "OGJ 2024: initial reservoir (BHP) 23,000–27,000 psi — higher than the 20,000-psi equipment rating; 275F max flowing temp; pay 30,000–34,000 ft TVD (Wilcox 1–4)."
+      },
+      "provenance": "Primary facts (operator, working interests, capex $5.6B, plateau 75 mbopd, GOR 1100 scf/bbl, opex $15/boe, first oil 2024-08, data through 2024-12-31) from in-repo anchor.yml. Life-cycle dates corroborated by public sources: discovery well Anchor-2 drilled 2014 (Green Canyon 807, ~5,180 ft), FID December 2019 (~$5.7B sanction), first oil August 2024 — world's first 20,000-psi HPHT deepwater development on a semisubmersible FPU, Lower Tertiary Wilcox play. Working interests (Chevron 62.5% / Equinor 25% / TotalEnergies 12.5%) per YAML; note older Offshore Technology page still lists pre-Equinor split (Chevron 62.86% / Total 37.14%). water depth ~5,180 (block-level estimate). projected end-of-production and lease year not confidently sourced; no notable incident.",
+      "norms": [
+        {
+          "delta_play_pct": 10.9,
+          "href": "norms/drill.html#anchor",
+          "n": 13,
+          "play_n": 171,
+          "stage": "drill",
+          "state": "ok",
+          "unit": "days",
+          "value": 51.0
+        },
+        {
+          "delta_play_pct": 16.1,
+          "href": "norms/complete.html#anchor",
+          "n": 13,
+          "play_n": 173,
+          "stage": "complete",
+          "state": "ok",
+          "unit": "days",
+          "value": 36.0
+        },
+        {
+          "delta_play_pct": -1.4,
+          "href": "norms/produce.html#anchor",
+          "n": 3,
+          "play_n": 53,
+          "stage": "produce",
+          "state": "low_n",
+          "unit": "%",
+          "value": 93.3
+        },
+        {
+          "delta_play_pct": -100.0,
+          "href": "norms/workover.html#anchor",
+          "n": 3,
+          "play_n": 53,
+          "stage": "workover",
+          "state": "low_n",
+          "unit": "per well",
+          "value": 0.0
+        },
+        {
+          "href": "norms/abandon.html#anchor",
+          "stage": "abandon",
+          "state": "unavailable"
+        }
+      ],
+      "performance": {
+        "avg_decline_pct_yr": 0.0,
+        "avg_uptime_pct": 88.1,
+        "breakeven_wti": 380.0,
+        "cum_oil_mmbbl": 18.6,
+        "display": "Anchor",
+        "eur_mmbbl": 998,
+        "interventions": 0,
+        "npv_mm": -1586.9,
+        "sens_mm_per_dollar": 5.1,
+        "wells": 3
+      }
+    },
+    "cascade_chinook": {
+      "id": "cascade_chinook",
+      "wellsHref": null,
+      "wellsCount": 0,
+      "assetsHref": null,
+      "economics_href": "../economics-cascade_chinook.html",
+      "benchmark_href": "../benchmark.html",
+      "name": "Cascade/Chinook",
+      "operator": "MP Gulf of Mexico LLC (Murphy EXPRO)",
+      "region": "Walker Ridge 206/250 (Cascade), 425/469 (Chinook) · US Gulf of Mexico",
+      "host": "FPSO (BW Pioneer) with subsea tieback",
+      "statusLabel": "Producing",
+      "statusHue": "var(--good)",
+      "treeType": "wet",
+      "treeLabel": "Wet tree · FPSO",
+      "currentPhase": "operate",
+      "metrics": [
+        {
+          "k": "Water depth",
+          "v": "8,200",
+          "u": "ft"
+        },
+        {
+          "k": "Gross CAPEX",
+          "v": "$2.9",
+          "u": "B"
+        },
+        {
+          "k": "Plateau rate",
+          "v": "75",
+          "u": "mbopd"
+        },
+        {
+          "k": "GOR",
+          "v": "1,400",
+          "u": "scf/bbl"
+        },
+        {
+          "k": "OPEX",
+          "v": "$18",
+          "u": "/boe"
+        },
+        {
+          "k": "Operator WI",
+          "v": "80",
+          "u": "%"
+        }
+      ],
+      "axis": {
+        "start": 2000,
+        "end": 2035,
+        "ticks": [
+          2000,
+          2005,
+          2010,
+          2015,
+          2020,
+          2025,
+          2030,
+          2035
+        ]
+      },
+      "gates": [
+        {
+          "year": 2002.0,
+          "phase": "explore",
+          "lab": "Discovery",
+          "dt": "2002",
+          "kind": "primary"
+        },
+        {
+          "year": 2012.125,
+          "phase": "operate",
+          "lab": "First oil",
+          "dt": "Feb 2012",
+          "kind": "now"
+        },
+        {
+          "year": 2026.5,
+          "phase": "operate",
+          "lab": "Today",
+          "dt": "2026",
+          "kind": "nowmark"
+        }
+      ],
+      "spans": [],
+      "workingInterest": [
+        {
+          "name": "Murphy EXPRO (MP Gulf of Mexico LLC)",
+          "wi": 80,
+          "lead": true
+        },
+        {
+          "name": "Petrobras America Inc.",
+          "wi": 20
+        }
+      ],
+      "hostFacts": [
+        [
+          "Host type",
+          "FPSO (BW Pioneer) with subsea tieback"
+        ],
+        [
+          "Water depth",
+          "8,200 ft (2,499 m)"
+        ],
+        [
+          "Play",
+          "Lower Tertiary (Wilcox)"
+        ],
+        [
+          "First oil",
+          "Feb 2012"
+        ],
+        [
+          "Data through",
+          "Dec 2024"
+        ]
+      ],
+      "reservoir": {
+        "formation": "Wilcox 1 (Eocene) / Wilcox 2 (Paleocene)",
+        "hpht_class": "HPHT",
+        "pressure_psi": 19500,
+        "pressure_qual": "~",
+        "equip_rating_psi": null,
+        "temp_f": 260,
+        "tvd_ft": 25600,
+        "fluid": "black oil (low GOR; CO₂ <1.5%, no H₂S)",
+        "api": null,
+        "source_note": "OTC-24162/24163 + JPT: initial reservoir pressure ~19,500 psi, BHT ~256–260F, reservoir mid-point ~25,600 ft TVD."
+      },
+      "provenance": "Life-cycle dates and ownership from public sources (Offshore Technology, Offshore Magazine, OGJ, Heerema, Rigzone); economics (capex $2.9B, plateau 75 mbopd, GOR 1400 scf/bbl, opex $18/boe) and data through from in-repo YAML. IMPORTANT: two YAML values were overridden as demonstrably wrong vs. well-documented public record — YAML first oil \"2021-08\" corrected to 2012-02 (Cascade first oil Feb 2012, Chinook Sep 2012; BW Pioneer was the first FPSO in the US GoM), and YAML operator/WI \"TotalEnergies 60% / Equinor 40%\" corrected to current MP Gulf of Mexico LLC (Murphy EXPRO 80% operator, Petrobras America 20%; originally Petrobras-operated with Total 33.33% in Chinook). LOW CONFIDENCE: FID year (sanction ~mid-2000s, no firm public citation — not available), lease year and projected end-of-production (not available); water depth 8,200 ft is the Cascade value (Chinook ~8,600 ft); capex is a YAML assumption not independently verified.",
+      "norms": [
+        {
+          "delta_play_pct": 47.8,
+          "href": "norms/drill.html#cascade_chinook",
+          "n": 14,
+          "play_n": 170,
+          "stage": "drill",
+          "state": "ok",
+          "unit": "days",
+          "value": 68.0
+        },
+        {
+          "delta_play_pct": 31.8,
+          "href": "norms/complete.html#cascade_chinook",
+          "n": 14,
+          "play_n": 172,
+          "stage": "complete",
+          "state": "ok",
+          "unit": "days",
+          "value": 43.5
+        },
+        {
+          "delta_play_pct": 0.4,
+          "href": "norms/produce.html#cascade_chinook",
+          "n": 3,
+          "play_n": 53,
+          "stage": "produce",
+          "state": "low_n",
+          "unit": "%",
+          "value": 94.7
+        },
+        {
+          "delta_play_pct": -100.0,
+          "href": "norms/workover.html#cascade_chinook",
+          "n": 3,
+          "play_n": 53,
+          "stage": "workover",
+          "state": "low_n",
+          "unit": "per well",
+          "value": 0.0
+        },
+        {
+          "href": "norms/abandon.html#cascade_chinook",
+          "stage": "abandon",
+          "state": "unavailable"
+        }
+      ],
+      "performance": {
+        "avg_decline_pct_yr": 35.9,
+        "avg_uptime_pct": 94.6,
+        "breakeven_wti": 338.0,
+        "cum_oil_mmbbl": 39.7,
+        "display": "Cascade Chinook",
+        "eur_mmbbl": 92,
+        "interventions": 0,
+        "npv_mm": -1480.5,
+        "sens_mm_per_dollar": 5.5,
+        "wells": 3
+      }
+    },
+    "jack_st_malo": {
+      "id": "jack_st_malo",
+      "wellsHref": null,
+      "wellsCount": 0,
+      "assetsHref": null,
+      "economics_href": "../economics-jack_st_malo.html",
+      "benchmark_href": "../benchmark.html",
+      "name": "Jack/St. Malo",
+      "operator": "Chevron",
+      "region": "Walker Ridge 678 (St. Malo) / 758-759 (Jack) · US Gulf of Mexico",
+      "host": "Semisubmersible FPU",
+      "statusLabel": "Producing",
+      "statusHue": "var(--good)",
+      "treeType": "wet",
+      "treeLabel": "Wet tree · Semisub FPU",
+      "currentPhase": "operate",
+      "metrics": [
+        {
+          "k": "Water depth",
+          "v": "7,000",
+          "u": "ft"
+        },
+        {
+          "k": "Gross CAPEX",
+          "v": "$7.5",
+          "u": "B"
+        },
+        {
+          "k": "Plateau rate",
+          "v": "94",
+          "u": "mbopd"
+        },
+        {
+          "k": "GOR",
+          "v": "1,200",
+          "u": "scf/bbl"
+        },
+        {
+          "k": "OPEX",
+          "v": "$15",
+          "u": "/boe"
+        },
+        {
+          "k": "Operator WI",
+          "v": "51",
+          "u": "%"
+        }
+      ],
+      "axis": {
+        "start": 2000,
+        "end": 2035,
+        "ticks": [
+          2000,
+          2005,
+          2010,
+          2015,
+          2020,
+          2025,
+          2030,
+          2035
+        ]
+      },
+      "gates": [
+        {
+          "year": 2003.0,
+          "phase": "explore",
+          "lab": "Discovery",
+          "dt": "2003",
+          "kind": "primary"
+        },
+        {
+          "year": 2010.0,
+          "phase": "define",
+          "lab": "FID / Sanction",
+          "dt": "2010",
+          "kind": "primary"
+        },
+        {
+          "year": 2014.9583333333333,
+          "phase": "operate",
+          "lab": "First oil",
+          "dt": "Dec 2014",
+          "kind": "now"
+        },
+        {
+          "year": 2026.5,
+          "phase": "operate",
+          "lab": "Today",
+          "dt": "2026",
+          "kind": "nowmark"
+        }
+      ],
+      "spans": [
+        {
+          "from": 2003.0,
+          "to": 2010.0,
+          "txt": "Discovery→FID ~7 yr"
+        },
+        {
+          "from": 2010.0,
+          "to": 2014.9583333333333,
+          "txt": "FID→first oil ~5 yr"
+        }
+      ],
+      "workingInterest": [
+        {
+          "name": "Chevron",
+          "wi": 51,
+          "lead": true
+        },
+        {
+          "name": "Equinor",
+          "wi": 24.5
+        },
+        {
+          "name": "Suncor",
+          "wi": 24.5
+        }
+      ],
+      "hostFacts": [
+        [
+          "Host type",
+          "Semisubmersible FPU"
+        ],
+        [
+          "Water depth",
+          "7,000 ft (2,134 m)"
+        ],
+        [
+          "Play",
+          "Lower Tertiary (Wilcox)"
+        ],
+        [
+          "First oil",
+          "Dec 2014"
+        ],
+        [
+          "Data through",
+          "Dec 2024"
+        ]
+      ],
+      "reservoir": {
+        "formation": "Wilcox (Lower Tertiary)",
+        "hpht_class": "HPHT",
+        "pressure_psi": 19374,
+        "pressure_qual": "",
+        "equip_rating_psi": null,
+        "temp_f": 224,
+        "tvd_ft": 26500,
+        "fluid": "black oil",
+        "api": null,
+        "source_note": "Dice regional Wilcox reservoir study: Jack initial pressure 19,374 psi @ 224F, St. Malo 19,023 psi @ 225F; reservoir ~26,500 ft TVD."
+      },
+      "provenance": "Facts from in-repo YAML (operator, WI Chevron 51%/Equinor 24.5%/Suncor 24.5%, capex $7.5B, opex $15/boe, plateau 94 mbopd, GOR 1200, status producing, data through 2024-12-31). Life-cycle dates from public sources: St. Malo discovered Oct 2003 and Jack Jul 2004 (discovery year=2003, earliest of pair); FID/sanction Oct 2010; first oil per Chevron press release Dec 2014 (\"2014-12\") — this OVERRIDES the YAML's first oil \"2014-02-01\", which appears erroneous. Water depth ~7000 ft at the FPU (Jack WR758/759 ~7000 ft, St. Malo WR678). host = Semisubmersible FPU. projected end-of-production not confidently estimable. lease year not available; no schedule-driving incident.",
+      "norms": [
+        {
+          "delta_play_pct": -28.3,
+          "href": "norms/drill.html#jack_st_malo",
+          "n": 65,
+          "play_n": 119,
+          "stage": "drill",
+          "state": "ok",
+          "unit": "days",
+          "value": 38.0
+        },
+        {
+          "delta_play_pct": -21.2,
+          "href": "norms/complete.html#jack_st_malo",
+          "n": 65,
+          "play_n": 121,
+          "stage": "complete",
+          "state": "ok",
+          "unit": "days",
+          "value": 26.0
+        },
+        {
+          "delta_play_pct": 2.6,
+          "href": "norms/produce.html#jack_st_malo",
+          "n": 24,
+          "play_n": 32,
+          "stage": "produce",
+          "state": "ok",
+          "unit": "%",
+          "value": 95.9
+        },
+        {
+          "delta_play_pct": -19.4,
+          "href": "norms/workover.html#jack_st_malo",
+          "n": 24,
+          "play_n": 32,
+          "stage": "workover",
+          "state": "ok",
+          "unit": "per well",
+          "value": 0.25
+        },
+        {
+          "href": "norms/abandon.html#jack_st_malo",
+          "stage": "abandon",
+          "state": "unavailable"
+        }
+      ],
+      "performance": {
+        "avg_decline_pct_yr": 18.4,
+        "avg_uptime_pct": 89.7,
+        "breakeven_wti": 79.0,
+        "cum_oil_mmbbl": 438.8,
+        "display": "Jack St Malo",
+        "eur_mmbbl": 1117,
+        "interventions": 6,
+        "npv_mm": -804.5,
+        "sens_mm_per_dollar": 52.3,
+        "wells": 24
+      }
+    },
+    "julia": {
+      "id": "julia",
+      "wellsHref": null,
+      "wellsCount": 0,
+      "assetsHref": null,
+      "economics_href": "../economics-julia.html",
+      "benchmark_href": "../benchmark.html",
+      "name": "Julia",
+      "operator": "ExxonMobil",
+      "region": "Walker Ridge 627 (WR 540/583/584/627/628) · US Gulf of Mexico",
+      "host": "Subsea tieback to Jack/St. Malo semisubmersible FPU (Chevron)",
+      "statusLabel": "Producing",
+      "statusHue": "var(--good)",
+      "treeType": "wet",
+      "treeLabel": "Wet tree · Subsea tieback",
+      "currentPhase": "operate",
+      "metrics": [
+        {
+          "k": "Water depth",
+          "v": "7,000",
+          "u": "ft"
+        },
+        {
+          "k": "Gross CAPEX",
+          "v": "$4.7",
+          "u": "B"
+        },
+        {
+          "k": "Plateau rate",
+          "v": "34",
+          "u": "mbopd"
+        },
+        {
+          "k": "GOR",
+          "v": "1,000",
+          "u": "scf/bbl"
+        },
+        {
+          "k": "OPEX",
+          "v": "$18",
+          "u": "/boe"
+        },
+        {
+          "k": "Operator WI",
+          "v": "50",
+          "u": "%"
+        }
+      ],
+      "axis": {
+        "start": 2005,
+        "end": 2040,
+        "ticks": [
+          2005,
+          2010,
+          2015,
+          2020,
+          2025,
+          2030,
+          2035,
+          2040
+        ]
+      },
+      "gates": [
+        {
+          "year": 2007.0,
+          "phase": "explore",
+          "lab": "Discovery",
+          "dt": "2007",
+          "kind": "primary"
+        },
+        {
+          "year": 2013.0,
+          "phase": "define",
+          "lab": "FID / Sanction",
+          "dt": "2013",
+          "kind": "primary"
+        },
+        {
+          "year": 2008.0,
+          "phase": "execute",
+          "lab": "Lease-extension dispute",
+          "dt": "2008",
+          "kind": "sec"
+        },
+        {
+          "year": 2016.2083333333333,
+          "phase": "operate",
+          "lab": "First oil",
+          "dt": "Mar 2016",
+          "kind": "now"
+        },
+        {
+          "year": 2026.5,
+          "phase": "operate",
+          "lab": "Today",
+          "dt": "2026",
+          "kind": "nowmark"
+        }
+      ],
+      "spans": [
+        {
+          "from": 2007.0,
+          "to": 2013.0,
+          "txt": "Discovery→FID ~6 yr"
+        },
+        {
+          "from": 2013.0,
+          "to": 2016.2083333333333,
+          "txt": "FID→first oil ~3 yr (incl. delay)"
+        }
+      ],
+      "workingInterest": [
+        {
+          "name": "ExxonMobil",
+          "wi": 50,
+          "lead": true
+        },
+        {
+          "name": "Equinor",
+          "wi": 50
+        }
+      ],
+      "hostFacts": [
+        [
+          "Host type",
+          "Subsea tieback to Jack/St. Malo semisubmersible FPU (Chevron)"
+        ],
+        [
+          "Water depth",
+          "7,000 ft (2,134 m)"
+        ],
+        [
+          "Play",
+          "Lower Tertiary Wilcox"
+        ],
+        [
+          "First oil",
+          "Mar 2016"
+        ],
+        [
+          "Data through",
+          "Dec 2024"
+        ]
+      ],
+      "reservoir": {
+        "formation": "Wilcox (Lower Tertiary)",
+        "hpht_class": "HPHT",
+        "pressure_psi": 13500,
+        "pressure_qual": "~",
+        "equip_rating_psi": 15000,
+        "temp_f": null,
+        "tvd_ft": 30000,
+        "fluid": "black oil",
+        "api": 24.7,
+        "source_note": "Offshore Mag: subsea pressures ~13,500 psi (15,000-psi-rated trees + first permanent HIPPS); Hart Energy production test: 24.7°API oil."
+      },
+      "provenance": "Primary facts (capex $4.7B, plateau 34 mbopd, GOR 1000, opex $18/boe, first oil, WI 50/50) from in-repo julia.yml; first oil = BSEE OGOR-A first production (2016-03) per YAML — note ExxonMobil press release states production start April 2016. Operator corrected to ExxonMobil (YAML flagged its \"Equinor\" operator field as disputed; public record = ExxonMobil-operated, Equinor/Statoil 50% partner). Discovery 2007, FID May 2013, water depth 7000+ ft, Walker Ridge blocks, and Jack/St. Malo tieback from Offshore Technology and operator/trade press. lease year and projected end-of-production not confidently sourced.",
+      "norms": [
+        {
+          "delta_play_pct": 108.7,
+          "href": "norms/drill.html#julia",
+          "n": 9,
+          "play_n": 175,
+          "stage": "drill",
+          "state": "ok",
+          "unit": "days",
+          "value": 96.0
+        },
+        {
+          "delta_play_pct": 220.0,
+          "href": "norms/complete.html#julia",
+          "n": 9,
+          "play_n": 177,
+          "stage": "complete",
+          "state": "ok",
+          "unit": "days",
+          "value": 96.0
+        },
+        {
+          "delta_play_pct": 2.0,
+          "href": "norms/produce.html#julia",
+          "n": 4,
+          "play_n": 52,
+          "stage": "produce",
+          "state": "low_n",
+          "unit": "%",
+          "value": 96.15
+        },
+        {
+          "delta_play_pct": -100.0,
+          "href": "norms/workover.html#julia",
+          "n": 4,
+          "play_n": 52,
+          "stage": "workover",
+          "state": "low_n",
+          "unit": "per well",
+          "value": 0.0
+        },
+        {
+          "href": "norms/abandon.html#julia",
+          "stage": "abandon",
+          "state": "unavailable"
+        }
+      ],
+      "performance": {
+        "avg_decline_pct_yr": 12.2,
+        "avg_uptime_pct": 96.3,
+        "breakeven_wti": 95.0,
+        "cum_oil_mmbbl": 77.5,
+        "display": "Julia",
+        "eur_mmbbl": 256,
+        "interventions": 0,
+        "npv_mm": -482.8,
+        "sens_mm_per_dollar": 17.2,
+        "wells": 4
+      }
+    },
+    "kaskida": {
+      "id": "kaskida",
+      "wellsHref": null,
+      "wellsCount": 0,
+      "assetsHref": null,
+      "economics_href": null,
+      "benchmark_href": "../benchmark.html",
+      "name": "Kaskida",
+      "operator": "BP",
+      "region": "Keathley Canyon 292 · US Gulf of Mexico",
+      "host": "Semisubmersible FPU (20,000 psi)",
+      "statusLabel": "Under construction",
+      "statusHue": "var(--done)",
+      "treeType": "wet",
+      "treeLabel": "Wet tree · Semisub FPU",
+      "currentPhase": "execute",
+      "metrics": [
+        {
+          "k": "Water depth",
+          "v": "6,000",
+          "u": "ft"
+        },
+        {
+          "k": "Gross CAPEX",
+          "v": "$5",
+          "u": "B"
+        },
+        {
+          "k": "Plateau rate",
+          "v": "80",
+          "u": "mbopd"
+        },
+        {
+          "k": "GOR",
+          "v": "1,000",
+          "u": "scf/bbl"
+        },
+        {
+          "k": "Operator WI",
+          "v": "100",
+          "u": "%"
+        }
+      ],
+      "axis": {
+        "start": 2000,
+        "end": 2040,
+        "ticks": [
+          2000,
+          2005,
+          2010,
+          2015,
+          2020,
+          2025,
+          2030,
+          2035,
+          2040
+        ]
+      },
+      "gates": [
+        {
+          "year": 2006.0,
+          "phase": "explore",
+          "lab": "Discovery",
+          "dt": "2006",
+          "kind": "primary"
+        },
+        {
+          "year": 2024.0,
+          "phase": "define",
+          "lab": "FID / Sanction",
+          "dt": "2024",
+          "kind": "primary"
+        },
+        {
+          "year": 2025.0,
+          "phase": "execute",
+          "lab": "BOEM rejected Kaskida De…",
+          "dt": "2025",
+          "kind": "sec"
+        }
+      ],
+      "spans": [
+        {
+          "from": 2006.0,
+          "to": 2024.0,
+          "txt": "Discovery→FID ~18 yr"
+        }
+      ],
+      "workingInterest": [
+        {
+          "name": "BP",
+          "wi": 100,
+          "lead": true
+        }
+      ],
+      "hostFacts": [
+        [
+          "Host type",
+          "Semisubmersible FPU (20,000 psi)"
+        ],
+        [
+          "Water depth",
+          "6,000 ft (1,829 m)"
+        ],
+        [
+          "Play",
+          "Lower Tertiary (Wilcox)"
+        ],
+        [
+          "Sanctioned",
+          "2024"
+        ],
+        [
+          "Data through",
+          "Dec 2024"
+        ]
+      ],
+      "reservoir": {
+        "formation": "Wilcox / Paleogene",
+        "hpht_class": "ultra-HPHT",
+        "pressure_psi": 20000,
+        "pressure_qual": "≥",
+        "equip_rating_psi": 20000,
+        "temp_f": null,
+        "tvd_ft": null,
+        "fluid": "black oil",
+        "api": null,
+        "source_note": "AAPG: deep Wilcox is a '20,000 psi or higher' reservoir environment (matches the 20K equipment rating); JPT/BOEM: BP 20,000-psi FPU. Exact pore pressure not published — shown as ≥20,000."
+      },
+      "provenance": "Discovery 2006 (Keathley Canyon 292, Lower Tertiary Wilcox), FID/sanction July 30 2024 (BP 100%, Devon's original 30% exited), first oil targeted 2029 but left blank as no oil has flowed and the Aug-2025 BOEM DPP rejection likely pushes it out. Public sanctioned figures used over YAML where they diverge: plateau/nameplate 80 mbopd (YAML said 120) and capex ~$5bn for Phase 1 (<$5B per BP; YAML total CAPEX 10000 = $10bn is a full-field/multi-phase estimate). GOR 1000 scf/bbl and data through 2024-12-31 from YAML. Water depth ~6,000 ft, 20,000-psi semisubmersible FPU. Low-confidence: capex (phase-1 vs full-field ambiguity), water depth (rounded), lease year unknown, opex unknown.",
+      "norms": [
+        {
+          "delta_play_pct": -21.3,
+          "href": "norms/drill.html#kaskida",
+          "n": 7,
+          "play_n": 177,
+          "stage": "drill",
+          "state": "low_n",
+          "unit": "days",
+          "value": 37.0
+        },
+        {
+          "delta_play_pct": 39.4,
+          "href": "norms/complete.html#kaskida",
+          "n": 7,
+          "play_n": 179,
+          "stage": "complete",
+          "state": "low_n",
+          "unit": "days",
+          "value": 46.0
+        },
+        {
+          "href": "norms/produce.html#kaskida",
+          "stage": "produce",
+          "state": "no_data"
+        },
+        {
+          "href": "norms/workover.html#kaskida",
+          "stage": "workover",
+          "state": "no_data"
+        },
+        {
+          "href": "norms/abandon.html#kaskida",
+          "stage": "abandon",
+          "state": "unavailable"
+        }
+      ],
+      "performance": null
+    },
+    "north_platte": {
+      "id": "north_platte",
+      "wellsHref": null,
+      "wellsCount": 0,
+      "assetsHref": null,
+      "economics_href": null,
+      "benchmark_href": "../benchmark.html",
+      "name": "North Platte (renamed Sparta)",
+      "operator": "Shell",
+      "region": "Garden Banks 959 (straddles GB 915/916/958/959) · US Gulf of Mexico",
+      "host": "Newbuild Semisubmersible FPU",
+      "statusLabel": "Under construction",
+      "statusHue": "var(--done)",
+      "treeType": "wet",
+      "treeLabel": "Wet tree · Semisub FPU",
+      "currentPhase": "execute",
+      "metrics": [
+        {
+          "k": "Water depth",
+          "v": "4,265",
+          "u": "ft"
+        },
+        {
+          "k": "Plateau rate",
+          "v": "75",
+          "u": "mbopd"
+        },
+        {
+          "k": "GOR",
+          "v": "1,100",
+          "u": "scf/bbl"
+        },
+        {
+          "k": "Operator WI",
+          "v": "51",
+          "u": "%"
+        }
+      ],
+      "axis": {
+        "start": 2010,
+        "end": 2035,
+        "ticks": [
+          2010,
+          2015,
+          2020,
+          2025,
+          2030,
+          2035
+        ]
+      },
+      "gates": [
+        {
+          "year": 2012.0,
+          "phase": "explore",
+          "lab": "Discovery",
+          "dt": "2012",
+          "kind": "primary"
+        },
+        {
+          "year": 2023.0,
+          "phase": "define",
+          "lab": "FID / Sanction",
+          "dt": "2023",
+          "kind": "primary"
+        },
+        {
+          "year": 2022.0,
+          "phase": "execute",
+          "lab": "TotalEnergies withdrew f…",
+          "dt": "2022",
+          "kind": "sec"
+        }
+      ],
+      "spans": [
+        {
+          "from": 2012.0,
+          "to": 2023.0,
+          "txt": "Discovery→FID ~11 yr"
+        }
+      ],
+      "workingInterest": [
+        {
+          "name": "Shell",
+          "wi": 51,
+          "lead": true
+        },
+        {
+          "name": "Equinor",
+          "wi": 49
+        }
+      ],
+      "hostFacts": [
+        [
+          "Host type",
+          "Newbuild Semisubmersible FPU"
+        ],
+        [
+          "Water depth",
+          "4,265 ft (1,300 m)"
+        ],
+        [
+          "Play",
+          "Wilcox (Lower Tertiary / Paleogene)"
+        ],
+        [
+          "Sanctioned",
+          "2023"
+        ],
+        [
+          "Data through",
+          "Dec 2024"
+        ]
+      ],
+      "reservoir": {
+        "formation": "Wilcox (subsalt Paleogene)",
+        "hpht_class": "ultra-HPHT",
+        "pressure_psi": null,
+        "pressure_qual": "",
+        "equip_rating_psi": 20000,
+        "temp_f": null,
+        "tvd_ft": null,
+        "fluid": "black oil",
+        "api": null,
+        "source_note": "World Oil/JPT: Sparta (ex-North Platte) is a 20,000-psi-rated development. All public '20,000 psi' figures are the equipment rating; true reservoir pore pressure not publicly disclosed — shown as —."
+      },
+      "provenance": "Basis: in-repo YAML (superseded TotalEnergies pre-FID case) reconciled against current public record. North Platte was discovered 2012 (Cobalt/Total, Garden Banks). TotalEnergies (then 60% op, Equinor 40%) withdrew Feb 2022; Shell bought 51% and took operatorship from Equinor (49%), redesigned and renamed the project \"Sparta.\" Shell took FID Dec 2023; first oil projected 2028 (left blank — not yet producing). Water depth ~4,265 ft, subsalt Wilcox, newbuild semisubmersible FPU (8 subsea wells) with ~90,000 boe/d peak (~75 mbopd oil plateau; GOR 1100 scf/bbl from YAML). LOW-CONFIDENCE: capex — YAML's $6B reflects the abandoned TotalEnergies ~$5-7B concept, not Shell's simplified Sparta scope (not publicly disclosed), so not available; opex and projected COP year not publicly defensible.",
+      "norms": [
+        {
+          "delta_play_pct": 0.0,
+          "href": "norms/drill.html#north_platte",
+          "n": 12,
+          "play_n": 172,
+          "stage": "drill",
+          "state": "ok",
+          "unit": "days",
+          "value": 46.5
+        },
+        {
+          "delta_play_pct": -27.4,
+          "href": "norms/complete.html#north_platte",
+          "n": 12,
+          "play_n": 174,
+          "stage": "complete",
+          "state": "ok",
+          "unit": "days",
+          "value": 26.5
+        },
+        {
+          "href": "norms/produce.html#north_platte",
+          "stage": "produce",
+          "state": "no_data"
+        },
+        {
+          "href": "norms/workover.html#north_platte",
+          "stage": "workover",
+          "state": "no_data"
+        },
+        {
+          "href": "norms/abandon.html#north_platte",
+          "stage": "abandon",
+          "state": "unavailable"
+        }
+      ],
+      "performance": null
+    },
+    "shenandoah": {
+      "id": "shenandoah",
+      "wellsHref": null,
+      "wellsCount": 0,
+      "assetsHref": null,
+      "economics_href": "../economics-shenandoah.html",
+      "benchmark_href": "../benchmark.html",
+      "name": "Shenandoah",
+      "operator": "Beacon Offshore Energy",
+      "region": "Walker Ridge 52 (blocks 51, 52, N/2 53) · US Gulf of Mexico",
+      "host": "Semisubmersible FPU (FPS, 20,000-psi)",
+      "statusLabel": "Producing",
+      "statusHue": "var(--good)",
+      "treeType": "wet",
+      "treeLabel": "Wet tree · Semisub FPU",
+      "currentPhase": "operate",
+      "metrics": [
+        {
+          "k": "Water depth",
+          "v": "5,800",
+          "u": "ft"
+        },
+        {
+          "k": "Gross CAPEX",
+          "v": "$1.8",
+          "u": "B"
+        },
+        {
+          "k": "Plateau rate",
+          "v": "100",
+          "u": "mbopd"
+        },
+        {
+          "k": "GOR",
+          "v": "1,300",
+          "u": "scf/bbl"
+        },
+        {
+          "k": "Operator WI",
+          "v": "31",
+          "u": "%"
+        }
+      ],
+      "axis": {
+        "start": 2005,
+        "end": 2045,
+        "ticks": [
+          2005,
+          2010,
+          2015,
+          2020,
+          2025,
+          2030,
+          2035,
+          2040,
+          2045
+        ]
+      },
+      "gates": [
+        {
+          "year": 2009.0,
+          "phase": "explore",
+          "lab": "Discovery",
+          "dt": "2009",
+          "kind": "primary"
+        },
+        {
+          "year": 2021.0,
+          "phase": "define",
+          "lab": "FID / Sanction",
+          "dt": "2021",
+          "kind": "primary"
+        },
+        {
+          "year": 2025.5416666666667,
+          "phase": "operate",
+          "lab": "First oil",
+          "dt": "Jul 2025",
+          "kind": "now"
+        },
+        {
+          "year": 2026.5,
+          "phase": "operate",
+          "lab": "Today",
+          "dt": "2026",
+          "kind": "nowmark"
+        }
+      ],
+      "spans": [
+        {
+          "from": 2009.0,
+          "to": 2021.0,
+          "txt": "Discovery→FID ~12 yr"
+        },
+        {
+          "from": 2021.0,
+          "to": 2025.5416666666667,
+          "txt": "FID→first oil ~5 yr"
+        }
+      ],
+      "workingInterest": [
+        {
+          "name": "Beacon Offshore Energy",
+          "wi": 31,
+          "lead": true
+        },
+        {
+          "name": "Navitas Petroleum",
+          "wi": 49
+        },
+        {
+          "name": "HEQ Deepwater (Quantum Energy Partners)",
+          "wi": 20
+        }
+      ],
+      "hostFacts": [
+        [
+          "Host type",
+          "Semisubmersible FPU (FPS, 20,000-psi)"
+        ],
+        [
+          "Water depth",
+          "5,800 ft (1,768 m)"
+        ],
+        [
+          "Play",
+          "Wilcox (Lower Tertiary)"
+        ],
+        [
+          "First oil",
+          "Jul 2025"
+        ],
+        [
+          "Data through",
+          "Dec 2024"
+        ]
+      ],
+      "reservoir": {
+        "formation": "Inboard Wilcox (Lower Wilcox)",
+        "hpht_class": "ultra-HPHT",
+        "pressure_psi": 22000,
+        "pressure_qual": "≥",
+        "equip_rating_psi": 20000,
+        "temp_f": 200,
+        "tvd_ft": 30000,
+        "fluid": "black oil",
+        "api": null,
+        "source_note": "Clariant/World Oil: reservoir/formation pressures above 22,000 psi at ~200F (ultra-high-PRESSURE, moderate temp), ~30,000 ft TVD; 20,000-psi equipment rating separate."
+      },
+      "provenance": "Base facts (operator, capex, plateau, GOR, data through) from in-repo YAML; discovery 2009 (Anadarko Shenandoah-1, WR52), FID/sanction Aug 2021 (Beacon+Navitas), and actual first oil (first of 4 wells online 25 Jul 2025; ramped to 100 kbopd plateau Oct 2025) from public sources — first oil corrected to 2025-07 vs YAML's placeholder 2025-10. Current WI (Beacon 31% op / Navitas 49% / HEQ 20%) post-2021 restructuring. CAPEX 1.8 is YAML-stated and largely reflects pre-development E&A spend (LOW CONFIDENCE for full development cost); OPEX and projected end-of-production, not available (not defensibly sourced); water depth ~5,800 ft.",
+      "norms": [
+        {
+          "delta_play_pct": 50.0,
+          "href": "norms/drill.html#shenandoah",
+          "n": 17,
+          "play_n": 167,
+          "stage": "drill",
+          "state": "ok",
+          "unit": "days",
+          "value": 69.0
+        },
+        {
+          "delta_play_pct": -44.1,
+          "href": "norms/complete.html#shenandoah",
+          "n": 17,
+          "play_n": 169,
+          "stage": "complete",
+          "state": "ok",
+          "unit": "days",
+          "value": 19.0
+        },
+        {
+          "delta_play_pct": -10.7,
+          "href": "norms/produce.html#shenandoah",
+          "n": 4,
+          "play_n": 52,
+          "stage": "produce",
+          "state": "low_n",
+          "unit": "%",
+          "value": 84.55
+        },
+        {
+          "delta_play_pct": -13.8,
+          "href": "norms/workover.html#shenandoah",
+          "n": 4,
+          "play_n": 52,
+          "stage": "workover",
+          "state": "low_n",
+          "unit": "per well",
+          "value": 0.25
+        },
+        {
+          "href": "norms/abandon.html#shenandoah",
+          "stage": "abandon",
+          "state": "unavailable"
+        }
+      ],
+      "performance": {
+        "avg_decline_pct_yr": 5.4,
+        "avg_uptime_pct": 80.2,
+        "breakeven_wti": 376.0,
+        "cum_oil_mmbbl": 21.2,
+        "display": "Shenandoah",
+        "eur_mmbbl": 1577,
+        "interventions": 1,
+        "npv_mm": -991.3,
+        "sens_mm_per_dollar": 3.2,
+        "wells": 4
+      }
+    },
+    "stones": {
+      "id": "stones",
+      "wellsHref": null,
+      "wellsCount": 0,
+      "assetsHref": "assets/stones_assets.html",
+      "economics_href": "../economics-stones.html",
+      "benchmark_href": "../benchmark.html",
+      "name": "Stones",
+      "operator": "Shell",
+      "region": "Walker Ridge 508 · US Gulf of Mexico",
+      "host": "FPSO (Turritella / Stones FPSO, disconnectable)",
+      "statusLabel": "Producing",
+      "statusHue": "var(--good)",
+      "treeType": "wet",
+      "treeLabel": "Wet tree · FPSO",
+      "currentPhase": "operate",
+      "metrics": [
+        {
+          "k": "Water depth",
+          "v": "9,500",
+          "u": "ft"
+        },
+        {
+          "k": "Gross CAPEX",
+          "v": "$3.8",
+          "u": "B"
+        },
+        {
+          "k": "Plateau rate",
+          "v": "50",
+          "u": "mbopd"
+        },
+        {
+          "k": "GOR",
+          "v": "850",
+          "u": "scf/bbl"
+        },
+        {
+          "k": "OPEX",
+          "v": "$15",
+          "u": "/boe"
+        },
+        {
+          "k": "Operator WI",
+          "v": "100",
+          "u": "%"
+        }
+      ],
+      "axis": {
+        "start": 2000,
+        "end": 2040,
+        "ticks": [
+          2000,
+          2005,
+          2010,
+          2015,
+          2020,
+          2025,
+          2030,
+          2035,
+          2040
+        ]
+      },
+      "gates": [
+        {
+          "year": 2005.0,
+          "phase": "explore",
+          "lab": "Discovery",
+          "dt": "2005",
+          "kind": "primary"
+        },
+        {
+          "year": 2013.0,
+          "phase": "define",
+          "lab": "FID / Sanction",
+          "dt": "2013",
+          "kind": "primary"
+        },
+        {
+          "year": 2016.7083333333333,
+          "phase": "operate",
+          "lab": "First oil",
+          "dt": "Sep 2016",
+          "kind": "now"
+        },
+        {
+          "year": 2026.5,
+          "phase": "operate",
+          "lab": "Today",
+          "dt": "2026",
+          "kind": "nowmark"
+        }
+      ],
+      "spans": [
+        {
+          "from": 2005.0,
+          "to": 2013.0,
+          "txt": "Discovery→FID ~8 yr"
+        },
+        {
+          "from": 2013.0,
+          "to": 2016.7083333333333,
+          "txt": "FID→first oil ~4 yr"
+        }
+      ],
+      "workingInterest": [
+        {
+          "name": "Shell",
+          "wi": 100,
+          "lead": true
+        }
+      ],
+      "hostFacts": [
+        [
+          "Host type",
+          "FPSO (Turritella / Stones FPSO, disconnectable)"
+        ],
+        [
+          "Water depth",
+          "9,500 ft (2,896 m)"
+        ],
+        [
+          "Play",
+          "Lower Tertiary Wilcox"
+        ],
+        [
+          "First oil",
+          "Sep 2016"
+        ],
+        [
+          "Data through",
+          "Dec 2024"
+        ]
+      ],
+      "reservoir": {
+        "formation": "Paleogene Wilcox (turbidite)",
+        "hpht_class": "HPHT",
+        "pressure_psi": null,
+        "pressure_qual": "",
+        "equip_rating_psi": null,
+        "temp_f": null,
+        "tvd_ft": 26500,
+        "fluid": "black oil",
+        "api": null,
+        "source_note": "Offshore Mag/S&D: Paleogene Wilcox, reservoir ~26,500 ft TVD (17,000 ft below mudline). Reservoir pressure/temperature not cleanly sourced — shown as —."
+      },
+      "provenance": "Capex ($3.8bn), plateau (50 mbopd), GOR (850 scf/bbl), opex ($15/boe), first oil (2016-09) and status from in-repo stones.yml (Shell FPSO development config). Discovery (2005), FID/sanction (May 2013, Shell 100% owner-operator), Walker Ridge Block 508, ~9,500 ft water depth, and Turritella/Stones FPSO host (world's deepest FPSO) confirmed via Offshore Technology, Offshore Magazine, and NS Energy public sources. lease year and projected end-of-production unknown; no notable schedule-driving incident identified.",
+      "norms": [
+        {
+          "delta_play_pct": 54.3,
+          "href": "norms/drill.html#stones",
+          "n": 21,
+          "play_n": 163,
+          "stage": "drill",
+          "state": "ok",
+          "unit": "days",
+          "value": 71.0
+        },
+        {
+          "delta_play_pct": 54.0,
+          "href": "norms/complete.html#stones",
+          "n": 22,
+          "play_n": 164,
+          "stage": "complete",
+          "state": "ok",
+          "unit": "days",
+          "value": 48.5
+        },
+        {
+          "delta_play_pct": -8.1,
+          "href": "norms/produce.html#stones",
+          "n": 10,
+          "play_n": 46,
+          "stage": "produce",
+          "state": "ok",
+          "unit": "%",
+          "value": 86.8
+        },
+        {
+          "delta_play_pct": 7.1,
+          "href": "norms/workover.html#stones",
+          "n": 10,
+          "play_n": 46,
+          "stage": "workover",
+          "state": "ok",
+          "unit": "per well",
+          "value": 0.3
+        },
+        {
+          "href": "norms/abandon.html#stones",
+          "stage": "abandon",
+          "state": "unavailable"
+        }
+      ],
+      "performance": {
+        "avg_decline_pct_yr": 21.4,
+        "avg_uptime_pct": 76.9,
+        "breakeven_wti": 165.0,
+        "cum_oil_mmbbl": 89.0,
+        "display": "Stones",
+        "eur_mmbbl": 509,
+        "interventions": 3,
+        "npv_mm": -1460.8,
+        "sens_mm_per_dollar": 14.9,
+        "wells": 10
+      }
+    },
+    "tiber": {
+      "id": "tiber",
+      "wellsHref": null,
+      "wellsCount": 0,
+      "assetsHref": null,
+      "economics_href": null,
+      "benchmark_href": "../benchmark.html",
+      "name": "Tiber",
+      "operator": "BP",
+      "region": "Keathley Canyon 102 · US Gulf of Mexico",
+      "host": "Semisubmersible FPU (single-lift topsides, Kaskida-derived design)",
+      "statusLabel": "Under construction",
+      "statusHue": "var(--done)",
+      "treeType": "wet",
+      "treeLabel": "Wet tree · Semisub FPU",
+      "currentPhase": "execute",
+      "metrics": [
+        {
+          "k": "Water depth",
+          "v": "4,132",
+          "u": "ft"
+        },
+        {
+          "k": "Gross CAPEX",
+          "v": "$5",
+          "u": "B"
+        },
+        {
+          "k": "Plateau rate",
+          "v": "80",
+          "u": "mbopd"
+        },
+        {
+          "k": "GOR",
+          "v": "900",
+          "u": "scf/bbl"
+        },
+        {
+          "k": "Operator WI",
+          "v": "100",
+          "u": "%"
+        }
+      ],
+      "axis": {
+        "start": 2005,
+        "end": 2040,
+        "ticks": [
+          2005,
+          2010,
+          2015,
+          2020,
+          2025,
+          2030,
+          2035,
+          2040
+        ]
+      },
+      "gates": [
+        {
+          "year": 2009.0,
+          "phase": "explore",
+          "lab": "Discovery",
+          "dt": "2009",
+          "kind": "primary"
+        },
+        {
+          "year": 2025.0,
+          "phase": "define",
+          "lab": "FID / Sanction",
+          "dt": "2025",
+          "kind": "primary"
+        }
+      ],
+      "spans": [
+        {
+          "from": 2009.0,
+          "to": 2025.0,
+          "txt": "Discovery→FID ~16 yr"
+        }
+      ],
+      "workingInterest": [
+        {
+          "name": "BP",
+          "wi": 100,
+          "lead": true
+        }
+      ],
+      "hostFacts": [
+        [
+          "Host type",
+          "Semisubmersible FPU (single-lift topsides, Kaskida-derived design)"
+        ],
+        [
+          "Water depth",
+          "4,132 ft (1,259 m)"
+        ],
+        [
+          "Play",
+          "Wilcox (Lower Tertiary / Paleogene)"
+        ],
+        [
+          "Sanctioned",
+          "2025"
+        ],
+        [
+          "Data through",
+          "Dec 2024"
+        ]
+      ],
+      "reservoir": {
+        "formation": "Paleogene Wilcox",
+        "hpht_class": "ultra-HPHT",
+        "pressure_psi": 20000,
+        "pressure_qual": "up to",
+        "equip_rating_psi": 20000,
+        "temp_f": null,
+        "tvd_ft": 28000,
+        "fluid": "black oil (light)",
+        "api": null,
+        "source_note": "BP FID 2025 (Tiber-Guadalupe): reservoirs 'under pressures of up to 20,000 psi', Paleogene Wilcox; ~28,000 ft TVD. Temperature not field-specific."
+      },
+      "provenance": "Basis: in-repo tiber.yml (operator BP, plateau 80 mbopd, GOR 900 scf/bbl, data through 2024-12-31) plus public sources. BP discovered Tiber Sept 2009 in Keathley Canyon 102, 4,132 ft water. BP reached FID on the combined Tiber-Guadalupe hub 29 Sep 2025 (FID year=2025); Seatrium awarded FPU EPCC. Ownership is now 100% BP (original discovery split BP 62% / Petrobras 20% / ConocoPhillips 18% no longer reflects current WI). Status: execution (post-FID, construction underway). capex set to the sanctioned public figure of $5.0bn for the Tiber-Guadalupe project (YAML's $8bn was a pre-FID Tiber-only planning assumption); note $5bn covers both fields. first oil left blank — oil has not flowed; projected first production is 2030. OPEX, not available (not publicly disclosed; the \"$3/bbl below Kaskida\" figure is development cost, not opex). projected end-of-production and lease year (not confidently sourced).",
+      "norms": [
+        {
+          "href": "norms/drill.html#tiber",
+          "stage": "drill",
+          "state": "insufficient"
+        },
+        {
+          "href": "norms/complete.html#tiber",
+          "stage": "complete",
+          "state": "insufficient"
+        },
+        {
+          "href": "norms/produce.html#tiber",
+          "stage": "produce",
+          "state": "no_data"
+        },
+        {
+          "href": "norms/workover.html#tiber",
+          "stage": "workover",
+          "state": "no_data"
+        },
+        {
+          "href": "norms/abandon.html#tiber",
+          "stage": "abandon",
+          "state": "unavailable"
+        }
+      ],
+      "performance": null
+    }
+  },
+  "wells": {
+    "fields": {
+      "big_foot": {
+        "display_name": "Big Foot",
+        "operator": "Chevron",
+        "host": "Extended Tension-Leg Platform (eTLP)",
+        "lease": "G16942",
+        "block": "Walker Ridge 29",
+        "play": "Wilcox / Lower Tertiary"
+      }
+    },
+    "wells": [
+      {
+        "api": "608124006001",
+        "slot": "A004",
+        "field_id": "big_foot",
+        "spud_date": "2019-03-10",
+        "td_date": "2019-03-25",
+        "drilling_rig_days": 15,
+        "completion_rig_days": 156,
+        "max_tvd_ft": 22253,
+        "mud_weight_ppg": 16.4,
+        "first_oil": "2019-06-01",
+        "workovers": [
+          {
+            "date": "2020-08-30",
+            "type": "Workover"
+          }
+        ],
+        "cum_oil_mmbbl": 32.2,
+        "uptime_pct": 93.7,
+        "status": "producing"
+      },
+      {
+        "api": "608124006603",
+        "slot": "A006",
+        "field_id": "big_foot",
+        "spud_date": "2020-02-12",
+        "td_date": "2020-03-01",
+        "drilling_rig_days": 18,
+        "completion_rig_days": 224,
+        "max_tvd_ft": 21395,
+        "mud_weight_ppg": 16.4,
+        "first_oil": "2020-09-01",
+        "workovers": [
+          {
+            "date": "2022-03-16",
+            "type": "Workover"
+          }
+        ],
+        "cum_oil_mmbbl": 21.3,
+        "uptime_pct": 92.2,
+        "status": "producing"
+      },
+      {
+        "api": "608124006200",
+        "slot": "A001",
+        "field_id": "big_foot",
+        "spud_date": "2012-04-03",
+        "td_date": "2012-08-07",
+        "drilling_rig_days": 126,
+        "completion_rig_days": 265,
+        "max_tvd_ft": 23187,
+        "mud_weight_ppg": 16.4,
+        "first_oil": "2018-11-01",
+        "workovers": [
+          {
+            "date": "2021-07-15",
+            "type": "Workover"
+          }
+        ],
+        "cum_oil_mmbbl": 14.9,
+        "uptime_pct": 94.6,
+        "status": "producing"
+      },
+      {
+        "api": "608124006800",
+        "slot": "A008",
+        "field_id": "big_foot",
+        "spud_date": "2013-01-22",
+        "td_date": "2021-12-02",
+        "drilling_rig_days": 118,
+        "completion_rig_days": 164,
+        "max_tvd_ft": 21801,
+        "mud_weight_ppg": 17,
+        "first_oil": "2022-07-01",
+        "workovers": [
+          {
+            "date": "2025-10-03",
+            "type": "Workover"
+          }
+        ],
+        "cum_oil_mmbbl": 4.7,
+        "uptime_pct": 92.4,
+        "status": "producing"
+      },
+      {
+        "api": "608124006302",
+        "slot": "A002",
+        "field_id": "big_foot",
+        "spud_date": "2024-07-11",
+        "td_date": "2024-07-24",
+        "drilling_rig_days": 13,
+        "completion_rig_days": 168,
+        "max_tvd_ft": 21830,
+        "mud_weight_ppg": 14,
+        "first_oil": "2025-01-01",
+        "workovers": [],
+        "cum_oil_mmbbl": 1.5,
+        "uptime_pct": 96.3,
+        "status": "producing"
+      }
+    ]
+  }
+}

--- a/scripts/build_pages.py
+++ b/scripts/build_pages.py
@@ -467,6 +467,13 @@ def build_lower_tertiary(available_viz: dict[str, bool]) -> list[tuple]:
                 lifecycle_src / "_performance.json",
                 lifecycle_dst / "_performance.json",
             )
+        if (lifecycle_src / "_explorer.json").exists():
+            # enriched field payloads + wells contract fetched by the
+            # field-atlas one-page Explorer shell (#946)
+            shutil.copy2(
+                lifecycle_src / "_explorer.json",
+                lifecycle_dst / "_explorer.json",
+            )
 
     # --- Drilling learning-curve front door (issue #775) ---
     # Self-contained HTML (inline CSS + inline-SVG charts) built by

--- a/scripts/field_atlas/build_field_atlas.py
+++ b/scripts/field_atlas/build_field_atlas.py
@@ -4,9 +4,16 @@ ABOUTME: Reads _roster.json (120 concept-matched fields) → interactive filter 
 
 The atlas is the browse funnel / front-of-house: it scales the flat capabilities list
 into a filterable field catalog with honest density tiers (rich = has a life-cycle hub;
-sample = concept data only; roadmap = name/block only). Rich fields link straight to
-their life-cycle poster. The long tail (the full 1,390-field GoM atlas) is noted, not
-rendered as links.
+sample = concept data only; roadmap = name/block only). Rich fields open in place via
+the Explorer shell (issue #946) and still link straight to their life-cycle poster.
+The long tail (the full 1,390-field GoM atlas) is noted, not rendered as links.
+
+The page markup lives in ``reports/field-atlas/atlas_template.html`` (same
+convention as ``lifecycle_template.html``); this script substitutes the embedded
+roster and injects the nav-spine crumb. The shell fetches
+``../lifecycle/_explorer.json`` at runtime, so local preview needs an HTTP
+server (``python3 -m http.server`` from ``public/``) — the funnel itself works
+without it.
 """
 
 from __future__ import annotations
@@ -26,6 +33,7 @@ from worldenergydata.common.fields_registry import load_fields  # noqa: E402
 
 HERE = Path(__file__).resolve().parents[2] / "reports/field-atlas"
 ROSTER = HERE / "_roster.json"
+TEMPLATE_PATH = HERE / "atlas_template.html"
 
 
 def build() -> str:
@@ -36,141 +44,10 @@ def build() -> str:
             registry.resolve(f["name"]) if f.get("has_lifecycle") else None
         )
     roster_json = json.dumps(fields, ensure_ascii=False)
+    template = TEMPLATE_PATH.read_text()
     return site_nav.inject_for(
-        TEMPLATE.replace("__ROSTER_JSON__", roster_json), "atlas"
+        template.replace("__ROSTER_JSON__", roster_json), "atlas"
     )
-
-
-TEMPLATE = r"""<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>GoM Field Atlas — worldenergydata</title>
-<style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--bg:#eef3fa;--panel:#fff;--ink:#13233f;--muted:#5b6b86;
-        --line:#dbe4f0;--soft:#f4f8fc;--rich:#1f9d57;--sample:#b7791f;--roadmap:#8a97ab}
-  *{box-sizing:border-box;margin:0;padding:0}
-  body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;background:var(--bg);color:var(--ink);line-height:1.5}
-  a{color:inherit;text-decoration:none}
-  .wrap{max-width:1180px;margin:0 auto;padding:36px 22px 80px}
-  .eyebrow{font-family:ui-monospace,monospace;font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:var(--muted)}
-  h1{font-size:30px;font-weight:800;letter-spacing:-.4px;color:var(--navy);margin:6px 0 8px}
-  .lede{color:var(--muted);font-size:16px;max-width:760px}
-  .story{display:inline-block;margin-top:14px;background:#fff;border:1px solid var(--line);border-left:4px solid var(--teal);
-         border-radius:10px;padding:10px 16px;font-size:14px}
-  .story b{color:var(--navy)}
-  .funnel{display:flex;flex-wrap:wrap;gap:10px;align-items:center;margin:26px 0 6px;
-          background:#fff;border:1px solid var(--line);border-radius:14px;padding:14px 16px}
-  .funnel label{font-family:ui-monospace,monospace;font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);display:block;margin-bottom:3px}
-  .funnel select,.funnel input{font:inherit;font-size:14px;padding:7px 10px;border:1px solid var(--line);border-radius:9px;background:var(--soft);color:var(--ink)}
-  .funnel .grp{display:flex;flex-direction:column}
-  .funnel .arrow{color:var(--muted);align-self:end;padding-bottom:8px}
-  .funnel input[type=search]{min-width:190px}
-  .tiers{display:flex;gap:8px;margin:14px 0 4px;flex-wrap:wrap}
-  .tierbtn{font-family:ui-monospace,monospace;font-size:12px;font-weight:700;padding:6px 12px;border-radius:20px;border:1px solid var(--line);background:#fff;color:var(--muted);cursor:pointer}
-  .tierbtn.on{background:var(--navy);color:#fff;border-color:var(--navy)}
-  .count{font-family:ui-monospace,monospace;font-size:13px;color:var(--muted);margin:10px 2px}
-  .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:14px}
-  .card{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:15px 17px;display:flex;flex-direction:column;
-        box-shadow:0 1px 2px rgba(16,40,80,.04);transition:transform .12s,border-color .12s,box-shadow .12s}
-  .card:hover{transform:translateY(-2px);border-color:#b9cbe6;box-shadow:0 8px 20px rgba(16,40,80,.09)}
-  .card h3{font-size:15.5px;font-weight:700;color:var(--ink);display:flex;align-items:center;gap:8px;justify-content:space-between}
-  .badge{font-family:ui-monospace,monospace;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;padding:3px 8px;border-radius:20px;white-space:nowrap}
-  .badge.rich{color:var(--rich);background:color-mix(in srgb,var(--rich) 12%,#fff);border:1px solid color-mix(in srgb,var(--rich) 35%,#fff)}
-  .badge.sample{color:var(--sample);background:color-mix(in srgb,var(--sample) 12%,#fff);border:1px solid color-mix(in srgb,var(--sample) 35%,#fff)}
-  .badge.roadmap{color:var(--roadmap);background:#f2f5f9;border:1px solid var(--line)}
-  .card .meta{font-size:12.5px;color:var(--muted);margin-top:5px}
-  .card .meta b{color:var(--ink);font-weight:600}
-  .card .concept{font-size:12.5px;color:var(--teal);font-weight:600;margin-top:6px}
-  .card .go{margin-top:12px}
-  .card .go a{font-size:13px;font-weight:700;color:#fff;background:linear-gradient(135deg,var(--teal),var(--navy));padding:6px 12px;border-radius:9px;display:inline-block}
-  .card .go span{font-size:12px;color:var(--muted);font-family:ui-monospace,monospace}
-  .note{margin-top:26px;font-size:13px;color:var(--muted);background:#fff;border:1px solid var(--line);border-radius:12px;padding:14px 18px}
-  .note b{color:var(--navy)}
-  @media (prefers-color-scheme:dark){
-    :root{--bg:#0a141f;--panel:#10202f;--ink:#e8eef4;--muted:#8ca0b3;--line:#24384b;--soft:#0d1b28;--navy:#5b9de0;--teal:#3fb99b}
-    .badge.roadmap{background:#182636}.card .go a{color:#08131f}
-  }
-</style>
-</head>
-<body>
-<div class="wrap">
-  <p class="eyebrow">worldenergydata · browse the field atlas</p>
-  <h1>Gulf of Mexico Field Atlas</h1>
-  <p class="lede">Browse deepwater fields top-down — Country → onshore/offshore → Region → geological play → field.
-     Fields with a full life-cycle analysis link straight to their stage-gate hub.</p>
-  <div class="story">The <b>Lower Tertiary (Wilcox)</b> play is ~8% of GoM fields but holds <b>~36% of the oil</b> — start there.</div>
-
-  <div class="funnel">
-    <div class="grp"><label>Country</label><select id="f-country"></select></div>
-    <span class="arrow">→</span>
-    <div class="grp"><label>Domain</label><select id="f-domain"></select></div>
-    <span class="arrow">→</span>
-    <div class="grp"><label>Region</label><select id="f-region"></select></div>
-    <span class="arrow">→</span>
-    <div class="grp"><label>Play</label><select id="f-play"></select></div>
-    <div class="grp" style="margin-left:auto"><label>Search</label><input id="f-search" type="search" placeholder="field or block…"></div>
-  </div>
-  <div class="tiers" id="f-tiers"></div>
-  <div class="count" id="f-count"></div>
-  <div class="grid" id="f-grid"></div>
-
-  <div class="note">Showing the <b>120 concept-matched</b> Gulf of Mexico fields. The full GoM atlas holds
-     <b>1,390 fields</b> (Lower Tertiary = 111 fields, ~36% of GoM oil); the long tail is a searchable catalog, not shown here.
-     Density: <b style="color:var(--rich)">rich</b> = life-cycle hub + economics · <b style="color:var(--sample)">sample</b> = concept data · <b style="color:var(--roadmap)">roadmap</b> = name/block only.</div>
-</div>
-
-<script>
-const ROSTER = __ROSTER_JSON__;
-const TIER_ORDER = {rich:0, sample:1, roadmap:2};
-const $ = id => document.getElementById(id);
-let tierFilter = "all";
-
-function uniq(key){ return [...new Set(ROSTER.map(f=>f[key]).filter(Boolean))].sort(); }
-function fillSelect(el, vals, allLabel){
-  el.innerHTML = `<option value="">${allLabel}</option>` + vals.map(v=>`<option>${v}</option>`).join("");
-}
-fillSelect($("f-country"), uniq("country"), "All countries");
-fillSelect($("f-domain"), uniq("domain"), "All");
-fillSelect($("f-region"), uniq("region"), "All regions");
-fillSelect($("f-play"), uniq("play"), "All plays");
-// sensible defaults: US · offshore · GoM
-$("f-country").value = "USA"; $("f-domain").value = "offshore"; $("f-region").value = "US Gulf of Mexico";
-
-const tiers = ["all","rich","sample","roadmap"];
-$("f-tiers").innerHTML = tiers.map(t=>`<button class="tierbtn${t==="all"?" on":""}" data-t="${t}">${t==="all"?"All tiers":t}</button>`).join("");
-$("f-tiers").onclick = e => { if(!e.target.dataset.t) return;
-  tierFilter = e.target.dataset.t;
-  [...$("f-tiers").children].forEach(b=>b.classList.toggle("on", b.dataset.t===tierFilter));
-  render(); };
-
-["f-country","f-domain","f-region","f-play","f-search"].forEach(id=>$(id).addEventListener("input", render));
-
-function render(){
-  const c=$("f-country").value, d=$("f-domain").value, r=$("f-region").value, p=$("f-play").value,
-        q=$("f-search").value.trim().toLowerCase();
-  let rows = ROSTER.filter(f =>
-    (!c||f.country===c) && (!d||f.domain===d) && (!r||f.region===r) && (!p||f.play===p) &&
-    (tierFilter==="all"||f.density_tier===tierFilter) &&
-    (!q || (f.name+" "+(f.block||"")+" "+(f.operator||"")).toLowerCase().includes(q)));
-  rows.sort((a,b)=> (TIER_ORDER[a.density_tier]-TIER_ORDER[b.density_tier]) || a.name.localeCompare(b.name));
-  $("f-count").textContent = `${rows.length} field${rows.length===1?"":"s"}`;
-  $("f-grid").innerHTML = rows.map(f=>{
-    const go = f.lifecycle_id
-      ? `<div class="go"><a href="../lifecycle/${f.lifecycle_id}_lifecycle.html">Life-cycle →</a></div>`
-      : (f.concept ? `<div class="go"><span>concept: ${f.concept}</span></div>` : "");
-    const meta = [f.operator, f.block].filter(Boolean).map(x=>`<b>${x}</b>`).join(" · ");
-    const play = f.play ? `<div class="concept">${f.play}</div>` : "";
-    return `<div class="card"><h3>${f.name}<span class="badge ${f.density_tier}">${f.density_tier}</span></h3>
-      ${meta?`<div class="meta">${meta}</div>`:""}${play}${go}</div>`;
-  }).join("");
-}
-render();
-</script>
-</body>
-</html>
-"""
 
 
 def main():

--- a/scripts/lower_tertiary/build_lifecycle_posters.py
+++ b/scripts/lower_tertiary/build_lifecycle_posters.py
@@ -442,6 +442,32 @@ def main():
     (HERE / "index.html").write_text(build_index(fields))
     print(f"  wrote index.html  ({len(fields)} fields)")
 
+    # Explorer sidecar (issue #946): the SAME post-enrichment payloads the
+    # posters embed (facts_to_field + norms + performance), keyed by id, plus
+    # the wells contract verbatim — one fetch for the field-atlas shell.
+    # Hrefs inside are lifecycle/-relative by contract; consumers outside
+    # lifecycle/ must rebase against ../lifecycle/ (link-graph gate enforces).
+    wells_contract = {}
+    wells_facts = HERE / "wells" / "_wells.json"
+    if wells_facts.exists():
+        wells_contract = json.loads(wells_facts.read_text())
+    (HERE / "_explorer.json").write_text(
+        json.dumps(
+            {
+                "meta": {
+                    "generated_by": "scripts/lower_tertiary/build_lifecycle_posters.py",
+                    "issue": 946,
+                },
+                "fields": {fl["id"]: fl for fl in fields},
+                "wells": wells_contract,
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+        + "\n"
+    )
+    print(f"  wrote _explorer.json  ({len(fields)} fields)")
+
 
 if __name__ == "__main__":
     main()

--- a/tests/integration/site/test_public_link_graph.py
+++ b/tests/integration/site/test_public_link_graph.py
@@ -235,12 +235,109 @@ def test_hand_authored_fixes_survive_clean_build(public):
 
 
 def test_roster_poster_targets_exist(public):
+    # lifecycle_id is computed at BUILD time (build_field_atlas.py L34-37) and
+    # never lands in the on-disk roster — the previous read of
+    # e.get("lifecycle_id") was always None, so this check asserted nothing
+    # (#946 r1 finding 3). Recompute ids exactly as the generator does.
+    from worldenergydata.common.fields_registry import load_fields
+
     roster = json.loads((REPO / "reports/field-atlas/_roster.json").read_text())
     entries = roster if isinstance(roster, list) else roster.get("fields", [])
+    registry = load_fields()
+    resolved = [registry.resolve(e["name"]) for e in entries if e.get("has_lifecycle")]
+    assert resolved and all(resolved), "rich roster entries must resolve to ids"
+    explorer = _explorer(public)
     missing = [
-        e["lifecycle_id"]
-        for e in entries
-        if e.get("lifecycle_id")
-        and not (public / f"lifecycle/{e['lifecycle_id']}_lifecycle.html").exists()
+        rid
+        for rid in resolved
+        if not (public / f"lifecycle/{rid}_lifecycle.html").exists()
+        or rid not in explorer["fields"]
     ]
-    assert not missing, f"roster lifecycle_ids without posters: {missing}"
+    assert not missing, f"roster ids without posters/explorer payloads: {missing}"
+
+
+# --- Explorer shell contract (issue #946) ----------------------------------
+
+EXPLORER_HREF_KEYS = ("wellsHref", "assetsHref", "economics_href", "benchmark_href")
+
+
+def _explorer(public):
+    return json.loads((public / "lifecycle/_explorer.json").read_text())
+
+
+def test_explorer_sidecar_published_and_covers_all_posters(public):
+    explorer = _explorer(public)
+    assert set(explorer["fields"]) == {f["id"] for f in FACTS}
+    assert explorer["wells"]["wells"], "wells contract embedded"
+
+
+def test_explorer_hrefs_resolve_from_poster_and_shell_bases(public):
+    # Payload hrefs are lifecycle/-relative BY CONTRACT. The shell at
+    # field-atlas/ rebases every href against ../lifecycle/ before it reaches
+    # the DOM (#946 r1 finding 2) — both resolutions must land on a published
+    # file, so a base-handling regression on either side goes red here.
+    bad = []
+    for fid, f in _explorer(public)["fields"].items():
+        targets = [f.get(k) for k in EXPLORER_HREF_KEYS]
+        targets += [c.get("href") for c in f.get("norms", [])]
+        for t in [t.split("#")[0] for t in targets if t]:
+            views = (
+                ("poster", _resolve(public, f"lifecycle/{fid}_lifecycle.html", t)),
+                (
+                    "shell",
+                    _resolve(
+                        public,
+                        "field-atlas/index.html",
+                        posixpath.join("../lifecycle", t),
+                    ),
+                ),
+            )
+            for label, p in views:
+                q = p / "index.html" if p.is_dir() else p
+                if not q.exists():
+                    bad.append((fid, label, t))
+    assert not bad, f"unresolved explorer hrefs: {bad}"
+
+
+def test_explorer_wells_pages_exist(public):
+    missing = [
+        f"{w['field_id']}_{w['slot']}"
+        for w in _explorer(public)["wells"]["wells"]
+        if not (
+            public / f"lifecycle/wells/{w['field_id']}_{w['slot']}_well.html"
+        ).exists()
+    ]
+    assert not missing, f"wells in contract without pages: {missing}"
+
+
+def test_explorer_identity_with_posters(public):
+    # Single-sourcing gate: the sidecar serializes the SAME post-enrichment
+    # dicts the posters embed (facts_to_field + norms + performance attached
+    # in main() — #946 r1 finding 1).
+    explorer = _explorer(public)
+    for f in FACTS:
+        text = (public / f"lifecycle/{f['id']}_lifecycle.html").read_text()
+        embedded = json.loads(FIELD_JSON_RE.search(text).group(1))
+        assert embedded == explorer["fields"][f["id"]], f["id"]
+
+
+def test_atlas_shell_pins(public):
+    # Zero-regression pins for the in-place rebuild of /field-atlas/ (#946):
+    # the funnel survives, the shell is present, and the page keeps exactly
+    # one <h1 so the fail-closed nav-spine inject stays unambiguous.
+    text = (public / "field-atlas/index.html").read_text()
+    roster = json.loads((REPO / "reports/field-atlas/_roster.json").read_text())
+    m = re.search(r"const ROSTER = (\[.*?\]);", text, re.S)
+    assert m, "embedded roster missing"
+    assert len(json.loads(m.group(1))) == len(roster)
+    for pin in (
+        'id="f-country"',
+        'id="f-play"',
+        'id="f-search"',
+        'id="f-tiers"',
+        'id="x-panel"',
+        "#/field/",
+        "_explorer.json",
+    ):
+        assert pin in text, pin
+    assert text.count("<h1") == 1

--- a/tests/test_build_pages.py
+++ b/tests/test_build_pages.py
@@ -14,6 +14,7 @@ we redirect those to a tmp dir so tests never touch the working tree.
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 
 import pytest
@@ -43,6 +44,17 @@ def test_full_build_renders_whole_site(bp):
     assert (public / "benchmark.html").exists()
     econ = list(public.glob("economics-*.html"))
     assert econ, "expected per-field economics pages"
+
+
+def test_lower_tertiary_publishes_explorer_sidecar(bp):
+    # Explorer shell contract (#946): the enriched-payload sidecar deploys
+    # next to the posters so /field-atlas/ can fetch ../lifecycle/_explorer.json.
+    bp.build(domains=["lower_tertiary"])
+    sidecar = bp.PUBLIC / "lifecycle" / "_explorer.json"
+    assert sidecar.exists()
+    data = json.loads(sidecar.read_text())
+    assert data["fields"], "explorer field payloads present"
+    assert "wells" in data
 
 
 def test_partial_build_only_touches_its_domain(bp):


### PR DESCRIPTION
Closes #946 (epic #940, program #939). Plan: workspace-hub `docs/plans/2026-07-10-issue-wed-946-explorer-shell-tracer.md` @ bdf26fa (adversarial-reviewed r1 MAJOR/5+MINOR/5 → all folded).

## What

The one-page Explorer tracer: `/field-atlas/` rebuilt **in place** — select **Big Foot** and drill high-level → detail without leaving the page (field panel → wells table → **A004 stage detail**), every state deep-linkable (`#/field/big_foot/wells/A004`). **Jack/St Malo** shows the honest no-wells path (note → #948, no dead link).

- **New published sidecar `lifecycle/_explorer.json`** — the SAME post-enrichment dicts the posters embed (`facts_to_field()` + `norms` + `performance`), keyed by id, + the wells contract verbatim. One fetch total; identity with posters is gate-tested.
- **Shell** (template extracted to `atlas_template.html`, `lifecycle_template.html` convention): hash router, in-place panels for the 10 rich fields only (110 sample/roadmap cards keep exactly their current behavior — id federation is #947), every payload href rebased against `../lifecycle/`, bare `#/…` router links, visible fetch-error fallback.
- **Gates**: sidecar↔poster identity; hrefs resolve from BOTH poster and shell bases; wells pages exist; atlas zero-regression pins (roster count, funnel ids, single `<h1`); `test_roster_poster_targets_exist` repaired (was vacuous — on-disk roster has no `lifecycle_id`; now recomputes via the registry).
- Funnel/search/tier chips/story: unchanged markup. Posters byte-identical (verified: empty diff after regeneration).

## Verification

- `tests/test_build_pages.py + tests/integration/site/ + tests/unit/site/`: **65 passed** (6 new/repaired gates confirmed individually).
- Lint mirror (pinned, per CI): black 25.9.0 ✓ · isort 8.0.1 ✓ · flake8 7.3.0 (`--max-line-length=100 --extend-ignore=E203,W503`, `src/` only) ✓.
- Stdlib-only build preserved (sidecar writer + publish step use json/shutil only).
- Post-deploy check (after merge): `/field-atlas/#/field/big_foot/wells/A004` restores full drill state; `lifecycle/_explorer.json` HTTP 200.

## Notes for review

- `_explorer.json` is a committed report artifact (Pages builds from frozen reports).
- Sidecar scoped to the 10 LT payloads (~40 KB); sharding at all-countries scale is explicitly #947's decision.
- Local preview of the shell needs `python3 -m http.server` from `public/` (fetch on `file://` fails; funnel works regardless).
