### PR TITLE
feat(capabilities): redirect capabilities overview to aceengineer.com hub [C10]

### DIFF
--- a/reports/capabilities/index.html
+++ b/reports/capabilities/index.html
@@ -3,249 +3,28 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>worldenergydata — Open Energy-Data Capabilities</title>
+<title>Capabilities have moved — AceEngineer</title>
+<!-- C10 (workspace-hub#3485 / #3494, decision A): aceengineer.com/capabilities is the single
+     canonical capabilities surface. This overview page redirects there and no longer carries
+     divergent capability copy (avoids figure drift + SEO cannibalization). Deep technical
+     content (insights hub, dashboards, one-pagers under /capabilities/) stays in this repo.
+     build_pages.py copies this file verbatim to /capabilities/index.html. -->
+<link rel="canonical" href="https://www.aceengineer.com/capabilities/">
+<meta name="robots" content="noindex, follow">
+<meta http-equiv="refresh" content="0; url=https://www.aceengineer.com/capabilities/">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--bg:#eef3fa;--panel:#ffffff;--ink:#13233f;
-        --muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc;--ok:#1f9d57;--warn:#b7791f;--side:288px}
-  *{box-sizing:border-box;margin:0;padding:0}
-  html{scroll-behavior:smooth}
-  body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;background:var(--bg);
-       color:var(--ink);line-height:1.5}
-  a{color:inherit;text-decoration:none}
-  code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;background:var(--soft);
-       border:1px solid var(--line);padding:1px 5px;border-radius:5px;font-size:12px}
-  .side{position:fixed;top:0;left:0;bottom:0;width:var(--side);background:#fff;
-        border-right:1px solid var(--line);display:flex;flex-direction:column;
-        padding:22px 16px;overflow-y:auto;z-index:20}
-  .side .brand{display:inline-flex;align-self:flex-start;background:#fff;border:1px solid var(--line);
-               border-radius:11px;padding:10px 14px;margin-bottom:6px}
-  .side .brand svg{height:30px;width:auto;display:block}
-  .side .tag{font-size:12px;color:var(--muted);margin:0 0 16px 3px}
-  .side nav{flex:1}
-  .navgroup{margin-bottom:4px}
-  .navh{display:block;font-size:13px;font-weight:700;color:var(--navy);padding:7px 10px;
-        border-radius:8px;border-left:3px solid transparent}
-  .navh:hover,.navh.active{background:var(--soft);border-left-color:var(--teal)}
-  .side .start{margin-top:14px;text-align:center;font-weight:700;color:#fff;
-               background:linear-gradient(135deg,var(--teal),var(--navy));padding:11px;
-               border-radius:11px}
-  main{margin-left:var(--side);max-width:1200px;padding:0 30px 80px}
-  .hero{padding:42px 4px 8px}
-  .hero h1{font-size:30px;font-weight:800;letter-spacing:-.4px;color:var(--navy)}
-  .hero p{color:var(--muted);font-size:17px;margin-top:10px;max-width:820px}
-  .hero .pill{display:inline-block;margin-top:16px;padding:4px 12px;border:1px solid var(--line);
-              background:#fff;border-radius:20px;color:var(--muted);font-size:12.5px}
-  .chan{margin-top:42px;scroll-margin-top:18px}
-  .chanhead{display:flex;align-items:center;justify-content:space-between;gap:14px;margin-bottom:6px;flex-wrap:wrap}
-  .chanhead h2{font-size:20px;border-left:4px solid var(--teal);padding-left:12px;color:var(--navy)}
-  .onepager{font-size:12px;font-weight:700;color:var(--navy);border:1px solid var(--line);
-            background:#fff;border-radius:9px;padding:6px 11px;white-space:nowrap}
-  .onepager:hover{border-color:var(--teal)}
-  .chan .lead{color:var(--muted);font-size:14px;padding-left:16px;margin-bottom:18px;max-width:820px}
-  .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(330px,1fr));gap:18px}
-  .card{display:flex;flex-direction:column;background:var(--panel);border:1px solid var(--line);
-        border-radius:16px;padding:18px 18px 16px;box-shadow:0 1px 2px rgba(16,40,80,.04);
-        transition:transform .15s,border-color .15s,box-shadow .15s}
-  .card:hover{transform:translateY(-3px);border-color:#b9cbe6;box-shadow:0 8px 22px rgba(16,40,80,.10)}
-  .card h3{font-size:15.5px;font-weight:700;line-height:1.3;color:var(--ink)}
-  .card .std{color:var(--teal);font-size:12px;font-weight:700;margin:5px 0 8px}
-  .card p{color:var(--muted);font-size:13.5px;flex:1}
-  .actions{display:flex;align-items:center;gap:8px;margin-top:14px;flex-wrap:wrap}
-  .actions .open{font-size:13px;font-weight:700;color:#fff;
-                 background:linear-gradient(135deg,var(--teal),var(--navy));padding:7px 13px;border-radius:10px}
-  .actions .sec{font-size:12.5px;font-weight:700;color:var(--navy);border:1px solid var(--line);
-                background:#fff;padding:6px 11px;border-radius:9px}
-  .actions .sec:hover{border-color:var(--teal)}
-  .actions .api{position:relative}
-  .actions .api:hover::after{content:attr(data-tip);position:absolute;left:0;bottom:132%;width:252px;
-    background:#0e1726;color:#e8eef9;font-size:11.5px;font-weight:500;line-height:1.45;
-    padding:9px 11px;border-radius:9px;box-shadow:0 6px 20px rgba(16,40,80,.25);z-index:9;white-space:normal}
-  .actions .api:hover::before{content:"";position:absolute;left:16px;bottom:122%;border:6px solid transparent;
-    border-top-color:#0e1726;z-index:9}
-  .actions .prompt{cursor:pointer}
-  .actions .prompt.copied{border-color:var(--ok);color:var(--ok)}
-  .tablewrap{overflow-x:auto;margin-top:6px}
-  table{width:100%;border-collapse:collapse;font-size:13.5px;background:var(--panel);
-        border:1px solid var(--line);border-radius:14px;overflow:hidden}
-  th,td{padding:9px 12px;text-align:left;border-bottom:1px solid var(--line)}
-  th{background:var(--soft);color:var(--muted);font-weight:700;font-size:11.5px;
-     text-transform:uppercase;letter-spacing:.4px}
-  tr:last-child td{border-bottom:none}
-  td.val{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;text-align:right}
-  .pub{color:var(--ok);font-weight:700}.der{color:var(--warn);font-weight:700}
-  .note{color:var(--muted);font-size:13px;margin:10px 0 0;padding-left:16px}
-  footer{margin-left:var(--side);text-align:center;color:var(--muted);font-size:13px;
-         padding:28px 30px 50px;border-top:1px solid var(--line)}
-  footer a{color:var(--teal)}
-  @media(max-width:980px){
-    :root{--side:0px}
-    .side{position:sticky;top:0;bottom:auto;width:auto;flex-direction:row;align-items:center;
-          gap:10px;overflow-x:auto;padding:9px 14px}
-    .side .brand{margin:0;flex:none}.side .tag,.side .start{display:none}
-    .side nav{display:flex;gap:6px}.navgroup{margin:0}
-    .navh{white-space:nowrap;border-left:0;border-bottom:3px solid transparent;padding:7px 10px}
-    .navh.active{border-left:0;border-bottom-color:var(--teal)}
-    main,footer{margin-left:0}.hero{padding-top:26px}
-  }
+  body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;background:#eef3fa;
+       color:#0B3D91;line-height:1.6;display:flex;min-height:100vh;align-items:center;
+       justify-content:center;margin:0;padding:24px;text-align:center}
+  a{color:#0f8a7e;font-weight:600}
 </style>
 </head>
 <body>
-<aside class="side">
-  <div class="brand">
-    <svg viewBox="0 0 400 64" role="img" aria-label="worldenergydata" xmlns="http://www.w3.org/2000/svg">
-      <g fill="none" stroke-width="3">
-        <circle cx="32" cy="32" r="23" stroke="#0B3D91"/>
-        <ellipse cx="32" cy="32" rx="9.5" ry="23" stroke="#2BB2A6" stroke-width="2.5"/>
-        <line x1="9" y1="32" x2="55" y2="32" stroke="#2BB2A6" stroke-width="2.5"/>
-        <line x1="13.5" y1="19" x2="50.5" y2="19" stroke="#0B3D91" stroke-width="2"/>
-        <line x1="13.5" y1="45" x2="50.5" y2="45" stroke="#0B3D91" stroke-width="2"/>
-      </g>
-      <circle cx="32" cy="32" r="3" fill="#2BB2A6"/>
-      <text x="74" y="43" font-family="-apple-system,'Segoe UI',Roboto,Arial,sans-serif"
-            font-size="31" font-weight="800" letter-spacing="-0.6">
-        <tspan fill="#0B3D91">world</tspan><tspan fill="#2BB2A6">energy</tspan><tspan fill="#0B3D91">data</tspan>
-      </text>
-    </svg>
-  </div>
-  <div class="tag">Open energy-data · deterministic outputs</div>
-  <nav>
-    <div class="navgroup"><a class="navh" href="#economics">Field economics</a></div>
-    <div class="navgroup"><a class="navh" href="#wells">Well operations</a></div>
-    <div class="navgroup"><a class="navh" href="#insights">Life-cycle insights</a></div>
-    <div class="navgroup"><a class="navh" href="#playbook">Field-development playbook</a></div>
-    <div class="navgroup"><a class="navh" href="#safety">Offshore safety &amp; HSE</a></div>
-    <div class="navgroup"><a class="navh" href="#validation">Sanctioned figures</a></div>
-  </nav>
-  <a class="start" href="../">All data outputs &rarr;</a>
-</aside>
-
-<main>
-  <header class="hero">
-    <!-- nav-spine --><div class="nav-spine" style="font:12px/1.6 ui-monospace,SFMono-Regular,Menlo,monospace;margin:0 0 10px;opacity:.75"><a href="../index.html">worldenergydata</a> ▸ <span>Capabilities</span></div>
-    <h1>worldenergydata — Open Energy-Data Capabilities</h1>
-    <p style="font-style:italic;font-size:14px;margin-top:6px">Everyday complex engineering — made deterministically simple.</p>
-    <p>Deterministic offshore field economics, a field-development playbook, and offshore safety
-    analytics &mdash; each result computed by unit-tested domain code on public regulatory filings,
-    frozen into a report artifact, and rendered to static HTML. Every work below opens a live page,
-    a 1-page client PDF, and a self-contained workflow-API call.</p>
-    <span class="pill">Live page · 1-page PDF · workflow-API call + starting prompt — for every capability</span>
-    <div style="margin-top:18px"><a href="../field-atlas/" style="display:inline-block;font-weight:700;color:#fff;background:linear-gradient(135deg,var(--teal),var(--navy));padding:10px 18px;border-radius:11px">Open the Field Explorer — drill Country &#9656; field &#9656; wells, with economics, underwriting &amp; landman lenses &rarr;</a></div>
-  </header>
-
-  <section class="chan" id="economics">
-    <div class="chanhead"><h2>Field economics &amp; benchmarking</h2><a class="onepager" href="pdf/sec-economics.pdf" download>Section 1-pager &darr;</a></div>
-    <p class="lead">Per-well, per-block and per-field NPV / MIRR / IRR for the seven Lower-Tertiary
-    deepwater fields, sanctioned against a frozen V30 golden baseline and guarded by a CI regression test.</p>
-    <div class="grid">
-      <div class="card"><h3>Anchor field economics</h3><div class="std">BSEE OGOR-A · sanctioned V30</div><p>Per-well stackup, NPV timeline and critical-operations detail.</p><div class="actions"><a class="open" href="../economics-anchor.html">Open &rarr;</a><a class="sec" href="pdf/economics-anchor.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/economics-anchor.html">API &rarr;</a></div></div>
-      <div class="card"><h3>Big Foot field economics</h3><div class="std">BSEE OGOR-A · sanctioned V30</div><p>Per-well stackup, NPV timeline and critical-operations detail.</p><div class="actions"><a class="open" href="../economics-big_foot.html">Open &rarr;</a><a class="sec" href="pdf/economics-big_foot.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/economics-big_foot.html">API &rarr;</a></div></div>
-      <div class="card"><h3>Cascade&ndash;Chinook field economics</h3><div class="std">BSEE OGOR-A · sanctioned V30</div><p>Per-well stackup, NPV timeline and critical-operations detail.</p><div class="actions"><a class="open" href="../economics-cascade_chinook.html">Open &rarr;</a><a class="sec" href="pdf/economics-cascade_chinook.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/economics-cascade_chinook.html">API &rarr;</a></div></div>
-      <div class="card"><h3>Jack / St. Malo field economics</h3><div class="std">BSEE OGOR-A · sanctioned V30</div><p>Per-well stackup, NPV timeline and critical-operations detail.</p><div class="actions"><a class="open" href="../economics-jack_st_malo.html">Open &rarr;</a><a class="sec" href="pdf/economics-jack_st_malo.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/economics-jack_st_malo.html">API &rarr;</a></div></div>
-      <div class="card"><h3>Julia field economics</h3><div class="std">BSEE OGOR-A · sanctioned V30</div><p>Per-well stackup, NPV timeline and critical-operations detail.</p><div class="actions"><a class="open" href="../economics-julia.html">Open &rarr;</a><a class="sec" href="pdf/economics-julia.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/economics-julia.html">API &rarr;</a></div></div>
-      <div class="card"><h3>Shenandoah field economics</h3><div class="std">BSEE OGOR-A · sanctioned V30</div><p>Per-well stackup, NPV timeline and critical-operations detail.</p><div class="actions"><a class="open" href="../economics-shenandoah.html">Open &rarr;</a><a class="sec" href="pdf/economics-shenandoah.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/economics-shenandoah.html">API &rarr;</a></div></div>
-      <div class="card"><h3>Stones field economics</h3><div class="std">BSEE OGOR-A · sanctioned V30</div><p>Per-well stackup, NPV timeline and critical-operations detail.</p><div class="actions"><a class="open" href="../economics-stones.html">Open &rarr;</a><a class="sec" href="pdf/economics-stones.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/economics-stones.html">API &rarr;</a></div></div>
-      <div class="card"><h3>Lower-Tertiary portfolio summary</h3><div class="std">field-by-field roll-up</div><p>The whole Lower-Tertiary play at a glance, aggregated from the per-field V30 economics.</p><div class="actions"><a class="open" href="../portfolio.html">Open &rarr;</a><a class="sec" href="pdf/portfolio.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/portfolio.html">API &rarr;</a></div></div>
-      <div class="card"><h3>Well benchmarking</h3><div class="std">BSEE OGOR-A · 2010&ndash;latest</div><p>Cross-field per-well performance, normalized cumulative &amp; rate comparisons.</p><div class="actions"><a class="open" href="../benchmark.html">Open &rarr;</a><a class="sec" href="pdf/benchmark.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/benchmark.html">API &rarr;</a></div></div>
-      <div class="card"><h3>Cross-country field benchmark</h3><div class="std">unified adapters · provenance-badged</div><p>Peak production, government take &amp; estimated operator NPV across offshore regions &mdash; every row badged real regulatory data vs illustrative seed, so no synthetic row is ever shown as real.</p><div class="actions"><a class="open" href="../field_benchmark/">Open &rarr;</a></div></div>
-    </div>
-  </section>
-
-  <section class="chan" id="wells">
-    <div class="chanhead"><h2>Well operations</h2><a class="onepager" href="pdf/sec-wells.pdf" download>Section 1-pager &darr;</a></div>
-    <p class="lead">Drilling and completion performance and well geometry reconstructed from BSEE
-    Well Activity Reports and directional surveys.</p>
-    <div class="grid">
-      <div class="card"><h3>Drilling &amp; completion days</h3><div class="std">BSEE Well Activity Reports</div><p>WAR-derived drilling &amp; completion durations for 217 wells across the 12 Lower-Tertiary fields, with medians by field.</p><div class="actions"><a class="open" href="../completion/">Open &rarr;</a><a class="sec" href="pdf/completion.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/completion.html">API &rarr;</a></div></div>
-      <div class="card"><h3>Julia well paths (3D)</h3><div class="std">BSEE directional surveys</div><p>Interactive 3D directional surveys &mdash; Plotly + Three.js renderers from one frozen JSON contract.</p><div class="actions"><a class="open" href="../well-path.html">Open &rarr;</a><a class="sec" href="pdf/well-path.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/well-path.html">API &rarr;</a></div></div>
-    </div>
-  </section>
-
-  <section class="chan" id="insights">
-    <div class="chanhead"><h2>Life-cycle insights</h2><a class="onepager" href="insights.html">Insights hub &rarr;</a></div>
-    <p class="lead">Front-door analyses along the offshore well life-cycle &mdash; Drill &rarr; Complete &rarr;
-    Produce &rarr; Workover &rarr; Decommission &mdash; each a single thesis backed by a number, computed
-    deterministically from public BSEE data. The <a href="insights.html">Insights hub</a> arranges them on the
-    life-cycle spine.</p>
-    <div class="grid">
-      <div class="card"><h3>Life-cycle Insights hub</h3><div class="std">Drill &rarr; Decommission spine</div><p>Every insight below arranged along the well life-cycle, plus the cross-cutting region and all-regions comparisons.</p><div class="actions"><a class="open" href="insights.html">Open &rarr;</a></div></div>
-      <div class="card"><h3>GoM Lower-Tertiary drilling learning curve</h3><div class="std">BSEE Well Activity Reports &middot; 184 wellbores</div><p>11,124 rig-days across 184 development wellbores; each +1,000 ft TVD adds only ~3.3 days and depth explains just 11% of the spread &mdash; execution, not geology, drives the curve.</p><div class="actions"><a class="open" href="../drilling-insights.html">Open &rarr;</a></div></div>
-      <div class="card"><h3>Region &times; development-type</h3><div class="std">SubseaIQ &times; BSEE crosswalk</div><p>Deepwater is wet-tree country: past ~1500 m the dry-tree share of producing trees collapses from 80% on the shelf to 20% in ultra-deepwater.</p><div class="actions"><a class="open" href="../region-devtype-comparison.html">Open &rarr;</a></div></div>
-      <div class="card"><h3>All-regions field atlas</h3><div class="std">205 countries in atlas scope &middot; 84 with offshore-field data</div><p>Reference-depth coverage across 205 countries in atlas scope, 84 with offshore-field data, the Gulf of Mexico at full life-cycle depth &mdash; 1 RICH region, 78 SAMPLE-reference, 5 ROADMAP. The Field Explorer's Country selector is the interactive way in.</p><div class="actions"><a class="open" href="../all-regions-atlas.html">Open &rarr;</a></div></div>
-      <div class="card"><h3>Well pressure atlas</h3><div class="std">GoM Lower Tertiary &times; Mid-Continent gas</div><p>Offshore HPHT over-pressure vs onshore under-pressure, browsable across the US Gulf of Mexico Lower Tertiary and the Mid-Continent gas basins &mdash; every pressure traced to a disclosed source, gaps rendered honestly.</p><div class="actions"><a class="open" href="../pressure-atlas/">Open &rarr;</a></div></div>
-      <div class="card"><h3>GoM P&amp;A liability wave</h3><div class="std">BSEE well inventory &middot; Abandon stage</div><p>8,161 boreholes drilled but not permanently plugged &mdash; $65&ndash;73B of latent P&amp;A liability, with 3,288 temporarily-abandoned wells ($26B) the imminent, Idle-Iron-overdue crest.</p><div class="actions"><a class="open" href="../decommissioning/pa-liability-wave.html">Open &rarr;</a></div></div>
-      <div class="card"><h3>Subsea intervention serviceability</h3><div class="std">well-inventory &times; fleet &middot; Workover stage</div><p>270 subsea wells sit in the 5,000&ndash;10,000 ft band against only ~3 GoM-resident heavy units &mdash; a 4.4&times; access-gap ratio and ~$1.0B/yr of exposure.</p><div class="actions"><a class="open" href="../intervention-db/intervention-stats-brief.html#serviceability">Open &rarr;</a></div></div>
-    </div>
-  </section>
-
-  <section class="chan" id="playbook">
-    <div class="chanhead"><h2>Offshore field-development playbook</h2><a class="onepager" href="pdf/sec-playbook.pdf" download>Section 1-pager &darr;</a></div>
-    <p class="lead">From a field's parameters to a ranked development concept, a to-scale subsea
-    schematic and indicative economics &mdash; generated deterministically across ~2,150 offshore
-    fields (333 in the Gulf of Mexico).</p>
-    <div class="grid">
-      <div class="card"><h3>Capability showcase</h3><div class="std">concept &rarr; schematic &rarr; economics</div><p>What the playbook produces end-to-end, with generated schematics for real fields across every offshore region.</p><div class="actions"><a class="open" href="../field-development/showcase.html">Open &rarr;</a><a class="sec" href="pdf/fd-showcase.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/fd-showcase.html">API &rarr;</a></div></div>
-      <div class="card"><h3>Interactive playbook</h3><div class="std">live sliders</div><p>Move water depth / reserves / tieback and watch the recommended concept and schematic update live.</p><div class="actions"><a class="open" href="../field-development/playbook.html">Open &rarr;</a><a class="sec" href="pdf/fd-playbook.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/fd-playbook.html">API &rarr;</a></div></div>
-      <div class="card"><h3>Deepwater portfolio</h3><div class="std">10-field Gulf of Mexico</div><p>Full field-development plans, one page per field, with DEXPI-style layout and 3D hardware.</p><div class="actions"><a class="open" href="../field-development/portfolio/">Open &rarr;</a><a class="sec" href="pdf/fd-portfolio.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/fd-portfolio.html">API &rarr;</a></div></div>
-      <div class="card"><h3>BSEE-matched fields</h3><div class="std">recommended vs as-built</div><p>Concept + schematics across 115 BSEE-cross-referenced Gulf of Mexico fields.</p><div class="actions"><a class="open" href="../field-development/bsee-matched/">Open &rarr;</a><a class="sec" href="pdf/fd-bsee-matched.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/fd-bsee-matched.html">API &rarr;</a></div></div>
-      <div class="card"><h3>Field life-cycle gallery</h3><div class="std">stage-gate &ldquo;page 1&rdquo; &middot; Acquire &rarr; Abandon</div><p>Each field's real gate dates (discovery &rarr; FID &rarr; first oil) plotted on the life-cycle spine, across 10 Lower-Tertiary fields.</p><div class="actions"><a class="open" href="../lifecycle/">Open &rarr;</a></div></div>
-    </div>
-  </section>
-
-  <section class="chan" id="safety">
-    <div class="chanhead"><h2>Offshore safety &amp; HSE</h2><a class="onepager" href="pdf/sec-safety.pdf" download>Section 1-pager &darr;</a></div>
-    <p class="lead">Public marine-casualty and offshore-incident data, normalized and analysed
-    deterministically &mdash; incident classification, cause-event breakdowns, and engineering
-    screens anchored to real failures.</p>
-    <div class="grid">
-      <div class="card"><h3>Marine safety analytics</h3><div class="std">TSB · IMO GISIS · MAIB</div><p>Cross-database casualty analysis over 102,618 incident records &mdash; the executive summary and entry point.</p><div class="actions"><a class="open" href="../marine_safety/executive_summary.html">Open &rarr;</a><a class="sec" href="pdf/ms-exec.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/ms-exec.html">API &rarr;</a></div></div>
-      <div class="card"><h3>Fatality analysis</h3><div class="std">cross-database</div><p>Fatal-incident breakdown and patterns across the combined casualty databases.</p><div class="actions"><a class="open" href="../marine_safety/fatality_analysis.html">Open &rarr;</a><a class="sec" href="pdf/ms-fatality.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/ms-fatality.html">API &rarr;</a></div></div>
-      <div class="card"><h3>Foundering analysis</h3><div class="std">cross-database</div><p>Foundering-incident breakdown, fatality distribution and patterns.</p><div class="actions"><a class="open" href="../marine_safety/foundering_analysis.html">Open &rarr;</a><a class="sec" href="pdf/ms-foundering.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/ms-foundering.html">API &rarr;</a></div></div>
-      <div class="card"><h3>Hatch analysis</h3><div class="std">cross-database</div><p>Hatch-maloperation incidents detected and classified by severity.</p><div class="actions"><a class="open" href="../marine_safety/hatch_analysis.html">Open &rarr;</a><a class="sec" href="pdf/ms-hatch.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/ms-hatch.html">API &rarr;</a></div></div>
-      <div class="card"><h3>IMO GISIS casualties</h3><div class="std">13,338 casualties · 1900&ndash;2025</div><p>Marine casualties by severity, vessel type and flag state from the IMO GISIS public database.</p><div class="actions"><a class="open" href="../IMO_GISIS_Executive_Report.html">Open &rarr;</a><a class="sec" href="pdf/imo.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/imo.html">API &rarr;</a></div></div>
-      <div class="card"><h3>Mooring-fatigue grounded card</h3><div class="std">DNV-OS-E301 T-N curves</div><p>Fatigue-life screening anchored to real BSEE mooring-failure incidents (governing line 18.4-yr vs 25-yr design).</p><div class="actions"><a class="open" href="../hse/mooring-fatigue-grounded-card.html">Open &rarr;</a><a class="sec" href="pdf/mooring.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/mooring.html">API &rarr;</a></div></div>
-    </div>
-  </section>
-
-  <section class="chan" id="validation">
-    <div class="chanhead"><h2>Sanctioned against frozen baselines</h2><a class="onepager" href="pdf/sec-validation.pdf" download>Section 1-pager &darr;</a></div>
-    <p class="note"><strong>Full validation &mdash; four linked reports:</strong>
-       <a href="../wo-april-2026-validation.html">World&nbsp;Oil April&nbsp;2026 article validation</a> (all four article tables reconciled, per-discrepancy comparison tables, BOEM reserves cross-check) &middot;
-       <a href="../completion/verification.html">live D&amp;C reconciliation &amp; 217-wellbore verification</a> &middot;
-       <a href="../fdas-revision-comparison.html">FDAS revision comparison &amp; V50-vs-wed reconciliation</a> (D&amp;C and financials, field-by-field and well-by-well) &mdash;
-       <a href="../economics-buckskin.html">Buckskin V50-KC economics recompute</a> (KC lease/D&amp;C input set and wed V50 NPV) &mdash;
-       every D&amp;C and financial number reconciled against the article on the current <strong>wed&nbsp;canonical (V50 / latest)</strong> basis.</p>
-    <p class="note"><span class="pub">■ sanctioned-baseline</span> = reproduces the frozen V30 golden baseline within tolerance (CI-guarded; V30 retained as the reproduction anchor, superseded by V50/latest for presented numbers);
-       <span class="der">■ data-derived</span> = aggregated directly from public regulatory filings.</p>
-    <div class="tablewrap"><table>
-      <thead><tr><th>Surface</th><th>Case</th><th>Result</th><th>Basis</th></tr></thead>
-      <tbody>
-        <tr><td>V30 field economics</td><td>Julia (G20351) terminal NPV @10%</td><td class="val">&minus;$530.6 M</td><td class="pub">sanctioned golden_baseline_v30</td></tr>
-        <tr><td>V30 field economics</td><td>Stones (G17001) terminal NPV @10%</td><td class="val">&minus;$1 479.5 M</td><td class="pub">sanctioned golden_baseline_v30</td></tr>
-        <tr><td>V30 field economics</td><td>Anchor terminal NPV @10%</td><td class="val">&minus;$1 732.8 M</td><td class="pub">sanctioned golden_baseline_v30</td></tr>
-        <tr><td><a href="../fdas-revision-comparison.html">FDAS revision comparison</a></td><td>V50-vs-wed D&amp;C + component economics</td><td class="val">D&amp;C Δ=0; 40 component rows verified</td><td class="pub">2026-04 wed-latest reconciliation</td></tr>
-        <tr><td>Julia price sensitivity</td><td>dNPV / d(realized WTI)</td><td class="val">+$16.3 M per $1/bbl</td><td class="pub">V30 model</td></tr>
-        <tr><td>Julia breakeven</td><td>realized-WTI price at NPV = 0</td><td class="val">$99 / bbl</td><td class="pub">V30 model</td></tr>
-        <tr><td>Julia MIRR</td><td>annual, life-to-date</td><td class="val">6.31 %</td><td class="pub">V30 model</td></tr>
-        <tr><td>Portfolio roll-up</td><td>cumulative oil, 6 active LT fields</td><td class="val">685.0 MMbbl</td><td class="der">BSEE OGOR-A</td></tr>
-        <tr><td>Portfolio roll-up</td><td>producing wells / federal leases</td><td class="val">158 / 19</td><td class="der">BSEE OGOR-A (Sep&nbsp;2000&ndash;Jul&nbsp;2025)</td></tr>
-        <tr><td>Drilling &amp; completion days</td><td>wells / fields covered (WAR-derived)</td><td class="val">217 / 12</td><td class="der">BSEE Well Activity Reports</td></tr>
-        <tr><td>Drilling &amp; completion days</td><td>median drilling / completion span</td><td class="val">38 d / 24 d</td><td class="der">BSEE WAR (V30 day-count method)</td></tr>
-        <tr><td>Marine-safety analytics</td><td>incident records analysed / fatalities</td><td class="val">102 618 / 7 349</td><td class="der">TSB · IMO GISIS · MAIB</td></tr>
-        <tr><td>IMO GISIS casualties</td><td>marine casualties, 1900&ndash;2025</td><td class="val">13 338</td><td class="der">IMO GISIS public database</td></tr>
-        <tr><td>Playbook coverage</td><td>global offshore fields (GoM subset)</td><td class="val">~2 150 (333)</td><td class="der">SubseaIQ catalog</td></tr>
-        <tr><td>BSEE-matched concepts</td><td>recommended vs as-built fields</td><td class="val">115</td><td class="der">BSEE × SubseaIQ join</td></tr>
-      </tbody>
-    </table></div>
-  </section>
-
-</main>
-
-<footer>
-  Built by <code>scripts/build_pages.py</code> from frozen report artifacts under <code>reports/**</code>;
-  1-page PDFs and workflow-API artifacts by <code>scripts/capabilities/build_onepagers.py</code>.
-  Every figure traces to a public regulatory filing; the sanctioned economics reproduce a frozen reference in
-  <a href="https://github.com/vamseeachanta/worldenergydata/blob/main/config/analysis/lower_tertiary/golden_baseline_v30.yml">golden_baseline_v30.yml</a>,
-  CI-guarded so a published number can never silently drift.
-</footer>
+  <main>
+    <p><strong>Our capabilities now live at
+      <a href="https://www.aceengineer.com/capabilities/">aceengineer.com/capabilities</a>.</strong></p>
+    <p>Redirecting… if you are not redirected,
+      <a href="https://www.aceengineer.com/capabilities/">follow this link</a>.</p>
+  </main>
 </body>
 </html>

--- a/tests/test_build_pages.py
+++ b/tests/test_build_pages.py
@@ -184,3 +184,20 @@ def test_registry_keys_match_reports_dirs(bp):
         assert (
             reports / name
         ).is_dir(), f"DOMAINS key {name!r} has no reports/{name}/ dir"
+
+
+def test_capabilities_overview_is_a_redirect_stub_to_the_hub(bp):
+    # C10 (workspace-hub#3485 / #3494, decision A): the /capabilities/ OVERVIEW page
+    # redirects to the single canonical surface (aceengineer.com/capabilities) instead
+    # of carrying divergent capability copy that could figure-drift or cannibalize SEO.
+    # This guards against the divergent overview creeping back in.
+    bp.build_capabilities({})
+    out = bp.PUBLIC / "capabilities" / "index.html"
+    assert out.exists()
+    html = out.read_text()
+    assert 'rel="canonical"' in html
+    assert "https://www.aceengineer.com/capabilities/" in html
+    assert 'http-equiv="refresh"' in html
+    assert 'content="noindex, follow"' in html
+    # the old hand-authored overview copy must not return to this page
+    assert "Capability Showcase" not in html


### PR DESCRIPTION
Part of epic **workspace-hub#3485** — **C10**, decision A (**workspace-hub#3494**). Plan approved by owner 2026-07-12. Pairs with digitalmodel#1573 (same stub).

Converts the GitHub Pages capabilities **overview** into a redirect stub to the single canonical surface at [aceengineer.com/capabilities](https://www.aceengineer.com/capabilities/).

## Changes
- **`reports/capabilities/index.html`** → redirect stub: **meta-refresh + `rel=canonical` + `noindex, follow` + visible link**. `build_pages.build_capabilities()` copies this file **verbatim** to `/capabilities/index.html`, so **no generator change is needed** — and nothing else regenerates it (verified), so it can't drift back.
- **`tests/test_build_pages.py`** — regression guard: the built `/capabilities/index.html` must be a redirect stub (canonical + refresh + noindex) and must **not** contain the old overview copy ("Capability Showcase").

## Scope / safety (decision A = landing page only)
- **Deep technical content stays:** the Insights hub (`insights.html`), one-pager PDFs (`pdf/`), and workflow-API artifacts (`api/`) under `/capabilities/` are **untouched** — `build_capabilities()` still publishes them.
- `noindex, follow` drops the duplicate from search while passing authority to the canonical hub (the #971 figure-drift / SEO-cannibalization lesson).

## Verified
- `black --check` + `isort --check` clean on the changed test (the CI Lint gate — the #821/#822 toolchain); flake8 is `src/`-only.
- `pytest tests/test_build_pages.py` → **13/13** (incl. the new guard), run with the repo's `--noconftest` recipe (conftest needs plotly).