### PR TITLE
feat(explorer): concept/development lens with FDP links + placeholders

### DIFF
--- a/reports/field-atlas/atlas_template.html
+++ b/reports/field-atlas/atlas_template.html
@@ -345,6 +345,22 @@ function renderField(x, f){
       <table class="xwells"><thead><tr><th>Lease</th><th>Depth</th><th>Dev</th><th>Status</th><th>Dates</th></tr></thead><tbody>${rows}</tbody></table>
       <p style="font-size:11.5px;color:var(--muted);margin-top:6px">Status, dates, per-lease block &amp; WI pending the <a href="${iss}">BSEE lease ingest (#${L.ingest_issue})</a> — contributions welcome.</p></div>`;
   }
+  // Concept & development card (#759): real concept/play/milestone for every
+  // field + FDP link when a portfolio page exists, else a placeholder linking
+  // the FDP-authoring issue.
+  let concept = "";
+  if (f.concept) {
+    const C = f.concept;
+    const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${C.fdp_issue}`;
+    const fdp = C.fdp_href
+      ? `<a href="${rb(C.fdp_href)}">FDP portfolio →</a>`
+      : `<a href="${iss}" style="color:var(--muted)">— concept detail pending</a>`;
+    const row = (k, v) => v ? `<tr><td>${esc(k)}</td><td>${v}</td></tr>` : "";
+    concept = `<div class="xcardlet"><div class="xh">Concept &amp; development</div><table>`
+      + row("Concept", esc(C.type || "—")) + row("Play", esc(C.play || "—"))
+      + (C.milestone ? row(C.milestone.label, esc(C.milestone.value)) : "")
+      + row("FDP", fdp) + `</table></div>`;
+  }
   show(`
     <div class="xtitle">${esc(f.name)}
       <span class="badge rich">${esc(f.statusLabel)}</span>
@@ -356,7 +372,7 @@ function renderField(x, f){
     <div class="xmets">${mets}</div>
     <div class="xcols">
       <div class="xcardlet"><div class="xh">Host &amp; field facts</div><table>${facts}</table></div>
-      ${perf}${resv}${uw}${landman}
+      ${concept}${perf}${resv}${uw}${landman}
     </div>
     <div class="xacts">${acts.join("")}</div>
     ${wellsNote}

--- a/reports/field-atlas/index.html
+++ b/reports/field-atlas/index.html
@@ -346,6 +346,22 @@ function renderField(x, f){
       <table class="xwells"><thead><tr><th>Lease</th><th>Depth</th><th>Dev</th><th>Status</th><th>Dates</th></tr></thead><tbody>${rows}</tbody></table>
       <p style="font-size:11.5px;color:var(--muted);margin-top:6px">Status, dates, per-lease block &amp; WI pending the <a href="${iss}">BSEE lease ingest (#${L.ingest_issue})</a> — contributions welcome.</p></div>`;
   }
+  // Concept & development card (#759): real concept/play/milestone for every
+  // field + FDP link when a portfolio page exists, else a placeholder linking
+  // the FDP-authoring issue.
+  let concept = "";
+  if (f.concept) {
+    const C = f.concept;
+    const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${C.fdp_issue}`;
+    const fdp = C.fdp_href
+      ? `<a href="${rb(C.fdp_href)}">FDP portfolio →</a>`
+      : `<a href="${iss}" style="color:var(--muted)">— concept detail pending</a>`;
+    const row = (k, v) => v ? `<tr><td>${esc(k)}</td><td>${v}</td></tr>` : "";
+    concept = `<div class="xcardlet"><div class="xh">Concept &amp; development</div><table>`
+      + row("Concept", esc(C.type || "—")) + row("Play", esc(C.play || "—"))
+      + (C.milestone ? row(C.milestone.label, esc(C.milestone.value)) : "")
+      + row("FDP", fdp) + `</table></div>`;
+  }
   show(`
     <div class="xtitle">${esc(f.name)}
       <span class="badge rich">${esc(f.statusLabel)}</span>
@@ -357,7 +373,7 @@ function renderField(x, f){
     <div class="xmets">${mets}</div>
     <div class="xcols">
       <div class="xcardlet"><div class="xh">Host &amp; field facts</div><table>${facts}</table></div>
-      ${perf}${resv}${uw}${landman}
+      ${concept}${perf}${resv}${uw}${landman}
     </div>
     <div class="xacts">${acts.join("")}</div>
     ${wellsNote}

--- a/reports/lower_tertiary/lifecycle/_explorer.json
+++ b/reports/lower_tertiary/lifecycle/_explorer.json
@@ -223,6 +223,17 @@
         ],
         "ingest_issue": 959
       },
+      "concept": {
+        "type": "eTLP",
+        "host": "Extended Tension-Leg Platform (eTLP)",
+        "play": "Wilcox / Lower Tertiary",
+        "milestone": {
+          "label": "First oil",
+          "value": "Nov 2018"
+        },
+        "fdp_href": null,
+        "fdp_issue": 962
+      },
       "provenance": "Data: big_foot.yml + Chevron public disclosures + BSEE (dates to be reconciled in #375)",
       "norms": [
         {
@@ -498,6 +509,17 @@
         ],
         "ingest_issue": 959
       },
+      "concept": {
+        "type": "Semisub FPU",
+        "host": "Semisubmersible FPU",
+        "play": "Lower Tertiary Wilcox",
+        "milestone": {
+          "label": "First oil",
+          "value": "Aug 2024"
+        },
+        "fdp_href": null,
+        "fdp_issue": 962
+      },
       "provenance": "Primary facts (operator, working interests, capex $5.6B, plateau 75 mbopd, GOR 1100 scf/bbl, opex $15/boe, first oil 2024-08, data through 2024-12-31) from in-repo anchor.yml. Life-cycle dates corroborated by public sources: discovery well Anchor-2 drilled 2014 (Green Canyon 807, ~5,180 ft), FID December 2019 (~$5.7B sanction), first oil August 2024 — world's first 20,000-psi HPHT deepwater development on a semisubmersible FPU, Lower Tertiary Wilcox play. Working interests (Chevron 62.5% / Equinor 25% / TotalEnergies 12.5%) per YAML; note older Offshore Technology page still lists pre-Equinor split (Chevron 62.86% / Total 37.14%). water depth ~5,180 (block-level estimate). projected end-of-production and lease year not confidently sourced; no notable incident.",
       "norms": [
         {
@@ -748,6 +770,17 @@
           "operator_of_record_history"
         ],
         "ingest_issue": 959
+      },
+      "concept": {
+        "type": "FPSO",
+        "host": "FPSO (BW Pioneer) with subsea tieback",
+        "play": "Lower Tertiary (Wilcox)",
+        "milestone": {
+          "label": "First oil",
+          "value": "Feb 2012"
+        },
+        "fdp_href": "../field-development/portfolio/chinook.html",
+        "fdp_issue": 962
       },
       "provenance": "Life-cycle dates and ownership from public sources (Offshore Technology, Offshore Magazine, OGJ, Heerema, Rigzone); economics (capex $2.9B, plateau 75 mbopd, GOR 1400 scf/bbl, opex $18/boe) and data through from in-repo YAML. IMPORTANT: two YAML values were overridden as demonstrably wrong vs. well-documented public record — YAML first oil \"2021-08\" corrected to 2012-02 (Cascade first oil Feb 2012, Chinook Sep 2012; BW Pioneer was the first FPSO in the US GoM), and YAML operator/WI \"TotalEnergies 60% / Equinor 40%\" corrected to current MP Gulf of Mexico LLC (Murphy EXPRO 80% operator, Petrobras America 20%; originally Petrobras-operated with Total 33.33% in Chinook). LOW CONFIDENCE: FID year (sanction ~mid-2000s, no firm public citation — not available), lease year and projected end-of-production (not available); water depth 8,200 ft is the Cascade value (Chinook ~8,600 ft); capex is a YAML assumption not independently verified.",
       "norms": [
@@ -1056,6 +1089,17 @@
         ],
         "ingest_issue": 959
       },
+      "concept": {
+        "type": "Semisub FPU",
+        "host": "Semisubmersible FPU",
+        "play": "Lower Tertiary (Wilcox)",
+        "milestone": {
+          "label": "First oil",
+          "value": "Dec 2014"
+        },
+        "fdp_href": null,
+        "fdp_issue": 962
+      },
       "provenance": "Facts from in-repo YAML (operator, WI Chevron 51%/Equinor 24.5%/Suncor 24.5%, capex $7.5B, opex $15/boe, plateau 94 mbopd, GOR 1200, status producing, data through 2024-12-31). Life-cycle dates from public sources: St. Malo discovered Oct 2003 and Jack Jul 2004 (discovery year=2003, earliest of pair); FID/sanction Oct 2010; first oil per Chevron press release Dec 2014 (\"2014-12\") — this OVERRIDES the YAML's first oil \"2014-02-01\", which appears erroneous. Water depth ~7000 ft at the FPU (Jack WR758/759 ~7000 ft, St. Malo WR678). host = Semisubmersible FPU. projected end-of-production not confidently estimable. lease year not available; no schedule-driving incident.",
       "norms": [
         {
@@ -1324,6 +1368,17 @@
         ],
         "ingest_issue": 959
       },
+      "concept": {
+        "type": "Subsea tieback",
+        "host": "Subsea tieback to Jack/St. Malo semisubmersible FPU (Chevron)",
+        "play": "Lower Tertiary Wilcox",
+        "milestone": {
+          "label": "First oil",
+          "value": "Mar 2016"
+        },
+        "fdp_href": "../field-development/portfolio/julia.html",
+        "fdp_issue": 962
+      },
       "provenance": "Primary facts (capex $4.7B, plateau 34 mbopd, GOR 1000, opex $18/boe, first oil, WI 50/50) from in-repo julia.yml; first oil = BSEE OGOR-A first production (2016-03) per YAML — note ExxonMobil press release states production start April 2016. Operator corrected to ExxonMobil (YAML flagged its \"Equinor\" operator field as disputed; public record = ExxonMobil-operated, Equinor/Statoil 50% partner). Discovery 2007, FID May 2013, water depth 7000+ ft, Walker Ridge blocks, and Jack/St. Malo tieback from Offshore Technology and operator/trade press. lease year and projected end-of-production not confidently sourced.",
       "norms": [
         {
@@ -1566,6 +1621,17 @@
         ],
         "ingest_issue": 959
       },
+      "concept": {
+        "type": "Semisub FPU",
+        "host": "Semisubmersible FPU (20,000 psi)",
+        "play": "Lower Tertiary (Wilcox)",
+        "milestone": {
+          "label": "Sanctioned",
+          "value": "2024"
+        },
+        "fdp_href": null,
+        "fdp_issue": 962
+      },
       "provenance": "Discovery 2006 (Keathley Canyon 292, Lower Tertiary Wilcox), FID/sanction July 30 2024 (BP 100%, Devon's original 30% exited), first oil targeted 2029 but left blank as no oil has flowed and the Aug-2025 BOEM DPP rejection likely pushes it out. Public sanctioned figures used over YAML where they diverge: plateau/nameplate 80 mbopd (YAML said 120) and capex ~$5bn for Phase 1 (<$5B per BP; YAML total CAPEX 10000 = $10bn is a full-field/multi-phase estimate). GOR 1000 scf/bbl and data through 2024-12-31 from YAML. Water depth ~6,000 ft, 20,000-psi semisubmersible FPU. Low-confidence: capex (phase-1 vs full-field ambiguity), water depth (rounded), lease year unknown, opex unknown.",
       "norms": [
         {
@@ -1789,6 +1855,17 @@
           "operator_of_record_history"
         ],
         "ingest_issue": 959
+      },
+      "concept": {
+        "type": "Semisub FPU",
+        "host": "Newbuild Semisubmersible FPU",
+        "play": "Wilcox (Lower Tertiary / Paleogene)",
+        "milestone": {
+          "label": "Sanctioned",
+          "value": "2023"
+        },
+        "fdp_href": null,
+        "fdp_issue": 962
       },
       "provenance": "Basis: in-repo YAML (superseded TotalEnergies pre-FID case) reconciled against current public record. North Platte was discovered 2012 (Cobalt/Total, Garden Banks). TotalEnergies (then 60% op, Equinor 40%) withdrew Feb 2022; Shell bought 51% and took operatorship from Equinor (49%), redesigned and renamed the project \"Sparta.\" Shell took FID Dec 2023; first oil projected 2028 (left blank — not yet producing). Water depth ~4,265 ft, subsalt Wilcox, newbuild semisubmersible FPU (8 subsea wells) with ~90,000 boe/d peak (~75 mbopd oil plateau; GOR 1100 scf/bbl from YAML). LOW-CONFIDENCE: capex — YAML's $6B reflects the abandoned TotalEnergies ~$5-7B concept, not Shell's simplified Sparta scope (not publicly disclosed), so not available; opex and projected COP year not publicly defensible.",
       "norms": [
@@ -2039,6 +2116,17 @@
           "operator_of_record_history"
         ],
         "ingest_issue": 959
+      },
+      "concept": {
+        "type": "Semisub FPU",
+        "host": "Semisubmersible FPU (FPS, 20,000-psi)",
+        "play": "Wilcox (Lower Tertiary)",
+        "milestone": {
+          "label": "First oil",
+          "value": "Jul 2025"
+        },
+        "fdp_href": null,
+        "fdp_issue": 962
       },
       "provenance": "Base facts (operator, capex, plateau, GOR, data through) from in-repo YAML; discovery 2009 (Anadarko Shenandoah-1, WR52), FID/sanction Aug 2021 (Beacon+Navitas), and actual first oil (first of 4 wells online 25 Jul 2025; ramped to 100 kbopd plateau Oct 2025) from public sources — first oil corrected to 2025-07 vs YAML's placeholder 2025-10. Current WI (Beacon 31% op / Navitas 49% / HEQ 20%) post-2021 restructuring. CAPEX 1.8 is YAML-stated and largely reflects pre-development E&A spend (LOW CONFIDENCE for full development cost); OPEX and projected end-of-production, not available (not defensibly sourced); water depth ~5,800 ft.",
       "norms": [
@@ -2298,6 +2386,17 @@
         ],
         "ingest_issue": 959
       },
+      "concept": {
+        "type": "FPSO",
+        "host": "FPSO (Turritella / Stones FPSO, disconnectable)",
+        "play": "Lower Tertiary Wilcox",
+        "milestone": {
+          "label": "First oil",
+          "value": "Sep 2016"
+        },
+        "fdp_href": "../field-development/portfolio/stones.html",
+        "fdp_issue": 962
+      },
       "provenance": "Capex ($3.8bn), plateau (50 mbopd), GOR (850 scf/bbl), opex ($15/boe), first oil (2016-09) and status from in-repo stones.yml (Shell FPSO development config). Discovery (2005), FID/sanction (May 2013, Shell 100% owner-operator), Walker Ridge Block 508, ~9,500 ft water depth, and Turritella/Stones FPSO host (world's deepest FPSO) confirmed via Offshore Technology, Offshore Magazine, and NS Energy public sources. lease year and projected end-of-production unknown; no notable schedule-driving incident identified.",
       "norms": [
         {
@@ -2524,6 +2623,17 @@
           "operator_of_record_history"
         ],
         "ingest_issue": 959
+      },
+      "concept": {
+        "type": "Semisub FPU",
+        "host": "Semisubmersible FPU (single-lift topsides, Kaskida-derived design)",
+        "play": "Wilcox (Lower Tertiary / Paleogene)",
+        "milestone": {
+          "label": "Sanctioned",
+          "value": "2025"
+        },
+        "fdp_href": null,
+        "fdp_issue": 962
       },
       "provenance": "Basis: in-repo tiber.yml (operator BP, plateau 80 mbopd, GOR 900 scf/bbl, data through 2024-12-31) plus public sources. BP discovered Tiber Sept 2009 in Keathley Canyon 102, 4,132 ft water. BP reached FID on the combined Tiber-Guadalupe hub 29 Sep 2025 (FID year=2025); Seatrium awarded FPU EPCC. Ownership is now 100% BP (original discovery split BP 62% / Petrobras 20% / ConocoPhillips 18% no longer reflects current WI). Status: execution (post-FID, construction underway). capex set to the sanctioned public figure of $5.0bn for the Tiber-Guadalupe project (YAML's $8bn was a pre-FID Tiber-only planning assumption); note $5bn covers both fields. first oil left blank — oil has not flowed; projected first production is 2030. OPEX, not available (not publicly disclosed; the \"$3/bbl below Kaskida\" figure is development cost, not opex). projected end-of-production and lease year (not confidently sourced).",
       "norms": [

--- a/reports/lower_tertiary/lifecycle/anchor_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/anchor_lifecycle.html
@@ -283,6 +283,7 @@
 <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-concept"></div>
     <div id="f-landman"></div>
 
     <div class="body">
@@ -607,6 +608,17 @@ const FIELD = {
     ],
     "ingest_issue": 959
   },
+  "concept": {
+    "type": "Semisub FPU",
+    "host": "Semisubmersible FPU",
+    "play": "Lower Tertiary Wilcox",
+    "milestone": {
+      "label": "First oil",
+      "value": "Aug 2024"
+    },
+    "fdp_href": null,
+    "fdp_issue": 962
+  },
   "provenance": "Primary facts (operator, working interests, capex $5.6B, plateau 75 mbopd, GOR 1100 scf/bbl, opex $15/boe, first oil 2024-08, data through 2024-12-31) from in-repo anchor.yml. Life-cycle dates corroborated by public sources: discovery well Anchor-2 drilled 2014 (Green Canyon 807, ~5,180 ft), FID December 2019 (~$5.7B sanction), first oil August 2024 — world's first 20,000-psi HPHT deepwater development on a semisubmersible FPU, Lower Tertiary Wilcox play. Working interests (Chevron 62.5% / Equinor 25% / TotalEnergies 12.5%) per YAML; note older Offshore Technology page still lists pre-Equinor split (Chevron 62.86% / Total 37.14%). water depth ~5,180 (block-level estimate). projected end-of-production and lease year not confidently sourced; no notable incident.",
   "norms": [
     {
@@ -710,6 +722,23 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Concept & development panel (#759). Real concept/play/milestone for every
+// field + FDP link when a portfolio page exists, else a placeholder linking the
+// FDP-authoring issue.
+if (FIELD.concept) {
+  const C = FIELD.concept;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${C.fdp_issue}`;
+  const fdp = C.fdp_href
+    ? `<a href="${C.fdp_href}">FDP portfolio →</a>`
+    : `<a href="${iss}" style="color:var(--muted)">— concept detail pending</a>`;
+  const bits = [C.type, C.play].filter(Boolean).map(x => `<b>${x}</b>`).join(" · ");
+  const ms = C.milestone ? ` · ${C.milestone.label} ${C.milestone.value}` : "";
+  $("f-concept").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Concept &amp; development</h3>`
+    + `<p style="margin:0;font-size:13px;color:var(--muted)">${bits}${ms} · ${fdp}</p></section>`;
+}
 
 // Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
 // operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the

--- a/reports/lower_tertiary/lifecycle/big_foot_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/big_foot_lifecycle.html
@@ -283,6 +283,7 @@
 <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-concept"></div>
     <div id="f-landman"></div>
 
     <div class="body">
@@ -612,6 +613,17 @@ const FIELD = {
     ],
     "ingest_issue": 959
   },
+  "concept": {
+    "type": "eTLP",
+    "host": "Extended Tension-Leg Platform (eTLP)",
+    "play": "Wilcox / Lower Tertiary",
+    "milestone": {
+      "label": "First oil",
+      "value": "Nov 2018"
+    },
+    "fdp_href": null,
+    "fdp_issue": 962
+  },
   "provenance": "Data: big_foot.yml + Chevron public disclosures + BSEE (dates to be reconciled in #375)",
   "norms": [
     {
@@ -715,6 +727,23 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Concept & development panel (#759). Real concept/play/milestone for every
+// field + FDP link when a portfolio page exists, else a placeholder linking the
+// FDP-authoring issue.
+if (FIELD.concept) {
+  const C = FIELD.concept;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${C.fdp_issue}`;
+  const fdp = C.fdp_href
+    ? `<a href="${C.fdp_href}">FDP portfolio →</a>`
+    : `<a href="${iss}" style="color:var(--muted)">— concept detail pending</a>`;
+  const bits = [C.type, C.play].filter(Boolean).map(x => `<b>${x}</b>`).join(" · ");
+  const ms = C.milestone ? ` · ${C.milestone.label} ${C.milestone.value}` : "";
+  $("f-concept").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Concept &amp; development</h3>`
+    + `<p style="margin:0;font-size:13px;color:var(--muted)">${bits}${ms} · ${fdp}</p></section>`;
+}
 
 // Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
 // operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the

--- a/reports/lower_tertiary/lifecycle/cascade_chinook_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/cascade_chinook_lifecycle.html
@@ -283,6 +283,7 @@
 <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-concept"></div>
     <div id="f-landman"></div>
 
     <div class="body">
@@ -583,6 +584,17 @@ const FIELD = {
     ],
     "ingest_issue": 959
   },
+  "concept": {
+    "type": "FPSO",
+    "host": "FPSO (BW Pioneer) with subsea tieback",
+    "play": "Lower Tertiary (Wilcox)",
+    "milestone": {
+      "label": "First oil",
+      "value": "Feb 2012"
+    },
+    "fdp_href": "../field-development/portfolio/chinook.html",
+    "fdp_issue": 962
+  },
   "provenance": "Life-cycle dates and ownership from public sources (Offshore Technology, Offshore Magazine, OGJ, Heerema, Rigzone); economics (capex $2.9B, plateau 75 mbopd, GOR 1400 scf/bbl, opex $18/boe) and data through from in-repo YAML. IMPORTANT: two YAML values were overridden as demonstrably wrong vs. well-documented public record — YAML first oil \"2021-08\" corrected to 2012-02 (Cascade first oil Feb 2012, Chinook Sep 2012; BW Pioneer was the first FPSO in the US GoM), and YAML operator/WI \"TotalEnergies 60% / Equinor 40%\" corrected to current MP Gulf of Mexico LLC (Murphy EXPRO 80% operator, Petrobras America 20%; originally Petrobras-operated with Total 33.33% in Chinook). LOW CONFIDENCE: FID year (sanction ~mid-2000s, no firm public citation — not available), lease year and projected end-of-production (not available); water depth 8,200 ft is the Cascade value (Chinook ~8,600 ft); capex is a YAML assumption not independently verified.",
   "norms": [
     {
@@ -686,6 +698,23 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Concept & development panel (#759). Real concept/play/milestone for every
+// field + FDP link when a portfolio page exists, else a placeholder linking the
+// FDP-authoring issue.
+if (FIELD.concept) {
+  const C = FIELD.concept;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${C.fdp_issue}`;
+  const fdp = C.fdp_href
+    ? `<a href="${C.fdp_href}">FDP portfolio →</a>`
+    : `<a href="${iss}" style="color:var(--muted)">— concept detail pending</a>`;
+  const bits = [C.type, C.play].filter(Boolean).map(x => `<b>${x}</b>`).join(" · ");
+  const ms = C.milestone ? ` · ${C.milestone.label} ${C.milestone.value}` : "";
+  $("f-concept").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Concept &amp; development</h3>`
+    + `<p style="margin:0;font-size:13px;color:var(--muted)">${bits}${ms} · ${fdp}</p></section>`;
+}
 
 // Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
 // operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the

--- a/reports/lower_tertiary/lifecycle/jack_st_malo_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/jack_st_malo_lifecycle.html
@@ -283,6 +283,7 @@
 <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-concept"></div>
     <div id="f-landman"></div>
 
     <div class="body">
@@ -639,6 +640,17 @@ const FIELD = {
     ],
     "ingest_issue": 959
   },
+  "concept": {
+    "type": "Semisub FPU",
+    "host": "Semisubmersible FPU",
+    "play": "Lower Tertiary (Wilcox)",
+    "milestone": {
+      "label": "First oil",
+      "value": "Dec 2014"
+    },
+    "fdp_href": null,
+    "fdp_issue": 962
+  },
   "provenance": "Facts from in-repo YAML (operator, WI Chevron 51%/Equinor 24.5%/Suncor 24.5%, capex $7.5B, opex $15/boe, plateau 94 mbopd, GOR 1200, status producing, data through 2024-12-31). Life-cycle dates from public sources: St. Malo discovered Oct 2003 and Jack Jul 2004 (discovery year=2003, earliest of pair); FID/sanction Oct 2010; first oil per Chevron press release Dec 2014 (\"2014-12\") — this OVERRIDES the YAML's first oil \"2014-02-01\", which appears erroneous. Water depth ~7000 ft at the FPU (Jack WR758/759 ~7000 ft, St. Malo WR678). host = Semisubmersible FPU. projected end-of-production not confidently estimable. lease year not available; no schedule-driving incident.",
   "norms": [
     {
@@ -742,6 +754,23 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Concept & development panel (#759). Real concept/play/milestone for every
+// field + FDP link when a portfolio page exists, else a placeholder linking the
+// FDP-authoring issue.
+if (FIELD.concept) {
+  const C = FIELD.concept;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${C.fdp_issue}`;
+  const fdp = C.fdp_href
+    ? `<a href="${C.fdp_href}">FDP portfolio →</a>`
+    : `<a href="${iss}" style="color:var(--muted)">— concept detail pending</a>`;
+  const bits = [C.type, C.play].filter(Boolean).map(x => `<b>${x}</b>`).join(" · ");
+  const ms = C.milestone ? ` · ${C.milestone.label} ${C.milestone.value}` : "";
+  $("f-concept").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Concept &amp; development</h3>`
+    + `<p style="margin:0;font-size:13px;color:var(--muted)">${bits}${ms} · ${fdp}</p></section>`;
+}
 
 // Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
 // operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the

--- a/reports/lower_tertiary/lifecycle/julia_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/julia_lifecycle.html
@@ -283,6 +283,7 @@
 <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-concept"></div>
     <div id="f-landman"></div>
 
     <div class="body">
@@ -600,6 +601,17 @@ const FIELD = {
     ],
     "ingest_issue": 959
   },
+  "concept": {
+    "type": "Subsea tieback",
+    "host": "Subsea tieback to Jack/St. Malo semisubmersible FPU (Chevron)",
+    "play": "Lower Tertiary Wilcox",
+    "milestone": {
+      "label": "First oil",
+      "value": "Mar 2016"
+    },
+    "fdp_href": "../field-development/portfolio/julia.html",
+    "fdp_issue": 962
+  },
   "provenance": "Primary facts (capex $4.7B, plateau 34 mbopd, GOR 1000, opex $18/boe, first oil, WI 50/50) from in-repo julia.yml; first oil = BSEE OGOR-A first production (2016-03) per YAML — note ExxonMobil press release states production start April 2016. Operator corrected to ExxonMobil (YAML flagged its \"Equinor\" operator field as disputed; public record = ExxonMobil-operated, Equinor/Statoil 50% partner). Discovery 2007, FID May 2013, water depth 7000+ ft, Walker Ridge blocks, and Jack/St. Malo tieback from Offshore Technology and operator/trade press. lease year and projected end-of-production not confidently sourced.",
   "norms": [
     {
@@ -703,6 +715,23 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Concept & development panel (#759). Real concept/play/milestone for every
+// field + FDP link when a portfolio page exists, else a placeholder linking the
+// FDP-authoring issue.
+if (FIELD.concept) {
+  const C = FIELD.concept;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${C.fdp_issue}`;
+  const fdp = C.fdp_href
+    ? `<a href="${C.fdp_href}">FDP portfolio →</a>`
+    : `<a href="${iss}" style="color:var(--muted)">— concept detail pending</a>`;
+  const bits = [C.type, C.play].filter(Boolean).map(x => `<b>${x}</b>`).join(" · ");
+  const ms = C.milestone ? ` · ${C.milestone.label} ${C.milestone.value}` : "";
+  $("f-concept").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Concept &amp; development</h3>`
+    + `<p style="margin:0;font-size:13px;color:var(--muted)">${bits}${ms} · ${fdp}</p></section>`;
+}
 
 // Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
 // operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the

--- a/reports/lower_tertiary/lifecycle/kaskida_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/kaskida_lifecycle.html
@@ -283,6 +283,7 @@
 <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-concept"></div>
     <div id="f-landman"></div>
 
     <div class="body">
@@ -574,6 +575,17 @@ const FIELD = {
     ],
     "ingest_issue": 959
   },
+  "concept": {
+    "type": "Semisub FPU",
+    "host": "Semisubmersible FPU (20,000 psi)",
+    "play": "Lower Tertiary (Wilcox)",
+    "milestone": {
+      "label": "Sanctioned",
+      "value": "2024"
+    },
+    "fdp_href": null,
+    "fdp_issue": 962
+  },
   "provenance": "Discovery 2006 (Keathley Canyon 292, Lower Tertiary Wilcox), FID/sanction July 30 2024 (BP 100%, Devon's original 30% exited), first oil targeted 2029 but left blank as no oil has flowed and the Aug-2025 BOEM DPP rejection likely pushes it out. Public sanctioned figures used over YAML where they diverge: plateau/nameplate 80 mbopd (YAML said 120) and capex ~$5bn for Phase 1 (<$5B per BP; YAML total CAPEX 10000 = $10bn is a full-field/multi-phase estimate). GOR 1000 scf/bbl and data through 2024-12-31 from YAML. Water depth ~6,000 ft, 20,000-psi semisubmersible FPU. Low-confidence: capex (phase-1 vs full-field ambiguity), water depth (rounded), lease year unknown, opex unknown.",
   "norms": [
     {
@@ -656,6 +668,23 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Concept & development panel (#759). Real concept/play/milestone for every
+// field + FDP link when a portfolio page exists, else a placeholder linking the
+// FDP-authoring issue.
+if (FIELD.concept) {
+  const C = FIELD.concept;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${C.fdp_issue}`;
+  const fdp = C.fdp_href
+    ? `<a href="${C.fdp_href}">FDP portfolio →</a>`
+    : `<a href="${iss}" style="color:var(--muted)">— concept detail pending</a>`;
+  const bits = [C.type, C.play].filter(Boolean).map(x => `<b>${x}</b>`).join(" · ");
+  const ms = C.milestone ? ` · ${C.milestone.label} ${C.milestone.value}` : "";
+  $("f-concept").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Concept &amp; development</h3>`
+    + `<p style="margin:0;font-size:13px;color:var(--muted)">${bits}${ms} · ${fdp}</p></section>`;
+}
 
 // Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
 // operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the

--- a/reports/lower_tertiary/lifecycle/lifecycle_template.html
+++ b/reports/lower_tertiary/lifecycle/lifecycle_template.html
@@ -282,6 +282,7 @@
     <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-concept"></div>
     <div id="f-landman"></div>
 
     <div class="body">
@@ -435,6 +436,23 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Concept & development panel (#759). Real concept/play/milestone for every
+// field + FDP link when a portfolio page exists, else a placeholder linking the
+// FDP-authoring issue.
+if (FIELD.concept) {
+  const C = FIELD.concept;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${C.fdp_issue}`;
+  const fdp = C.fdp_href
+    ? `<a href="${C.fdp_href}">FDP portfolio →</a>`
+    : `<a href="${iss}" style="color:var(--muted)">— concept detail pending</a>`;
+  const bits = [C.type, C.play].filter(Boolean).map(x => `<b>${x}</b>`).join(" · ");
+  const ms = C.milestone ? ` · ${C.milestone.label} ${C.milestone.value}` : "";
+  $("f-concept").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Concept &amp; development</h3>`
+    + `<p style="margin:0;font-size:13px;color:var(--muted)">${bits}${ms} · ${fdp}</p></section>`;
+}
 
 // Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
 // operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the

--- a/reports/lower_tertiary/lifecycle/north_platte_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/north_platte_lifecycle.html
@@ -283,6 +283,7 @@
 <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-concept"></div>
     <div id="f-landman"></div>
 
     <div class="body">
@@ -577,6 +578,17 @@ const FIELD = {
     ],
     "ingest_issue": 959
   },
+  "concept": {
+    "type": "Semisub FPU",
+    "host": "Newbuild Semisubmersible FPU",
+    "play": "Wilcox (Lower Tertiary / Paleogene)",
+    "milestone": {
+      "label": "Sanctioned",
+      "value": "2023"
+    },
+    "fdp_href": null,
+    "fdp_issue": 962
+  },
   "provenance": "Basis: in-repo YAML (superseded TotalEnergies pre-FID case) reconciled against current public record. North Platte was discovered 2012 (Cobalt/Total, Garden Banks). TotalEnergies (then 60% op, Equinor 40%) withdrew Feb 2022; Shell bought 51% and took operatorship from Equinor (49%), redesigned and renamed the project \"Sparta.\" Shell took FID Dec 2023; first oil projected 2028 (left blank — not yet producing). Water depth ~4,265 ft, subsalt Wilcox, newbuild semisubmersible FPU (8 subsea wells) with ~90,000 boe/d peak (~75 mbopd oil plateau; GOR 1100 scf/bbl from YAML). LOW-CONFIDENCE: capex — YAML's $6B reflects the abandoned TotalEnergies ~$5-7B concept, not Shell's simplified Sparta scope (not publicly disclosed), so not available; opex and projected COP year not publicly defensible.",
   "norms": [
     {
@@ -659,6 +671,23 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Concept & development panel (#759). Real concept/play/milestone for every
+// field + FDP link when a portfolio page exists, else a placeholder linking the
+// FDP-authoring issue.
+if (FIELD.concept) {
+  const C = FIELD.concept;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${C.fdp_issue}`;
+  const fdp = C.fdp_href
+    ? `<a href="${C.fdp_href}">FDP portfolio →</a>`
+    : `<a href="${iss}" style="color:var(--muted)">— concept detail pending</a>`;
+  const bits = [C.type, C.play].filter(Boolean).map(x => `<b>${x}</b>`).join(" · ");
+  const ms = C.milestone ? ` · ${C.milestone.label} ${C.milestone.value}` : "";
+  $("f-concept").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Concept &amp; development</h3>`
+    + `<p style="margin:0;font-size:13px;color:var(--muted)">${bits}${ms} · ${fdp}</p></section>`;
+}
 
 // Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
 // operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the

--- a/reports/lower_tertiary/lifecycle/shenandoah_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/shenandoah_lifecycle.html
@@ -283,6 +283,7 @@
 <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-concept"></div>
     <div id="f-landman"></div>
 
     <div class="body">
@@ -603,6 +604,17 @@ const FIELD = {
     ],
     "ingest_issue": 959
   },
+  "concept": {
+    "type": "Semisub FPU",
+    "host": "Semisubmersible FPU (FPS, 20,000-psi)",
+    "play": "Wilcox (Lower Tertiary)",
+    "milestone": {
+      "label": "First oil",
+      "value": "Jul 2025"
+    },
+    "fdp_href": null,
+    "fdp_issue": 962
+  },
   "provenance": "Base facts (operator, capex, plateau, GOR, data through) from in-repo YAML; discovery 2009 (Anadarko Shenandoah-1, WR52), FID/sanction Aug 2021 (Beacon+Navitas), and actual first oil (first of 4 wells online 25 Jul 2025; ramped to 100 kbopd plateau Oct 2025) from public sources — first oil corrected to 2025-07 vs YAML's placeholder 2025-10. Current WI (Beacon 31% op / Navitas 49% / HEQ 20%) post-2021 restructuring. CAPEX 1.8 is YAML-stated and largely reflects pre-development E&A spend (LOW CONFIDENCE for full development cost); OPEX and projected end-of-production, not available (not defensibly sourced); water depth ~5,800 ft.",
   "norms": [
     {
@@ -706,6 +718,23 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Concept & development panel (#759). Real concept/play/milestone for every
+// field + FDP link when a portfolio page exists, else a placeholder linking the
+// FDP-authoring issue.
+if (FIELD.concept) {
+  const C = FIELD.concept;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${C.fdp_issue}`;
+  const fdp = C.fdp_href
+    ? `<a href="${C.fdp_href}">FDP portfolio →</a>`
+    : `<a href="${iss}" style="color:var(--muted)">— concept detail pending</a>`;
+  const bits = [C.type, C.play].filter(Boolean).map(x => `<b>${x}</b>`).join(" · ");
+  const ms = C.milestone ? ` · ${C.milestone.label} ${C.milestone.value}` : "";
+  $("f-concept").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Concept &amp; development</h3>`
+    + `<p style="margin:0;font-size:13px;color:var(--muted)">${bits}${ms} · ${fdp}</p></section>`;
+}
 
 // Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
 // operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the

--- a/reports/lower_tertiary/lifecycle/stones_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/stones_lifecycle.html
@@ -283,6 +283,7 @@
 <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-concept"></div>
     <div id="f-landman"></div>
 
     <div class="body">
@@ -590,6 +591,17 @@ const FIELD = {
     ],
     "ingest_issue": 959
   },
+  "concept": {
+    "type": "FPSO",
+    "host": "FPSO (Turritella / Stones FPSO, disconnectable)",
+    "play": "Lower Tertiary Wilcox",
+    "milestone": {
+      "label": "First oil",
+      "value": "Sep 2016"
+    },
+    "fdp_href": "../field-development/portfolio/stones.html",
+    "fdp_issue": 962
+  },
   "provenance": "Capex ($3.8bn), plateau (50 mbopd), GOR (850 scf/bbl), opex ($15/boe), first oil (2016-09) and status from in-repo stones.yml (Shell FPSO development config). Discovery (2005), FID/sanction (May 2013, Shell 100% owner-operator), Walker Ridge Block 508, ~9,500 ft water depth, and Turritella/Stones FPSO host (world's deepest FPSO) confirmed via Offshore Technology, Offshore Magazine, and NS Energy public sources. lease year and projected end-of-production unknown; no notable schedule-driving incident identified.",
   "norms": [
     {
@@ -693,6 +705,23 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Concept & development panel (#759). Real concept/play/milestone for every
+// field + FDP link when a portfolio page exists, else a placeholder linking the
+// FDP-authoring issue.
+if (FIELD.concept) {
+  const C = FIELD.concept;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${C.fdp_issue}`;
+  const fdp = C.fdp_href
+    ? `<a href="${C.fdp_href}">FDP portfolio →</a>`
+    : `<a href="${iss}" style="color:var(--muted)">— concept detail pending</a>`;
+  const bits = [C.type, C.play].filter(Boolean).map(x => `<b>${x}</b>`).join(" · ");
+  const ms = C.milestone ? ` · ${C.milestone.label} ${C.milestone.value}` : "";
+  $("f-concept").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Concept &amp; development</h3>`
+    + `<p style="margin:0;font-size:13px;color:var(--muted)">${bits}${ms} · ${fdp}</p></section>`;
+}
 
 // Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
 // operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the

--- a/reports/lower_tertiary/lifecycle/tiber_lifecycle.html
+++ b/reports/lower_tertiary/lifecycle/tiber_lifecycle.html
@@ -283,6 +283,7 @@
 <div class="metrics" id="f-metrics"></div>
     <div id="f-wells"></div>
     <div id="f-assets"></div>
+    <div id="f-concept"></div>
     <div id="f-landman"></div>
 
     <div class="body">
@@ -559,6 +560,17 @@ const FIELD = {
     ],
     "ingest_issue": 959
   },
+  "concept": {
+    "type": "Semisub FPU",
+    "host": "Semisubmersible FPU (single-lift topsides, Kaskida-derived design)",
+    "play": "Wilcox (Lower Tertiary / Paleogene)",
+    "milestone": {
+      "label": "Sanctioned",
+      "value": "2025"
+    },
+    "fdp_href": null,
+    "fdp_issue": 962
+  },
   "provenance": "Basis: in-repo tiber.yml (operator BP, plateau 80 mbopd, GOR 900 scf/bbl, data through 2024-12-31) plus public sources. BP discovered Tiber Sept 2009 in Keathley Canyon 102, 4,132 ft water. BP reached FID on the combined Tiber-Guadalupe hub 29 Sep 2025 (FID year=2025); Seatrium awarded FPU EPCC. Ownership is now 100% BP (original discovery split BP 62% / Petrobras 20% / ConocoPhillips 18% no longer reflects current WI). Status: execution (post-FID, construction underway). capex set to the sanctioned public figure of $5.0bn for the Tiber-Guadalupe project (YAML's $8bn was a pre-FID Tiber-only planning assumption); note $5bn covers both fields. first oil left blank — oil has not flowed; projected first production is 2030. OPEX, not available (not publicly disclosed; the \"$3/bbl below Kaskida\" figure is development cost, not opex). projected end-of-production and lease year (not confidently sourced).",
   "norms": [
     {
@@ -631,6 +643,23 @@ if (FIELD.assetsHref) $("f-assets").innerHTML =
   + `<span>▾ Asset drill-down · facility → asset → component → engineering</span><span>Open →</span></a>`;
 if (FIELD.statusHue) document.querySelector(".status").style.setProperty("--sc", FIELD.statusHue);
 $("f-prov").textContent = FIELD.provenance;
+
+// Concept & development panel (#759). Real concept/play/milestone for every
+// field + FDP link when a portfolio page exists, else a placeholder linking the
+// FDP-authoring issue.
+if (FIELD.concept) {
+  const C = FIELD.concept;
+  const iss = `https://github.com/vamseeachanta/worldenergydata/issues/${C.fdp_issue}`;
+  const fdp = C.fdp_href
+    ? `<a href="${C.fdp_href}">FDP portfolio →</a>`
+    : `<a href="${iss}" style="color:var(--muted)">— concept detail pending</a>`;
+  const bits = [C.type, C.play].filter(Boolean).map(x => `<b>${x}</b>`).join(" · ");
+  const ms = C.milestone ? ` · ${C.milestone.label} ${C.milestone.value}` : "";
+  $("f-concept").innerHTML =
+    `<section style="padding:18px clamp(18px,2.4vw,30px);border-top:1px solid var(--line)">`
+    + `<h3 style="margin:0 0 6px;font-size:15px">Concept &amp; development</h3>`
+    + `<p style="margin:0;font-size:13px;color:var(--muted)">${bits}${ms} · ${fdp}</p></section>`;
+}
 
 // Lease & landman panel (#951). Real: lease id, water depth, dev system, blocks,
 // operator, partner WI. Placeholders (status/dates/per-lease block/WI) LINK the

--- a/scripts/lower_tertiary/build_lifecycle_posters.py
+++ b/scripts/lower_tertiary/build_lifecycle_posters.py
@@ -41,6 +41,7 @@ from worldenergydata.field_development.hpht_risk import classify_hpht  # noqa: E
 from worldenergydata.field_development.landman import (  # noqa: E402
     build_landman,
 )
+from worldenergydata.field_development.concept import build_concept  # noqa: E402
 
 _SCRIPTS = Path(__file__).resolve().parents[1]
 if str(_SCRIPTS) not in sys.path:
@@ -77,6 +78,8 @@ FIELDS_REGISTRY = load_fields()
 # placeholders linking the ingest issue below. Build-time only (pandas); the
 # published site just copies the frozen posters + _explorer.json.
 _LEASE_INGEST_ISSUE = 959
+# FDP-authoring backlog for the 7 LT fields without a portfolio page (#759).
+_FDP_INGEST_ISSUE = 962
 _V30_DIR = (
     Path(__file__).resolve().parents[2]
     / "docs/modules/bsee/analysis/production/FDAS_V30"
@@ -396,6 +399,16 @@ def facts_to_field(f: dict) -> dict:
             _LEASE_ROWS,
             _LEASE_INGEST_ISSUE,
             registry_field.bsee_block_note,
+        ),
+        "concept": build_concept(
+            concept_label=concept_label,
+            host_type=f.get("host_type"),
+            play=f.get("play"),
+            first_oil=_pretty(g["first_oil"]) if g.get("first_oil") else None,
+            fid_year=g.get("fid_year"),
+            fdp_slug=registry_field.fdp_slug,
+            has_fdp=bool(registry_field.surfaces.get("fdp_page")),
+            fdp_issue=_FDP_INGEST_ISSUE,
         ),
         "provenance": f.get(
             "provenance", "Data: field YAML + public disclosures + BSEE"

--- a/src/worldenergydata/field_development/concept.py
+++ b/src/worldenergydata/field_development/concept.py
@@ -1,0 +1,57 @@
+# ABOUTME: Assemble a per-field concept/development block for the Explorer field view.
+# ABOUTME: Real concept for all fields; FDP link is registry-gated, else a placeholder (#759).
+"""
+worldenergydata.field_development.concept
+=========================================
+
+Build the concept/development panel: the field's development concept (tree
+type + host), play, and its lead development milestone (first oil for producers,
+sanction year for pre-production fields), plus a link to its FDP portfolio page
+when one exists.
+
+Only 3 of the 10 Lower Tertiary fields have a committed FDP page
+(``surfaces.fdp_page: true`` — cascade_chinook/julia/stones); the other 7 carry
+an ``fdp_slug`` but no page yet, so the panel shows a **placeholder linking the
+FDP-authoring ingest issue** (owner principle: missing data → grabbable issue,
+never silent omission).
+"""
+
+from __future__ import annotations
+
+
+def build_concept(
+    *,
+    concept_label: str | None,
+    host_type: str | None,
+    play: str | None,
+    first_oil: str | None,
+    fid_year: int | None,
+    fdp_slug: str | None,
+    has_fdp: bool,
+    fdp_issue: int,
+) -> dict:
+    """Return the concept block for one field.
+
+    ``first_oil`` is a display string (or ``None``); ``fid_year`` an int (or
+    ``None``). Lead milestone prefers first oil (producers) and falls back to
+    the sanction year (pre-production).
+    """
+    if first_oil:
+        milestone = {"label": "First oil", "value": first_oil}
+    elif fid_year is not None:
+        milestone = {"label": "Sanctioned", "value": str(fid_year)}
+    else:
+        milestone = None
+    fdp_href = (
+        f"../field-development/portfolio/{fdp_slug}.html"
+        if (has_fdp and fdp_slug)
+        else None
+    )
+    return {
+        "type": concept_label or host_type,
+        "host": host_type,
+        "play": play,
+        "milestone": milestone,
+        "fdp_href": fdp_href,
+        "fdp_issue": fdp_issue,
+    }

--- a/tests/integration/site/test_public_link_graph.py
+++ b/tests/integration/site/test_public_link_graph.py
@@ -350,6 +350,36 @@ def test_underwriting_risk_signals(public):
     assert hpht["anchor"]["exceedance_pct"] == 25
 
 
+def test_concept_fdp_links(public):
+    # #759: the concept.fdp_href is a JS-built link the data-driven edge extractor
+    # does NOT auto-catch, so assert it explicitly. Exactly 3 LT fields have an FDP
+    # page; their hrefs resolve; the other 7 carry a placeholder issue.
+    import re as _re
+
+    fields = _explorer(public)["fields"]
+    with_fdp = {
+        fid: c["concept"]["fdp_href"]
+        for fid, c in fields.items()
+        if c["concept"]["fdp_href"]
+    }
+    assert set(with_fdp) == {"cascade_chinook", "julia", "stones"}
+    for fid, href in with_fdp.items():
+        assert _re.fullmatch(
+            r"\.\./field-development/portfolio/[a-z_-]+\.html", href
+        ), href
+        assert (
+            public / "field-development/portfolio" / href.rsplit("/", 1)[1]
+        ).exists()
+    for fid, f in fields.items():
+        c = f["concept"]
+        assert c["fdp_issue"] == 962
+        if fid not in with_fdp:
+            assert c["fdp_href"] is None  # placeholder, not a dead link
+    # Milestone split (review correction): 7 first-oil / 3 sanctioned.
+    labels = [f["concept"]["milestone"]["label"] for f in fields.values()]
+    assert labels.count("First oil") == 7 and labels.count("Sanctioned") == 3
+
+
 def test_landman_lease_panel(public):
     # #951: all 10 LT fields carry a landman panel; 20 leases total; field-level
     # blocks only (NO per-lease block — false-precision guard); placeholders link

--- a/tests/unit/field_development/test_concept.py
+++ b/tests/unit/field_development/test_concept.py
@@ -1,0 +1,49 @@
+"""Unit tests for the concept/development block builder (issue #759)."""
+
+from __future__ import annotations
+
+from worldenergydata.field_development.concept import build_concept
+
+
+def _c(**kw):
+    base = dict(
+        concept_label="FPSO",
+        host_type="FPSO (BW Pioneer)",
+        play="Wilcox",
+        first_oil="Feb 2012",
+        fid_year=None,
+        fdp_slug="chinook",
+        has_fdp=True,
+        fdp_issue=962,
+    )
+    base.update(kw)
+    return build_concept(**base)
+
+
+def test_producer_shows_first_oil_and_fdp_link():
+    c = _c()
+    assert c["milestone"] == {"label": "First oil", "value": "Feb 2012"}
+    assert c["fdp_href"] == "../field-development/portfolio/chinook.html"
+
+
+def test_none_fid_year_with_first_oil_is_fine():
+    # cascade_chinook has fid_year=None but first_oil set (#759 review edge case).
+    c = _c(fid_year=None, first_oil="Feb 2012")
+    assert c["milestone"]["label"] == "First oil"
+
+
+def test_pre_production_shows_sanction_year():
+    c = _c(first_oil=None, fid_year=2024, has_fdp=False, fdp_slug="kaskida")
+    assert c["milestone"] == {"label": "Sanctioned", "value": "2024"}
+    # No FDP page -> placeholder (fdp_href None, issue carried).
+    assert c["fdp_href"] is None and c["fdp_issue"] == 962
+
+
+def test_no_milestone_when_no_dates():
+    c = _c(first_oil=None, fid_year=None)
+    assert c["milestone"] is None
+
+
+def test_type_falls_back_to_host():
+    c = _c(concept_label=None, host_type="Spar")
+    assert c["type"] == "Spar"


### PR DESCRIPTION
Closes #759 (epic #943, program #939). Planned via a parallel-agent workflow (grounding + adversarial verify); verdict APPROVE, partial-with-placeholder.

## What

A **Concept & development** card on the 10 LT posters + Explorer field panel:
- **Real for every field**: development concept (tree type + host), play, and lead milestone — **first oil for the 7 producers, sanction year for the 3 pre-production fields**.
- **FDP link** for the 3 fields with a committed portfolio page (cascade_chinook→chinook, julia, stones — resolved via the `config/fields.yml` registry crosswalk `surfaces.fdp_page`).
- **Placeholder** for the other 7: "— concept detail pending" linking the newly-filed FDP-authoring issue **#962** (owner placeholder-links-to-issue principle).

Rides the shipped poster payload → `_explorer.json` (new `concept` key, like risk/landman) — no new sidecar.

## Review corrections folded
- Milestone split is **7 first-oil / 3 sanctioned** (the draft said 6/4). cascade_chinook (`fid_year=None` but has first_oil) correctly shows First oil — covered by a unit test.
- The link-graph gate does NOT auto-catch `concept.fdp_href` (it only extracts wellsHref/assetsHref/economics/benchmark), so an **explicit FDP-href gate** asserts the 3 hrefs resolve to real pages and the 7 placeholders carry no dead link.

## Verification
- 139 tests (6 new: 5 concept units incl. the None-fid_year edge + the FDP-href gate). Green.
- Lint mirror clean; single-`<h1>` preserved (card heading is `<h3>`).
- **Disjoint from the parallel #945 PDF lane** — this PR touches only the poster generator + templates + concept module; it does NOT touch build_pages.py or add any export script.
