### PR TITLE
fix(spain): update stale Spain CORES adapter tests (#983)

### DIFF
--- a/tests/unit/production/unified/test_spain_cores_adapter_loader.py
+++ b/tests/unit/production/unified/test_spain_cores_adapter_loader.py
@@ -17,6 +17,10 @@ from worldenergydata.spain.production.cores_live import (
 )
 from worldenergydata.spain.production.cores_loader import GWH_TO_MCF, TONNES_TO_BBL
 
+# Cited operator-sourced Ayoluengo density factor accepted in 9f544b0c
+# (feat(spain): accept Ayoluengo operator density factor, Refs #807).
+AYOLUENGO_OPERATOR_BBL_PER_TONNE = 7.489986677157665
+
 
 class FixtureCoresLoader:
     """Duck-typed CORES loader returning normalized per-field monthly rows."""
@@ -173,9 +177,10 @@ def test_default_adapter_loads_committed_ayoluengo_fixture():
     assert set(out["source"]) == {"cores"}
     assert out["oil_bbl"].gt(0).any()
     audit = metadata["oil_conversion_audit"]
-    assert audit["coverage_status"] == "defaulted"
-    assert audit["defaulted_fields"] == ["Ayoluengo"]
-    assert audit["default_bbl_per_tonne"] == TONNES_TO_BBL
+    assert audit["coverage_status"] == "complete"
+    assert audit["used_fields"] == ["Ayoluengo"]
+    assert audit["defaulted_fields"] == []
+    assert audit["default_bbl_per_tonne"] is None
 
 
 def test_embedded_fixture_loader_exposes_default_density_metadata():
@@ -231,7 +236,9 @@ def test_adapter_accepts_live_cores_loader(tmp_path):
 
     assert list(out.columns) == list(STANDARD_COLUMNS)
     assert len(out) == 1
-    assert out.iloc[0]["oil_bbl"] == pytest.approx(2.0 * TONNES_TO_BBL)
+    assert out.iloc[0]["oil_bbl"] == pytest.approx(
+        2.0 * AYOLUENGO_OPERATOR_BBL_PER_TONNE
+    )
     assert out.iloc[0]["gas_mcf"] == pytest.approx(3.0 * GWH_TO_MCF)
     assert out.iloc[0]["source"] == "cores"
 


### PR DESCRIPTION
## Problem

`main` is red: two tests in `tests/unit/production/unified/test_spain_cores_adapter_loader.py` fail, which fails the required `Test (PR gate)` and blocks ALL PRs (e.g. the innocent assetutilities-pin bump #980).

- `test_default_adapter_loads_committed_ayoluengo_fixture` — `AssertionError: assert 'complete' == 'defaulted'`
- `test_adapter_accepts_live_cores_loader` — `assert 14.97997335431533 == 14.66 ± 1.5e-05`

## Bisect

Confirmed introducing commit for **both** failures:

**`9f544b0c` — feat(spain): accept Ayoluengo operator density factor (Refs #807)**

- At `9f544b0c^` both tests PASS; at HEAD both FAIL.
- That commit deliberately accepted Ayoluengo as a cited operator-sourced CORES density factor (API 37.0 → **7.489986677157665** bbl/tonne), regenerated the committed `_metadata.json` fixture to `coverage_status="complete"` / `used_fields=["Ayoluengo"]`, and updated the sibling `tests/unit/spain/*` tests (repointing the default-density path to a non-cited field, `Albatros`).
- It **missed** this `tests/unit/production/unified/` adapter test file.

## Decision: test-vs-code → TEST (both stale), not a regression

The behavior change was intentional and internally consistent (fixture + sibling tests + registry all updated together in one commit). Both failing tests still asserted the pre-`9f544b0c` `defaulted`/`7.33` behavior. `TONNES_TO_BBL` (7.33) and `DEFAULT_OIL_BBL_PER_TONNE` (7.33) are equal and unchanged — the higher value comes entirely from the newly-cited Ayoluengo factor, not a divergent constant. No code fix warranted.

- `test_default_adapter_loads_committed_ayoluengo_fixture` (real `CoresFixtureProductionLoader` reading the committed fixture): now expects `coverage_status="complete"`, `used_fields=["Ayoluengo"]`, `defaulted_fields=[]`, `default_bbl_per_tonne=None`.
- `test_adapter_accepts_live_cores_loader` (fully deterministic — writes a local tmp xlsx, no network; default registry now cites Ayoluengo): now expects `oil_bbl = 2.0 * 7.489986677157665` via a `AYOLUENGO_OPERATOR_BBL_PER_TONNE` constant mirroring the sibling `test_cores_live.py`.

## Verification

- Target file: 8 passed.
- Broader `tests/unit/production/`: 220 passed, 0 failed.
- Lint on changed file: `black --check` ✓, `isort --check-only` ✓, `flake8` ✓.

Refs #983