### PR TITLE
feat(landman): per-field BSEE lease panel with grabbable placeholders

### DIFF
--- a/reports/field-atlas/atlas_template.html
+++ b/reports/field-atlas/atlas_template.html
@@ -329,6 +329,22 @@ function renderField(x, f){
     uw = `<div class="xcardlet"><div class="xh">Underwriting signals</div><table>${lines.join("")}</table>
       <p style="font-size:11.5px;color:var(--muted);margin-top:6px">Well-plugging P&amp;A is not attributed per field (BSEE well data lacks a lease join for these fields).</p></div>`;
   }
+  // Lease & landman card (#951): real lease id/depth/dev-system + placeholders
+  // linking the BSEE lease ingest issue.
+  let landman = "";
+  if (f.landman && f.landman.leases && f.landman.leases.length) {
+    const L = f.landman;
+    const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${L.ingest_issue}`;
+    const ph = `<a href="${iss}" style="color:var(--muted)">— pending</a>`;
+    const rows = L.leases.map(r =>
+      `<tr><td>${esc(r.lease_num)}</td><td>${r.water_depth_ft?esc(r.water_depth_ft.toLocaleString())+" ft":ph}</td>`
+      + `<td>${r.dev_system?esc(r.dev_system):ph}</td><td>${ph}</td><td>${ph}</td></tr>`).join("");
+    const wi = (L.working_interest||[]).map(w=>`${esc(w.name)} ${w.wi}%${w.operator?" (op)":""}`).join(" · ");
+    landman = `<div class="xcardlet"><div class="xh">Lease &amp; landman</div>
+      <p style="font-size:12px;color:var(--muted);margin:0 0 6px">Operator <b>${esc(L.operator||"—")}</b>${wi?" · WI "+wi:""} · Blocks ${esc(L.blocks.join(", "))}</p>
+      <table class="xwells"><thead><tr><th>Lease</th><th>Depth</th><th>Dev</th><th>Status</th><th>Dates</th></tr></thead><tbody>${rows}</tbody></table>
+      <p style="font-size:11.5px;color:var(--muted);margin-top:6px">Status, dates, per-lease block &amp; WI pending the <a href="${iss}">BSEE lease ingest (#${L.ingest_issue})</a> — contributions welcome.</p></div>`;
+  }
   show(`
     <div class="xtitle">${esc(f.name)}
       <span class="badge rich">${esc(f.statusLabel)}</span>
@@ -340,7 +356,7 @@ function renderField(x, f){
     <div class="xmets">${mets}</div>
     <div class="xcols">
       <div class="xcardlet"><div class="xh">Host &amp; field facts</div><table>${facts}</table></div>
-      ${perf}${resv}${uw}
+      ${perf}${resv}${uw}${landman}
     </div>
     <div class="xacts">${acts.join("")}</div>
     ${wellsNote}

--- a/reports/field-atlas/index.html
+++ b/reports/field-atlas/index.html
@@ -330,6 +330,22 @@ function renderField(x, f){
     uw = `<div class="xcardlet"><div class="xh">Underwriting signals</div><table>${lines.join("")}</table>
       <p style="font-size:11.5px;color:var(--muted);margin-top:6px">Well-plugging P&amp;A is not attributed per field (BSEE well data lacks a lease join for these fields).</p></div>`;
   }
+  // Lease & landman card (#951): real lease id/depth/dev-system + placeholders
+  // linking the BSEE lease ingest issue.
+  let landman = "";
+  if (f.landman && f.landman.leases && f.landman.leases.length) {
+    const L = f.landman;
+    const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${L.ingest_issue}`;
+    const ph = `<a href="${iss}" style="color:var(--muted)">— pending</a>`;
+    const rows = L.leases.map(r =>
+      `<tr><td>${esc(r.lease_num)}</td><td>${r.water_depth_ft?esc(r.water_depth_ft.toLocaleString())+" ft":ph}</td>`
+      + `<td>${r.dev_system?esc(r.dev_system):ph}</td><td>${ph}</td><td>${ph}</td></tr>`).join("");
+    const wi = (L.working_interest||[]).map(w=>`${esc(w.name)} ${w.wi}%${w.operator?" (op)":""}`).join(" · ");
+    landman = `<div class="xcardlet"><div class="xh">Lease &amp; landman</div>
+      <p style="font-size:12px;color:var(--muted);margin:0 0 6px">Operator <b>${esc(L.operator||"—")}</b>${wi?" · WI "+wi:""} · Blocks ${esc(L.blocks.join(", "))}</p>
+      <table class="xwells"><thead><tr><th>Lease</th><th>Depth</th><th>Dev</th><th>Status</th><th>Dates</th></tr></thead><tbody>${rows}</tbody></table>
+      <p style="font-size:11.5px;color:var(--muted);margin-top:6px">Status, dates, per-lease block &amp; WI pending the <a href="${iss}">BSEE lease ingest (#${L.ingest_issue})</a> — contributions welcome.</p></div>`;
+  }
   show(`
     <div class="xtitle">${esc(f.name)}
       <span class="badge rich">${esc(f.statusLabel)}</span>
@@ -341,7 +357,7 @@ function renderField(x, f){
     <div class="xmets">${mets}</div>
     <div class="xcols">
       <div class="xcardlet"><div class="xh">Host &amp; field facts</div><table>${facts}</table></div>
-      ${perf}${resv}${uw}
+      ${perf}${resv}${uw}${landman}
     </div>
     <div class="xacts">${acts.join("")}</div>
     ${wellsNote}

--- a/reports/lower_tertiary/lifecycle/_explorer.json
+++ b/reports/lower_tertiary/lifecycle/_explorer.json
@@ -180,6 +180,49 @@
           "label": "Decommission ~$43.2M"
         }
       },
+      "landman": {
+        "leases": [
+          {
+            "lease_num": "G16942",
+            "lease_name": "Big Foot",
+            "water_depth_ft": 5190,
+            "dev_system": "dry"
+          }
+        ],
+        "n_leases": 1,
+        "blocks": [
+          "WR029"
+        ],
+        "block_note": "Walker Ridge 29",
+        "operator": "Chevron",
+        "working_interest": [
+          {
+            "name": "Chevron",
+            "wi": 60,
+            "operator": true
+          },
+          {
+            "name": "Equinor",
+            "wi": 27.5,
+            "operator": false
+          },
+          {
+            "name": "Marubeni Oil & Gas",
+            "wi": 12.5,
+            "operator": false
+          }
+        ],
+        "pending": [
+          "status",
+          "effective_date",
+          "expiration_date",
+          "lease_type",
+          "per_lease_block",
+          "per_lease_working_interest",
+          "operator_of_record_history"
+        ],
+        "ingest_issue": 959
+      },
       "provenance": "Data: big_foot.yml + Chevron public disclosures + BSEE (dates to be reconciled in #375)",
       "norms": [
         {
@@ -406,6 +449,55 @@
         },
         "decommissioning": null
       },
+      "landman": {
+        "leases": [
+          {
+            "lease_num": "G31751",
+            "lease_name": "Anchor",
+            "water_depth_ft": 5080,
+            "dev_system": "subsea20"
+          },
+          {
+            "lease_num": "G31752",
+            "lease_name": "Anchor",
+            "water_depth_ft": 5080,
+            "dev_system": "subsea20"
+          }
+        ],
+        "n_leases": 2,
+        "blocks": [
+          "GC807"
+        ],
+        "block_note": "Green Canyon 807",
+        "operator": "Chevron",
+        "working_interest": [
+          {
+            "name": "Chevron",
+            "wi": 62.5,
+            "operator": true
+          },
+          {
+            "name": "Equinor",
+            "wi": 25,
+            "operator": false
+          },
+          {
+            "name": "TotalEnergies",
+            "wi": 12.5,
+            "operator": false
+          }
+        ],
+        "pending": [
+          "status",
+          "effective_date",
+          "expiration_date",
+          "lease_type",
+          "per_lease_block",
+          "per_lease_working_interest",
+          "operator_of_record_history"
+        ],
+        "ingest_issue": 959
+      },
       "provenance": "Primary facts (operator, working interests, capex $5.6B, plateau 75 mbopd, GOR 1100 scf/bbl, opex $15/boe, first oil 2024-08, data through 2024-12-31) from in-repo anchor.yml. Life-cycle dates corroborated by public sources: discovery well Anchor-2 drilled 2014 (Green Canyon 807, ~5,180 ft), FID December 2019 (~$5.7B sanction), first oil August 2024 — world's first 20,000-psi HPHT deepwater development on a semisubmersible FPU, Lower Tertiary Wilcox play. Working interests (Chevron 62.5% / Equinor 25% / TotalEnergies 12.5%) per YAML; note older Offshore Technology page still lists pre-Equinor split (Chevron 62.86% / Total 37.14%). water depth ~5,180 (block-level estimate). projected end-of-production and lease year not confidently sourced; no notable incident.",
       "norms": [
         {
@@ -609,6 +701,53 @@
           "label": "HPHT · 19.5k psi"
         },
         "decommissioning": null
+      },
+      "landman": {
+        "leases": [
+          {
+            "lease_num": "G16965",
+            "lease_name": "Cascade",
+            "water_depth_ft": 8200,
+            "dev_system": "subsea15"
+          },
+          {
+            "lease_num": "G16997",
+            "lease_name": "Chinook",
+            "water_depth_ft": 8900,
+            "dev_system": "subsea15"
+          }
+        ],
+        "n_leases": 2,
+        "blocks": [
+          "WR205",
+          "WR206",
+          "WR469",
+          "WR470"
+        ],
+        "block_note": "Walker Ridge 206/250 (Cascade), 425/469 (Chinook)",
+        "operator": "MP Gulf of Mexico LLC (Murphy EXPRO)",
+        "working_interest": [
+          {
+            "name": "Murphy EXPRO (MP Gulf of Mexico LLC)",
+            "wi": 80,
+            "operator": true
+          },
+          {
+            "name": "Petrobras America Inc.",
+            "wi": 20,
+            "operator": false
+          }
+        ],
+        "pending": [
+          "status",
+          "effective_date",
+          "expiration_date",
+          "lease_type",
+          "per_lease_block",
+          "per_lease_working_interest",
+          "operator_of_record_history"
+        ],
+        "ingest_issue": 959
       },
       "provenance": "Life-cycle dates and ownership from public sources (Offshore Technology, Offshore Magazine, OGJ, Heerema, Rigzone); economics (capex $2.9B, plateau 75 mbopd, GOR 1400 scf/bbl, opex $18/boe) and data through from in-repo YAML. IMPORTANT: two YAML values were overridden as demonstrably wrong vs. well-documented public record — YAML first oil \"2021-08\" corrected to 2012-02 (Cascade first oil Feb 2012, Chinook Sep 2012; BW Pioneer was the first FPSO in the US GoM), and YAML operator/WI \"TotalEnergies 60% / Equinor 40%\" corrected to current MP Gulf of Mexico LLC (Murphy EXPRO 80% operator, Petrobras America 20%; originally Petrobras-operated with Total 33.33% in Chinook). LOW CONFIDENCE: FID year (sanction ~mid-2000s, no firm public citation — not available), lease year and projected end-of-production (not available); water depth 8,200 ft is the Cascade value (Chinook ~8,600 ft); capex is a YAML assumption not independently verified.",
       "norms": [
@@ -842,6 +981,81 @@
           "label": "Decommission ~$80M (FPSO base)"
         }
       },
+      "landman": {
+        "leases": [
+          {
+            "lease_num": "G17015",
+            "lease_name": "St Malo",
+            "water_depth_ft": 6820,
+            "dev_system": "subsea15"
+          },
+          {
+            "lease_num": "G17016",
+            "lease_name": "St Malo",
+            "water_depth_ft": 6820,
+            "dev_system": "subsea15"
+          },
+          {
+            "lease_num": "G18745",
+            "lease_name": "St Malo",
+            "water_depth_ft": 6820,
+            "dev_system": "subsea15"
+          },
+          {
+            "lease_num": "G18753",
+            "lease_name": "St Malo",
+            "water_depth_ft": 6820,
+            "dev_system": "subsea15"
+          },
+          {
+            "lease_num": "G20394",
+            "lease_name": "St Malo",
+            "water_depth_ft": 6820,
+            "dev_system": "subsea15"
+          },
+          {
+            "lease_num": "G21245",
+            "lease_name": "Jack",
+            "water_depth_ft": 7240,
+            "dev_system": "subsea15"
+          }
+        ],
+        "n_leases": 6,
+        "blocks": [
+          "WR678",
+          "WR758",
+          "WR759"
+        ],
+        "block_note": "Walker Ridge 678 (St. Malo) / 758-759 (Jack)",
+        "operator": "Chevron",
+        "working_interest": [
+          {
+            "name": "Chevron",
+            "wi": 51,
+            "operator": true
+          },
+          {
+            "name": "Equinor",
+            "wi": 24.5,
+            "operator": false
+          },
+          {
+            "name": "Suncor",
+            "wi": 24.5,
+            "operator": false
+          }
+        ],
+        "pending": [
+          "status",
+          "effective_date",
+          "expiration_date",
+          "lease_type",
+          "per_lease_block",
+          "per_lease_working_interest",
+          "operator_of_record_history"
+        ],
+        "ingest_issue": 959
+      },
       "provenance": "Facts from in-repo YAML (operator, WI Chevron 51%/Equinor 24.5%/Suncor 24.5%, capex $7.5B, opex $15/boe, plateau 94 mbopd, GOR 1200, status producing, data through 2024-12-31). Life-cycle dates from public sources: St. Malo discovered Oct 2003 and Jack Jul 2004 (discovery year=2003, earliest of pair); FID/sanction Oct 2010; first oil per Chevron press release Dec 2014 (\"2014-12\") — this OVERRIDES the YAML's first oil \"2014-02-01\", which appears erroneous. Water depth ~7000 ft at the FPU (Jack WR758/759 ~7000 ft, St. Malo WR678). host = Semisubmersible FPU. projected end-of-production not confidently estimable. lease year not available; no schedule-driving incident.",
       "norms": [
         {
@@ -1072,6 +1286,44 @@
         },
         "decommissioning": null
       },
+      "landman": {
+        "leases": [
+          {
+            "lease_num": "G20351",
+            "lease_name": "Julia",
+            "water_depth_ft": 7335,
+            "dev_system": "tieback15"
+          }
+        ],
+        "n_leases": 1,
+        "blocks": [
+          "WR627"
+        ],
+        "block_note": "Walker Ridge 627 (WR 540/583/584/627/628)",
+        "operator": "ExxonMobil",
+        "working_interest": [
+          {
+            "name": "ExxonMobil",
+            "wi": 50,
+            "operator": true
+          },
+          {
+            "name": "Equinor",
+            "wi": 50,
+            "operator": false
+          }
+        ],
+        "pending": [
+          "status",
+          "effective_date",
+          "expiration_date",
+          "lease_type",
+          "per_lease_block",
+          "per_lease_working_interest",
+          "operator_of_record_history"
+        ],
+        "ingest_issue": 959
+      },
       "provenance": "Primary facts (capex $4.7B, plateau 34 mbopd, GOR 1000, opex $18/boe, first oil, WI 50/50) from in-repo julia.yml; first oil = BSEE OGOR-A first production (2016-03) per YAML — note ExxonMobil press release states production start April 2016. Operator corrected to ExxonMobil (YAML flagged its \"Equinor\" operator field as disputed; public record = ExxonMobil-operated, Equinor/Statoil 50% partner). Discovery 2007, FID May 2013, water depth 7000+ ft, Walker Ridge blocks, and Jack/St. Malo tieback from Offshore Technology and operator/trade press. lease year and projected end-of-production not confidently sourced.",
       "norms": [
         {
@@ -1274,6 +1526,46 @@
         },
         "decommissioning": null
       },
+      "landman": {
+        "leases": [
+          {
+            "lease_num": "G19555",
+            "lease_name": "Kaskida",
+            "water_depth_ft": 5860,
+            "dev_system": "subsea20"
+          },
+          {
+            "lease_num": "G25792",
+            "lease_name": "Kaskida",
+            "water_depth_ft": 5860,
+            "dev_system": "subsea20"
+          }
+        ],
+        "n_leases": 2,
+        "blocks": [
+          "KC291",
+          "KC292"
+        ],
+        "block_note": "Keathley Canyon 292",
+        "operator": "BP",
+        "working_interest": [
+          {
+            "name": "BP",
+            "wi": 100,
+            "operator": true
+          }
+        ],
+        "pending": [
+          "status",
+          "effective_date",
+          "expiration_date",
+          "lease_type",
+          "per_lease_block",
+          "per_lease_working_interest",
+          "operator_of_record_history"
+        ],
+        "ingest_issue": 959
+      },
       "provenance": "Discovery 2006 (Keathley Canyon 292, Lower Tertiary Wilcox), FID/sanction July 30 2024 (BP 100%, Devon's original 30% exited), first oil targeted 2029 but left blank as no oil has flowed and the Aug-2025 BOEM DPP rejection likely pushes it out. Public sanctioned figures used over YAML where they diverge: plateau/nameplate 80 mbopd (YAML said 120) and capex ~$5bn for Phase 1 (<$5B per BP; YAML total CAPEX 10000 = $10bn is a full-field/multi-phase estimate). GOR 1000 scf/bbl and data through 2024-12-31 from YAML. Water depth ~6,000 ft, 20,000-psi semisubmersible FPU. Low-confidence: capex (phase-1 vs full-field ambiguity), water depth (rounded), lease year unknown, opex unknown.",
       "norms": [
         {
@@ -1450,6 +1742,53 @@
           "label": "ultra-HPHT · 20k-psi equipment"
         },
         "decommissioning": null
+      },
+      "landman": {
+        "leases": [
+          {
+            "lease_num": "G30876",
+            "lease_name": "North Platte",
+            "water_depth_ft": 5840,
+            "dev_system": "subsea20"
+          },
+          {
+            "lease_num": "G32460",
+            "lease_name": "North Platte",
+            "water_depth_ft": 4230,
+            "dev_system": "subsea20"
+          }
+        ],
+        "n_leases": 2,
+        "blocks": [
+          "GB915",
+          "GB916",
+          "GB958",
+          "GB959"
+        ],
+        "block_note": "Garden Banks 959 (straddles GB 915/916/958/959)",
+        "operator": "Shell",
+        "working_interest": [
+          {
+            "name": "Shell",
+            "wi": 51,
+            "operator": true
+          },
+          {
+            "name": "Equinor",
+            "wi": 49,
+            "operator": false
+          }
+        ],
+        "pending": [
+          "status",
+          "effective_date",
+          "expiration_date",
+          "lease_type",
+          "per_lease_block",
+          "per_lease_working_interest",
+          "operator_of_record_history"
+        ],
+        "ingest_issue": 959
       },
       "provenance": "Basis: in-repo YAML (superseded TotalEnergies pre-FID case) reconciled against current public record. North Platte was discovered 2012 (Cobalt/Total, Garden Banks). TotalEnergies (then 60% op, Equinor 40%) withdrew Feb 2022; Shell bought 51% and took operatorship from Equinor (49%), redesigned and renamed the project \"Sparta.\" Shell took FID Dec 2023; first oil projected 2028 (left blank — not yet producing). Water depth ~4,265 ft, subsalt Wilcox, newbuild semisubmersible FPU (8 subsea wells) with ~90,000 boe/d peak (~75 mbopd oil plateau; GOR 1100 scf/bbl from YAML). LOW-CONFIDENCE: capex — YAML's $6B reflects the abandoned TotalEnergies ~$5-7B concept, not Shell's simplified Sparta scope (not publicly disclosed), so not available; opex and projected COP year not publicly defensible.",
       "norms": [
@@ -1651,6 +1990,55 @@
           "label": "ultra-HPHT · 22k vs 20k psi (+10%)"
         },
         "decommissioning": null
+      },
+      "landman": {
+        "leases": [
+          {
+            "lease_num": "G25232",
+            "lease_name": "Shenandoah",
+            "water_depth_ft": 5840,
+            "dev_system": "subsea20"
+          },
+          {
+            "lease_num": "G31938",
+            "lease_name": "Shenandoah",
+            "water_depth_ft": 5800,
+            "dev_system": "subsea20"
+          }
+        ],
+        "n_leases": 2,
+        "blocks": [
+          "WR051"
+        ],
+        "block_note": "Walker Ridge 52 (blocks 51, 52, N/2 53)",
+        "operator": "Beacon Offshore Energy",
+        "working_interest": [
+          {
+            "name": "Beacon Offshore Energy",
+            "wi": 31,
+            "operator": true
+          },
+          {
+            "name": "Navitas Petroleum",
+            "wi": 49,
+            "operator": false
+          },
+          {
+            "name": "HEQ Deepwater (Quantum Energy Partners)",
+            "wi": 20,
+            "operator": false
+          }
+        ],
+        "pending": [
+          "status",
+          "effective_date",
+          "expiration_date",
+          "lease_type",
+          "per_lease_block",
+          "per_lease_working_interest",
+          "operator_of_record_history"
+        ],
+        "ingest_issue": 959
       },
       "provenance": "Base facts (operator, capex, plateau, GOR, data through) from in-repo YAML; discovery 2009 (Anadarko Shenandoah-1, WR52), FID/sanction Aug 2021 (Beacon+Navitas), and actual first oil (first of 4 wells online 25 Jul 2025; ramped to 100 kbopd plateau Oct 2025) from public sources — first oil corrected to 2025-07 vs YAML's placeholder 2025-10. Current WI (Beacon 31% op / Navitas 49% / HEQ 20%) post-2021 restructuring. CAPEX 1.8 is YAML-stated and largely reflects pre-development E&A spend (LOW CONFIDENCE for full development cost); OPEX and projected end-of-production, not available (not defensibly sourced); water depth ~5,800 ft.",
       "norms": [
@@ -1877,6 +2265,39 @@
           "label": "Decommission ~$80M (FPSO base)"
         }
       },
+      "landman": {
+        "leases": [
+          {
+            "lease_num": "G17001",
+            "lease_name": "Stones",
+            "water_depth_ft": 9525,
+            "dev_system": "subsea15"
+          }
+        ],
+        "n_leases": 1,
+        "blocks": [
+          "WR508"
+        ],
+        "block_note": "Walker Ridge 508",
+        "operator": "Shell",
+        "working_interest": [
+          {
+            "name": "Shell",
+            "wi": 100,
+            "operator": true
+          }
+        ],
+        "pending": [
+          "status",
+          "effective_date",
+          "expiration_date",
+          "lease_type",
+          "per_lease_block",
+          "per_lease_working_interest",
+          "operator_of_record_history"
+        ],
+        "ingest_issue": 959
+      },
       "provenance": "Capex ($3.8bn), plateau (50 mbopd), GOR (850 scf/bbl), opex ($15/boe), first oil (2016-09) and status from in-repo stones.yml (Shell FPSO development config). Discovery (2005), FID/sanction (May 2013, Shell 100% owner-operator), Walker Ridge Block 508, ~9,500 ft water depth, and Turritella/Stones FPSO host (world's deepest FPSO) confirmed via Offshore Technology, Offshore Magazine, and NS Energy public sources. lease year and projected end-of-production unknown; no notable schedule-driving incident identified.",
       "norms": [
         {
@@ -2070,6 +2491,39 @@
           "label": "ultra-HPHT · 20k vs 20k psi (0%)"
         },
         "decommissioning": null
+      },
+      "landman": {
+        "leases": [
+          {
+            "lease_num": "G25782",
+            "lease_name": "Tiber",
+            "water_depth_ft": 4130,
+            "dev_system": "subsea20"
+          }
+        ],
+        "n_leases": 1,
+        "blocks": [
+          "KC102"
+        ],
+        "block_note": "Keathley Canyon 102",
+        "operator": "BP",
+        "working_interest": [
+          {
+            "name": "BP",
+            "wi": 100,
+            "operator": true
+          }
+        ],
+        "pending": [
+          "status",
+          "effective_date",
+          "expiration_date",
+          "lease_type",
+          "per_lease_block",
+          "per_lease_working_interest",
+          "operator_of_record_history"
+        ],
+        "ingest_issue": 959
       },
       "provenance": "Basis: in-repo tiber.yml (operator BP, plateau 80 mbopd, GOR 900 scf/bbl, data through 2024-12-31) plus public sources. BP discovered Tiber Sept 2009 in Keathley Canyon 102, 4,132 ft water. BP reached FID on the combined Tiber-Guadalupe hub 29 Sep 2025 (FID year=2025); Seatrium awarded FPU EPCC. Ownership is now 100% BP (original discovery split BP 62% / Petrobras 20% / ConocoPhillips 18% no longer reflects current WI). Status: execution (post-FID, construction underway). capex set to the sanctioned public figure of $5.0bn for the Tiber-Guadalupe project (YAML's $8bn was a pre-FID Tiber-only planning assumption); note $5bn covers both fields. first oil left blank — oil has not flowed; projected first production is 2030. OPEX, not available (not publicly disclosed; the \"$3/bbl below Kaskida\" figure is development cost, not opex). projected end-of-production and lease year (not confidently sourced).",
       "norms": [

--- a/reports/lower_tertiary/lifecycle/anchor_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/anchor_lifecycle.html
@@ -283,6 +283,7 @@
 <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-landman"></div>
 
     <div class="body">
       <section>
@@ -557,6 +558,55 @@ const FIELD = {
     },
     "decommissioning": null
   },
+  "landman": {
+    "leases": [
+      {
+        "lease_num": "G31751",
+        "lease_name": "Anchor",
+        "water_depth_ft": 5080,
+        "dev_system": "subsea20"
+      },
+      {
+        "lease_num": "G31752",
+        "lease_name": "Anchor",
+        "water_depth_ft": 5080,
+        "dev_system": "subsea20"
+      }
+    ],
+    "n_leases": 2,
+    "blocks": [
+      "GC807"
+    ],
+    "block_note": "Green Canyon 807",
+    "operator": "Chevron",
+    "working_interest": [
+      {
+        "name": "Chevron",
+        "wi": 62.5,
+        "operator": true
+      },
+      {
+        "name": "Equinor",
+        "wi": 25,
+        "operator": false
+      },
+      {
+        "name": "TotalEnergies",
+        "wi": 12.5,
+        "operator": false
+      }
+    ],
+    "pending": [
+      "status",
+      "effective_date",
+      "expiration_date",
+      "lease_type",
+      "per_lease_block",
+      "per_lease_working_interest",
+      "operator_of_record_history"
+    ],
+    "ingest_issue": 959
+  },
   "provenance": "Primary facts (operator, working interests, capex $5.6B, plateau 75 mbopd, GOR 1100 scf/bbl, opex $15/boe, first oil 2024-08, data through 2024-12-31) from in-repo anchor.yml. Life-cycle dates corroborated by public sources: discovery well Anchor-2 drilled 2014 (Green Canyon 807, ~5,180 ft), FID December 2019 (~$5.7B sanction), first oil August 2024 — world's first 20,000-psi HPHT deepwater development on a semisubmersible FPU, Lower Tertiary Wilcox play. Working interests (Chevron 62.5% / Equinor 25% / TotalEnergies 12.5%) per YAML; note older Offshore Technology page still lists pre-Equinor split (Chevron 62.86% / Total 37.14%). water depth ~5,180 (block-level estimate). projected end-of-production and lease year not confidently sourced; no notable incident.",
   "norms": [
     {
@@ -660,6 +710,30 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
+// operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the
+// BSEE lease ingest issue — grabbable work, never a blank cell.
+if (FIELD.landman) {
+  const L = FIELD.landman;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${L.ingest_issue}`;
+  const ph = `<a href="${iss}" style="color:var(--muted)">— pending</a>`;
+  const rows = L.leases.map(r =>
+    `<tr><td>${r.lease_num}</td><td>${r.water_depth_ft ? r.water_depth_ft.toLocaleString()+" ft" : ph}</td>`
+    + `<td>${r.dev_system || ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td></tr>`).join("");
+  const wi = (L.working_interest || []).map(w =>
+    `${w.name} ${w.wi}%${w.operator ? " (op)" : ""}`).join(" · ");
+  $("f-landman").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Lease &amp; landman</h3>`
+    + `<p style="margin:0 0 4px;font-size:13px;color:var(--muted)">Operator <b>${L.operator||"—"}</b>`
+    + `${wi ? " · WI " + wi : ""} · Blocks ${L.blocks.join(", ")}${L.block_note ? " ("+L.block_note+")" : ""}</p>`
+    + `<p style="margin:0 0 10px;font-size:12px;color:var(--muted)">Lease status, dates, per-lease block &amp; working interest pending the `
+    + `<a href="${iss}">BSEE lease-data ingest (#${L.ingest_issue})</a> — contributions welcome.</p>`
+    + `<div class="scrollx"><table style="width:100%;border-collapse:collapse;font-size:12.5px">`
+    + `<thead><tr style="text-align:left;color:var(--muted)"><th>Lease</th><th>Water depth</th><th>Dev system</th>`
+    + `<th>Status</th><th>Effective</th><th>Expiration</th><th>WI</th></tr></thead><tbody>${rows}</tbody></table></div></section>`;
+}
 
 $("f-metrics").innerHTML = FIELD.metrics.map(m =>
   `<div class="metric"><div class="k">${m.k}</div><div class="v">${m.v} <small>${m.u}</small></div></div>`

--- a/reports/lower_tertiary/lifecycle/big_foot_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/big_foot_lifecycle.html
@@ -283,6 +283,7 @@
 <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-landman"></div>
 
     <div class="body">
       <section>
@@ -568,6 +569,49 @@ const FIELD = {
       "label": "Decommission ~$43.2M"
     }
   },
+  "landman": {
+    "leases": [
+      {
+        "lease_num": "G16942",
+        "lease_name": "Big Foot",
+        "water_depth_ft": 5190,
+        "dev_system": "dry"
+      }
+    ],
+    "n_leases": 1,
+    "blocks": [
+      "WR029"
+    ],
+    "block_note": "Walker Ridge 29",
+    "operator": "Chevron",
+    "working_interest": [
+      {
+        "name": "Chevron",
+        "wi": 60,
+        "operator": true
+      },
+      {
+        "name": "Equinor",
+        "wi": 27.5,
+        "operator": false
+      },
+      {
+        "name": "Marubeni Oil & Gas",
+        "wi": 12.5,
+        "operator": false
+      }
+    ],
+    "pending": [
+      "status",
+      "effective_date",
+      "expiration_date",
+      "lease_type",
+      "per_lease_block",
+      "per_lease_working_interest",
+      "operator_of_record_history"
+    ],
+    "ingest_issue": 959
+  },
   "provenance": "Data: big_foot.yml + Chevron public disclosures + BSEE (dates to be reconciled in #375)",
   "norms": [
     {
@@ -671,6 +715,30 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
+// operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the
+// BSEE lease ingest issue — grabbable work, never a blank cell.
+if (FIELD.landman) {
+  const L = FIELD.landman;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${L.ingest_issue}`;
+  const ph = `<a href="${iss}" style="color:var(--muted)">— pending</a>`;
+  const rows = L.leases.map(r =>
+    `<tr><td>${r.lease_num}</td><td>${r.water_depth_ft ? r.water_depth_ft.toLocaleString()+" ft" : ph}</td>`
+    + `<td>${r.dev_system || ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td></tr>`).join("");
+  const wi = (L.working_interest || []).map(w =>
+    `${w.name} ${w.wi}%${w.operator ? " (op)" : ""}`).join(" · ");
+  $("f-landman").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Lease &amp; landman</h3>`
+    + `<p style="margin:0 0 4px;font-size:13px;color:var(--muted)">Operator <b>${L.operator||"—"}</b>`
+    + `${wi ? " · WI " + wi : ""} · Blocks ${L.blocks.join(", ")}${L.block_note ? " ("+L.block_note+")" : ""}</p>`
+    + `<p style="margin:0 0 10px;font-size:12px;color:var(--muted)">Lease status, dates, per-lease block &amp; working interest pending the `
+    + `<a href="${iss}">BSEE lease-data ingest (#${L.ingest_issue})</a> — contributions welcome.</p>`
+    + `<div class="scrollx"><table style="width:100%;border-collapse:collapse;font-size:12.5px">`
+    + `<thead><tr style="text-align:left;color:var(--muted)"><th>Lease</th><th>Water depth</th><th>Dev system</th>`
+    + `<th>Status</th><th>Effective</th><th>Expiration</th><th>WI</th></tr></thead><tbody>${rows}</tbody></table></div></section>`;
+}
 
 $("f-metrics").innerHTML = FIELD.metrics.map(m =>
   `<div class="metric"><div class="k">${m.k}</div><div class="v">${m.v} <small>${m.u}</small></div></div>`

--- a/reports/lower_tertiary/lifecycle/cascade_chinook_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/cascade_chinook_lifecycle.html
@@ -283,6 +283,7 @@
 <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-landman"></div>
 
     <div class="body">
       <section>
@@ -535,6 +536,53 @@ const FIELD = {
     },
     "decommissioning": null
   },
+  "landman": {
+    "leases": [
+      {
+        "lease_num": "G16965",
+        "lease_name": "Cascade",
+        "water_depth_ft": 8200,
+        "dev_system": "subsea15"
+      },
+      {
+        "lease_num": "G16997",
+        "lease_name": "Chinook",
+        "water_depth_ft": 8900,
+        "dev_system": "subsea15"
+      }
+    ],
+    "n_leases": 2,
+    "blocks": [
+      "WR205",
+      "WR206",
+      "WR469",
+      "WR470"
+    ],
+    "block_note": "Walker Ridge 206/250 (Cascade), 425/469 (Chinook)",
+    "operator": "MP Gulf of Mexico LLC (Murphy EXPRO)",
+    "working_interest": [
+      {
+        "name": "Murphy EXPRO (MP Gulf of Mexico LLC)",
+        "wi": 80,
+        "operator": true
+      },
+      {
+        "name": "Petrobras America Inc.",
+        "wi": 20,
+        "operator": false
+      }
+    ],
+    "pending": [
+      "status",
+      "effective_date",
+      "expiration_date",
+      "lease_type",
+      "per_lease_block",
+      "per_lease_working_interest",
+      "operator_of_record_history"
+    ],
+    "ingest_issue": 959
+  },
   "provenance": "Life-cycle dates and ownership from public sources (Offshore Technology, Offshore Magazine, OGJ, Heerema, Rigzone); economics (capex $2.9B, plateau 75 mbopd, GOR 1400 scf/bbl, opex $18/boe) and data through from in-repo YAML. IMPORTANT: two YAML values were overridden as demonstrably wrong vs. well-documented public record — YAML first oil \"2021-08\" corrected to 2012-02 (Cascade first oil Feb 2012, Chinook Sep 2012; BW Pioneer was the first FPSO in the US GoM), and YAML operator/WI \"TotalEnergies 60% / Equinor 40%\" corrected to current MP Gulf of Mexico LLC (Murphy EXPRO 80% operator, Petrobras America 20%; originally Petrobras-operated with Total 33.33% in Chinook). LOW CONFIDENCE: FID year (sanction ~mid-2000s, no firm public citation — not available), lease year and projected end-of-production (not available); water depth 8,200 ft is the Cascade value (Chinook ~8,600 ft); capex is a YAML assumption not independently verified.",
   "norms": [
     {
@@ -638,6 +686,30 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
+// operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the
+// BSEE lease ingest issue — grabbable work, never a blank cell.
+if (FIELD.landman) {
+  const L = FIELD.landman;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${L.ingest_issue}`;
+  const ph = `<a href="${iss}" style="color:var(--muted)">— pending</a>`;
+  const rows = L.leases.map(r =>
+    `<tr><td>${r.lease_num}</td><td>${r.water_depth_ft ? r.water_depth_ft.toLocaleString()+" ft" : ph}</td>`
+    + `<td>${r.dev_system || ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td></tr>`).join("");
+  const wi = (L.working_interest || []).map(w =>
+    `${w.name} ${w.wi}%${w.operator ? " (op)" : ""}`).join(" · ");
+  $("f-landman").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Lease &amp; landman</h3>`
+    + `<p style="margin:0 0 4px;font-size:13px;color:var(--muted)">Operator <b>${L.operator||"—"}</b>`
+    + `${wi ? " · WI " + wi : ""} · Blocks ${L.blocks.join(", ")}${L.block_note ? " ("+L.block_note+")" : ""}</p>`
+    + `<p style="margin:0 0 10px;font-size:12px;color:var(--muted)">Lease status, dates, per-lease block &amp; working interest pending the `
+    + `<a href="${iss}">BSEE lease-data ingest (#${L.ingest_issue})</a> — contributions welcome.</p>`
+    + `<div class="scrollx"><table style="width:100%;border-collapse:collapse;font-size:12.5px">`
+    + `<thead><tr style="text-align:left;color:var(--muted)"><th>Lease</th><th>Water depth</th><th>Dev system</th>`
+    + `<th>Status</th><th>Effective</th><th>Expiration</th><th>WI</th></tr></thead><tbody>${rows}</tbody></table></div></section>`;
+}
 
 $("f-metrics").innerHTML = FIELD.metrics.map(m =>
   `<div class="metric"><div class="k">${m.k}</div><div class="v">${m.v} <small>${m.u}</small></div></div>`

--- a/reports/lower_tertiary/lifecycle/jack_st_malo_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/jack_st_malo_lifecycle.html
@@ -283,6 +283,7 @@
 <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-landman"></div>
 
     <div class="body">
       <section>
@@ -563,6 +564,81 @@ const FIELD = {
       "label": "Decommission ~$80M (FPSO base)"
     }
   },
+  "landman": {
+    "leases": [
+      {
+        "lease_num": "G17015",
+        "lease_name": "St Malo",
+        "water_depth_ft": 6820,
+        "dev_system": "subsea15"
+      },
+      {
+        "lease_num": "G17016",
+        "lease_name": "St Malo",
+        "water_depth_ft": 6820,
+        "dev_system": "subsea15"
+      },
+      {
+        "lease_num": "G18745",
+        "lease_name": "St Malo",
+        "water_depth_ft": 6820,
+        "dev_system": "subsea15"
+      },
+      {
+        "lease_num": "G18753",
+        "lease_name": "St Malo",
+        "water_depth_ft": 6820,
+        "dev_system": "subsea15"
+      },
+      {
+        "lease_num": "G20394",
+        "lease_name": "St Malo",
+        "water_depth_ft": 6820,
+        "dev_system": "subsea15"
+      },
+      {
+        "lease_num": "G21245",
+        "lease_name": "Jack",
+        "water_depth_ft": 7240,
+        "dev_system": "subsea15"
+      }
+    ],
+    "n_leases": 6,
+    "blocks": [
+      "WR678",
+      "WR758",
+      "WR759"
+    ],
+    "block_note": "Walker Ridge 678 (St. Malo) / 758-759 (Jack)",
+    "operator": "Chevron",
+    "working_interest": [
+      {
+        "name": "Chevron",
+        "wi": 51,
+        "operator": true
+      },
+      {
+        "name": "Equinor",
+        "wi": 24.5,
+        "operator": false
+      },
+      {
+        "name": "Suncor",
+        "wi": 24.5,
+        "operator": false
+      }
+    ],
+    "pending": [
+      "status",
+      "effective_date",
+      "expiration_date",
+      "lease_type",
+      "per_lease_block",
+      "per_lease_working_interest",
+      "operator_of_record_history"
+    ],
+    "ingest_issue": 959
+  },
   "provenance": "Facts from in-repo YAML (operator, WI Chevron 51%/Equinor 24.5%/Suncor 24.5%, capex $7.5B, opex $15/boe, plateau 94 mbopd, GOR 1200, status producing, data through 2024-12-31). Life-cycle dates from public sources: St. Malo discovered Oct 2003 and Jack Jul 2004 (discovery year=2003, earliest of pair); FID/sanction Oct 2010; first oil per Chevron press release Dec 2014 (\"2014-12\") — this OVERRIDES the YAML's first oil \"2014-02-01\", which appears erroneous. Water depth ~7000 ft at the FPU (Jack WR758/759 ~7000 ft, St. Malo WR678). host = Semisubmersible FPU. projected end-of-production not confidently estimable. lease year not available; no schedule-driving incident.",
   "norms": [
     {
@@ -666,6 +742,30 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
+// operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the
+// BSEE lease ingest issue — grabbable work, never a blank cell.
+if (FIELD.landman) {
+  const L = FIELD.landman;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${L.ingest_issue}`;
+  const ph = `<a href="${iss}" style="color:var(--muted)">— pending</a>`;
+  const rows = L.leases.map(r =>
+    `<tr><td>${r.lease_num}</td><td>${r.water_depth_ft ? r.water_depth_ft.toLocaleString()+" ft" : ph}</td>`
+    + `<td>${r.dev_system || ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td></tr>`).join("");
+  const wi = (L.working_interest || []).map(w =>
+    `${w.name} ${w.wi}%${w.operator ? " (op)" : ""}`).join(" · ");
+  $("f-landman").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Lease &amp; landman</h3>`
+    + `<p style="margin:0 0 4px;font-size:13px;color:var(--muted)">Operator <b>${L.operator||"—"}</b>`
+    + `${wi ? " · WI " + wi : ""} · Blocks ${L.blocks.join(", ")}${L.block_note ? " ("+L.block_note+")" : ""}</p>`
+    + `<p style="margin:0 0 10px;font-size:12px;color:var(--muted)">Lease status, dates, per-lease block &amp; working interest pending the `
+    + `<a href="${iss}">BSEE lease-data ingest (#${L.ingest_issue})</a> — contributions welcome.</p>`
+    + `<div class="scrollx"><table style="width:100%;border-collapse:collapse;font-size:12.5px">`
+    + `<thead><tr style="text-align:left;color:var(--muted)"><th>Lease</th><th>Water depth</th><th>Dev system</th>`
+    + `<th>Status</th><th>Effective</th><th>Expiration</th><th>WI</th></tr></thead><tbody>${rows}</tbody></table></div></section>`;
+}
 
 $("f-metrics").innerHTML = FIELD.metrics.map(m =>
   `<div class="metric"><div class="k">${m.k}</div><div class="v">${m.v} <small>${m.u}</small></div></div>`

--- a/reports/lower_tertiary/lifecycle/julia_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/julia_lifecycle.html
@@ -283,6 +283,7 @@
 <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-landman"></div>
 
     <div class="body">
       <section>
@@ -561,6 +562,44 @@ const FIELD = {
     },
     "decommissioning": null
   },
+  "landman": {
+    "leases": [
+      {
+        "lease_num": "G20351",
+        "lease_name": "Julia",
+        "water_depth_ft": 7335,
+        "dev_system": "tieback15"
+      }
+    ],
+    "n_leases": 1,
+    "blocks": [
+      "WR627"
+    ],
+    "block_note": "Walker Ridge 627 (WR 540/583/584/627/628)",
+    "operator": "ExxonMobil",
+    "working_interest": [
+      {
+        "name": "ExxonMobil",
+        "wi": 50,
+        "operator": true
+      },
+      {
+        "name": "Equinor",
+        "wi": 50,
+        "operator": false
+      }
+    ],
+    "pending": [
+      "status",
+      "effective_date",
+      "expiration_date",
+      "lease_type",
+      "per_lease_block",
+      "per_lease_working_interest",
+      "operator_of_record_history"
+    ],
+    "ingest_issue": 959
+  },
   "provenance": "Primary facts (capex $4.7B, plateau 34 mbopd, GOR 1000, opex $18/boe, first oil, WI 50/50) from in-repo julia.yml; first oil = BSEE OGOR-A first production (2016-03) per YAML — note ExxonMobil press release states production start April 2016. Operator corrected to ExxonMobil (YAML flagged its \"Equinor\" operator field as disputed; public record = ExxonMobil-operated, Equinor/Statoil 50% partner). Discovery 2007, FID May 2013, water depth 7000+ ft, Walker Ridge blocks, and Jack/St. Malo tieback from Offshore Technology and operator/trade press. lease year and projected end-of-production not confidently sourced.",
   "norms": [
     {
@@ -664,6 +703,30 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
+// operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the
+// BSEE lease ingest issue — grabbable work, never a blank cell.
+if (FIELD.landman) {
+  const L = FIELD.landman;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${L.ingest_issue}`;
+  const ph = `<a href="${iss}" style="color:var(--muted)">— pending</a>`;
+  const rows = L.leases.map(r =>
+    `<tr><td>${r.lease_num}</td><td>${r.water_depth_ft ? r.water_depth_ft.toLocaleString()+" ft" : ph}</td>`
+    + `<td>${r.dev_system || ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td></tr>`).join("");
+  const wi = (L.working_interest || []).map(w =>
+    `${w.name} ${w.wi}%${w.operator ? " (op)" : ""}`).join(" · ");
+  $("f-landman").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Lease &amp; landman</h3>`
+    + `<p style="margin:0 0 4px;font-size:13px;color:var(--muted)">Operator <b>${L.operator||"—"}</b>`
+    + `${wi ? " · WI " + wi : ""} · Blocks ${L.blocks.join(", ")}${L.block_note ? " ("+L.block_note+")" : ""}</p>`
+    + `<p style="margin:0 0 10px;font-size:12px;color:var(--muted)">Lease status, dates, per-lease block &amp; working interest pending the `
+    + `<a href="${iss}">BSEE lease-data ingest (#${L.ingest_issue})</a> — contributions welcome.</p>`
+    + `<div class="scrollx"><table style="width:100%;border-collapse:collapse;font-size:12.5px">`
+    + `<thead><tr style="text-align:left;color:var(--muted)"><th>Lease</th><th>Water depth</th><th>Dev system</th>`
+    + `<th>Status</th><th>Effective</th><th>Expiration</th><th>WI</th></tr></thead><tbody>${rows}</tbody></table></div></section>`;
+}
 
 $("f-metrics").innerHTML = FIELD.metrics.map(m =>
   `<div class="metric"><div class="k">${m.k}</div><div class="v">${m.v} <small>${m.u}</small></div></div>`

--- a/reports/lower_tertiary/lifecycle/kaskida_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/kaskida_lifecycle.html
@@ -283,6 +283,7 @@
 <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-landman"></div>
 
     <div class="body">
       <section>
@@ -533,6 +534,46 @@ const FIELD = {
     },
     "decommissioning": null
   },
+  "landman": {
+    "leases": [
+      {
+        "lease_num": "G19555",
+        "lease_name": "Kaskida",
+        "water_depth_ft": 5860,
+        "dev_system": "subsea20"
+      },
+      {
+        "lease_num": "G25792",
+        "lease_name": "Kaskida",
+        "water_depth_ft": 5860,
+        "dev_system": "subsea20"
+      }
+    ],
+    "n_leases": 2,
+    "blocks": [
+      "KC291",
+      "KC292"
+    ],
+    "block_note": "Keathley Canyon 292",
+    "operator": "BP",
+    "working_interest": [
+      {
+        "name": "BP",
+        "wi": 100,
+        "operator": true
+      }
+    ],
+    "pending": [
+      "status",
+      "effective_date",
+      "expiration_date",
+      "lease_type",
+      "per_lease_block",
+      "per_lease_working_interest",
+      "operator_of_record_history"
+    ],
+    "ingest_issue": 959
+  },
   "provenance": "Discovery 2006 (Keathley Canyon 292, Lower Tertiary Wilcox), FID/sanction July 30 2024 (BP 100%, Devon's original 30% exited), first oil targeted 2029 but left blank as no oil has flowed and the Aug-2025 BOEM DPP rejection likely pushes it out. Public sanctioned figures used over YAML where they diverge: plateau/nameplate 80 mbopd (YAML said 120) and capex ~$5bn for Phase 1 (<$5B per BP; YAML total CAPEX 10000 = $10bn is a full-field/multi-phase estimate). GOR 1000 scf/bbl and data through 2024-12-31 from YAML. Water depth ~6,000 ft, 20,000-psi semisubmersible FPU. Low-confidence: capex (phase-1 vs full-field ambiguity), water depth (rounded), lease year unknown, opex unknown.",
   "norms": [
     {
@@ -615,6 +656,30 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
+// operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the
+// BSEE lease ingest issue — grabbable work, never a blank cell.
+if (FIELD.landman) {
+  const L = FIELD.landman;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${L.ingest_issue}`;
+  const ph = `<a href="${iss}" style="color:var(--muted)">— pending</a>`;
+  const rows = L.leases.map(r =>
+    `<tr><td>${r.lease_num}</td><td>${r.water_depth_ft ? r.water_depth_ft.toLocaleString()+" ft" : ph}</td>`
+    + `<td>${r.dev_system || ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td></tr>`).join("");
+  const wi = (L.working_interest || []).map(w =>
+    `${w.name} ${w.wi}%${w.operator ? " (op)" : ""}`).join(" · ");
+  $("f-landman").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Lease &amp; landman</h3>`
+    + `<p style="margin:0 0 4px;font-size:13px;color:var(--muted)">Operator <b>${L.operator||"—"}</b>`
+    + `${wi ? " · WI " + wi : ""} · Blocks ${L.blocks.join(", ")}${L.block_note ? " ("+L.block_note+")" : ""}</p>`
+    + `<p style="margin:0 0 10px;font-size:12px;color:var(--muted)">Lease status, dates, per-lease block &amp; working interest pending the `
+    + `<a href="${iss}">BSEE lease-data ingest (#${L.ingest_issue})</a> — contributions welcome.</p>`
+    + `<div class="scrollx"><table style="width:100%;border-collapse:collapse;font-size:12.5px">`
+    + `<thead><tr style="text-align:left;color:var(--muted)"><th>Lease</th><th>Water depth</th><th>Dev system</th>`
+    + `<th>Status</th><th>Effective</th><th>Expiration</th><th>WI</th></tr></thead><tbody>${rows}</tbody></table></div></section>`;
+}
 
 $("f-metrics").innerHTML = FIELD.metrics.map(m =>
   `<div class="metric"><div class="k">${m.k}</div><div class="v">${m.v} <small>${m.u}</small></div></div>`

--- a/reports/lower_tertiary/lifecycle/lifecycle_template.html
+++ b/reports/lower_tertiary/lifecycle/lifecycle_template.html
@@ -282,6 +282,7 @@
     <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-landman"></div>
 
     <div class="body">
       <section>
@@ -434,6 +435,30 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
+// operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the
+// BSEE lease ingest issue — grabbable work, never a blank cell.
+if (FIELD.landman) {
+  const L = FIELD.landman;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${L.ingest_issue}`;
+  const ph = `<a href="${iss}" style="color:var(--muted)">— pending</a>`;
+  const rows = L.leases.map(r =>
+    `<tr><td>${r.lease_num}</td><td>${r.water_depth_ft ? r.water_depth_ft.toLocaleString()+" ft" : ph}</td>`
+    + `<td>${r.dev_system || ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td></tr>`).join("");
+  const wi = (L.working_interest || []).map(w =>
+    `${w.name} ${w.wi}%${w.operator ? " (op)" : ""}`).join(" · ");
+  $("f-landman").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Lease &amp; landman</h3>`
+    + `<p style="margin:0 0 4px;font-size:13px;color:var(--muted)">Operator <b>${L.operator||"—"}</b>`
+    + `${wi ? " · WI " + wi : ""} · Blocks ${L.blocks.join(", ")}${L.block_note ? " ("+L.block_note+")" : ""}</p>`
+    + `<p style="margin:0 0 10px;font-size:12px;color:var(--muted)">Lease status, dates, per-lease block &amp; working interest pending the `
+    + `<a href="${iss}">BSEE lease-data ingest (#${L.ingest_issue})</a> — contributions welcome.</p>`
+    + `<div class="scrollx"><table style="width:100%;border-collapse:collapse;font-size:12.5px">`
+    + `<thead><tr style="text-align:left;color:var(--muted)"><th>Lease</th><th>Water depth</th><th>Dev system</th>`
+    + `<th>Status</th><th>Effective</th><th>Expiration</th><th>WI</th></tr></thead><tbody>${rows}</tbody></table></div></section>`;
+}
 
 $("f-metrics").innerHTML = FIELD.metrics.map(m =>
   `<div class="metric"><div class="k">${m.k}</div><div class="v">${m.v} <small>${m.u}</small></div></div>`

--- a/reports/lower_tertiary/lifecycle/north_platte_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/north_platte_lifecycle.html
@@ -283,6 +283,7 @@
 <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-landman"></div>
 
     <div class="body">
       <section>
@@ -529,6 +530,53 @@ const FIELD = {
     },
     "decommissioning": null
   },
+  "landman": {
+    "leases": [
+      {
+        "lease_num": "G30876",
+        "lease_name": "North Platte",
+        "water_depth_ft": 5840,
+        "dev_system": "subsea20"
+      },
+      {
+        "lease_num": "G32460",
+        "lease_name": "North Platte",
+        "water_depth_ft": 4230,
+        "dev_system": "subsea20"
+      }
+    ],
+    "n_leases": 2,
+    "blocks": [
+      "GB915",
+      "GB916",
+      "GB958",
+      "GB959"
+    ],
+    "block_note": "Garden Banks 959 (straddles GB 915/916/958/959)",
+    "operator": "Shell",
+    "working_interest": [
+      {
+        "name": "Shell",
+        "wi": 51,
+        "operator": true
+      },
+      {
+        "name": "Equinor",
+        "wi": 49,
+        "operator": false
+      }
+    ],
+    "pending": [
+      "status",
+      "effective_date",
+      "expiration_date",
+      "lease_type",
+      "per_lease_block",
+      "per_lease_working_interest",
+      "operator_of_record_history"
+    ],
+    "ingest_issue": 959
+  },
   "provenance": "Basis: in-repo YAML (superseded TotalEnergies pre-FID case) reconciled against current public record. North Platte was discovered 2012 (Cobalt/Total, Garden Banks). TotalEnergies (then 60% op, Equinor 40%) withdrew Feb 2022; Shell bought 51% and took operatorship from Equinor (49%), redesigned and renamed the project \"Sparta.\" Shell took FID Dec 2023; first oil projected 2028 (left blank — not yet producing). Water depth ~4,265 ft, subsalt Wilcox, newbuild semisubmersible FPU (8 subsea wells) with ~90,000 boe/d peak (~75 mbopd oil plateau; GOR 1100 scf/bbl from YAML). LOW-CONFIDENCE: capex — YAML's $6B reflects the abandoned TotalEnergies ~$5-7B concept, not Shell's simplified Sparta scope (not publicly disclosed), so not available; opex and projected COP year not publicly defensible.",
   "norms": [
     {
@@ -611,6 +659,30 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
+// operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the
+// BSEE lease ingest issue — grabbable work, never a blank cell.
+if (FIELD.landman) {
+  const L = FIELD.landman;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${L.ingest_issue}`;
+  const ph = `<a href="${iss}" style="color:var(--muted)">— pending</a>`;
+  const rows = L.leases.map(r =>
+    `<tr><td>${r.lease_num}</td><td>${r.water_depth_ft ? r.water_depth_ft.toLocaleString()+" ft" : ph}</td>`
+    + `<td>${r.dev_system || ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td></tr>`).join("");
+  const wi = (L.working_interest || []).map(w =>
+    `${w.name} ${w.wi}%${w.operator ? " (op)" : ""}`).join(" · ");
+  $("f-landman").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Lease &amp; landman</h3>`
+    + `<p style="margin:0 0 4px;font-size:13px;color:var(--muted)">Operator <b>${L.operator||"—"}</b>`
+    + `${wi ? " · WI " + wi : ""} · Blocks ${L.blocks.join(", ")}${L.block_note ? " ("+L.block_note+")" : ""}</p>`
+    + `<p style="margin:0 0 10px;font-size:12px;color:var(--muted)">Lease status, dates, per-lease block &amp; working interest pending the `
+    + `<a href="${iss}">BSEE lease-data ingest (#${L.ingest_issue})</a> — contributions welcome.</p>`
+    + `<div class="scrollx"><table style="width:100%;border-collapse:collapse;font-size:12.5px">`
+    + `<thead><tr style="text-align:left;color:var(--muted)"><th>Lease</th><th>Water depth</th><th>Dev system</th>`
+    + `<th>Status</th><th>Effective</th><th>Expiration</th><th>WI</th></tr></thead><tbody>${rows}</tbody></table></div></section>`;
+}
 
 $("f-metrics").innerHTML = FIELD.metrics.map(m =>
   `<div class="metric"><div class="k">${m.k}</div><div class="v">${m.v} <small>${m.u}</small></div></div>`

--- a/reports/lower_tertiary/lifecycle/shenandoah_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/shenandoah_lifecycle.html
@@ -283,6 +283,7 @@
 <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-landman"></div>
 
     <div class="body">
       <section>
@@ -553,6 +554,55 @@ const FIELD = {
     },
     "decommissioning": null
   },
+  "landman": {
+    "leases": [
+      {
+        "lease_num": "G25232",
+        "lease_name": "Shenandoah",
+        "water_depth_ft": 5840,
+        "dev_system": "subsea20"
+      },
+      {
+        "lease_num": "G31938",
+        "lease_name": "Shenandoah",
+        "water_depth_ft": 5800,
+        "dev_system": "subsea20"
+      }
+    ],
+    "n_leases": 2,
+    "blocks": [
+      "WR051"
+    ],
+    "block_note": "Walker Ridge 52 (blocks 51, 52, N/2 53)",
+    "operator": "Beacon Offshore Energy",
+    "working_interest": [
+      {
+        "name": "Beacon Offshore Energy",
+        "wi": 31,
+        "operator": true
+      },
+      {
+        "name": "Navitas Petroleum",
+        "wi": 49,
+        "operator": false
+      },
+      {
+        "name": "HEQ Deepwater (Quantum Energy Partners)",
+        "wi": 20,
+        "operator": false
+      }
+    ],
+    "pending": [
+      "status",
+      "effective_date",
+      "expiration_date",
+      "lease_type",
+      "per_lease_block",
+      "per_lease_working_interest",
+      "operator_of_record_history"
+    ],
+    "ingest_issue": 959
+  },
   "provenance": "Base facts (operator, capex, plateau, GOR, data through) from in-repo YAML; discovery 2009 (Anadarko Shenandoah-1, WR52), FID/sanction Aug 2021 (Beacon+Navitas), and actual first oil (first of 4 wells online 25 Jul 2025; ramped to 100 kbopd plateau Oct 2025) from public sources — first oil corrected to 2025-07 vs YAML's placeholder 2025-10. Current WI (Beacon 31% op / Navitas 49% / HEQ 20%) post-2021 restructuring. CAPEX 1.8 is YAML-stated and largely reflects pre-development E&A spend (LOW CONFIDENCE for full development cost); OPEX and projected end-of-production, not available (not defensibly sourced); water depth ~5,800 ft.",
   "norms": [
     {
@@ -656,6 +706,30 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
+// operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the
+// BSEE lease ingest issue — grabbable work, never a blank cell.
+if (FIELD.landman) {
+  const L = FIELD.landman;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${L.ingest_issue}`;
+  const ph = `<a href="${iss}" style="color:var(--muted)">— pending</a>`;
+  const rows = L.leases.map(r =>
+    `<tr><td>${r.lease_num}</td><td>${r.water_depth_ft ? r.water_depth_ft.toLocaleString()+" ft" : ph}</td>`
+    + `<td>${r.dev_system || ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td></tr>`).join("");
+  const wi = (L.working_interest || []).map(w =>
+    `${w.name} ${w.wi}%${w.operator ? " (op)" : ""}`).join(" · ");
+  $("f-landman").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Lease &amp; landman</h3>`
+    + `<p style="margin:0 0 4px;font-size:13px;color:var(--muted)">Operator <b>${L.operator||"—"}</b>`
+    + `${wi ? " · WI " + wi : ""} · Blocks ${L.blocks.join(", ")}${L.block_note ? " ("+L.block_note+")" : ""}</p>`
+    + `<p style="margin:0 0 10px;font-size:12px;color:var(--muted)">Lease status, dates, per-lease block &amp; working interest pending the `
+    + `<a href="${iss}">BSEE lease-data ingest (#${L.ingest_issue})</a> — contributions welcome.</p>`
+    + `<div class="scrollx"><table style="width:100%;border-collapse:collapse;font-size:12.5px">`
+    + `<thead><tr style="text-align:left;color:var(--muted)"><th>Lease</th><th>Water depth</th><th>Dev system</th>`
+    + `<th>Status</th><th>Effective</th><th>Expiration</th><th>WI</th></tr></thead><tbody>${rows}</tbody></table></div></section>`;
+}
 
 $("f-metrics").innerHTML = FIELD.metrics.map(m =>
   `<div class="metric"><div class="k">${m.k}</div><div class="v">${m.v} <small>${m.u}</small></div></div>`

--- a/reports/lower_tertiary/lifecycle/stones_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/stones_lifecycle.html
@@ -283,6 +283,7 @@
 <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-landman"></div>
 
     <div class="body">
       <section>
@@ -556,6 +557,39 @@ const FIELD = {
       "label": "Decommission ~$80M (FPSO base)"
     }
   },
+  "landman": {
+    "leases": [
+      {
+        "lease_num": "G17001",
+        "lease_name": "Stones",
+        "water_depth_ft": 9525,
+        "dev_system": "subsea15"
+      }
+    ],
+    "n_leases": 1,
+    "blocks": [
+      "WR508"
+    ],
+    "block_note": "Walker Ridge 508",
+    "operator": "Shell",
+    "working_interest": [
+      {
+        "name": "Shell",
+        "wi": 100,
+        "operator": true
+      }
+    ],
+    "pending": [
+      "status",
+      "effective_date",
+      "expiration_date",
+      "lease_type",
+      "per_lease_block",
+      "per_lease_working_interest",
+      "operator_of_record_history"
+    ],
+    "ingest_issue": 959
+  },
   "provenance": "Capex ($3.8bn), plateau (50 mbopd), GOR (850 scf/bbl), opex ($15/boe), first oil (2016-09) and status from in-repo stones.yml (Shell FPSO development config). Discovery (2005), FID/sanction (May 2013, Shell 100% owner-operator), Walker Ridge Block 508, ~9,500 ft water depth, and Turritella/Stones FPSO host (world's deepest FPSO) confirmed via Offshore Technology, Offshore Magazine, and NS Energy public sources. lease year and projected end-of-production unknown; no notable schedule-driving incident identified.",
   "norms": [
     {
@@ -659,6 +693,30 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
+// operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the
+// BSEE lease ingest issue — grabbable work, never a blank cell.
+if (FIELD.landman) {
+  const L = FIELD.landman;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${L.ingest_issue}`;
+  const ph = `<a href="${iss}" style="color:var(--muted)">— pending</a>`;
+  const rows = L.leases.map(r =>
+    `<tr><td>${r.lease_num}</td><td>${r.water_depth_ft ? r.water_depth_ft.toLocaleString()+" ft" : ph}</td>`
+    + `<td>${r.dev_system || ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td></tr>`).join("");
+  const wi = (L.working_interest || []).map(w =>
+    `${w.name} ${w.wi}%${w.operator ? " (op)" : ""}`).join(" · ");
+  $("f-landman").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Lease &amp; landman</h3>`
+    + `<p style="margin:0 0 4px;font-size:13px;color:var(--muted)">Operator <b>${L.operator||"—"}</b>`
+    + `${wi ? " · WI " + wi : ""} · Blocks ${L.blocks.join(", ")}${L.block_note ? " ("+L.block_note+")" : ""}</p>`
+    + `<p style="margin:0 0 10px;font-size:12px;color:var(--muted)">Lease status, dates, per-lease block &amp; working interest pending the `
+    + `<a href="${iss}">BSEE lease-data ingest (#${L.ingest_issue})</a> — contributions welcome.</p>`
+    + `<div class="scrollx"><table style="width:100%;border-collapse:collapse;font-size:12.5px">`
+    + `<thead><tr style="text-align:left;color:var(--muted)"><th>Lease</th><th>Water depth</th><th>Dev system</th>`
+    + `<th>Status</th><th>Effective</th><th>Expiration</th><th>WI</th></tr></thead><tbody>${rows}</tbody></table></div></section>`;
+}
 
 $("f-metrics").innerHTML = FIELD.metrics.map(m =>
   `<div class="metric"><div class="k">${m.k}</div><div class="v">${m.v} <small>${m.u}</small></div></div>`

--- a/reports/lower_tertiary/lifecycle/tiber_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/tiber_lifecycle.html
@@ -283,6 +283,7 @@
 <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-landman"></div>
 
     <div class="body">
       <section>
@@ -525,6 +526,39 @@ const FIELD = {
     },
     "decommissioning": null
   },
+  "landman": {
+    "leases": [
+      {
+        "lease_num": "G25782",
+        "lease_name": "Tiber",
+        "water_depth_ft": 4130,
+        "dev_system": "subsea20"
+      }
+    ],
+    "n_leases": 1,
+    "blocks": [
+      "KC102"
+    ],
+    "block_note": "Keathley Canyon 102",
+    "operator": "BP",
+    "working_interest": [
+      {
+        "name": "BP",
+        "wi": 100,
+        "operator": true
+      }
+    ],
+    "pending": [
+      "status",
+      "effective_date",
+      "expiration_date",
+      "lease_type",
+      "per_lease_block",
+      "per_lease_working_interest",
+      "operator_of_record_history"
+    ],
+    "ingest_issue": 959
+  },
   "provenance": "Basis: in-repo tiber.yml (operator BP, plateau 80 mbopd, GOR 900 scf/bbl, data through 2024-12-31) plus public sources. BP discovered Tiber Sept 2009 in Keathley Canyon 102, 4,132 ft water. BP reached FID on the combined Tiber-Guadalupe hub 29 Sep 2025 (FID year=2025); Seatrium awarded FPU EPCC. Ownership is now 100% BP (original discovery split BP 62% / Petrobras 20% / ConocoPhillips 18% no longer reflects current WI). Status: execution (post-FID, construction underway). capex set to the sanctioned public figure of $5.0bn for the Tiber-Guadalupe project (YAML's $8bn was a pre-FID Tiber-only planning assumption); note $5bn covers both fields. first oil left blank — oil has not flowed; projected first production is 2030. OPEX, not available (not publicly disclosed; the \"$3/bbl below Kaskida\" figure is development cost, not opex). projected end-of-production and lease year (not confidently sourced).",
   "norms": [
     {
@@ -597,6 +631,30 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
+// operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the
+// BSEE lease ingest issue — grabbable work, never a blank cell.
+if (FIELD.landman) {
+  const L = FIELD.landman;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${L.ingest_issue}`;
+  const ph = `<a href="${iss}" style="color:var(--muted)">— pending</a>`;
+  const rows = L.leases.map(r =>
+    `<tr><td>${r.lease_num}</td><td>${r.water_depth_ft ? r.water_depth_ft.toLocaleString()+" ft" : ph}</td>`
+    + `<td>${r.dev_system || ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td><td>${ph}</td></tr>`).join("");
+  const wi = (L.working_interest || []).map(w =>
+    `${w.name} ${w.wi}%${w.operator ? " (op)" : ""}`).join(" · ");
+  $("f-landman").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Lease &amp; landman</h3>`
+    + `<p style="margin:0 0 4px;font-size:13px;color:var(--muted)">Operator <b>${L.operator||"—"}</b>`
+    + `${wi ? " · WI " + wi : ""} · Blocks ${L.blocks.join(", ")}${L.block_note ? " ("+L.block_note+")" : ""}</p>`
+    + `<p style="margin:0 0 10px;font-size:12px;color:var(--muted)">Lease status, dates, per-lease block &amp; working interest pending the `
+    + `<a href="${iss}">BSEE lease-data ingest (#${L.ingest_issue})</a> — contributions welcome.</p>`
+    + `<div class="scrollx"><table style="width:100%;border-collapse:collapse;font-size:12.5px">`
+    + `<thead><tr style="text-align:left;color:var(--muted)"><th>Lease</th><th>Water depth</th><th>Dev system</th>`
+    + `<th>Status</th><th>Effective</th><th>Expiration</th><th>WI</th></tr></thead><tbody>${rows}</tbody></table></div></section>`;
+}
 
 $("f-metrics").innerHTML = FIELD.metrics.map(m =>
   `<div class="metric"><div class="k">${m.k}</div><div class="v">${m.v} <small>${m.u}</small></div></div>`

--- a/scripts/lower_tertiary/build_lifecycle_posters.py
+++ b/scripts/lower_tertiary/build_lifecycle_posters.py
@@ -38,6 +38,9 @@ from worldenergydata.field_development.decommission_risk import (  # noqa: E402
     classify_decommissioning,
 )
 from worldenergydata.field_development.hpht_risk import classify_hpht  # noqa: E402
+from worldenergydata.field_development.landman import (  # noqa: E402
+    build_landman,
+)
 
 _SCRIPTS = Path(__file__).resolve().parents[1]
 if str(_SCRIPTS) not in sys.path:
@@ -68,6 +71,53 @@ def _load_decom_rows() -> list[dict]:
 _DECOM_ROWS = _load_decom_rows()
 TODAY_YEAR = 2026.5  # generated 2026-07-03; a fixed "you are here" marker on the axis
 FIELDS_REGISTRY = load_fields()
+
+# BSEE lease attributes for the landman panel (#951). Committed source is the
+# FDAS V30 lease workbook (name/depth/dev-system only); status/dates/WI/block are
+# placeholders linking the ingest issue below. Build-time only (pandas); the
+# published site just copies the frozen posters + _explorer.json.
+_LEASE_INGEST_ISSUE = 959
+_V30_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "docs/modules/bsee/analysis/production/FDAS_V30"
+)
+
+
+def _load_lease_rows() -> dict:
+    """{normalized_lease_num: {water_depth_ft, dev_system, lease_name}}."""
+    try:
+        import pandas as pd
+    except ImportError:
+        return {}
+    rows: dict[str, dict] = {}
+    for name in ("leases.xlsx", "leases_v21_kc.csv"):
+        path = _V30_DIR / name
+        if not path.exists():
+            continue
+        df = pd.read_excel(path) if name.endswith(".xlsx") else pd.read_csv(path)
+        for _, r in df.iterrows():
+            key = str(r["LEASE_NUM"]).upper().replace(" ", "").strip()
+            wd = pd.to_numeric(r.get("WATER_DEPTH"), errors="coerce")
+            rows.setdefault(
+                key,
+                {
+                    "lease_name": (
+                        str(r["LEASE_NAME"]).strip()
+                        if pd.notna(r.get("LEASE_NAME"))
+                        else None
+                    ),
+                    "water_depth_ft": int(wd) if pd.notna(wd) else None,
+                    "dev_system": (
+                        str(r["DEV_SYSTEM"]).strip()
+                        if pd.notna(r.get("DEV_SYSTEM"))
+                        else None
+                    ),
+                },
+            )
+    return rows
+
+
+_LEASE_ROWS = _load_lease_rows()
 
 PHASE_KEYS = [
     "acquire",
@@ -339,6 +389,14 @@ def facts_to_field(f: dict) -> dict:
                 f.get("decommissioning_facility"), _DECOM_ROWS
             ),
         },
+        "landman": build_landman(
+            f,
+            list(registry_field.leases),
+            list(registry_field.area_blocks),
+            _LEASE_ROWS,
+            _LEASE_INGEST_ISSUE,
+            registry_field.bsee_block_note,
+        ),
         "provenance": f.get(
             "provenance", "Data: field YAML + public disclosures + BSEE"
         ),

--- a/src/worldenergydata/field_development/landman.py
+++ b/src/worldenergydata/field_development/landman.py
@@ -1,0 +1,81 @@
+# ABOUTME: Assemble a per-field landman lease panel from the canonical registry.
+# ABOUTME: Ships the leases we can source; missing attributes become grabbable placeholders (#951).
+"""
+worldenergydata.field_development.landman
+=========================================
+
+Build the per-field **Lease & landman** panel for the life-cycle posters and the
+Explorer field panel.
+
+What is real (committed data):
+  * lease numbers + blocks — ``config/fields.yml`` (the canonical registry, #755);
+  * per-lease water depth + development system — the FDAS V30 lease workbook;
+  * field-level operator + working-interest partners — ``_facts.json``.
+
+What is NOT in committed data (→ grabbable placeholders linking an ingest issue,
+per the owner's 2026-07-11 guidance): lease **status**, **effective/expiration
+dates**, **lease type**, **per-lease block**, **per-lease working interest**,
+**operator-of-record history**. ``config/fields.yml`` lists ``leases`` and
+``area_blocks`` as UNPAIRED parallel lists, so a block is NEVER placed next to an
+individual lease (that pairing is one of the deferred placeholders).
+"""
+
+from __future__ import annotations
+
+# Attributes the committed data cannot supply yet; each renders as a placeholder
+# cell linking the BSEE Lease & Lease-Owner ingest issue.
+PENDING_ATTRS = [
+    "status",
+    "effective_date",
+    "expiration_date",
+    "lease_type",
+    "per_lease_block",
+    "per_lease_working_interest",
+    "operator_of_record_history",
+]
+
+
+def build_landman(
+    field_facts: dict,
+    leases: list[str],
+    blocks: list[str],
+    lease_rows: dict,
+    ingest_issue: int,
+    block_note: str | None = None,
+) -> dict:
+    """Return the landman panel dict for one field.
+
+    ``lease_rows`` maps a normalized lease number -> ``{water_depth_ft,
+    dev_system, lease_name}`` (from the V30 workbook). ``leases``/``blocks`` are
+    the canonical registry lists. Per-lease block is deliberately absent.
+    """
+    rows = []
+    for lease in leases:
+        v = lease_rows.get(_norm(lease), {})
+        rows.append(
+            {
+                "lease_num": lease,
+                "lease_name": v.get("lease_name"),
+                "water_depth_ft": v.get("water_depth_ft"),
+                "dev_system": v.get("dev_system"),
+            }
+        )
+    wi = field_facts.get("working_interest") or []
+    return {
+        "leases": rows,
+        "n_leases": len(rows),
+        "blocks": list(blocks),
+        "block_note": block_note,
+        "operator": field_facts.get("operator"),
+        "working_interest": wi,  # per-FIELD partner split (real)
+        "pending": list(PENDING_ATTRS),
+        "ingest_issue": ingest_issue,
+    }
+
+
+def _norm(lease: str) -> str:
+    """Normalize a lease number for joining: 'OCS-G 25806' -> 'G25806'.
+
+    Strips the 'OCS-' prefix (keeping the region letter) and all spaces, uppercase.
+    """
+    return lease.upper().replace("OCS-", "").replace(" ", "").strip()

--- a/tests/integration/site/test_public_link_graph.py
+++ b/tests/integration/site/test_public_link_graph.py
@@ -350,6 +350,30 @@ def test_underwriting_risk_signals(public):
     assert hpht["anchor"]["exceedance_pct"] == 25
 
 
+def test_landman_lease_panel(public):
+    # #951: all 10 LT fields carry a landman panel; 20 leases total; field-level
+    # blocks only (NO per-lease block — false-precision guard); placeholders link
+    # the ingest issue.
+    fields = _explorer(public)["fields"]
+    total = 0
+    for fid, f in fields.items():
+        lm = f["landman"]
+        assert lm and lm["leases"], fid
+        assert lm["blocks"] and lm["ingest_issue"] == 959
+        assert "per_lease_block" in lm["pending"]
+        for r in lm["leases"]:
+            assert "block" not in r  # never a per-lease block
+        total += lm["n_leases"]
+    assert total == 20, f"expected 20 LT leases, got {total}"
+    # Every canonical LT lease resolves through the registry.
+    from worldenergydata.common.fields_registry import load_fields
+
+    registry = load_fields()
+    for fid, f in fields.items():
+        for r in f["landman"]["leases"]:
+            assert registry.by_lease(r["lease_num"]) == fid, r["lease_num"]
+
+
 def test_every_well_has_a_page(public):
     embedded = _explorer(public)["wells"]["wells"]
     missing = [

--- a/tests/unit/field_development/test_landman.py
+++ b/tests/unit/field_development/test_landman.py
@@ -1,0 +1,72 @@
+"""Unit tests for the landman lease-panel builder (issue #951)."""
+
+from __future__ import annotations
+
+from worldenergydata.field_development.landman import PENDING_ATTRS, build_landman
+
+FACTS = {
+    "operator": "Chevron",
+    "working_interest": [
+        {"name": "Chevron", "wi": 51, "operator": True},
+        {"name": "Equinor", "wi": 24.5, "operator": False},
+        {"name": "Suncor", "wi": 24.5, "operator": False},
+    ],
+}
+LEASE_ROWS = {
+    "G17015": {"lease_name": "Jack", "water_depth_ft": 7000, "dev_system": "subsea20"},
+}
+
+
+def test_build_landman_rows_and_fieldlevel():
+    lm = build_landman(
+        FACTS,
+        ["G17015", "G17016", "G18745"],
+        ["WR678", "WR758", "WR759"],
+        LEASE_ROWS,
+        959,
+        "Walker Ridge 678",
+    )
+    assert lm["n_leases"] == 3
+    # Field-level blocks list (NOT per-lease), operator + partner WI are real.
+    assert lm["blocks"] == ["WR678", "WR758", "WR759"]
+    assert lm["operator"] == "Chevron"
+    assert lm["working_interest"][0]["name"] == "Chevron"
+    assert lm["ingest_issue"] == 959
+
+
+def test_no_per_lease_block_key():
+    # False-precision guard (#951 r1 f4): leases and blocks are unpaired parallel
+    # lists — a lease row must NEVER carry a specific block.
+    lm = build_landman(
+        FACTS, ["G17015", "G17016"], ["WR678", "WR758", "WR759"], {}, 959
+    )
+    for row in lm["leases"]:
+        assert "block" not in row
+    assert PENDING_ATTRS and "per_lease_block" in lm["pending"]
+
+
+def test_join_and_placeholders():
+    lm = build_landman(FACTS, ["G17015", "G17016"], ["WR678"], LEASE_ROWS, 959)
+    matched = lm["leases"][0]
+    assert matched["lease_num"] == "G17015"
+    assert matched["water_depth_ft"] == 7000 and matched["dev_system"] == "subsea20"
+    # Unmatched lease: real fields null, still listed (never dropped).
+    unmatched = lm["leases"][1]
+    assert unmatched["lease_num"] == "G17016"
+    assert unmatched["water_depth_ft"] is None
+    # The rich landman attributes are all deferred placeholders.
+    for attr in (
+        "status",
+        "effective_date",
+        "expiration_date",
+        "per_lease_working_interest",
+    ):
+        assert attr in lm["pending"]
+
+
+def test_lease_normalization():
+    rows = {
+        "G25806": {"lease_name": "Buckskin", "water_depth_ft": 6800, "dev_system": "x"}
+    }
+    lm = build_landman(FACTS, ["OCS-G 25806"], ["KC872"], rows, 959)
+    assert lm["leases"][0]["water_depth_ft"] == 6800


### PR DESCRIPTION
Closes #951 (epic #943, program #939). Plan: workspace-hub `docs/plans/2026-07-11-issue-wed-951-landman-offshore.md` @ 7f5ecfa0 (adversarial-reviewed r1 MAJOR/2 → folded; owner-approved).

## What

The landman-offshore lens: a **Lease & landman** panel on the 10 LT posters + Explorer field panel — built with the owner's placeholder-links-to-issue pattern.

- **Ships the real data** — 20 leases across 10 fields (lease id · water depth · dev-system from `config/fields.yml` + the FDAS V30 lease workbook), plus field-level operator, working-interest partners, and blocks list.
- **Missing landman attributes → grabbable placeholders**: lease status, effective/expiration dates, per-lease block, per-lease working interest render as "— pending" cells that **link the newly-filed ingest issue #959** (BSEE Lease & Lease-Owner data — verified source carries all of them). Nothing is silently omitted; every gap is delegable work.
- **Round-up issues filed**: **#959** (lease ingest, the panel filler) and **#960** (per-field well-plugging P&A, deferred from #949, retro-linked).

## The review caught two real defects

1. **Lease count** — I wrote 26; the 10 poster-fields have exactly **20** leases (26 double-counted buckskin, which has no poster). Gate now asserts 20.
2. **Per-lease block = false precision** — `fields.yml` lists `leases` and `area_blocks` as *unpaired parallel lists*, so 4 of 10 fields would have fabricated a lease→block pairing. Blocks are now a **field-level list**; per-lease block is a deferred placeholder (the BSEE Lease/Block table carries it). A gate asserts no per-lease `block` key is ever emitted.

Implementation also caught a lease-normalization bug (`OCS-G 25806` → `G25806`, not `25806`) via a RED unit test.

## Verification
- 133 tests (8 new: landman builder units incl. the no-per-lease-block guard + normalization, and a site gate asserting 20 leases / 10 fields / registry round-trip / no per-lease block). All green.
- Lint mirror clean; single-`<h1>` nav-spine rule preserved (panel heading is `<h3>`); no null/nan strings; identity gate green with the new `landman` key.
- Placeholders link #959 (external GitHub href, outside the link-graph gate — live precedent).
- Build-time pandas for the xlsx read; Pages deploy unaffected (copies frozen artifacts).
