### PR TITLE
feat(underwriting): per-field HPHT + decommissioning risk badges

### DIFF
--- a/reports/field-atlas/atlas_template.html
+++ b/reports/field-atlas/atlas_template.html
@@ -312,17 +312,35 @@ function renderField(x, f){
     `<p class="xnote">Well-level timelines cover the benchmark's producing wells;
      this field is pre-production, so it has none yet (rollout
      <a href="https://github.com/vamseeachanta/worldenergydata/issues/948">#948</a>).</p>`;
+  // Underwriting-lens chips + panel (#949): HPHT and facility decommissioning,
+  // honesty-gated. Well-plugging P&A is NOT attributed per field (documented).
+  const risk = f.risk || {};
+  const sevColor = {"over-rating":"#e5484d","at-rating":"#f5a524"};
+  const chip = (label, color, dashed) =>
+    `<span class="badge" style="color:${color};border:1px ${dashed?"dashed":"solid"} ${color};background:transparent">${esc(label)}</span>`;
+  const riskChips =
+    (risk.hpht ? chip(risk.hpht.label, sevColor[risk.hpht.severity]||"var(--muted)", false) : "") +
+    (risk.decommissioning ? chip(risk.decommissioning.label, "var(--teal)", risk.decommissioning.confidence==="low") : "");
+  let uw = "";
+  if (risk.hpht || risk.decommissioning) {
+    const lines = [];
+    if (risk.hpht) lines.push(`<tr><td>HPHT</td><td>${esc(risk.hpht.label)} · <a href="${rb("pressure-atlas/")}">pressure atlas →</a></td></tr>`);
+    if (risk.decommissioning) lines.push(`<tr><td>Decommission</td><td>${esc(risk.decommissioning.label)} <small>(facility removal, ${esc(risk.decommissioning.confidence)}-confidence)</small> · <a href="${rb("decommissioning/pa-liability-wave.html")}">P&amp;A wave →</a></td></tr>`);
+    uw = `<div class="xcardlet"><div class="xh">Underwriting signals</div><table>${lines.join("")}</table>
+      <p style="font-size:11.5px;color:var(--muted);margin-top:6px">Well-plugging P&amp;A is not attributed per field (BSEE well data lacks a lease join for these fields).</p></div>`;
+  }
   show(`
     <div class="xtitle">${esc(f.name)}
       <span class="badge rich">${esc(f.statusLabel)}</span>
-      ${f.treeLabel?`<span class="badge sample">${esc(f.treeLabel)}</span>`:""}</div>
+      ${f.treeLabel?`<span class="badge sample">${esc(f.treeLabel)}</span>`:""}
+      ${riskChips}</div>
     <p class="xsub">${esc(f.operator)} · ${esc(f.region)}</p>
     <div class="xstrip">${strip}</div>
     ${gates?`<div class="xgates">${gates}</div>`:""}
     <div class="xmets">${mets}</div>
     <div class="xcols">
       <div class="xcardlet"><div class="xh">Host &amp; field facts</div><table>${facts}</table></div>
-      ${perf}${resv}
+      ${perf}${resv}${uw}
     </div>
     <div class="xacts">${acts.join("")}</div>
     ${wellsNote}

--- a/reports/field-atlas/index.html
+++ b/reports/field-atlas/index.html
@@ -313,17 +313,35 @@ function renderField(x, f){
     `<p class="xnote">Well-level timelines cover the benchmark's producing wells;
      this field is pre-production, so it has none yet (rollout
      <a href="https://github.com/vamseeachanta/worldenergydata/issues/948">#948</a>).</p>`;
+  // Underwriting-lens chips + panel (#949): HPHT and facility decommissioning,
+  // honesty-gated. Well-plugging P&A is NOT attributed per field (documented).
+  const risk = f.risk || {};
+  const sevColor = {"over-rating":"#e5484d","at-rating":"#f5a524"};
+  const chip = (label, color, dashed) =>
+    `<span class="badge" style="color:${color};border:1px ${dashed?"dashed":"solid"} ${color};background:transparent">${esc(label)}</span>`;
+  const riskChips =
+    (risk.hpht ? chip(risk.hpht.label, sevColor[risk.hpht.severity]||"var(--muted)", false) : "") +
+    (risk.decommissioning ? chip(risk.decommissioning.label, "var(--teal)", risk.decommissioning.confidence==="low") : "");
+  let uw = "";
+  if (risk.hpht || risk.decommissioning) {
+    const lines = [];
+    if (risk.hpht) lines.push(`<tr><td>HPHT</td><td>${esc(risk.hpht.label)} · <a href="${rb("pressure-atlas/")}">pressure atlas →</a></td></tr>`);
+    if (risk.decommissioning) lines.push(`<tr><td>Decommission</td><td>${esc(risk.decommissioning.label)} <small>(facility removal, ${esc(risk.decommissioning.confidence)}-confidence)</small> · <a href="${rb("decommissioning/pa-liability-wave.html")}">P&amp;A wave →</a></td></tr>`);
+    uw = `<div class="xcardlet"><div class="xh">Underwriting signals</div><table>${lines.join("")}</table>
+      <p style="font-size:11.5px;color:var(--muted);margin-top:6px">Well-plugging P&amp;A is not attributed per field (BSEE well data lacks a lease join for these fields).</p></div>`;
+  }
   show(`
     <div class="xtitle">${esc(f.name)}
       <span class="badge rich">${esc(f.statusLabel)}</span>
-      ${f.treeLabel?`<span class="badge sample">${esc(f.treeLabel)}</span>`:""}</div>
+      ${f.treeLabel?`<span class="badge sample">${esc(f.treeLabel)}</span>`:""}
+      ${riskChips}</div>
     <p class="xsub">${esc(f.operator)} · ${esc(f.region)}</p>
     <div class="xstrip">${strip}</div>
     ${gates?`<div class="xgates">${gates}</div>`:""}
     <div class="xmets">${mets}</div>
     <div class="xcols">
       <div class="xcardlet"><div class="xh">Host &amp; field facts</div><table>${facts}</table></div>
-      ${perf}${resv}
+      ${perf}${resv}${uw}
     </div>
     <div class="xacts">${acts.join("")}</div>
     ${wellsNote}

--- a/reports/lower_tertiary/lifecycle/_explorer.json
+++ b/reports/lower_tertiary/lifecycle/_explorer.json
@@ -170,6 +170,16 @@
         "api": null,
         "source_note": "Wilcox oil field (Offshore Technology; Chevron). Field-specific reservoir pressure/temperature not publicly disclosed — shown as — rather than borrowed from neighbouring fields."
       },
+      "risk": {
+        "hpht": null,
+        "decommissioning": {
+          "cost_musd": 43.2,
+          "host_type": "Mini-TLP",
+          "confidence": "modeled",
+          "basis": "facility removal (not well P&A)",
+          "label": "Decommission ~$43.2M"
+        }
+      },
       "provenance": "Data: big_foot.yml + Chevron public disclosures + BSEE (dates to be reconciled in #375)",
       "norms": [
         {
@@ -384,6 +394,18 @@
         "api": null,
         "source_note": "OGJ 2024: initial reservoir (BHP) 23,000–27,000 psi — higher than the 20,000-psi equipment rating; 275F max flowing temp; pay 30,000–34,000 ft TVD (Wilcox 1–4)."
       },
+      "risk": {
+        "hpht": {
+          "class": "ultra-HPHT",
+          "pressure_psi": 25000,
+          "equip_rating_psi": 20000,
+          "exceedance_pct": 25,
+          "severity": "over-rating",
+          "basis": "reservoir",
+          "label": "ultra-HPHT · 25k vs 20k psi (+25%)"
+        },
+        "decommissioning": null
+      },
       "provenance": "Primary facts (operator, working interests, capex $5.6B, plateau 75 mbopd, GOR 1100 scf/bbl, opex $15/boe, first oil 2024-08, data through 2024-12-31) from in-repo anchor.yml. Life-cycle dates corroborated by public sources: discovery well Anchor-2 drilled 2014 (Green Canyon 807, ~5,180 ft), FID December 2019 (~$5.7B sanction), first oil August 2024 — world's first 20,000-psi HPHT deepwater development on a semisubmersible FPU, Lower Tertiary Wilcox play. Working interests (Chevron 62.5% / Equinor 25% / TotalEnergies 12.5%) per YAML; note older Offshore Technology page still lists pre-Equinor split (Chevron 62.86% / Total 37.14%). water depth ~5,180 (block-level estimate). projected end-of-production and lease year not confidently sourced; no notable incident.",
       "norms": [
         {
@@ -575,6 +597,18 @@
         "fluid": "black oil (low GOR; CO₂ <1.5%, no H₂S)",
         "api": null,
         "source_note": "OTC-24162/24163 + JPT: initial reservoir pressure ~19,500 psi, BHT ~256–260F, reservoir mid-point ~25,600 ft TVD."
+      },
+      "risk": {
+        "hpht": {
+          "class": "HPHT",
+          "pressure_psi": 19500,
+          "equip_rating_psi": null,
+          "exceedance_pct": null,
+          "severity": "class-only",
+          "basis": "reservoir",
+          "label": "HPHT · 19.5k psi"
+        },
+        "decommissioning": null
       },
       "provenance": "Life-cycle dates and ownership from public sources (Offshore Technology, Offshore Magazine, OGJ, Heerema, Rigzone); economics (capex $2.9B, plateau 75 mbopd, GOR 1400 scf/bbl, opex $18/boe) and data through from in-repo YAML. IMPORTANT: two YAML values were overridden as demonstrably wrong vs. well-documented public record — YAML first oil \"2021-08\" corrected to 2012-02 (Cascade first oil Feb 2012, Chinook Sep 2012; BW Pioneer was the first FPSO in the US GoM), and YAML operator/WI \"TotalEnergies 60% / Equinor 40%\" corrected to current MP Gulf of Mexico LLC (Murphy EXPRO 80% operator, Petrobras America 20%; originally Petrobras-operated with Total 33.33% in Chinook). LOW CONFIDENCE: FID year (sanction ~mid-2000s, no firm public citation — not available), lease year and projected end-of-production (not available); water depth 8,200 ft is the Cascade value (Chinook ~8,600 ft); capex is a YAML assumption not independently verified.",
       "norms": [
@@ -790,6 +824,24 @@
         "api": null,
         "source_note": "Dice regional Wilcox reservoir study: Jack initial pressure 19,374 psi @ 224F, St. Malo 19,023 psi @ 225F; reservoir ~26,500 ft TVD."
       },
+      "risk": {
+        "hpht": {
+          "class": "HPHT",
+          "pressure_psi": 19374,
+          "equip_rating_psi": null,
+          "exceedance_pct": null,
+          "severity": "class-only",
+          "basis": "reservoir",
+          "label": "HPHT · 19.4k psi"
+        },
+        "decommissioning": {
+          "cost_musd": 80.0,
+          "host_type": "FPU/FPS",
+          "confidence": "low",
+          "basis": "facility removal (not well P&A)",
+          "label": "Decommission ~$80M (FPSO base)"
+        }
+      },
       "provenance": "Facts from in-repo YAML (operator, WI Chevron 51%/Equinor 24.5%/Suncor 24.5%, capex $7.5B, opex $15/boe, plateau 94 mbopd, GOR 1200, status producing, data through 2024-12-31). Life-cycle dates from public sources: St. Malo discovered Oct 2003 and Jack Jul 2004 (discovery year=2003, earliest of pair); FID/sanction Oct 2010; first oil per Chevron press release Dec 2014 (\"2014-12\") — this OVERRIDES the YAML's first oil \"2014-02-01\", which appears erroneous. Water depth ~7000 ft at the FPU (Jack WR758/759 ~7000 ft, St. Malo WR678). host = Semisubmersible FPU. projected end-of-production not confidently estimable. lease year not available; no schedule-driving incident.",
       "norms": [
         {
@@ -1000,12 +1052,25 @@
         "hpht_class": "HPHT",
         "pressure_psi": 13500,
         "pressure_qual": "~",
+        "pressure_basis": "subsea_system",
         "equip_rating_psi": 15000,
         "temp_f": null,
         "tvd_ft": 30000,
         "fluid": "black oil",
         "api": 24.7,
         "source_note": "Offshore Mag: subsea pressures ~13,500 psi (15,000-psi-rated trees + first permanent HIPPS); Hart Energy production test: 24.7°API oil."
+      },
+      "risk": {
+        "hpht": {
+          "class": "HPHT",
+          "pressure_psi": 13500,
+          "equip_rating_psi": 15000,
+          "exceedance_pct": null,
+          "severity": "class-only",
+          "basis": "subsea_system",
+          "label": "HPHT · subsea system 13.5k / 15k-psi trees"
+        },
+        "decommissioning": null
       },
       "provenance": "Primary facts (capex $4.7B, plateau 34 mbopd, GOR 1000, opex $18/boe, first oil, WI 50/50) from in-repo julia.yml; first oil = BSEE OGOR-A first production (2016-03) per YAML — note ExxonMobil press release states production start April 2016. Operator corrected to ExxonMobil (YAML flagged its \"Equinor\" operator field as disputed; public record = ExxonMobil-operated, Equinor/Statoil 50% partner). Discovery 2007, FID May 2013, water depth 7000+ ft, Walker Ridge blocks, and Jack/St. Malo tieback from Offshore Technology and operator/trade press. lease year and projected end-of-production not confidently sourced.",
       "norms": [
@@ -1197,6 +1262,18 @@
         "api": null,
         "source_note": "AAPG: deep Wilcox is a '20,000 psi or higher' reservoir environment (matches the 20K equipment rating); JPT/BOEM: BP 20,000-psi FPU. Exact pore pressure not published — shown as ≥20,000."
       },
+      "risk": {
+        "hpht": {
+          "class": "ultra-HPHT",
+          "pressure_psi": 20000,
+          "equip_rating_psi": 20000,
+          "exceedance_pct": 0,
+          "severity": "at-rating",
+          "basis": "reservoir",
+          "label": "ultra-HPHT · 20k vs 20k psi (0%)"
+        },
+        "decommissioning": null
+      },
       "provenance": "Discovery 2006 (Keathley Canyon 292, Lower Tertiary Wilcox), FID/sanction July 30 2024 (BP 100%, Devon's original 30% exited), first oil targeted 2029 but left blank as no oil has flowed and the Aug-2025 BOEM DPP rejection likely pushes it out. Public sanctioned figures used over YAML where they diverge: plateau/nameplate 80 mbopd (YAML said 120) and capex ~$5bn for Phase 1 (<$5B per BP; YAML total CAPEX 10000 = $10bn is a full-field/multi-phase estimate). GOR 1000 scf/bbl and data through 2024-12-31 from YAML. Water depth ~6,000 ft, 20,000-psi semisubmersible FPU. Low-confidence: capex (phase-1 vs full-field ambiguity), water depth (rounded), lease year unknown, opex unknown.",
       "norms": [
         {
@@ -1361,6 +1438,18 @@
         "fluid": "black oil",
         "api": null,
         "source_note": "World Oil/JPT: Sparta (ex-North Platte) is a 20,000-psi-rated development. All public '20,000 psi' figures are the equipment rating; true reservoir pore pressure not publicly disclosed — shown as —."
+      },
+      "risk": {
+        "hpht": {
+          "class": "ultra-HPHT",
+          "pressure_psi": null,
+          "equip_rating_psi": 20000,
+          "exceedance_pct": null,
+          "severity": "class-only",
+          "basis": "reservoir",
+          "label": "ultra-HPHT · 20k-psi equipment"
+        },
+        "decommissioning": null
       },
       "provenance": "Basis: in-repo YAML (superseded TotalEnergies pre-FID case) reconciled against current public record. North Platte was discovered 2012 (Cobalt/Total, Garden Banks). TotalEnergies (then 60% op, Equinor 40%) withdrew Feb 2022; Shell bought 51% and took operatorship from Equinor (49%), redesigned and renamed the project \"Sparta.\" Shell took FID Dec 2023; first oil projected 2028 (left blank — not yet producing). Water depth ~4,265 ft, subsalt Wilcox, newbuild semisubmersible FPU (8 subsea wells) with ~90,000 boe/d peak (~75 mbopd oil plateau; GOR 1100 scf/bbl from YAML). LOW-CONFIDENCE: capex — YAML's $6B reflects the abandoned TotalEnergies ~$5-7B concept, not Shell's simplified Sparta scope (not publicly disclosed), so not available; opex and projected COP year not publicly defensible.",
       "norms": [
@@ -1550,6 +1639,18 @@
         "fluid": "black oil",
         "api": null,
         "source_note": "Clariant/World Oil: reservoir/formation pressures above 22,000 psi at ~200F (ultra-high-PRESSURE, moderate temp), ~30,000 ft TVD; 20,000-psi equipment rating separate."
+      },
+      "risk": {
+        "hpht": {
+          "class": "ultra-HPHT",
+          "pressure_psi": 22000,
+          "equip_rating_psi": 20000,
+          "exceedance_pct": 10,
+          "severity": "over-rating",
+          "basis": "reservoir",
+          "label": "ultra-HPHT · 22k vs 20k psi (+10%)"
+        },
+        "decommissioning": null
       },
       "provenance": "Base facts (operator, capex, plateau, GOR, data through) from in-repo YAML; discovery 2009 (Anadarko Shenandoah-1, WR52), FID/sanction Aug 2021 (Beacon+Navitas), and actual first oil (first of 4 wells online 25 Jul 2025; ramped to 100 kbopd plateau Oct 2025) from public sources — first oil corrected to 2025-07 vs YAML's placeholder 2025-10. Current WI (Beacon 31% op / Navitas 49% / HEQ 20%) post-2021 restructuring. CAPEX 1.8 is YAML-stated and largely reflects pre-development E&A spend (LOW CONFIDENCE for full development cost); OPEX and projected end-of-production, not available (not defensibly sourced); water depth ~5,800 ft.",
       "norms": [
@@ -1758,6 +1859,24 @@
         "api": null,
         "source_note": "Offshore Mag/S&D: Paleogene Wilcox, reservoir ~26,500 ft TVD (17,000 ft below mudline). Reservoir pressure/temperature not cleanly sourced — shown as —."
       },
+      "risk": {
+        "hpht": {
+          "class": "HPHT",
+          "pressure_psi": null,
+          "equip_rating_psi": null,
+          "exceedance_pct": null,
+          "severity": "class-only",
+          "basis": "reservoir",
+          "label": "HPHT"
+        },
+        "decommissioning": {
+          "cost_musd": 80.0,
+          "host_type": "FPSO",
+          "confidence": "low",
+          "basis": "facility removal (not well P&A)",
+          "label": "Decommission ~$80M (FPSO base)"
+        }
+      },
       "provenance": "Capex ($3.8bn), plateau (50 mbopd), GOR (850 scf/bbl), opex ($15/boe), first oil (2016-09) and status from in-repo stones.yml (Shell FPSO development config). Discovery (2005), FID/sanction (May 2013, Shell 100% owner-operator), Walker Ridge Block 508, ~9,500 ft water depth, and Turritella/Stones FPSO host (world's deepest FPSO) confirmed via Offshore Technology, Offshore Magazine, and NS Energy public sources. lease year and projected end-of-production unknown; no notable schedule-driving incident identified.",
       "norms": [
         {
@@ -1939,6 +2058,18 @@
         "fluid": "black oil (light)",
         "api": null,
         "source_note": "BP FID 2025 (Tiber-Guadalupe): reservoirs 'under pressures of up to 20,000 psi', Paleogene Wilcox; ~28,000 ft TVD. Temperature not field-specific."
+      },
+      "risk": {
+        "hpht": {
+          "class": "ultra-HPHT",
+          "pressure_psi": 20000,
+          "equip_rating_psi": 20000,
+          "exceedance_pct": 0,
+          "severity": "at-rating",
+          "basis": "reservoir",
+          "label": "ultra-HPHT · 20k vs 20k psi (0%)"
+        },
+        "decommissioning": null
       },
       "provenance": "Basis: in-repo tiber.yml (operator BP, plateau 80 mbopd, GOR 900 scf/bbl, data through 2024-12-31) plus public sources. BP discovered Tiber Sept 2009 in Keathley Canyon 102, 4,132 ft water. BP reached FID on the combined Tiber-Guadalupe hub 29 Sep 2025 (FID year=2025); Seatrium awarded FPU EPCC. Ownership is now 100% BP (original discovery split BP 62% / Petrobras 20% / ConocoPhillips 18% no longer reflects current WI). Status: execution (post-FID, construction underway). capex set to the sanctioned public figure of $5.0bn for the Tiber-Guadalupe project (YAML's $8bn was a pre-FID Tiber-only planning assumption); note $5bn covers both fields. first oil left blank — oil has not flowed; projected first production is 2030. OPEX, not available (not publicly disclosed; the \"$3/bbl below Kaskida\" figure is development cost, not opex). projected end-of-production and lease year (not confidently sourced).",
       "norms": [

--- a/reports/lower_tertiary/lifecycle/_facts.json
+++ b/reports/lower_tertiary/lifecycle/_facts.json
@@ -2,6 +2,7 @@
   {
     "id": "big_foot",
     "name": "Big Foot",
+    "decommissioning_facility": "Big Foot TLP",
     "operator": "Chevron",
     "region_block": "Walker Ridge 29 (G16942)",
     "basin": "US Gulf of Mexico",
@@ -185,6 +186,7 @@
   {
     "id": "jack_st_malo",
     "name": "Jack/St. Malo",
+    "decommissioning_facility": "Jack/St. Malo FPU",
     "operator": "Chevron",
     "status": "producing",
     "current_phase": "operate",
@@ -296,6 +298,7 @@
       "hpht_class": "HPHT",
       "pressure_psi": 13500,
       "pressure_qual": "~",
+      "pressure_basis": "subsea_system",
       "equip_rating_psi": 15000,
       "temp_f": null,
       "tvd_ft": 30000,
@@ -490,6 +493,7 @@
   {
     "id": "stones",
     "name": "Stones",
+    "decommissioning_facility": "Stones FPSO",
     "operator": "Shell",
     "status": "producing",
     "current_phase": "operate",

--- a/reports/lower_tertiary/lifecycle/anchor_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/anchor_lifecycle.html
@@ -77,6 +77,15 @@
   .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
   .devtype[data-tree="wet"]::before { border-radius: 50%; }
   .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
+  /* Underwriting risk chips (#949): HPHT + facility decommissioning. */
+  .riskchip { display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 var(--mono, ui-monospace,monospace);
+    text-transform: uppercase; letter-spacing: .04em; text-decoration: none; padding: 6px 11px; border-radius: 999px;
+    color: var(--rc, var(--muted)); background: color-mix(in srgb, var(--rc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--rc, var(--muted)) 40%, transparent); }
+  .riskchip::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: var(--rc, var(--muted)); }
+  .riskchip[data-sev="over-rating"] { --rc: #e5484d; }
+  .riskchip[data-sev="at-rating"] { --rc: #f5a524; }
+  .riskchip[data-conf="low"] { border-style: dashed; }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -264,6 +273,8 @@
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
         <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
+        <a class="riskchip" id="f-risk-hpht" href="../pressure-atlas/" hidden></a>
+        <a class="riskchip" id="f-risk-decom" href="../decommissioning/pa-liability-wave.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -534,6 +545,18 @@ const FIELD = {
     "api": null,
     "source_note": "OGJ 2024: initial reservoir (BHP) 23,000–27,000 psi — higher than the 20,000-psi equipment rating; 275F max flowing temp; pay 30,000–34,000 ft TVD (Wilcox 1–4)."
   },
+  "risk": {
+    "hpht": {
+      "class": "ultra-HPHT",
+      "pressure_psi": 25000,
+      "equip_rating_psi": 20000,
+      "exceedance_pct": 25,
+      "severity": "over-rating",
+      "basis": "reservoir",
+      "label": "ultra-HPHT · 25k vs 20k psi (+25%)"
+    },
+    "decommissioning": null
+  },
   "provenance": "Primary facts (operator, working interests, capex $5.6B, plateau 75 mbopd, GOR 1100 scf/bbl, opex $15/boe, first oil 2024-08, data through 2024-12-31) from in-repo anchor.yml. Life-cycle dates corroborated by public sources: discovery well Anchor-2 drilled 2014 (Green Canyon 807, ~5,180 ft), FID December 2019 (~$5.7B sanction), first oil August 2024 — world's first 20,000-psi HPHT deepwater development on a semisubmersible FPU, Lower Tertiary Wilcox play. Working interests (Chevron 62.5% / Equinor 25% / TotalEnergies 12.5%) per YAML; note older Offshore Technology page still lists pre-Equinor split (Chevron 62.86% / Total 37.14%). water depth ~5,180 (block-level estimate). projected end-of-production and lease year not confidently sourced; no notable incident.",
   "norms": [
     {
@@ -611,6 +634,19 @@ if (FIELD.treeLabel) {
   dt.textContent = FIELD.treeLabel;
   dt.setAttribute("data-tree", FIELD.treeType || "");
   dt.hidden = false;
+}
+const RISK = FIELD.risk || {};
+if (RISK.hpht) {
+  const c = $("f-risk-hpht");
+  c.textContent = RISK.hpht.label;
+  c.setAttribute("data-sev", RISK.hpht.severity);
+  c.hidden = false;
+}
+if (RISK.decommissioning) {
+  const c = $("f-risk-decom");
+  c.textContent = RISK.decommissioning.label;
+  c.setAttribute("data-conf", RISK.decommissioning.confidence);
+  c.hidden = false;
 }
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`

--- a/reports/lower_tertiary/lifecycle/big_foot_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/big_foot_lifecycle.html
@@ -77,6 +77,15 @@
   .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
   .devtype[data-tree="wet"]::before { border-radius: 50%; }
   .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
+  /* Underwriting risk chips (#949): HPHT + facility decommissioning. */
+  .riskchip { display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 var(--mono, ui-monospace,monospace);
+    text-transform: uppercase; letter-spacing: .04em; text-decoration: none; padding: 6px 11px; border-radius: 999px;
+    color: var(--rc, var(--muted)); background: color-mix(in srgb, var(--rc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--rc, var(--muted)) 40%, transparent); }
+  .riskchip::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: var(--rc, var(--muted)); }
+  .riskchip[data-sev="over-rating"] { --rc: #e5484d; }
+  .riskchip[data-sev="at-rating"] { --rc: #f5a524; }
+  .riskchip[data-conf="low"] { border-style: dashed; }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -264,6 +273,8 @@
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
         <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
+        <a class="riskchip" id="f-risk-hpht" href="../pressure-atlas/" hidden></a>
+        <a class="riskchip" id="f-risk-decom" href="../decommissioning/pa-liability-wave.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -547,6 +558,16 @@ const FIELD = {
     "api": null,
     "source_note": "Wilcox oil field (Offshore Technology; Chevron). Field-specific reservoir pressure/temperature not publicly disclosed — shown as — rather than borrowed from neighbouring fields."
   },
+  "risk": {
+    "hpht": null,
+    "decommissioning": {
+      "cost_musd": 43.2,
+      "host_type": "Mini-TLP",
+      "confidence": "modeled",
+      "basis": "facility removal (not well P&A)",
+      "label": "Decommission ~$43.2M"
+    }
+  },
   "provenance": "Data: big_foot.yml + Chevron public disclosures + BSEE (dates to be reconciled in #375)",
   "norms": [
     {
@@ -624,6 +645,19 @@ if (FIELD.treeLabel) {
   dt.textContent = FIELD.treeLabel;
   dt.setAttribute("data-tree", FIELD.treeType || "");
   dt.hidden = false;
+}
+const RISK = FIELD.risk || {};
+if (RISK.hpht) {
+  const c = $("f-risk-hpht");
+  c.textContent = RISK.hpht.label;
+  c.setAttribute("data-sev", RISK.hpht.severity);
+  c.hidden = false;
+}
+if (RISK.decommissioning) {
+  const c = $("f-risk-decom");
+  c.textContent = RISK.decommissioning.label;
+  c.setAttribute("data-conf", RISK.decommissioning.confidence);
+  c.hidden = false;
 }
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`

--- a/reports/lower_tertiary/lifecycle/cascade_chinook_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/cascade_chinook_lifecycle.html
@@ -77,6 +77,15 @@
   .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
   .devtype[data-tree="wet"]::before { border-radius: 50%; }
   .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
+  /* Underwriting risk chips (#949): HPHT + facility decommissioning. */
+  .riskchip { display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 var(--mono, ui-monospace,monospace);
+    text-transform: uppercase; letter-spacing: .04em; text-decoration: none; padding: 6px 11px; border-radius: 999px;
+    color: var(--rc, var(--muted)); background: color-mix(in srgb, var(--rc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--rc, var(--muted)) 40%, transparent); }
+  .riskchip::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: var(--rc, var(--muted)); }
+  .riskchip[data-sev="over-rating"] { --rc: #e5484d; }
+  .riskchip[data-sev="at-rating"] { --rc: #f5a524; }
+  .riskchip[data-conf="low"] { border-style: dashed; }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -264,6 +273,8 @@
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
         <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
+        <a class="riskchip" id="f-risk-hpht" href="../pressure-atlas/" hidden></a>
+        <a class="riskchip" id="f-risk-decom" href="../decommissioning/pa-liability-wave.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -512,6 +523,18 @@ const FIELD = {
     "api": null,
     "source_note": "OTC-24162/24163 + JPT: initial reservoir pressure ~19,500 psi, BHT ~256–260F, reservoir mid-point ~25,600 ft TVD."
   },
+  "risk": {
+    "hpht": {
+      "class": "HPHT",
+      "pressure_psi": 19500,
+      "equip_rating_psi": null,
+      "exceedance_pct": null,
+      "severity": "class-only",
+      "basis": "reservoir",
+      "label": "HPHT · 19.5k psi"
+    },
+    "decommissioning": null
+  },
   "provenance": "Life-cycle dates and ownership from public sources (Offshore Technology, Offshore Magazine, OGJ, Heerema, Rigzone); economics (capex $2.9B, plateau 75 mbopd, GOR 1400 scf/bbl, opex $18/boe) and data through from in-repo YAML. IMPORTANT: two YAML values were overridden as demonstrably wrong vs. well-documented public record — YAML first oil \"2021-08\" corrected to 2012-02 (Cascade first oil Feb 2012, Chinook Sep 2012; BW Pioneer was the first FPSO in the US GoM), and YAML operator/WI \"TotalEnergies 60% / Equinor 40%\" corrected to current MP Gulf of Mexico LLC (Murphy EXPRO 80% operator, Petrobras America 20%; originally Petrobras-operated with Total 33.33% in Chinook). LOW CONFIDENCE: FID year (sanction ~mid-2000s, no firm public citation — not available), lease year and projected end-of-production (not available); water depth 8,200 ft is the Cascade value (Chinook ~8,600 ft); capex is a YAML assumption not independently verified.",
   "norms": [
     {
@@ -589,6 +612,19 @@ if (FIELD.treeLabel) {
   dt.textContent = FIELD.treeLabel;
   dt.setAttribute("data-tree", FIELD.treeType || "");
   dt.hidden = false;
+}
+const RISK = FIELD.risk || {};
+if (RISK.hpht) {
+  const c = $("f-risk-hpht");
+  c.textContent = RISK.hpht.label;
+  c.setAttribute("data-sev", RISK.hpht.severity);
+  c.hidden = false;
+}
+if (RISK.decommissioning) {
+  const c = $("f-risk-decom");
+  c.textContent = RISK.decommissioning.label;
+  c.setAttribute("data-conf", RISK.decommissioning.confidence);
+  c.hidden = false;
 }
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`

--- a/reports/lower_tertiary/lifecycle/jack_st_malo_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/jack_st_malo_lifecycle.html
@@ -77,6 +77,15 @@
   .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
   .devtype[data-tree="wet"]::before { border-radius: 50%; }
   .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
+  /* Underwriting risk chips (#949): HPHT + facility decommissioning. */
+  .riskchip { display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 var(--mono, ui-monospace,monospace);
+    text-transform: uppercase; letter-spacing: .04em; text-decoration: none; padding: 6px 11px; border-radius: 999px;
+    color: var(--rc, var(--muted)); background: color-mix(in srgb, var(--rc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--rc, var(--muted)) 40%, transparent); }
+  .riskchip::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: var(--rc, var(--muted)); }
+  .riskchip[data-sev="over-rating"] { --rc: #e5484d; }
+  .riskchip[data-sev="at-rating"] { --rc: #f5a524; }
+  .riskchip[data-conf="low"] { border-style: dashed; }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -264,6 +273,8 @@
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
         <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
+        <a class="riskchip" id="f-risk-hpht" href="../pressure-atlas/" hidden></a>
+        <a class="riskchip" id="f-risk-decom" href="../decommissioning/pa-liability-wave.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -534,6 +545,24 @@ const FIELD = {
     "api": null,
     "source_note": "Dice regional Wilcox reservoir study: Jack initial pressure 19,374 psi @ 224F, St. Malo 19,023 psi @ 225F; reservoir ~26,500 ft TVD."
   },
+  "risk": {
+    "hpht": {
+      "class": "HPHT",
+      "pressure_psi": 19374,
+      "equip_rating_psi": null,
+      "exceedance_pct": null,
+      "severity": "class-only",
+      "basis": "reservoir",
+      "label": "HPHT · 19.4k psi"
+    },
+    "decommissioning": {
+      "cost_musd": 80.0,
+      "host_type": "FPU/FPS",
+      "confidence": "low",
+      "basis": "facility removal (not well P&A)",
+      "label": "Decommission ~$80M (FPSO base)"
+    }
+  },
   "provenance": "Facts from in-repo YAML (operator, WI Chevron 51%/Equinor 24.5%/Suncor 24.5%, capex $7.5B, opex $15/boe, plateau 94 mbopd, GOR 1200, status producing, data through 2024-12-31). Life-cycle dates from public sources: St. Malo discovered Oct 2003 and Jack Jul 2004 (discovery year=2003, earliest of pair); FID/sanction Oct 2010; first oil per Chevron press release Dec 2014 (\"2014-12\") — this OVERRIDES the YAML's first oil \"2014-02-01\", which appears erroneous. Water depth ~7000 ft at the FPU (Jack WR758/759 ~7000 ft, St. Malo WR678). host = Semisubmersible FPU. projected end-of-production not confidently estimable. lease year not available; no schedule-driving incident.",
   "norms": [
     {
@@ -611,6 +640,19 @@ if (FIELD.treeLabel) {
   dt.textContent = FIELD.treeLabel;
   dt.setAttribute("data-tree", FIELD.treeType || "");
   dt.hidden = false;
+}
+const RISK = FIELD.risk || {};
+if (RISK.hpht) {
+  const c = $("f-risk-hpht");
+  c.textContent = RISK.hpht.label;
+  c.setAttribute("data-sev", RISK.hpht.severity);
+  c.hidden = false;
+}
+if (RISK.decommissioning) {
+  const c = $("f-risk-decom");
+  c.textContent = RISK.decommissioning.label;
+  c.setAttribute("data-conf", RISK.decommissioning.confidence);
+  c.hidden = false;
 }
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`

--- a/reports/lower_tertiary/lifecycle/julia_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/julia_lifecycle.html
@@ -77,6 +77,15 @@
   .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
   .devtype[data-tree="wet"]::before { border-radius: 50%; }
   .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
+  /* Underwriting risk chips (#949): HPHT + facility decommissioning. */
+  .riskchip { display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 var(--mono, ui-monospace,monospace);
+    text-transform: uppercase; letter-spacing: .04em; text-decoration: none; padding: 6px 11px; border-radius: 999px;
+    color: var(--rc, var(--muted)); background: color-mix(in srgb, var(--rc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--rc, var(--muted)) 40%, transparent); }
+  .riskchip::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: var(--rc, var(--muted)); }
+  .riskchip[data-sev="over-rating"] { --rc: #e5484d; }
+  .riskchip[data-sev="at-rating"] { --rc: #f5a524; }
+  .riskchip[data-conf="low"] { border-style: dashed; }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -264,6 +273,8 @@
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
         <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
+        <a class="riskchip" id="f-risk-hpht" href="../pressure-atlas/" hidden></a>
+        <a class="riskchip" id="f-risk-decom" href="../decommissioning/pa-liability-wave.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -530,12 +541,25 @@ const FIELD = {
     "hpht_class": "HPHT",
     "pressure_psi": 13500,
     "pressure_qual": "~",
+    "pressure_basis": "subsea_system",
     "equip_rating_psi": 15000,
     "temp_f": null,
     "tvd_ft": 30000,
     "fluid": "black oil",
     "api": 24.7,
     "source_note": "Offshore Mag: subsea pressures ~13,500 psi (15,000-psi-rated trees + first permanent HIPPS); Hart Energy production test: 24.7°API oil."
+  },
+  "risk": {
+    "hpht": {
+      "class": "HPHT",
+      "pressure_psi": 13500,
+      "equip_rating_psi": 15000,
+      "exceedance_pct": null,
+      "severity": "class-only",
+      "basis": "subsea_system",
+      "label": "HPHT · subsea system 13.5k / 15k-psi trees"
+    },
+    "decommissioning": null
   },
   "provenance": "Primary facts (capex $4.7B, plateau 34 mbopd, GOR 1000, opex $18/boe, first oil, WI 50/50) from in-repo julia.yml; first oil = BSEE OGOR-A first production (2016-03) per YAML — note ExxonMobil press release states production start April 2016. Operator corrected to ExxonMobil (YAML flagged its \"Equinor\" operator field as disputed; public record = ExxonMobil-operated, Equinor/Statoil 50% partner). Discovery 2007, FID May 2013, water depth 7000+ ft, Walker Ridge blocks, and Jack/St. Malo tieback from Offshore Technology and operator/trade press. lease year and projected end-of-production not confidently sourced.",
   "norms": [
@@ -614,6 +638,19 @@ if (FIELD.treeLabel) {
   dt.textContent = FIELD.treeLabel;
   dt.setAttribute("data-tree", FIELD.treeType || "");
   dt.hidden = false;
+}
+const RISK = FIELD.risk || {};
+if (RISK.hpht) {
+  const c = $("f-risk-hpht");
+  c.textContent = RISK.hpht.label;
+  c.setAttribute("data-sev", RISK.hpht.severity);
+  c.hidden = false;
+}
+if (RISK.decommissioning) {
+  const c = $("f-risk-decom");
+  c.textContent = RISK.decommissioning.label;
+  c.setAttribute("data-conf", RISK.decommissioning.confidence);
+  c.hidden = false;
 }
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`

--- a/reports/lower_tertiary/lifecycle/kaskida_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/kaskida_lifecycle.html
@@ -77,6 +77,15 @@
   .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
   .devtype[data-tree="wet"]::before { border-radius: 50%; }
   .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
+  /* Underwriting risk chips (#949): HPHT + facility decommissioning. */
+  .riskchip { display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 var(--mono, ui-monospace,monospace);
+    text-transform: uppercase; letter-spacing: .04em; text-decoration: none; padding: 6px 11px; border-radius: 999px;
+    color: var(--rc, var(--muted)); background: color-mix(in srgb, var(--rc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--rc, var(--muted)) 40%, transparent); }
+  .riskchip::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: var(--rc, var(--muted)); }
+  .riskchip[data-sev="over-rating"] { --rc: #e5484d; }
+  .riskchip[data-sev="at-rating"] { --rc: #f5a524; }
+  .riskchip[data-conf="low"] { border-style: dashed; }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -264,6 +273,8 @@
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
         <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
+        <a class="riskchip" id="f-risk-hpht" href="../pressure-atlas/" hidden></a>
+        <a class="riskchip" id="f-risk-decom" href="../decommissioning/pa-liability-wave.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -510,6 +521,18 @@ const FIELD = {
     "api": null,
     "source_note": "AAPG: deep Wilcox is a '20,000 psi or higher' reservoir environment (matches the 20K equipment rating); JPT/BOEM: BP 20,000-psi FPU. Exact pore pressure not published — shown as ≥20,000."
   },
+  "risk": {
+    "hpht": {
+      "class": "ultra-HPHT",
+      "pressure_psi": 20000,
+      "equip_rating_psi": 20000,
+      "exceedance_pct": 0,
+      "severity": "at-rating",
+      "basis": "reservoir",
+      "label": "ultra-HPHT · 20k vs 20k psi (0%)"
+    },
+    "decommissioning": null
+  },
   "provenance": "Discovery 2006 (Keathley Canyon 292, Lower Tertiary Wilcox), FID/sanction July 30 2024 (BP 100%, Devon's original 30% exited), first oil targeted 2029 but left blank as no oil has flowed and the Aug-2025 BOEM DPP rejection likely pushes it out. Public sanctioned figures used over YAML where they diverge: plateau/nameplate 80 mbopd (YAML said 120) and capex ~$5bn for Phase 1 (<$5B per BP; YAML total CAPEX 10000 = $10bn is a full-field/multi-phase estimate). GOR 1000 scf/bbl and data through 2024-12-31 from YAML. Water depth ~6,000 ft, 20,000-psi semisubmersible FPU. Low-confidence: capex (phase-1 vs full-field ambiguity), water depth (rounded), lease year unknown, opex unknown.",
   "norms": [
     {
@@ -566,6 +589,19 @@ if (FIELD.treeLabel) {
   dt.textContent = FIELD.treeLabel;
   dt.setAttribute("data-tree", FIELD.treeType || "");
   dt.hidden = false;
+}
+const RISK = FIELD.risk || {};
+if (RISK.hpht) {
+  const c = $("f-risk-hpht");
+  c.textContent = RISK.hpht.label;
+  c.setAttribute("data-sev", RISK.hpht.severity);
+  c.hidden = false;
+}
+if (RISK.decommissioning) {
+  const c = $("f-risk-decom");
+  c.textContent = RISK.decommissioning.label;
+  c.setAttribute("data-conf", RISK.decommissioning.confidence);
+  c.hidden = false;
 }
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`

--- a/reports/lower_tertiary/lifecycle/lifecycle_template.html
+++ b/reports/lower_tertiary/lifecycle/lifecycle_template.html
@@ -77,6 +77,15 @@
   .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
   .devtype[data-tree="wet"]::before { border-radius: 50%; }
   .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
+  /* Underwriting risk chips (#949): HPHT + facility decommissioning. */
+  .riskchip { display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 var(--mono, ui-monospace,monospace);
+    text-transform: uppercase; letter-spacing: .04em; text-decoration: none; padding: 6px 11px; border-radius: 999px;
+    color: var(--rc, var(--muted)); background: color-mix(in srgb, var(--rc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--rc, var(--muted)) 40%, transparent); }
+  .riskchip::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: var(--rc, var(--muted)); }
+  .riskchip[data-sev="over-rating"] { --rc: #e5484d; }
+  .riskchip[data-sev="at-rating"] { --rc: #f5a524; }
+  .riskchip[data-conf="low"] { border-style: dashed; }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -264,6 +273,8 @@
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
         <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
+        <a class="riskchip" id="f-risk-hpht" href="../pressure-atlas/" hidden></a>
+        <a class="riskchip" id="f-risk-decom" href="../decommissioning/pa-liability-wave.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -397,6 +408,19 @@ if (FIELD.treeLabel) {
   dt.textContent = FIELD.treeLabel;
   dt.setAttribute("data-tree", FIELD.treeType || "");
   dt.hidden = false;
+}
+const RISK = FIELD.risk || {};
+if (RISK.hpht) {
+  const c = $("f-risk-hpht");
+  c.textContent = RISK.hpht.label;
+  c.setAttribute("data-sev", RISK.hpht.severity);
+  c.hidden = false;
+}
+if (RISK.decommissioning) {
+  const c = $("f-risk-decom");
+  c.textContent = RISK.decommissioning.label;
+  c.setAttribute("data-conf", RISK.decommissioning.confidence);
+  c.hidden = false;
 }
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`

--- a/reports/lower_tertiary/lifecycle/north_platte_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/north_platte_lifecycle.html
@@ -77,6 +77,15 @@
   .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
   .devtype[data-tree="wet"]::before { border-radius: 50%; }
   .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
+  /* Underwriting risk chips (#949): HPHT + facility decommissioning. */
+  .riskchip { display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 var(--mono, ui-monospace,monospace);
+    text-transform: uppercase; letter-spacing: .04em; text-decoration: none; padding: 6px 11px; border-radius: 999px;
+    color: var(--rc, var(--muted)); background: color-mix(in srgb, var(--rc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--rc, var(--muted)) 40%, transparent); }
+  .riskchip::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: var(--rc, var(--muted)); }
+  .riskchip[data-sev="over-rating"] { --rc: #e5484d; }
+  .riskchip[data-sev="at-rating"] { --rc: #f5a524; }
+  .riskchip[data-conf="low"] { border-style: dashed; }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -264,6 +273,8 @@
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
         <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
+        <a class="riskchip" id="f-risk-hpht" href="../pressure-atlas/" hidden></a>
+        <a class="riskchip" id="f-risk-decom" href="../decommissioning/pa-liability-wave.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -506,6 +517,18 @@ const FIELD = {
     "api": null,
     "source_note": "World Oil/JPT: Sparta (ex-North Platte) is a 20,000-psi-rated development. All public '20,000 psi' figures are the equipment rating; true reservoir pore pressure not publicly disclosed — shown as —."
   },
+  "risk": {
+    "hpht": {
+      "class": "ultra-HPHT",
+      "pressure_psi": null,
+      "equip_rating_psi": 20000,
+      "exceedance_pct": null,
+      "severity": "class-only",
+      "basis": "reservoir",
+      "label": "ultra-HPHT · 20k-psi equipment"
+    },
+    "decommissioning": null
+  },
   "provenance": "Basis: in-repo YAML (superseded TotalEnergies pre-FID case) reconciled against current public record. North Platte was discovered 2012 (Cobalt/Total, Garden Banks). TotalEnergies (then 60% op, Equinor 40%) withdrew Feb 2022; Shell bought 51% and took operatorship from Equinor (49%), redesigned and renamed the project \"Sparta.\" Shell took FID Dec 2023; first oil projected 2028 (left blank — not yet producing). Water depth ~4,265 ft, subsalt Wilcox, newbuild semisubmersible FPU (8 subsea wells) with ~90,000 boe/d peak (~75 mbopd oil plateau; GOR 1100 scf/bbl from YAML). LOW-CONFIDENCE: capex — YAML's $6B reflects the abandoned TotalEnergies ~$5-7B concept, not Shell's simplified Sparta scope (not publicly disclosed), so not available; opex and projected COP year not publicly defensible.",
   "norms": [
     {
@@ -562,6 +585,19 @@ if (FIELD.treeLabel) {
   dt.textContent = FIELD.treeLabel;
   dt.setAttribute("data-tree", FIELD.treeType || "");
   dt.hidden = false;
+}
+const RISK = FIELD.risk || {};
+if (RISK.hpht) {
+  const c = $("f-risk-hpht");
+  c.textContent = RISK.hpht.label;
+  c.setAttribute("data-sev", RISK.hpht.severity);
+  c.hidden = false;
+}
+if (RISK.decommissioning) {
+  const c = $("f-risk-decom");
+  c.textContent = RISK.decommissioning.label;
+  c.setAttribute("data-conf", RISK.decommissioning.confidence);
+  c.hidden = false;
 }
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`

--- a/reports/lower_tertiary/lifecycle/shenandoah_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/shenandoah_lifecycle.html
@@ -77,6 +77,15 @@
   .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
   .devtype[data-tree="wet"]::before { border-radius: 50%; }
   .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
+  /* Underwriting risk chips (#949): HPHT + facility decommissioning. */
+  .riskchip { display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 var(--mono, ui-monospace,monospace);
+    text-transform: uppercase; letter-spacing: .04em; text-decoration: none; padding: 6px 11px; border-radius: 999px;
+    color: var(--rc, var(--muted)); background: color-mix(in srgb, var(--rc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--rc, var(--muted)) 40%, transparent); }
+  .riskchip::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: var(--rc, var(--muted)); }
+  .riskchip[data-sev="over-rating"] { --rc: #e5484d; }
+  .riskchip[data-sev="at-rating"] { --rc: #f5a524; }
+  .riskchip[data-conf="low"] { border-style: dashed; }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -264,6 +273,8 @@
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
         <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
+        <a class="riskchip" id="f-risk-hpht" href="../pressure-atlas/" hidden></a>
+        <a class="riskchip" id="f-risk-decom" href="../decommissioning/pa-liability-wave.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -530,6 +541,18 @@ const FIELD = {
     "api": null,
     "source_note": "Clariant/World Oil: reservoir/formation pressures above 22,000 psi at ~200F (ultra-high-PRESSURE, moderate temp), ~30,000 ft TVD; 20,000-psi equipment rating separate."
   },
+  "risk": {
+    "hpht": {
+      "class": "ultra-HPHT",
+      "pressure_psi": 22000,
+      "equip_rating_psi": 20000,
+      "exceedance_pct": 10,
+      "severity": "over-rating",
+      "basis": "reservoir",
+      "label": "ultra-HPHT · 22k vs 20k psi (+10%)"
+    },
+    "decommissioning": null
+  },
   "provenance": "Base facts (operator, capex, plateau, GOR, data through) from in-repo YAML; discovery 2009 (Anadarko Shenandoah-1, WR52), FID/sanction Aug 2021 (Beacon+Navitas), and actual first oil (first of 4 wells online 25 Jul 2025; ramped to 100 kbopd plateau Oct 2025) from public sources — first oil corrected to 2025-07 vs YAML's placeholder 2025-10. Current WI (Beacon 31% op / Navitas 49% / HEQ 20%) post-2021 restructuring. CAPEX 1.8 is YAML-stated and largely reflects pre-development E&A spend (LOW CONFIDENCE for full development cost); OPEX and projected end-of-production, not available (not defensibly sourced); water depth ~5,800 ft.",
   "norms": [
     {
@@ -607,6 +630,19 @@ if (FIELD.treeLabel) {
   dt.textContent = FIELD.treeLabel;
   dt.setAttribute("data-tree", FIELD.treeType || "");
   dt.hidden = false;
+}
+const RISK = FIELD.risk || {};
+if (RISK.hpht) {
+  const c = $("f-risk-hpht");
+  c.textContent = RISK.hpht.label;
+  c.setAttribute("data-sev", RISK.hpht.severity);
+  c.hidden = false;
+}
+if (RISK.decommissioning) {
+  const c = $("f-risk-decom");
+  c.textContent = RISK.decommissioning.label;
+  c.setAttribute("data-conf", RISK.decommissioning.confidence);
+  c.hidden = false;
 }
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`

--- a/reports/lower_tertiary/lifecycle/stones_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/stones_lifecycle.html
@@ -77,6 +77,15 @@
   .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
   .devtype[data-tree="wet"]::before { border-radius: 50%; }
   .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
+  /* Underwriting risk chips (#949): HPHT + facility decommissioning. */
+  .riskchip { display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 var(--mono, ui-monospace,monospace);
+    text-transform: uppercase; letter-spacing: .04em; text-decoration: none; padding: 6px 11px; border-radius: 999px;
+    color: var(--rc, var(--muted)); background: color-mix(in srgb, var(--rc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--rc, var(--muted)) 40%, transparent); }
+  .riskchip::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: var(--rc, var(--muted)); }
+  .riskchip[data-sev="over-rating"] { --rc: #e5484d; }
+  .riskchip[data-sev="at-rating"] { --rc: #f5a524; }
+  .riskchip[data-conf="low"] { border-style: dashed; }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -264,6 +273,8 @@
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
         <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
+        <a class="riskchip" id="f-risk-hpht" href="../pressure-atlas/" hidden></a>
+        <a class="riskchip" id="f-risk-decom" href="../decommissioning/pa-liability-wave.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -527,6 +538,24 @@ const FIELD = {
     "api": null,
     "source_note": "Offshore Mag/S&D: Paleogene Wilcox, reservoir ~26,500 ft TVD (17,000 ft below mudline). Reservoir pressure/temperature not cleanly sourced — shown as —."
   },
+  "risk": {
+    "hpht": {
+      "class": "HPHT",
+      "pressure_psi": null,
+      "equip_rating_psi": null,
+      "exceedance_pct": null,
+      "severity": "class-only",
+      "basis": "reservoir",
+      "label": "HPHT"
+    },
+    "decommissioning": {
+      "cost_musd": 80.0,
+      "host_type": "FPSO",
+      "confidence": "low",
+      "basis": "facility removal (not well P&A)",
+      "label": "Decommission ~$80M (FPSO base)"
+    }
+  },
   "provenance": "Capex ($3.8bn), plateau (50 mbopd), GOR (850 scf/bbl), opex ($15/boe), first oil (2016-09) and status from in-repo stones.yml (Shell FPSO development config). Discovery (2005), FID/sanction (May 2013, Shell 100% owner-operator), Walker Ridge Block 508, ~9,500 ft water depth, and Turritella/Stones FPSO host (world's deepest FPSO) confirmed via Offshore Technology, Offshore Magazine, and NS Energy public sources. lease year and projected end-of-production unknown; no notable schedule-driving incident identified.",
   "norms": [
     {
@@ -604,6 +633,19 @@ if (FIELD.treeLabel) {
   dt.textContent = FIELD.treeLabel;
   dt.setAttribute("data-tree", FIELD.treeType || "");
   dt.hidden = false;
+}
+const RISK = FIELD.risk || {};
+if (RISK.hpht) {
+  const c = $("f-risk-hpht");
+  c.textContent = RISK.hpht.label;
+  c.setAttribute("data-sev", RISK.hpht.severity);
+  c.hidden = false;
+}
+if (RISK.decommissioning) {
+  const c = $("f-risk-decom");
+  c.textContent = RISK.decommissioning.label;
+  c.setAttribute("data-conf", RISK.decommissioning.confidence);
+  c.hidden = false;
 }
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`

--- a/reports/lower_tertiary/lifecycle/tiber_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/tiber_lifecycle.html
@@ -77,6 +77,15 @@
   .devtype[data-tree="wet"] { --dc: var(--good); }        /* wet = teal/green */
   .devtype[data-tree="wet"]::before { border-radius: 50%; }
   .devtype:hover { background: color-mix(in srgb, var(--dc, var(--muted)) 20%, transparent); }
+  /* Underwriting risk chips (#949): HPHT + facility decommissioning. */
+  .riskchip { display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 var(--mono, ui-monospace,monospace);
+    text-transform: uppercase; letter-spacing: .04em; text-decoration: none; padding: 6px 11px; border-radius: 999px;
+    color: var(--rc, var(--muted)); background: color-mix(in srgb, var(--rc, var(--muted)) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--rc, var(--muted)) 40%, transparent); }
+  .riskchip::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: var(--rc, var(--muted)); }
+  .riskchip[data-sev="over-rating"] { --rc: #e5484d; }
+  .riskchip[data-sev="at-rating"] { --rc: #f5a524; }
+  .riskchip[data-conf="low"] { border-style: dashed; }
 
   .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
     gap: 1px; background: var(--line); border-top: 1px solid var(--line); }
@@ -264,6 +273,8 @@
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:10px;">
         <span class="status"><span class="dot"></span><span id="f-status">—</span></span>
         <a class="devtype" id="f-devtype" data-tree="" href="../region-devtype-comparison.html" hidden></a>
+        <a class="riskchip" id="f-risk-hpht" href="../pressure-atlas/" hidden></a>
+        <a class="riskchip" id="f-risk-decom" href="../decommissioning/pa-liability-wave.html" hidden></a>
         <span class="draft">Draft tracer · #738</span>
       </div>
     </header>
@@ -502,6 +513,18 @@ const FIELD = {
     "api": null,
     "source_note": "BP FID 2025 (Tiber-Guadalupe): reservoirs 'under pressures of up to 20,000 psi', Paleogene Wilcox; ~28,000 ft TVD. Temperature not field-specific."
   },
+  "risk": {
+    "hpht": {
+      "class": "ultra-HPHT",
+      "pressure_psi": 20000,
+      "equip_rating_psi": 20000,
+      "exceedance_pct": 0,
+      "severity": "at-rating",
+      "basis": "reservoir",
+      "label": "ultra-HPHT · 20k vs 20k psi (0%)"
+    },
+    "decommissioning": null
+  },
   "provenance": "Basis: in-repo tiber.yml (operator BP, plateau 80 mbopd, GOR 900 scf/bbl, data through 2024-12-31) plus public sources. BP discovered Tiber Sept 2009 in Keathley Canyon 102, 4,132 ft water. BP reached FID on the combined Tiber-Guadalupe hub 29 Sep 2025 (FID year=2025); Seatrium awarded FPU EPCC. Ownership is now 100% BP (original discovery split BP 62% / Petrobras 20% / ConocoPhillips 18% no longer reflects current WI). Status: execution (post-FID, construction underway). capex set to the sanctioned public figure of $5.0bn for the Tiber-Guadalupe project (YAML's $8bn was a pre-FID Tiber-only planning assumption); note $5bn covers both fields. first oil left blank — oil has not flowed; projected first production is 2030. OPEX, not available (not publicly disclosed; the \"$3/bbl below Kaskida\" figure is development cost, not opex). projected end-of-production and lease year (not confidently sourced).",
   "norms": [
     {
@@ -548,6 +571,19 @@ if (FIELD.treeLabel) {
   dt.textContent = FIELD.treeLabel;
   dt.setAttribute("data-tree", FIELD.treeType || "");
   dt.hidden = false;
+}
+const RISK = FIELD.risk || {};
+if (RISK.hpht) {
+  const c = $("f-risk-hpht");
+  c.textContent = RISK.hpht.label;
+  c.setAttribute("data-sev", RISK.hpht.severity);
+  c.hidden = false;
+}
+if (RISK.decommissioning) {
+  const c = $("f-risk-decom");
+  c.textContent = RISK.decommissioning.label;
+  c.setAttribute("data-conf", RISK.decommissioning.confidence);
+  c.hidden = false;
 }
 if (FIELD.wellsHref) $("f-wells").innerHTML =
   `<a href="${FIELD.wellsHref}" style="display:flex;align-items:center;justify-content:space-between;gap:12px;`

--- a/scripts/lower_tertiary/build_lifecycle_posters.py
+++ b/scripts/lower_tertiary/build_lifecycle_posters.py
@@ -22,6 +22,7 @@ Usage
 from __future__ import annotations
 
 import argparse
+import csv
 import json
 import sys
 from pathlib import Path
@@ -33,6 +34,10 @@ if str(_SRC) not in sys.path:
 from worldenergydata.field_development.host_text_classifier import (  # noqa: E402
     classify_tree_type,
 )
+from worldenergydata.field_development.decommission_risk import (  # noqa: E402
+    classify_decommissioning,
+)
+from worldenergydata.field_development.hpht_risk import classify_hpht  # noqa: E402
 
 _SCRIPTS = Path(__file__).resolve().parents[1]
 if str(_SCRIPTS) not in sys.path:
@@ -45,6 +50,22 @@ from worldenergydata.common.fields_registry import load_fields  # noqa: E402
 HERE = Path(__file__).resolve().parents[2] / "reports/lower_tertiary/lifecycle"
 TEMPLATE = HERE / "lifecycle_template.html"
 FACTS = HERE / "_facts.json"
+# Facility decommissioning liabilities (#949 underwriting badge). Comment lines
+# (leading '#') are the provenance header; skip them.
+_DECOM_CSV = (
+    Path(__file__).resolve().parents[2]
+    / "reports/decommissioning/regional_liability.csv"
+)
+
+
+def _load_decom_rows() -> list[dict]:
+    if not _DECOM_CSV.exists():
+        return []
+    lines = [ln for ln in _DECOM_CSV.read_text().splitlines() if not ln.startswith("#")]
+    return list(csv.DictReader(lines))
+
+
+_DECOM_ROWS = _load_decom_rows()
 TODAY_YEAR = 2026.5  # generated 2026-07-03; a fixed "you are here" marker on the axis
 FIELDS_REGISTRY = load_fields()
 
@@ -312,6 +333,12 @@ def facts_to_field(f: dict) -> dict:
         ],
         "hostFacts": host_facts,
         "reservoir": f.get("reservoir"),
+        "risk": {
+            "hpht": classify_hpht(f.get("reservoir")),
+            "decommissioning": classify_decommissioning(
+                f.get("decommissioning_facility"), _DECOM_ROWS
+            ),
+        },
         "provenance": f.get(
             "provenance", "Data: field YAML + public disclosures + BSEE"
         ),

--- a/src/worldenergydata/field_development/decommission_risk.py
+++ b/src/worldenergydata/field_development/decommission_risk.py
@@ -1,0 +1,51 @@
+# ABOUTME: Match a field to its facility decommissioning liability figure.
+# ABOUTME: Side-effect-free; drives the decommissioning risk badge on the posters (#949).
+"""
+worldenergydata.field_development.decommission_risk
+===================================================
+
+Surface the per-facility decommissioning liability already modeled in
+``reports/decommissioning/regional_liability.csv`` as a per-field underwriting
+signal, by matching a curated facility name.
+
+HONESTY (per the #949 review):
+  * This is **facility removal** liability, NOT well-plugging (P&A). Per-field
+    well-plugging counts are not attributable (BSEE ``well_data.csv`` has no
+    lease column and only 23 shelf field codes, none Lower Tertiary).
+  * The source CSV flags "FPSO base low-confidence": an FPSO/FPU facility
+    carries a flat placeholder cost, so its estimate is ``confidence="low"``;
+    a depth-differentiated host (e.g. Big Foot's Mini-TLP) is ``"modeled"``.
+"""
+
+from __future__ import annotations
+
+BASIS = "facility removal (not well P&A)"
+
+
+def classify_decommissioning(
+    facility_name: str | None, rows: list[dict]
+) -> dict | None:
+    """Return a decommissioning badge dict for ``facility_name``, or ``None``.
+
+    ``rows`` are the parsed ``regional_liability.csv`` records (dicts with
+    ``facility_name``, ``cost_musd``, ``host_type``). Matching is exact on the
+    curated facility name.
+    """
+    if not facility_name:
+        return None
+    match = next((r for r in rows if r.get("facility_name") == facility_name), None)
+    if match is None:
+        return None
+    host = (match.get("host_type") or "").upper()
+    low = "FPSO" in host or "FPU" in host or "FPS" in host
+    try:
+        cost = round(float(match["cost_musd"]), 1)
+    except (TypeError, ValueError, KeyError):
+        return None
+    return {
+        "cost_musd": cost,
+        "host_type": match.get("host_type"),
+        "confidence": "low" if low else "modeled",
+        "basis": BASIS,
+        "label": f"Decommission ~${cost:g}M" + (" (FPSO base)" if low else ""),
+    }

--- a/src/worldenergydata/field_development/hpht_risk.py
+++ b/src/worldenergydata/field_development/hpht_risk.py
@@ -1,0 +1,87 @@
+# ABOUTME: Classify a field's reservoir facts into an HPHT underwriting signal.
+# ABOUTME: Side-effect-free; drives the HPHT risk badge on the life-cycle posters (#949).
+"""
+worldenergydata.field_development.hpht_risk
+===========================================
+
+Derive an HPHT (high-pressure / high-temperature) underwriting badge from the
+per-field ``reservoir`` block already curated in
+``reports/lower_tertiary/lifecycle/_facts.json``.
+
+The signal an underwriter cares about is **reservoir pore pressure vs the
+installed equipment rating** — e.g. Anchor's 25,000-psi reservoir against
+20,000-psi equipment (+25%). That exceedance is only meaningful when the
+pressure figure is a reservoir pore pressure; a *subsea-system* pressure (a
+tree/HIPPS rating, as for Julia) is NOT reservoir-vs-equipment and must not be
+rendered as an exceedance (``pressure_basis == "subsea_system"``).
+"""
+
+from __future__ import annotations
+
+# Severity buckets, most-to-least severe.
+OVER_RATING = "over-rating"  # reservoir pressure exceeds equipment rating
+AT_RATING = "at-rating"  # reservoir pressure equals equipment rating
+WITHIN = "within"  # reservoir pressure below equipment rating
+CLASS_ONLY = "class-only"  # HPHT class known, no reservoir-vs-equipment pair
+
+
+def classify_hpht(reservoir: dict | None) -> dict | None:
+    """Return an HPHT badge dict, or ``None`` when there is no HPHT signal.
+
+    ``None`` when the field has neither a pressure nor an HPHT class (e.g. Big
+    Foot). Otherwise a dict with ``class``, ``pressure_psi``,
+    ``equip_rating_psi``, ``exceedance_pct`` (or ``None``), ``severity``,
+    ``basis`` and a human ``label``.
+    """
+    if not reservoir:
+        return None
+    hpht_class = reservoir.get("hpht_class")
+    pressure = reservoir.get("pressure_psi")
+    equip = reservoir.get("equip_rating_psi")
+    if hpht_class is None and pressure is None:
+        return None
+
+    basis = reservoir.get("pressure_basis") or "reservoir"
+    exceedance = None
+    severity = CLASS_ONLY
+    # Exceedance is only a reservoir-vs-equipment statement when BOTH values are
+    # present AND the pressure is a reservoir pore pressure (not a system rating).
+    if pressure is not None and equip and basis == "reservoir":
+        exceedance = round((pressure - equip) / equip * 100)
+        if exceedance > 0:
+            severity = OVER_RATING
+        elif exceedance == 0:
+            severity = AT_RATING
+        else:
+            severity = WITHIN
+
+    label = _label(hpht_class, pressure, equip, exceedance, severity, basis)
+    return {
+        "class": hpht_class,
+        "pressure_psi": pressure,
+        "equip_rating_psi": equip,
+        "exceedance_pct": exceedance,
+        "severity": severity,
+        "basis": basis,
+        "label": label,
+    }
+
+
+def _k(psi: int) -> str:
+    """20000 -> '20k', 13500 -> '13.5k', 19374 -> '19.4k'."""
+    return f"{round(psi / 1000, 1):g}k"
+
+
+def _label(hpht_class, pressure, equip, exceedance, severity, basis) -> str:
+    cls = hpht_class or "HPHT"
+    if severity in (OVER_RATING, AT_RATING, WITHIN):
+        sign = "+" if exceedance > 0 else ""
+        return f"{cls} · {_k(pressure)} vs {_k(equip)} psi ({sign}{exceedance}%)"
+    if basis == "subsea_system" and pressure is not None:
+        rating = f" / {_k(equip)}-psi trees" if equip else ""
+        return f"{cls} · subsea system {_k(pressure)}{rating}"
+    if pressure is not None:
+        return f"{cls} · {_k(pressure)} psi"
+    if equip is not None:
+        return f"{cls} · {_k(equip)}-psi equipment"
+    return cls

--- a/tests/integration/site/test_public_link_graph.py
+++ b/tests/integration/site/test_public_link_graph.py
@@ -308,6 +308,48 @@ def test_wells_rollout_fields_and_no_null_strings(public):
     assert not bad, f"null/NaN leakage in well pages: {bad}"
 
 
+def test_underwriting_risk_signals(public):
+    # #949: HPHT badge for the 9 fields with reservoir HPHT data (not big_foot);
+    # facility-decommissioning badge for exactly the 3 name-matched LT facilities.
+    import importlib.util as _il
+
+    _hs = _il.spec_from_file_location(
+        "hpht_risk_ig", REPO / "src/worldenergydata/field_development/hpht_risk.py"
+    )
+    hr = _il.module_from_spec(_hs)
+    _hs.loader.exec_module(hr)
+
+    fields = _explorer(public)["fields"]
+    hpht = {k: v["risk"]["hpht"] for k, v in fields.items() if v["risk"]["hpht"]}
+    decom = {
+        k: v["risk"]["decommissioning"]
+        for k, v in fields.items()
+        if v["risk"]["decommissioning"]
+    }
+    assert set(hpht) == {
+        "anchor",
+        "cascade_chinook",
+        "jack_st_malo",
+        "julia",
+        "kaskida",
+        "north_platte",
+        "shenandoah",
+        "stones",
+        "tiber",
+    }
+    assert fields["big_foot"]["risk"]["hpht"] is None
+    assert set(decom) == {"big_foot", "jack_st_malo", "stones"}
+    assert decom["big_foot"]["confidence"] == "modeled"
+    assert decom["jack_st_malo"]["confidence"] == "low"
+    # Parity: severity recomputed from each field's reservoir matches the sidecar.
+    facts = {f["id"]: f for f in FACTS}
+    for fid, sig in hpht.items():
+        assert hr.classify_hpht(facts[fid]["reservoir"])["severity"] == sig["severity"]
+    # Julia's subsea-system pressure must NOT be rendered as an exceedance.
+    assert hpht["julia"]["exceedance_pct"] is None
+    assert hpht["anchor"]["exceedance_pct"] == 25
+
+
 def test_every_well_has_a_page(public):
     embedded = _explorer(public)["wells"]["wells"]
     missing = [

--- a/tests/unit/field_development/test_risk_classifiers.py
+++ b/tests/unit/field_development/test_risk_classifiers.py
@@ -1,0 +1,89 @@
+"""Unit tests for the underwriting-lens risk classifiers (issue #949)."""
+
+from __future__ import annotations
+
+from worldenergydata.field_development.decommission_risk import (
+    classify_decommissioning,
+)
+from worldenergydata.field_development.hpht_risk import classify_hpht
+
+
+def test_hpht_over_rating_anchor():
+    r = classify_hpht(
+        {"hpht_class": "ultra-HPHT", "pressure_psi": 25000, "equip_rating_psi": 20000}
+    )
+    assert r["exceedance_pct"] == 25
+    assert r["severity"] == "over-rating"
+    assert "25k vs 20k psi (+25%)" in r["label"]
+
+
+def test_hpht_at_and_within():
+    assert (
+        classify_hpht(
+            {
+                "hpht_class": "ultra-HPHT",
+                "pressure_psi": 20000,
+                "equip_rating_psi": 20000,
+            }
+        )["severity"]
+        == "at-rating"
+    )
+    assert (
+        classify_hpht(
+            {"hpht_class": "HPHT", "pressure_psi": 22000, "equip_rating_psi": 20000}
+        )["exceedance_pct"]
+        == 10
+    )
+
+
+def test_hpht_julia_system_basis_is_not_an_exceedance():
+    # Julia's 13,500 psi is a subsea-system figure (15k-rated trees + HIPPS),
+    # NOT reservoir pore pressure -> no reservoir-vs-equipment exceedance (#949 f4).
+    r = classify_hpht(
+        {
+            "hpht_class": "HPHT",
+            "pressure_psi": 13500,
+            "equip_rating_psi": 15000,
+            "pressure_basis": "subsea_system",
+        }
+    )
+    assert r["exceedance_pct"] is None
+    assert r["severity"] == "class-only"
+    assert "subsea system" in r["label"]
+
+
+def test_hpht_class_only_and_none():
+    assert classify_hpht({"hpht_class": "HPHT"})["severity"] == "class-only"
+    # rating-only (north_platte) is still class-only, not an exceedance.
+    assert (
+        classify_hpht({"hpht_class": "ultra-HPHT", "equip_rating_psi": 20000})[
+            "exceedance_pct"
+        ]
+        is None
+    )
+    # No class and no pressure (big_foot) -> no signal.
+    assert classify_hpht({"formation": "Wilcox"}) is None
+    assert classify_hpht(None) is None
+
+
+DECOM_ROWS = [
+    {"facility_name": "Big Foot TLP", "cost_musd": "43.23", "host_type": "Mini-TLP"},
+    {"facility_name": "Jack/St. Malo FPU", "cost_musd": "80.0", "host_type": "FPU/FPS"},
+    {"facility_name": "Stones FPSO", "cost_musd": "80.0", "host_type": "FPSO"},
+    {"facility_name": "Some Other", "cost_musd": "10.0", "host_type": "SPAR"},
+]
+
+
+def test_decommissioning_modeled_vs_low_confidence():
+    bf = classify_decommissioning("Big Foot TLP", DECOM_ROWS)
+    assert bf["cost_musd"] == 43.2 and bf["confidence"] == "modeled"
+    jsm = classify_decommissioning("Jack/St. Malo FPU", DECOM_ROWS)
+    assert jsm["cost_musd"] == 80.0 and jsm["confidence"] == "low"
+    assert "FPSO base" in jsm["label"]
+    st = classify_decommissioning("Stones FPSO", DECOM_ROWS)
+    assert st["confidence"] == "low"
+
+
+def test_decommissioning_no_match_or_no_name():
+    assert classify_decommissioning("Anchor Semisub", DECOM_ROWS) is None
+    assert classify_decommissioning(None, DECOM_ROWS) is None


### PR DESCRIPTION
Closes #949 (epic #943, program #939). Plan: workspace-hub `docs/plans/2026-07-11-issue-wed-949-underwriting-pilot.md` @ 49ae18df (adversarial-reviewed r1 → all folded; owner-approved).

## What

The underwriting-lens pilot — **two honest per-field risk signals** on the LT posters and the Explorer field panel, riding the shipped poster payload → `_explorer.json` (no new sidecar file):

1. **HPHT badge** (9 fields) — reservoir pressure vs equipment rating, severity-graded. Flagship: **Anchor 25,000 vs 20,000 psi (+25%, over-rating, red)**; Shenandoah +10%; Kaskida/Tiber at-rating (amber). Links `/pressure-atlas/`.
2. **Facility-decommissioning badge** (3 fields) — sourced from `regional_liability.csv`: **Big Foot $43M (modeled)**, Jack/St Malo + Stones $80M (low-confidence, dashed chip). Links the P&A wave.

Two `src/` classifiers (`hpht_risk`, `decommission_risk`) beside the existing tree-type classifier.

## The review made this pilot better

My draft re-scoped to HPHT-only, claiming "no per-LT-field P&A number exists." The reviewer **name-matched the CSV and proved that false** — 3 LT facilities have real decommissioning figures. r2 restored that as the second signal, honestly confidence-flagged (Big Foot's is depth-modeled; the two FPSO/FPU are the CSV's flagged flat placeholder). The reviewer also caught that **Julia's 13,500 psi is a subsea-*system* figure** (15k-rated trees + HIPPS), not reservoir pore pressure — so the classifier now refuses to render it as a "−10% within-rating" reservoir exceedance and marks it class-only.

Honest exclusions (documented, not dropped): well-plugging P&A per field is genuinely unattributable (BSEE well data has no lease join for these fields); under-pressure is the opposite population (onshore gas → onshore lens #951). Both are linked, not faked.

## Verification
- 86 tests (7 new: classifier units incl. the julia system-basis case, + a site gate asserting exactly 9 HPHT / 3 decommissioning with recomputed severity parity). All green.
- Lint mirror clean; `_facts.json` diff is 4 surgical lines; identity gate (poster embed == `_explorer.json`) still green with the new `risk` key.
- Post-deploy live verify to follow: Anchor red +25% chip, Julia not shown as an exceedance, Big Foot no HPHT chip but a $43M decom chip, Stones dashed low-confidence chip.
