### PR TITLE
docs(cost): contract-award asset registry — tranche 1 research record

### DIFF
--- a/docs/modules/cost/research/2026-07-14-contract-award-asset-registry-tranche1.md
+++ b/docs/modules/cost/research/2026-07-14-contract-award-asset-registry-tranche1.md
@@ -1,0 +1,179 @@
+# Contract-award asset registry — tranche 1 research record (2026-07-14)
+
+**Issue:** vamseeachanta/worldenergydata#1020 · feeds decision **A1** in #1017
+**Method:** three parallel research passes over the 12 strongest reconciliation-anchor
+projects (Guyana ×4, US GoM ×4, international ×4), collecting public contract awards
+by asset class (production_hub / sps / surf / installation / drilling_rig / other)
+AND operator/partner annual-statement / SEC-filing figures.
+
+## Synthesis
+
+### Publicly-valued award coverage vs sanctioned gross CAPEX
+
+| Project | Sanctioned gross | Valued-award coverage | Best anchors |
+|---|---|---|---|
+| GranMorgu | $10.5bn | ~45% | Saipem SURF **$1.9bn explicit**; TFMC iEPCI >$1bn; T.EN topsides >€1bn; Noble $753M firm |
+| Yellowtail | $10.0bn | ~40–45% | ONE GUYANA buyout $2.32bn; TFMC "large" $0.5–1bn; Saipem ≤$1.1bn combined |
+| Liza Phase 2 | $6.0bn | ~60% (incl lease-cap overlap) | Unity buyout $1.26bn; lease cap $1.6bn; Saipem ~$0.7bn explicit |
+| Liza Phase 1 | $4.4bn | ~40% | lease cap $1.2bn; Destiny buyout $535M |
+| Payara | $9.0bn | ~30–35% | Prosperity buyout $1.23bn; TFMC "large" $0.5–1bn; Saipem ≤$0.88bn combined |
+| Bacalhau | $8.0bn | ~20% | Subsea7 "major" >$750M; Seadrill $380M+$114M; services $455M |
+| Sangomar | $5.0bn final | ~10–15% | SIA "very large" $0.5–0.75bn (Subsea7 share); MODEC FPSO price not public |
+| Barossa | $3.6bn FID | small (capex-like) | BW Opal $4.6bn is 15-yr LEASE+OPEX, not capex; Subsea7 $0.3–0.5bn; TFMC $75–250M |
+| Anchor | $5.7bn | ~15% | Transocean Titan $830M backlog; everything else frame-agreement-undisclosed |
+| Kaskida | <$5.0bn | ~10–15% | TFMC iEPCI "substantial" $250–500M; Transocean Atlas $232M |
+| Ballymore | $1.6bn | ~4–10% | Subsea7 "sizeable" $50–150M; Expro >$15M |
+| Whale | not disclosed | 0% | zero public values — Shell frame agreements throughout |
+
+### Structural findings
+
+1. **Contractor disclosure incentives, not operator ones, set visibility.** Hard values
+   exist where the CONTRACTOR reports to its own investors: Transocean backlog releases,
+   SBM buyout/financing disclosures, Saipem explicit values, TFMC/Subsea7/T.EN band words.
+   US GoM operators procure hulls/topsides/trees/SURF under long-term frame agreements
+   with values never announced.
+2. **Band definitions (verified verbatim from publishers):** TechnipFMC significant $75–250M,
+   large $500M–$1bn, substantial $250–500M, major >$1bn · Subsea7 sizeable $50–150M,
+   large $300–500M, very large $500–750M, major >$750M · Technip Energies major >€1bn.
+   A band is a sourced RANGE — usable as low/high bounds, never a point.
+3. **Partner statements are the second ladder** (per owner direction): Hess discloses
+   per-project net shares — and the Yellowtail reconciliation proves Hess "net share"
+   EXCLUDES the FPSO element ($2.3bn ÷ 30% = $7.67bn ≈ $10bn − $2.32bn FPSO). APA's
+   10-K carries the GranMorgu carry mechanics (12.5% of first $10bn + 25% of next $5bn).
+   SK E&S's $1.4bn ≈ 37.5% × Barossa $3.6bn. CNOOC and TotalEnergies disclose interests
+   but not project-level nets.
+4. **SBM FPSO buyouts give hard production_hub anchors for all four Guyana hulls**:
+   $535M (Destiny), $1.26bn (Unity), $1.23bn (Prosperity), $2.32bn (ONE GUYANA), each with
+   its project-financing figure.
+5. **Integrated awards blur asset classes**: SIA SPS+SURF single contracts (band = Subsea7
+   share only); Kaskida TFMC iEPCI spans sps+surf (must not double-count); installation is
+   usually embedded in SURF EPCIs — standalone transport/installation awards (Boskalis,
+   SBM, Ocean Installer) are almost never valued.
+6. **Premise corrections from verification**: Anchor SPS = OneSubsea (not TechnipFMC);
+   Ballymore had NO TechnipFMC iEPCI; Whale SURF = McDermott (not Subsea7). Registry rows
+   record what sources actually attribute.
+7. **Cost-trail bonus**: Woodside's Sangomar disclosures give a complete FID→final trail
+   ($4.2bn → $4.6bn → $4.9–5.2bn → ~$5.0bn final) — a sourced cost-growth curve for one
+   project; Santos Barossa similarly ($3.6bn → $4.5–4.6bn incl DPD).
+
+## Raw research record (verbatim from the three passes)
+
+AWARD|Liza Phase 1|2017|SBM Offshore|production_hub|Liza Destiny FPSO construct+install+lease&operate up to 10yr|VALUE-NOT-PUBLIC at award (~1200 lease cap in FID cost)|SBM/Offshore Energy — https://www.offshore-energy.biz/sbm-confirms-fpso-contract-award-for-liza-project/
+AWARD|Liza Phase 1|2024|SBM Offshore|production_hub|Destiny purchase by ExxonMobil Guyana; SBM O&M to 2033|535|SBM/OE Digital — https://www.oedigital.com/news/520511-exxonmobil-concludes-535m-liza-destiny-fpso-buy-from-sbm-offshore
+AWARD|Liza Phase 1|2017|TechnipFMC|sps|17 EVDT trees + 5 manifolds + controls|VALUE-NOT-PUBLIC (pre-band era)|TechnipFMC — https://www.technipfmc.com/en/investors/financial-news-releases/press-release/technipfmc-awarded-subsea-contract-for-exxonmobil-liza-in-guyana/
+AWARD|Liza Phase 1|2017|Saipem|surf|EPCI risers/flowlines/structures + T&I umbilicals/manifolds (66 km as-built)|VALUE-NOT-PUBLIC|Saipem — https://www.saipem.com/en/media/press-releases/2017-05-10/saipem-new-epci-contract-awarded-exxonmobil-development-offshore
+AWARD|Liza Phase 1|2017|Noble (Bob Douglas)|drilling_rig|3-yr development drilling from 2018|VALUE-NOT-PUBLIC|Offshore Magazine — http://www.offshore-mag.com/articles/2017/08/noble-drillship-to-work-for-exxonmobil-offshore-guyana.html
+AWARD|Liza Phase 2|2019|SBM Offshore|production_hub|Liza Unity FPSO (first Fast4Ward) construct+install+lease; $1.14bn project financing|VALUE-NOT-PUBLIC at award (~1600 lease cap)|SBM — https://www.sbmoffshore.com/newsroom/press-releases/2019/10-05-2019/sbm-offshore-awarded-contracts-exxonmobil-fpso-liza-unity
+AWARD|Liza Phase 2|2023|SBM Offshore|production_hub|Unity purchase (Nov 2023)|1260|SBM — https://www.sbmoffshore.com/newsroom/fpso-liza-unity-purchase-exxonmobil-completed/
+AWARD|Liza Phase 2|2018|TechnipFMC|sps|30 EVDT trees + 8 manifolds + controls|VALUE-NOT-PUBLIC|TechnipFMC/BusinessWire — https://www.businesswire.com/news/home/20181022005773/en/TechnipFMC-Awarded-Subsea-Contract-ExxonMobil-Liza-Phase
+AWARD|Liza Phase 2|2018|Saipem|surf|SURF EPCI|~700|Saipem — https://www.saipem.com/en/media/press-releases/2018-08-21/saipem-awarded-surf-contracts-liza-phase-2-development-exxonmobil ("approximately 700 million USD")
+AWARD|Liza Phase 2|2020|Noble|drilling_rig|Drilling services agreement, 4 drillships, market-based dayrates reset 2x/yr; pooled campaign|VALUE-NOT-PUBLIC|Noble/PRN — https://www.prnewswire.com/news-releases/noble-corporation-plc-announces-drilling-services-agreement-with-exxonmobil-in-the-guyana-suriname-basin-301003226.html
+AWARD|Payara|2020|SBM Offshore|production_hub|Prosperity FPSO construct+install+lease; ~$0.98bn financing|VALUE-NOT-PUBLIC at award|SBM — https://www.sbmoffshore.com/newsroom/sbm-offshore-awarded-contracts-exxonmobil-fpso-prosperity/
+AWARD|Payara|2024|SBM Offshore|production_hub|Prosperity purchase (Nov 2024)|1230|SBM/World Oil — https://worldoil.com/news/2024/11/7/exxonmobil-guyana-sbm-offshore-complete-purchase-of-fpso-prosperity/
+AWARD|Payara|2020|TechnipFMC|sps|41 EVDT trees + 10 manifolds + 6 flex risers + controls|BAND 500-1000 "large" ($500M-$1bn per TechnipFMC definition)|TechnipFMC/OE Digital — https://www.oedigital.com/news/482115-technipfmc-nets-large-subsea-order-from-exxon-for-payara-development-in-guyana
+AWARD|Payara|2019|Saipem|surf|EPCI ~130 km flowlines/rigid risers/manifolds/flex/umbilicals|<=880 COMBINED w/ variation orders on other projects — split not published|Saipem — https://www.saipem.com/en/media/press-releases/2019-11-14/saipem-new-subsea-contract-guyana-and-variation-orders-ongoing
+AWARD|Payara|2020|Halliburton|other|D&C services|VALUE-NOT-PUBLIC|Offshore Technology — https://www.offshore-technology.com/news/exxonmobil-technipfmc-halliburton-payara/
+AWARD|Payara|2022|Noble|drilling_rig|CEA 4 drillships pooled; dayrates low-to-high $400k range, biannual reset|VALUE-NOT-PUBLIC per project|Noble 8-K/Kaieteur — https://kaieteurnewsonline.com/2026/04/29/exxon-awards-new-rig-contract-to-noble-at-us375000-day-rate/
+AWARD|Yellowtail|2022|SBM Offshore|production_hub|ONE GUYANA FPSO (250k bopd); $1.75bn financing Jul 2022|VALUE-NOT-PUBLIC at award|SBM — https://www.sbmoffshore.com/newsroom/press-releases/2022/21-07-2022/sbm-offshore-completes-us175-billion-financing-one-guyana
+AWARD|Yellowtail|2026|SBM Offshore|production_hub|ONE GUYANA purchase (Feb 2026); SBM operates to 2035|2320|SBM/GlobeNewswire — https://www.globenewswire.com/news-release/2026/02/04/3232326/0/en/FPSO-ONE-GUYANA-Purchase-by-ExxonMobil-Guyana-Completed.html
+AWARD|Yellowtail|2021|TechnipFMC|sps|51 EVDT trees + 12 manifolds + controls|BAND 500-1000 "large"|TechnipFMC/Upstream — https://www.upstreamonline.com/field-development/exxonmobil-hands-out-big-subsea-hardware-contract-for-guyanas-yellowtail-project/2-1-1098871
+AWARD|Yellowtail|2022|TechnipFMC|sps|6 HPHT flexible risers|BAND 75-250 "significant"|TechnipFMC/OE Digital — https://www.oedigital.com/news/496219-technipfmc-gets-notice-to-proceed-wins-more-work-at-exxon-s-yellowtail-project-offshore-guyana
+AWARD|Yellowtail|2022|Saipem|surf|SURF EPCI ~1800m WD|<=1100 COMBINED w/ Scarborough — split not published|Saipem — https://www.saipem.com/en/media/press-releases/2022-01-11/saipem-awarded-two-new-offshore-contracts-australia-and-guyana
+AWARD|Yellowtail|2022|Noble|drilling_rig|CEA pooled; extensions to Feb 2029 within $1.3bn multi-region backlog adds (Jan 2026)|VALUE-NOT-PUBLIC per project|Noble/OilNOW — https://oilnow.gy/news/guyana-rigs-extended-to-2029-as-noble-secures-us1-3b-in-new-contracts/
+AWARD|Guyana fleet|2023|SBM Offshore|other|10-yr O&M Enabling Agreement, Guyana FPSO fleet|VALUE-NOT-PUBLIC|SBM — https://www.sbmoffshore.com/newsroom/sbm-offshore-signed-10-year-operations-and-maintenance/
+STMT|Liza Phase 1|2017|ExxonMobil/Hess joint FID|gross capex|4400 (incl ~1200 FPSO lease cap; ~3200 drilling+subsea)|Hess/BusinessWire — https://www.businesswire.com/news/home/20170616005327/en/Hess-Takes-Final-Investment-Decision-Liza-Phase
+STMT|Liza Phase 1|2017|Hess (partner 30%)|net share capex (EXCL pre-sanction + lease)|955|same — "approximately $955 million, of which $110 million is already included in Hess' 2017 capital budget"
+STMT|Liza Phase 2|2019|Hess (30%)|gross capex|6000 (incl ~1600 FPSO lease cap)|Hess — https://investors.hess.com/news-releases/news-release-details/hess-sanctions-liza-phase-2-development-offshore-guyana
+STMT|Liza Phase 2|2019|Hess (30%)|net share capex (EXCL pre-sanction + lease)|1600|same
+STMT|Payara|2020|ExxonMobil (operator 45%)|gross capex|9000|https://corporate.exxonmobil.com/news/news-releases/2020/0930_exxonmobil-to-proceed-with-payara-development-offshore-guyana
+STMT|Payara|2020|Hess (30%)|net share capex (EXCL pre-sanction + FPSO purchase); phasing 250/450/500/300/225 (2021-25)|1800|Hess/BusinessWire — https://www.businesswire.com/news/home/20200930006005/en/Hess-Sanctions-Payara-Development-Offshore-Guyana
+STMT|Yellowtail|2022|ExxonMobil (45%)|gross capex|10000|https://corporate.exxonmobil.com/news/news-releases/2022/0404_exxonmobil-makes-final-investment-decision-on-fourth-guyana-offshore-project
+STMT|Yellowtail|2022|Hess (30%)|net share capex (EXCL pre-sanction + FPSO purchase)|2300|Hess/BusinessWire — https://www.businesswire.com/news/home/20220401005508/en/Hess-Sanctions-Yellowtail-Development-Offshore-Guyana
+STMT|All Guyana|2023|CNOOC (25%)|net per project NOT disclosed (company-wide capex only)|n/a|CNOOC/PRN — https://www.prnewswire.com/news-releases/cnooc-limited-announces-payara-project-in-guyana-commences-production-301987379.html
+# Coverage vs gross: Liza P1 ~40% publicly valued; Liza P2 ~60% (incl lease-cap overlap); Payara ~30-35%; Yellowtail ~40-45%.
+# KEY cross-check: Yellowtail Hess net 2300/0.30 = 7,667 ≈ 10,000 − 2,320 FPSO (7,680) — Hess "net share" EXCLUDES the FPSO element throughout; partner-net÷interest must compare to gross EX-FPSO.
+# Systematic gaps: rigs pooled block-wide (never project-attributed; dayrate color $375k-$400k+ 2024-26); Saipem bundles 2 of 4 values; SBM award-day lease values never public but the 4 buyouts + project financings give hard FPSO anchors for all hulls.
+== ANCHOR (Chevron 62.86% / TotalEnergies 37.14%, $5.7bn gross Stage 1 FID 2019) — valued coverage ~15%
+AWARD|Anchor|2019|DSME|production_hub|Semi FPU hull (22,000t lightship, Okpo; KBR hull FEED)|VALUE-NOT-PUBLIC|OE Digital — https://www.oedigital.com/news/473766-chevron-hits-go-on-anchor
+AWARD|Anchor|2019|Kiewit Offshore|production_hub|Topsides fab + integration, Ingleside TX (Wood FEED)|VALUE-NOT-PUBLIC|same
+AWARD|Anchor|2019|OneSubsea (SLB) — NOT TechnipFMC|sps|Industry-first fully integrated 20K SPS: monobore trees, 20K multiphase meters, manifolds, 16.5K pump station; under 20-yr Chevron subsea MSA|VALUE-NOT-PUBLIC|World Oil — https://www.worldoil.com/news/2019/12/12/chevron-awards-onesubsea-industry-s-first-fully-integrated-20-000-psi-production-system
+AWARD|Anchor|2020|Subsea 7|surf|SURF EPCI (flowlines, risers, umbilical install, jumpers; Ingleside spoolbase)|VALUE-NOT-PUBLIC (atypically NO band word)|Subsea7/GlobeNewswire — https://www.globenewswire.com/news-release/2020/04/14/2015348/0/en/Subsea-7-awarded-contract-offshore-US-Gulf-of-Mexico.html
+AWARD|Anchor|2020|Aker Solutions|surf|~24 km 20K dynamic steel-tube + power umbilicals; first order under 20-yr Chevron umbilicals master|VALUE-NOT-PUBLIC|Aker — https://www.akersolutions.com/news/news-archive/2020/aker-solutions-wins-20-year-umbilicals-master-order-with-chevron/
+AWARD|Anchor|2018|Transocean|drilling_rig|Deepwater Titan 5-yr (first 20K floater, dual 20K BOPs, ~$455k/day implied)|830 backlog excl mob|Transocean — https://www.deepwater.com/news/detail?ID=23251
+AWARD|Anchor|2021|Boskalis|installation|Heavy transport hull Okpo→Ingleside (BOKA Vanguard); no Heerema T&I found|VALUE-NOT-PUBLIC|Chevron — https://www.chevron.com/newsroom/2023/q2/offshore-project-to-help-meet-energy-demand
+AWARD|Anchor|2020|Oceaneering|other|First 20K hydraulic junction plates, connection hardware, IFLs under 20-yr GoM MSA|VALUE-NOT-PUBLIC|OE Digital — https://www.oedigital.com/news/484071-industry-s-first-oceaneering-s-20-000-psi-equipment-for-chevron-s-anchor-project
+== BALLYMORE (Chevron 60% / TotalEnergies 40%, $1.6bn FID 2022) — valued coverage ~4-10%
+AWARD|Ballymore|2022|Subsea 7|installation|SCR + flowline + control system install, 3-well tieback to Blind Faith|BAND 50-150 "sizeable" (Subsea7 definition verified)|Subsea7/GlobeNewswire — https://www.globenewswire.com/news-release/2022/06/01/2454567/0/en/Subsea-7-awarded-contract-offshore-Gulf-of-Mexico.html
+AWARD|Ballymore|2021|Worley (+Intecsea)|production_hub|Blind Faith brownfield mods eng+procurement|VALUE-NOT-PUBLIC|Offshore Technology — https://www.offshore-technology.com/projects/ballymore-oil-and-gas-field-gulf-of-mexico-usa/
+AWARD|Ballymore|2022|NOT-PUBLICLY-DISCLOSED|sps|Trees/manifolds supplier never announced (Chevron frame agreement; Westwood tracked a 2Q22 tree award, no winner named). NO TechnipFMC iEPCI existed (premise correction)|VALUE-NOT-PUBLIC|TechnipFMC archive + SEC 8-K checked
+AWARD|Ballymore|2023|rig not publicly named|drilling_rig|3 dev wells 2023-24; no disclosure names Ballymore|VALUE-NOT-PUBLIC|Offshore Technology profile
+AWARD|Ballymore|2022|Expro|other|3-yr in-riser 15K ball-valve completion/intervention system|15+ ("over $15 million")|JPT — https://jpt.spe.org/expro-scoops-ballymore-valve-contract
+== KASKIDA (BP 100%, <$5bn phase 1 FID 2024) — valued coverage ~10-15%
+AWARD|Kaskida|2024|Seatrium|production_hub|FPU EPC 4-column semi + single topside module (80kbopd; Exmar OPTI hull design, Audubon topsides design)|VALUE-NOT-PUBLIC|Seatrium SGX/World Oil — https://worldoil.com/news/2024/12/24/seatrium-awarded-fpu-contract-for-bp-s-kaskida-development-in-gulf-of-mexico/
+AWARD|Kaskida|2024|TechnipFMC|sps+surf|Integrated iEPCI: 20K standardized trees + manifolds AND umbilicals/risers/flowlines design-manufacture-install (single contract — do not double count)|BAND 250-500 "substantial" (TFMC definition verified)|TFMC — https://www.technipfmc.com/media/u51ngpkc/tfmc-kaskida-award-press-release.pdf
+AWARD|Kaskida|2025|SBM Offshore|installation|Wet tow + offshore installation of FPU|VALUE-NOT-PUBLIC|OE Digital — https://www.oedigital.com/news/525202-bp-hires-sbm-offshore-to-install-kaskida-fpu-in-gulf-of-america
+AWARD|Kaskida|2024|Transocean|drilling_rig|Deepwater Atlas (only 20K-completion 8th-gen) 365-day from Q2 2028 + option (~$635k/day implied); release doesn't name Kaskida — linkage via 20K + BP AR statement|232 backlog excl mob|Transocean — https://www.deepwater.com/news/detail?ID=28871
+AWARD|Kaskida|2024|Transocean|drilling_rig|Deepwater Invictus 1,095-day BP GoM from 2025 — project attribution UNCONFIRMED|531 backlog (UNCONFIRMED attribution)|Riviera — https://www.rivieramm.com/news-content-hub/news-content-hub/transocean-snags-531m-gom-contract-for-drillship-81813
+AWARD|Kaskida|2024|Enbridge|other|Canyon Oil Pipeline (24/26in 200kbpd) + Canyon Gathering (12in) — Enbridge builds/owns/operates; midstream, OUTSIDE BP capex|700 Enbridge investment|Enbridge — https://www.enbridge.com/media-center/news/details?id=123829&lang=en
+== WHALE (Shell 60% / Chevron 40%, capex never disclosed, FID 2021) — valued coverage 0%
+AWARD|Whale|2019|Sembcorp Marine (Seatrium)|production_hub|EPC topsides + hull (~25,000t, Tuas, replicates Vito; delivered Oct 2023 on time/budget)|VALUE-NOT-PUBLIC ("specific financial terms were not disclosed")|Offshore Energy — https://www.offshore-energy.biz/sembcorp-marine-to-build-fpu-for-shells-whale-field-in-gulf-of-mexico/
+AWARD|Whale|2021|McDermott — NOT Subsea7 (premise correction)|surf|EPCIC ~50km pipeline + 15km umbilicals, 5 drill centers, ~2,800m; completed early 2025|VALUE-NOT-PUBLIC|McDermott/PRN — https://www.prnewswire.com/news-releases/mcdermott-completes-epcic-project-in-gulf-of-mexico-302392063.html
+AWARD|Whale|2020|NOT-PUBLICLY-ANNOUNCED|sps|Main trees/manifolds supplier never press-released (Shell enterprise frame agreements); only SPS-adjacent public award = Deep Down Inc riser isolation valve controls Feb 2020|VALUE-NOT-PUBLIC|OGJ — https://www.ogj.com/exploration-development/article/14168282/shell-lets-contract-for-gulf-of-mexico-whale-development
+AWARD|Whale|2023|Boskalis|installation|Dry tow 25,000t FPU Singapore→Ingleside (Boka Vanguard) + wet tow to Alaminos Canyon|VALUE-NOT-PUBLIC|Offshore Energy — https://www.offshore-energy.biz/shells-new-gulf-of-mexico-platform-arrives-on-boskalis-giant-heavy-transport-vessel/
+AWARD|Whale|2017|Noble (Globetrotter I, discovery only)|drilling_rig|Dev-rig attribution not publicly confirmed (Shell long-term fleet contracts)|VALUE-NOT-PUBLIC|Offshore Magazine — https://www.offshore-mag.com/field-development/article/14207502/shell-sanctions-deepwater-whale-project-in-the-gulf-of-mexico
+AWARD|Whale|2021|Williams|other|25-mi gas lateral + 125-mi oil pipeline (Williams-owned, not Shell capex); pipelay Allseas Solitaire 2023|VALUE-NOT-PUBLIC|Offshore Energy — https://www.offshore-energy.biz/williams-infrastructure-to-serve-shells-deepwater-project/
+STMT|Anchor|2019|Chevron (op 62.86%)|gross Stage 1 FID|5700|World Oil reprint — https://www.worldoil.com/news/2019/12/12/chevron-greenlights-its-anchor-20-000-psi-deepwater-project-in-the-gulf-of-mexico ("investment of approximately $5.7 billion"; interests verified 62.86/37.14)
+STMT|Anchor|2019|TotalEnergies (37.14%)|net share NOT disclosed|n/a|https://totalenergies.com/media/news/press-releases/total-moves-forward-two-deepwater-projects-us-gulf-mexico
+STMT|Anchor|2023|Chevron|gross restatement pre-startup ~5700|Chevron — https://www.chevron.com/newsroom/2023/q2/offshore-project-to-help-meet-energy-demand
+STMT|Ballymore|2022|Chevron (op 60%)|gross FID|1600|https://www.chevron.com/newsroom/2022/q2/chevron-sanctions-ballymore-project-in-deepwater-us-gulf-of-mexico
+STMT|Ballymore|2022|TotalEnergies (40%)|net NOT disclosed (SEC 6-K Ex-99.6 confirms interest only)|n/a|https://www.sec.gov/Archives/edgar/data/879764/000110465922066800/tm2216889d1_ex99-6.htm
+STMT|Kaskida|2024|BP (op 100% at FID)|gross phase 1 "<$5bn" (CEO 2Q24 call; sanction release figure-free)|<5000|JPT — https://jpt.spe.org/bp-oks-20k-psi-kaskida-project-in-gulf-of-mexico
+STMT|Whale|2021|Shell (op 60%)|gross NOT disclosed (IRR >25% only)|n/a|https://www.prnewswire.com/news-releases/shell-invests-in-the-whale-development-in-the-gulf-of-mexico-301340654.html
+STMT|Whale|2022|Chevron (40% non-op)|net NOT disclosed (FY2021 10-K confirms WI + FID only — no net÷interest cross-check possible)|n/a|https://www.sec.gov/Archives/edgar/data/93410/000009341022000019/cvx-20211231.htm
+# Coverage: Anchor ~15% ($830M Titan only); Ballymore ~4-10%; Kaskida ~10-15% (excl unconfirmed $531M + $700M Enbridge midstream OUTSIDE BP capex); Whale 0%.
+# Premise corrections: Anchor SPS = OneSubsea NOT TechnipFMC; Ballymore had NO TFMC iEPCI; Whale SURF = McDermott NOT Subsea7; Titan=Anchor ($455k/d) vs Atlas=BP/Kaskida ($635k/d).
+# STRUCTURAL: GoM operators award hulls/topsides/trees/SURF under long-term frame/master agreements with values undisclosed — hard numbers exist only where the CONTRACTOR has disclosure incentives (Transocean backlog, TFMC/Subsea7 band vocabulary, Enbridge midstream). Band-word + definition capture = primary valuation signal.
+== BACALHAU PHASE 1 (Equinor, $8.0bn gross FID 2021) — coverage ~20%
+AWARD|Bacalhau|2021|MODEC|production_hub|FPSO EPCI turnkey newbuild 220kbpd + 1st-yr O&M|VALUE-NOT-PUBLIC|MODEC — https://www.modec.com/news/2021/20210603_pr_bacalhau.html
+AWARD|Bacalhau|2020|Aibel (sub from MODEC)|production_hub|Topsides ~20,000t detail eng+procurement+construction|VALUE-NOT-PUBLIC|Aibel — https://aibel.com/news/aibel-awarded-major-fpso-contract
+AWARD|Bacalhau|2021|Subsea7 (SIA)|surf|Integrated SPS+SURF EPCI Subsea7 share: 140km rigid risers/flowlines, 40km umbilicals, T&I included|BAND >750 "major" (Subsea7: major = share > USD 750MM)|OEDigital — https://www.oedigital.com/news/488110-subsea-integration-alliance-confirms-bacalhau-epci-contract
+AWARD|Bacalhau|2021|OneSubsea (SIA)|sps|19 trees + wellheads/controls/connections within integrated EPCI|VALUE-NOT-PUBLIC (SLB "large", no band definitions)|same
+AWARD|Bacalhau|2021|Seadrill|drilling_rig|West Saturn 4yr firm + 4x1yr options, 6 wells, from Q1 2022|380 (incl mob, upgrades, integrated services)|Offshore Technology — https://www.offshore-technology.com/news/seadrill-380m-drillship-contract-equinor/
+AWARD|Bacalhau|2026|Seadrill|drilling_rig|West Saturn 1-yr option exercised → Oct 2027|114|OGJ — https://www.ogj.com/drilling-production/drilling-operations/news/55354291/equinor-exercises-drillship-contract-extension-for-work-offshore-brazil
+AWARD|Bacalhau|2020|Baker Hughes/Halliburton/SLB|other|Drilling & well services (combined, Nov 2020)|455|Offshore Technology profile — https://www.offshore-technology.com/projects/bacalhau-oil-field-santos-basin-brazil/
+AWARD|Bacalhau|2020|SOFEC (MODEC grp)|other|Mooring system (intra-group sub)|VALUE-NOT-PUBLIC|same
+AWARD|Bacalhau|2026|Ocean Installer|installation|Rigid jumpers/spools + cables + pre-comm, 4.5yr, first campaign 2027|VALUE-NOT-PUBLIC|Inspenet — https://inspenet.com/en/news/ocean-installer-obtains-contract-with-equinor/
+STMT|Bacalhau|2021|Equinor (op, 40%)|gross capex FID|8000|https://www.equinor.com/news/archive/20210601-final-investment-decision-bacalhau-phase1-brazil
+STMT|Bacalhau|2021|Galp/Petrogal (20%)|gross confirm (implies ~1600 net)|8000|https://www.galp.com/corp/en/media/press-releases/press-release/id/1229/final-investment-decision-for-bacalhau-phase-1-in-brazil
+STMT|Bacalhau|2023|Galp (20%)|company net capex FY2022 EUR1,266MM "mostly... Bacalhau" (not project-specific)|~1370|Galp 4Q22 — https://www.galp.com/corp/Portals/0/Recursos/Investidores/4Q_Results_2022/Galp_4Q22.pdf
+== SANGOMAR PHASE 1 (Woodside, $4.2bn FID → $5.0bn final) — coverage ~10-15%
+AWARD|Sangomar|2020|MODEC|production_hub|FPSO PURCHASE (EPCC, VLCC conversion, 100kbpd, SOFEC turret); title→Woodside Dec 2023; price NOT disclosed|VALUE-NOT-PUBLIC|Woodside ASX 10 Jan 2020 — https://www.woodside.com/docs/default-source/asx-announcements/2020-asx/sangomar-field-development-approved.pdf
+AWARD|Sangomar|2020|MODEC SENEGAL|other|O&M initial 10yr + up to 10yr options|VALUE-NOT-PUBLIC|MODEC — https://www.modec.com/news/2020/20201214_pr_sangomar-om.html
+AWARD|Sangomar|2020|Subsea Integration Alliance|sps+surf|Integrated SPS+SURF EPCI incl T&I: 23 wells, 107km rigid flowlines, 28km flex, 45km umbilicals|BAND 500-750 "very large" (Subsea7 share only)|Subsea7/GlobeNewswire — https://www.globenewswire.com/news-release/2020/01/10/1968794/0/en/Subsea-Integration-Alliance-awarded-contract-offshore-Senegal.html
+AWARD|Sangomar|2019|Diamond Offshore|drilling_rig|Ocean BlackRhino 18 firm wells 4Q20-4Q23 + options; Ocean BlackHawk 1Q22-1Q23|VALUE-NOT-PUBLIC|Offshore Energy — https://www.offshore-energy.biz/woodside-hires-two-diamond-drillships-for-senegal-operations/
+AWARD|Sangomar|2020|SOFEC|other|External turret mooring EPC (sub from MODEC)|VALUE-NOT-PUBLIC|OE — https://www.oedigital.com/news/474801-sofec-to-supply-sangomar-fpso-turret-mooring-system
+STMT trail|Sangomar|Woodside gross: 4200 (2020 FID) → 4600 (Q1 2021 report) → 4900-5200 (ASX Jul 2023) → ~5000 FINAL (ASX 17 Feb 2025, "lower end of range")|full URLs in session transcript; ASX docs woodside.com
+== BAROSSA (Santos, $3.6bn FID; $4.5-4.6bn incl DPD 2024; $3.95bn spent Jun 2025) — capex-like coverage small; FPSO is LEASE
+AWARD|Barossa|2021|BW Offshore|production_hub|FPSO BW Opal LEASE-AND-OPERATE 15yr firm + 10yr options; ~$2.0bn FPSO capex + ~$1bn advance lease during construction|4600 firm-period contract value (lease+opex — NOT comparable to project capex)|BW/GlobeNewswire — https://www.globenewswire.com/news-release/2021/03/23/2198157/0/en/BW-Offshore-Signed-contract-for-Barossa-FPSO.html
+AWARD|Barossa|2021|TechnipFMC|sps|Trees/controls/manifolds/wellheads + install support (NTP Apr 2021)|BAND 75-250 "significant"|TechnipFMC/Euro-Petrole — https://www.euro-petrole.com/technipfmc-receives-notice-to-proceed-for-subsea-contract-for-santos-barossa-project-offshore-australia-n-i-22165
+AWARD|Barossa|2020|Subsea 7|surf|EPC+T&I 36km infield flowlines + install client-supplied risers/umbilicals/structures (T&I embedded)|BAND 300-500 "large"|Subsea7/GlobeNewswire — https://www.globenewswire.com/news-release/2020/03/03/1993972/0/en/Subsea-7-awarded-contract-offshore-Australia.html
+AWARD|Barossa|2020|Aker Solutions / NOV Denmark|surf|Umbilicals EPC (Aker) + flexible risers (NOV) client-supplied|VALUE-NOT-PUBLIC|Offshore Energy — https://www.offshore-energy.biz/partners-nearly-set-to-push-the-button-on-barossa-development-after-subsea-contract-awards/
+AWARD|Barossa|2019|Allseas|other|Gas Export Pipeline EPCI 262km 26in + PLETs + pre-comm|VALUE-NOT-PUBLIC|Santos — https://www.santos.com/news/another-major-barossa-contract-awarded/
+AWARD|Barossa|2021|Valaris|drilling_rig|VALARIS MS-1 moored semisub, 6-well campaign Jul22-Oct23 + options (suspended Sep22-2024, court EP)|VALUE-NOT-PUBLIC|Valaris FSR Oct 2022 SEC — https://www.sec.gov/Archives/edgar/data/314808/000031480822000121/ex99_1october2022.htm
+STMT|Barossa|2021|Santos (op 50%)|gross FID 3600 + separate 600 Darwin LNG life-ext/tie-in|Santos — https://www.santos.com/news/santos-announces-fid-on-the-barossa-gas-project-for-darwin-lng/
+STMT|Barossa|2024|Santos|gross update incl DPD|4500-4600|Santos 2023 Q4 report
+STMT|Barossa|2021|SK E&S (37.5%)|net investment plan KRW1.6tn|1400 (cross-check 0.375×3600=1350 ≈)|Korea Herald — http://www.koreaherald.com/view.php?ud=20210330000633
+STMT|Barossa|2021|JERA (12.5%)|ENTRY price for interest (not capex)|~300 (completed 327)|Santos — https://www.santos.com/news/santos-agrees-sale-of-12-5-interest-in-barossa-project-to-jera/
+== GRANMORGU (TotalEnergies, $10.5bn gross FID 2024) — BEST coverage ~45%
+AWARD|GranMorgu|2024|SBM Offshore (+T.EN)|production_hub|FPSO construct+install (Fast4Ward 220kbpd, spread-moored); separate O&M expected|VALUE-NOT-PUBLIC|SBM — https://www.sbmoffshore.com/newsroom/sbm-offshore-awarded-contracts-for-the-granmorgu-field-development/
+AWARD|GranMorgu|2024|Technip Energies|production_hub|FPSO topsides EPC|BAND >~1055 "major" (T.EN: major = > EUR 1bn revenue)|T.EN — https://www.ten.com/en/media/press-releases/technip-energies-awarded-major-contract-totalenergies-topsides-granmorgu-fpso
+AWARD|GranMorgu|2024|TechnipFMC|sps|Major iEPCI: Subsea 2.0 trees, manifolds, connectors, topside controls + umbilicals/flex jumpers/flex risers|BAND >1000 "major" (TFMC: major > $1bn)|TFMC — https://www.technipfmc.com/en/investors/financial-news-releases/press-release/technipfmc-awarded-major-iepci-contract-for-totalenergies-granmorgu-development-offshore-suriname/
+AWARD|GranMorgu|2024|Saipem|surf|SURF EPCI ~100km production + 90km injection lines + flex risers/umbilicals/structures, S-Lay+J-Lay 2027-28|1900 EXPLICIT|Saipem — https://www.saipem.com/en/media/press-releases/2024-11-14/saipem-new-offshore-contract-totalenergies-suriname-19-billion-usd
+AWARD|GranMorgu|2025|Noble|drilling_rig|Two 16-well contracts ~1,060 days each (Noble Discoverer + Noble Valiant) from Q4 2026|753 firm + up to 297 performance (max 1050)|Noble Q1 2025 — https://www.prnewswire.com/news-releases/noble-corporation-plc-announces-first-quarter-2025-results-302440174.html
+AWARD|GranMorgu|2026|Halliburton|other|Integrated D&C services, long-term program|VALUE-NOT-PUBLIC|Halliburton — https://www.halliburton.com/en/about-us/press-release/halliburton-wins-integrated-drilling-completions-contract-granmorgu-suriname-total-energies
+STMT|GranMorgu|2024|TotalEnergies (op 50%)|gross FID|10500|https://totalenergies.com/news/press-releases/suriname-totalenergies-announces-final-investment-decision-granmorgu
+STMT|GranMorgu|2025|APA Corp (50%, carried)|10-K FY2024 carry mechanics: APA pays 12.5% of first $10bn + 25% of next $5bn → ~1375 implied net on $10.5bn|SEC 10-K — https://www.sec.gov/Archives/edgar/data/1841666/000204026625000007/apa-20241231.htm
+STMT|GranMorgu|2025|Staatsolie (NOC, option 20%)|states TOTAL $12.2bn (incl drilling/extra scope?) → their share $2.4bn; bond raise launched Jan 2025|Offshore Energy — https://www.offshore-energy.biz/noc-raising-funds-to-cover-its-share-of-costs-for-totalenergies-led-12-2b-oil-project-off-suriname/
+# Band definitions verified: Subsea7 large $300-500M / very large $500-750M / major >$750M; TFMC significant $75-250M / major >$1bn; T.EN major > EUR 1bn.
+# Integrated awards blur asset classes (SIA SPS+SURF single contracts; band = Subsea7 share only). Installation embedded in SURF EPCIs; no standalone heavy-lift award in tranche except Ocean Installer (unvalued).
+# Gross caveats: GranMorgu $10.5bn (Total/APA) vs $12.2bn (Staatsolie, incl drilling?); Sangomar cost trail documented FID→final; Barossa BW Opal $4.6bn is 15yr lease+opex NOT capex.


### PR DESCRIPTION
Traceability record for the #1020 tranche-1 research (12 anchor projects): public contract awards by asset class + operator/partner annual-statement figures, with the synthesis (coverage table, verified band definitions, partner-net reconciliation findings) and the verbatim raw pass records.

Key findings for decision **A1** (#1017):
- GranMorgu ~45% of $10.5bn publicly valued (incl. Saipem's explicit $1.9bn SURF)
- SBM buyouts anchor all four Guyana FPSOs ($535M/$1.26bn/$1.23bn/$2.32bn)
- Hess per-project net shares EXCLUDE the FPSO element (proven by exact Yellowtail reconciliation)
- US GoM frame agreements hide values — band-word + definition capture is the primary signal there

Follow-up (separate PR): normalize into `data/modules/cost/curated/contract_awards.csv` + `project_cost_statements.csv` with schema rails mirroring `sanctioned_projects.csv`.

Refs #1020 #1017 #844

🤖 Generated with [Claude Code](https://claude.com/claude-code)