### PR TITLE
feat(lower_tertiary): D&C QA/QC report hub — self-contained entry point

### DIFF
--- a/config/repo_structure.yml
+++ b/config/repo_structure.yml
@@ -411,6 +411,7 @@ temporary_exceptions:
       - reports/lower_tertiary/v30_v50_brief.html
       - reports/lower_tertiary/v30_vs_v50_comparison.md
       - reports/lower_tertiary/wo-april-2026-per-well-dc.md
+      - reports/lower_tertiary/wo-april-2026-qaqc-hub.html
       - reports/lower_tertiary/wo-april-2026-validation.md
       - reports/lower_tertiary/wrk010_latest_data_report.md
       - reports/lower_tertiary_field_summary.html

--- a/reports/lower_tertiary/wo-april-2026-qaqc-hub.html
+++ b/reports/lower_tertiary/wo-april-2026-qaqc-hub.html
@@ -1,0 +1,431 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>D&C Days QA/QC — Report Hub</title>
+<style>
+  :root {
+    --bg: #eaeff2;
+    --surface: #ffffff;
+    --surface-2: #f3f7f9;
+    --ink: #0e2733;
+    --ink-soft: #48606b;
+    --ink-faint: #7c929c;
+    --line: #d8e3e8;
+    --line-strong: #c3d3da;
+    --accent: #0e7c8b;
+    --accent-strong: #0a5f6c;
+    --accent-wash: #e2f0f2;
+    --ok: #2e8b6f;
+    --ok-wash: #e2f1ec;
+    --warn: #b3781a;
+    --warn-wash: #f6ecdb;
+    --bad: #b4544a;
+    --bad-wash: #f6e5e3;
+    --hold: #647680;
+    --hold-wash: #eaeef0;
+    --shadow: 0 1px 2px rgba(14,39,51,.06), 0 8px 24px -12px rgba(14,39,51,.18);
+    --radius: 14px;
+    --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    --mono: ui-monospace, "SF Mono", "Cascadia Code", "Roboto Mono", Menlo, Consolas, monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #081820; --surface: #0e2732; --surface-2: #12303c;
+      --ink: #e6eef1; --ink-soft: #9fb4bd; --ink-faint: #6b8290;
+      --line: #1e3a47; --line-strong: #274653;
+      --accent: #3fbfd0; --accent-strong: #6fd4e2; --accent-wash: #10323d;
+      --ok: #4fc79f; --ok-wash: #10322a; --warn: #e0a94a; --warn-wash: #33280f;
+      --bad: #e08078; --bad-wash: #351c1a; --hold: #8ea4ae; --hold-wash: #17272f;
+      --shadow: 0 1px 2px rgba(0,0,0,.3), 0 10px 30px -14px rgba(0,0,0,.6);
+    }
+  }
+  :root[data-theme="light"] {
+    --bg: #eaeff2; --surface: #ffffff; --surface-2: #f3f7f9;
+    --ink: #0e2733; --ink-soft: #48606b; --ink-faint: #7c929c;
+    --line: #d8e3e8; --line-strong: #c3d3da;
+    --accent: #0e7c8b; --accent-strong: #0a5f6c; --accent-wash: #e2f0f2;
+    --ok: #2e8b6f; --ok-wash: #e2f1ec; --warn: #b3781a; --warn-wash: #f6ecdb;
+    --bad: #b4544a; --bad-wash: #f6e5e3; --hold: #647680; --hold-wash: #eaeef0;
+    --shadow: 0 1px 2px rgba(14,39,51,.06), 0 8px 24px -12px rgba(14,39,51,.18);
+  }
+  :root[data-theme="dark"] {
+    --bg: #081820; --surface: #0e2732; --surface-2: #12303c;
+    --ink: #e6eef1; --ink-soft: #9fb4bd; --ink-faint: #6b8290;
+    --line: #1e3a47; --line-strong: #274653;
+    --accent: #3fbfd0; --accent-strong: #6fd4e2; --accent-wash: #10323d;
+    --ok: #4fc79f; --ok-wash: #10322a; --warn: #e0a94a; --warn-wash: #33280f;
+    --bad: #e08078; --bad-wash: #351c1a; --hold: #8ea4ae; --hold-wash: #17272f;
+    --shadow: 0 1px 2px rgba(0,0,0,.3), 0 10px 30px -14px rgba(0,0,0,.6);
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--sans);
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+  }
+  a { color: inherit; }
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
+
+  .eyebrow {
+    font-family: var(--mono);
+    font-size: .7rem;
+    letter-spacing: .16em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    margin: 0;
+  }
+
+  header.site {
+    position: sticky; top: 0; z-index: 20;
+    background: color-mix(in srgb, var(--surface) 88%, transparent);
+    backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--line);
+  }
+  .site-inner { display: flex; align-items: center; gap: 20px; height: 60px; }
+  .wordmark { display: flex; align-items: center; gap: 10px; font-weight: 600; letter-spacing: -.01em; white-space: nowrap; }
+  .wordmark .glyph { width: 22px; height: 22px; flex: none; }
+  nav.capability { margin-left: auto; display: flex; gap: 2px; flex-wrap: wrap; align-items: center; }
+  nav.capability a {
+    font-family: var(--mono); font-size: .78rem; text-decoration: none;
+    color: var(--ink-soft); padding: 6px 10px; border-radius: 8px; white-space: nowrap;
+  }
+  nav.capability a:hover { background: var(--surface-2); color: var(--ink); }
+  nav.capability a.active { background: var(--accent-wash); color: var(--accent-strong); font-weight: 600; }
+  nav.capability a.ext::after { content: " ↗"; color: var(--ink-faint); }
+  nav.capability a:focus-visible, a:focus-visible, .card:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+  .crumb { font-family: var(--mono); font-size: .74rem; color: var(--ink-faint); padding: 18px 0 0; }
+  .crumb a { text-decoration: none; }
+  .crumb a:hover { color: var(--accent); }
+  .crumb .sep { padding: 0 8px; opacity: .6; }
+
+  .hero { padding: 22px 0 30px; }
+  .hero h1 {
+    font-size: clamp(2.1rem, 5vw, 3.05rem);
+    line-height: 1.05; letter-spacing: -.025em;
+    margin: 12px 0 14px; text-wrap: balance; font-weight: 700;
+  }
+  .hero .lede { font-size: 1.14rem; color: var(--ink-soft); max-width: 60ch; margin: 0 0 20px; }
+  .disposition {
+    display: inline-flex; align-items: center; gap: 10px;
+    background: var(--warn-wash); color: var(--warn);
+    border: 1px solid color-mix(in srgb, var(--warn) 32%, transparent);
+    border-radius: 999px; padding: 7px 15px 7px 12px;
+    font-family: var(--mono); font-size: .78rem; font-weight: 600;
+  }
+  .disposition .dot { width: 8px; height: 8px; border-radius: 50%; background: currentColor; box-shadow: 0 0 0 4px color-mix(in srgb, var(--warn) 20%, transparent); }
+  .facts { display: flex; flex-wrap: wrap; gap: 8px 26px; margin-top: 22px; }
+  .facts div { font-size: .86rem; color: var(--ink-soft); }
+  .facts span { font-family: var(--mono); color: var(--ink); }
+
+  .glance { display: grid; grid-template-columns: 1.15fr 1fr; gap: 18px; margin: 8px 0 44px; }
+  .tiles { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; align-content: start; }
+  .tile {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 12px;
+    padding: 16px 16px 14px; box-shadow: var(--shadow);
+  }
+  .tile .k { font-family: var(--mono); font-size: .66rem; letter-spacing: .12em; text-transform: uppercase; color: var(--ink-faint); }
+  .tile .v { font-size: 1.72rem; font-weight: 700; letter-spacing: -.02em; margin-top: 6px; font-variant-numeric: tabular-nums; }
+  .tile .v small { font-size: .9rem; font-weight: 600; color: var(--ink-soft); margin-left: 2px; }
+  .tile .sub { font-size: .78rem; color: var(--ink-soft); margin-top: 2px; }
+  .tile .v.ok { color: var(--ok); } .tile .v.accent { color: var(--accent); } .tile .v.warn { color: var(--warn); }
+
+  .chartcard {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 12px;
+    padding: 16px 18px 12px; box-shadow: var(--shadow); display: flex; flex-direction: column;
+  }
+  .chartcard h3 { margin: 0; font-size: .95rem; letter-spacing: -.01em; }
+  .chartcard .cap { font-size: .78rem; color: var(--ink-soft); margin: 2px 0 8px; }
+  .chartcard svg { width: 100%; height: auto; display: block; }
+
+  .sec { margin: 46px 0 0; }
+  .sec-head { display: flex; align-items: baseline; justify-content: space-between; gap: 16px; margin-bottom: 6px; }
+  .sec-head h2 { font-size: 1.5rem; letter-spacing: -.02em; margin: 6px 0 4px; }
+  .sec-note { font-size: .92rem; color: var(--ink-soft); max-width: 64ch; margin: 0 0 22px; }
+
+  .tier { margin-top: 30px; }
+  .tier-label { display: flex; align-items: center; gap: 12px; margin: 0 0 14px; }
+  .tier-label .eyebrow { color: var(--accent-strong); }
+  .tier-label .rule { flex: 1; height: 1px; background: var(--line); }
+  .cards { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }
+  .card {
+    display: flex; flex-direction: column; gap: 10px;
+    background: var(--surface); border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 20px; text-decoration: none; color: inherit;
+    box-shadow: var(--shadow); transition: transform .16s ease, border-color .16s ease, box-shadow .16s ease;
+  }
+  .card:hover { transform: translateY(-3px); border-color: var(--accent); box-shadow: 0 1px 2px rgba(14,39,51,.06), 0 18px 40px -18px color-mix(in srgb, var(--accent) 60%, transparent); }
+  .card .top { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+  .card .kind { font-family: var(--mono); font-size: .66rem; letter-spacing: .14em; text-transform: uppercase; color: var(--ink-faint); }
+  .card h3 { margin: 0; font-size: 1.18rem; letter-spacing: -.02em; }
+  .card p { margin: 0; font-size: .92rem; color: var(--ink-soft); }
+  .card ul { margin: 4px 0 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 5px; }
+  .card li { font-size: .84rem; color: var(--ink-soft); padding-left: 16px; position: relative; }
+  .card li::before { content: ""; position: absolute; left: 2px; top: .62em; width: 5px; height: 5px; border-radius: 50%; background: var(--accent); opacity: .7; }
+  .card .foot { margin-top: auto; padding-top: 6px; display: flex; align-items: center; justify-content: space-between; }
+  .arrow { font-family: var(--mono); color: var(--accent); font-size: .82rem; font-weight: 600; }
+  .card:hover .arrow { color: var(--accent-strong); }
+
+  .badge {
+    font-family: var(--mono); font-size: .66rem; letter-spacing: .06em; text-transform: uppercase;
+    padding: 4px 9px; border-radius: 999px; font-weight: 600; white-space: nowrap;
+    display: inline-flex; align-items: center; gap: 6px; border: 1px solid transparent;
+  }
+  .badge .d { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+  .badge.ok { color: var(--ok); background: var(--ok-wash); border-color: color-mix(in srgb, var(--ok) 26%, transparent); }
+  .badge.warn { color: var(--warn); background: var(--warn-wash); border-color: color-mix(in srgb, var(--warn) 26%, transparent); }
+  .badge.bad { color: var(--bad); background: var(--bad-wash); border-color: color-mix(in srgb, var(--bad) 26%, transparent); }
+  .badge.hold { color: var(--hold); background: var(--hold-wash); border-color: color-mix(in srgb, var(--hold) 26%, transparent); }
+  .badge.idx { color: var(--accent-strong); background: var(--accent-wash); border-color: color-mix(in srgb, var(--accent) 26%, transparent); }
+
+  .card.wide { grid-column: 1 / -1; }
+  .card.ext { background: var(--surface-2); border-style: dashed; }
+  .card.ext:hover { border-style: solid; }
+
+  .path { margin: 40px 0 0; background: var(--surface); border: 1px solid var(--line); border-radius: var(--radius); padding: 22px 24px; box-shadow: var(--shadow); }
+  .path h3 { margin: 0 0 4px; font-size: 1.05rem; letter-spacing: -.01em; }
+  .path p { margin: 0 0 16px; font-size: .9rem; color: var(--ink-soft); }
+  .steps { display: flex; flex-wrap: wrap; align-items: stretch; gap: 8px; }
+  .step { display: flex; align-items: center; gap: 8px; }
+  .step a { display: flex; flex-direction: column; text-decoration: none; padding: 8px 14px; border: 1px solid var(--line); border-radius: 10px; background: var(--surface-2); min-width: 96px; }
+  .step a:hover { border-color: var(--accent); }
+  .step .n { font-family: var(--mono); font-size: .62rem; letter-spacing: .1em; color: var(--ink-faint); }
+  .step .t { font-size: .9rem; font-weight: 600; }
+  .step .sep { color: var(--ink-faint); font-family: var(--mono); }
+
+  .legend { display: flex; flex-wrap: wrap; gap: 10px 18px; margin: 18px 0 0; padding: 16px 18px; background: var(--surface-2); border: 1px solid var(--line); border-radius: 12px; }
+  .legend .item { display: flex; align-items: center; gap: 8px; font-size: .82rem; color: var(--ink-soft); }
+  .legend .sw { width: 10px; height: 10px; border-radius: 3px; }
+
+  footer.site { margin: 56px 0 40px; padding-top: 24px; border-top: 1px solid var(--line); color: var(--ink-soft); font-size: .84rem; }
+  footer.site .row { display: flex; flex-wrap: wrap; gap: 6px 20px; align-items: center; justify-content: space-between; }
+  footer.site a { color: var(--accent); text-decoration: none; }
+  footer.site a:hover { text-decoration: underline; }
+  .note { margin-top: 14px; font-size: .78rem; color: var(--ink-faint); font-family: var(--mono); }
+
+  @media (max-width: 760px) {
+    .glance { grid-template-columns: 1fr; }
+    .cards { grid-template-columns: 1fr; }
+    nav.capability { display: none; }
+  }
+  @media (prefers-reduced-motion: reduce) { * { transition: none !important; } }
+</style>
+</head>
+<body>
+<header class="site">
+  <div class="wrap site-inner">
+    <span class="wordmark">
+      <svg class="glyph" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <rect x="1.5" y="1.5" width="21" height="21" rx="4" stroke="var(--accent)" stroke-width="1.6"/>
+        <path d="M2 14c2.6 0 2.6-3 5.2-3s2.6 3 5.2 3 2.6-3 5.2-3 2.6 3 4.2 3" stroke="var(--accent)" stroke-width="1.6" fill="none" stroke-linecap="round"/>
+        <path d="M2 18c2.6 0 2.6-2 5.2-2s2.6 2 5.2 2 2.6-2 5.2-2 2.6 2 4.2 2" stroke="var(--accent)" stroke-width="1.2" fill="none" stroke-linecap="round" opacity=".5"/>
+      </svg>
+      AceEngineer
+    </span>
+    <nav class="capability" aria-label="D&amp;C QA/QC report navigation">
+      <a href="#" class="active">QA/QC</a>
+      <a href="wo-april-2026-validation.html">Matrix</a>
+      <a href="wo-april-2026-per-well-dc.html">Per-well</a>
+      <a href="fdas-revision-comparison.html">Lineage</a>
+      <a href="completion/verification.html">Frozen</a>
+      <a href="https://github.com/vamseeachanta/worldenergydata/issues/846" class="ext">#846</a>
+      <a href="https://github.com/vamseeachanta/worldenergydata/blob/main/docs/modules/bsee/analysis/production/FDAS_V30/drilling_and_completion_days_v21_kc.csv" class="ext">Data</a>
+    </nav>
+  </div>
+</header>
+
+<div class="wrap">
+  <div class="crumb"><a href="index.html">Reports</a><span class="sep">▸</span><span>D&amp;C Days QA/QC</span></div>
+
+  <section class="hero">
+    <p class="eyebrow">BSEE WAR rig-days · World Oil April 2026 Table 1 · Lower Tertiary</p>
+    <h1>D&amp;C Days QA/QC</h1>
+    <p class="lede">One entry point to the whole reconciliation — the field-level matrix, the bore-by-bore listing, the drilling-days resolution, and the revision lineage. Everything below is reachable from this page, and every number traces to committed extractor output.</p>
+    <span class="disposition"><span class="dot"></span>Reconciled to the article — completion-boundary rule (#846) open</span>
+    <div class="facts">
+      <div>Basis <span>V50 = wed · WAR 2026-02-19</span></div>
+      <div>Universe <span>253 bores · 11 developments</span></div>
+      <div>Total <span>25,404 D&amp;C days</span></div>
+      <div>Article <span>211 bores · 21,944 days</span></div>
+    </div>
+  </section>
+
+  <section class="glance" aria-label="Reconciliation at a glance">
+    <div class="tiles">
+      <div class="tile">
+        <div class="k">Drilling stability</div>
+        <div class="v ok">0<small>/253</small></div>
+        <div class="sub">bores changed drilling days across vintages</div>
+      </div>
+      <div class="tile">
+        <div class="k">Matrix agreement</div>
+        <div class="v accent">7<small>/10</small></div>
+        <div class="sub">developments tie the article to the day</div>
+      </div>
+      <div class="tile">
+        <div class="k">Open delta</div>
+        <div class="v warn">+119<small>days</small></div>
+        <div class="sub">Jack St Malo — two late bores + #846 boundary</div>
+      </div>
+      <div class="tile">
+        <div class="k">Recovered</div>
+        <div class="v">25<small>bores</small></div>
+        <div class="sub">Buckskin, missing from the article's shelf extract</div>
+      </div>
+    </div>
+
+    <div class="chartcard">
+      <h3>Δ vs the article, by development</h3>
+      <p class="cap">Total D&amp;C days, wed minus World Oil Table 1 — seven exact, three explained.</p>
+      <svg viewBox="0 0 600 230" role="img" aria-label="Delta bars: Jack St Malo +119 days, Buckskin +52, Shenandoah +24; Anchor, Cascade Chinook, Stones, Julia, Kaskida, North Platte and Tiber all zero.">
+        <g stroke="var(--line-strong)" stroke-width="1">
+          <line x1="150" y1="14" x2="150" y2="196"/>
+        </g>
+        <g font-family="ui-monospace, monospace" font-size="10.5" fill="var(--ink-soft)" text-anchor="end">
+          <text x="142" y="32">Jack St Malo</text>
+          <text x="142" y="56">Buckskin</text>
+          <text x="142" y="80">Shenandoah</text>
+          <text x="142" y="104">Stones</text>
+          <text x="142" y="128">Anchor</text>
+          <text x="142" y="152">Cascade Chinook</text>
+          <text x="142" y="176">4 others</text>
+        </g>
+        <g>
+          <rect x="150" y="22" width="357" height="13" rx="2.5" fill="var(--warn)"/>
+          <rect x="150" y="46" width="156" height="13" rx="2.5" fill="var(--accent)"/>
+          <rect x="150" y="70" width="72" height="13" rx="2.5" fill="var(--accent)"/>
+          <rect x="150" y="94" width="3" height="13" rx="1.5" fill="var(--ok)"/>
+          <rect x="150" y="118" width="3" height="13" rx="1.5" fill="var(--ok)"/>
+          <rect x="150" y="142" width="3" height="13" rx="1.5" fill="var(--ok)"/>
+          <rect x="150" y="166" width="3" height="13" rx="1.5" fill="var(--ok)"/>
+        </g>
+        <g font-family="ui-monospace, monospace" font-size="10.5" font-weight="700">
+          <text x="515" y="32" fill="var(--warn)">+119 · open</text>
+          <text x="314" y="56" fill="var(--accent-strong)">+52 · recovered bore</text>
+          <text x="230" y="80" fill="var(--accent-strong)">+24 · recompletion</text>
+          <text x="161" y="104" fill="var(--ok)">0 · exact</text>
+          <text x="161" y="128" fill="var(--ok)">0 · exact</text>
+          <text x="161" y="152" fill="var(--ok)">0 · exact</text>
+          <text x="161" y="176" fill="var(--ok)">0 · exact</text>
+        </g>
+        <g font-family="ui-monospace, monospace" font-size="10" fill="var(--ink-faint)">
+          <text x="150" y="216">0</text>
+          <text x="440" y="216">+100 days</text>
+          <text x="300" y="216" fill="var(--ink-soft)">wed − article, total D&amp;C days</text>
+        </g>
+      </svg>
+    </div>
+  </section>
+
+  <section class="sec">
+    <div class="sec-head"><div><p class="eyebrow">The report set</p><h2>How it holds together</h2></div></div>
+    <p class="sec-note">Five report roles, grouped by how deep you're going. Start with the reconciliation narrative, drill into the bore-level data, then follow the one open accounting question. Each card carries an evidence badge so you always know what weight the page can bear.</p>
+
+    <div class="tier">
+      <div class="tier-label"><p class="eyebrow">Understand</p><span class="rule"></span></div>
+      <div class="cards">
+        <a class="card" href="wo-april-2026-validation.html">
+          <div class="top"><span class="kind">Narrative</span><span class="badge ok"><span class="d"></span>Reconciled</span></div>
+          <h3>Validation &amp; Matrix</h3>
+          <p>The field-level D&amp;C reconciliation against the article as published, plus the article errata hand-back.</p>
+          <ul><li>7 exact · Shenandoah +24 resolved · Buckskin recovered</li><li>Post-cutoff delta isolated: +53 days, all servicing</li><li>BOEM cross-check and change log</li></ul>
+          <div class="foot"><span></span><span class="arrow">Open →</span></div>
+        </a>
+        <a class="card" href="fdas-revision-comparison.html">
+          <div class="top"><span class="kind">Narrative</span><span class="badge warn"><span class="d"></span>Verification</span></div>
+          <h3>Revision Lineage</h3>
+          <p>V30 → V50 → wed, field by field — the canonical-basis story behind every number on these pages.</p>
+          <ul><li>V50 = wed to the day, every field</li><li>What changed at each revision and why</li><li>The bug corrections, documented</li></ul>
+          <div class="foot"><span></span><span class="arrow">Open →</span></div>
+        </a>
+      </div>
+    </div>
+
+    <div class="tier">
+      <div class="tier-label"><p class="eyebrow">Explore the data</p><span class="rule"></span></div>
+      <div class="cards">
+        <a class="card" href="wo-april-2026-per-well-dc.html">
+          <div class="top"><span class="kind">Bore-level index</span><span class="badge idx"><span class="d"></span>253 bores</span></div>
+          <h3>Per-Well Listing</h3>
+          <p>One row per wellbore behind every matrix cell — the "listing" the QA/QC review asked for.</p>
+          <ul><li>Spud, TD, drilling / completion split per bore</li><li>Producer and sidetrack markers</li><li>Article comparison columns per development</li></ul>
+          <div class="foot"><span></span><span class="arrow">Open →</span></div>
+        </a>
+        <a class="card" href="wo-april-2026-per-well-dc.html">
+          <div class="top"><span class="kind">Vintage diff</span><span class="badge warn"><span class="d"></span>Basis caveat</span></div>
+          <h3>Drilling-Days Resolution</h3>
+          <p>Frozen V30 vs wed, per bore — drilling days never change once TD is reached; all movement is data arrival.</p>
+          <ul><li>0 of 253 bores changed drilling days</li><li>7 late-data bores · 5 servicing-accrual bores</li><li>Known caveat: two bases in one column — calendar ≤250 d, WAR-union beyond; batch-drilled wells undercount (PS004: 44 d at 28,692 ft)</li></ul>
+          <div class="foot"><span></span><span class="arrow">Open →</span></div>
+        </a>
+      </div>
+    </div>
+
+    <div class="tier">
+      <div class="tier-label"><p class="eyebrow">The open question</p><span class="rule"></span></div>
+      <div class="cards">
+        <a class="card" href="https://github.com/vamseeachanta/worldenergydata/pull/897">
+          <div class="top"><span class="kind">Diagnostic · per bore</span><span class="badge hold"><span class="d"></span>PR #897 pending</span></div>
+          <h3>JSM D&amp;C Diff</h3>
+          <p>The +234-day frozen-vs-candidate difference localized to two producer bores — every boundary rule tested regresses another field's pins.</p>
+          <ul><li>608124015400 · +48 drill / +71 compl</li><li>608124015504 · +68 drill / +47 compl</li><li>Rule sensitivity table → owner decision</li></ul>
+          <div class="foot"><span></span><span class="arrow">Open PR →</span></div>
+        </a>
+        <a class="card" href="completion/verification.html">
+          <div class="top"><span class="kind">Frozen benchmark</span><span class="badge ok"><span class="d"></span>Like-for-like</span></div>
+          <h3>Frozen Verification</h3>
+          <p>The like-for-like check against the article's own frozen V30 universe — 217 wells, matched-9 within −2.5%.</p>
+          <ul><li>22,478 wed vs 21,944 article D&amp;C days</li><li>Same universe, same vintage, same rules</li><li>The WO_APRIL_2026_ARTICLE pinned benchmark</li></ul>
+          <div class="foot"><span></span><span class="arrow">Open →</span></div>
+        </a>
+      </div>
+    </div>
+
+    <div class="tier">
+      <div class="tier-label"><p class="eyebrow">Source</p><span class="rule"></span></div>
+      <div class="cards">
+        <a class="card wide ext" href="https://github.com/vamseeachanta/worldenergydata/blob/main/docs/modules/bsee/analysis/production/FDAS_V30/drilling_and_completion_days_v21_kc.csv">
+          <div class="top"><span class="kind">Committed extractor output</span><span class="badge hold"><span class="d"></span>Provenance</span></div>
+          <h3>Data &amp; Provenance ↗</h3>
+          <p>The canonical per-bore extract (253 rows) and the vintage diff (dc_vintage_diff.csv), both committed and pinned by tests — every number on these pages traces back here.</p>
+          <div class="foot"><span></span><span class="arrow">github.com/vamseeachanta/worldenergydata →</span></div>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <div class="path">
+    <h3>Guided reading path</h3>
+    <p>If you'd rather be walked through it, follow the reconciliation in the order it was built.</p>
+    <div class="steps">
+      <div class="step"><a href="wo-april-2026-validation.html"><span class="n">START</span><span class="t">Matrix</span></a><span class="sep">→</span></div>
+      <div class="step"><a href="wo-april-2026-per-well-dc.html"><span class="n">DRILL IN</span><span class="t">Per-well</span></a><span class="sep">→</span></div>
+      <div class="step"><a href="wo-april-2026-per-well-dc.html"><span class="n">RESOLVE</span><span class="t">Vintage diff</span></a><span class="sep">→</span></div>
+      <div class="step"><a href="https://github.com/vamseeachanta/worldenergydata/issues/846"><span class="n">DECIDE</span><span class="t">#846 rule</span></a></div>
+    </div>
+  </div>
+
+  <div class="legend" aria-label="Evidence badge legend">
+    <span class="eyebrow" style="align-self:center">Evidence badges</span>
+    <span class="item"><span class="sw" style="background:var(--ok)"></span>Reconciled / like-for-like</span>
+    <span class="item"><span class="sw" style="background:var(--warn)"></span>Verification / caveat retained</span>
+    <span class="item"><span class="sw" style="background:var(--accent)"></span>Bore-level index</span>
+    <span class="item"><span class="sw" style="background:var(--hold)"></span>Pending / provenance</span>
+  </div>
+
+  <footer class="site">
+    <div class="row">
+      <span>D&amp;C Days QA/QC — World Oil April 2026 · report hub</span>
+      <a href="https://github.com/vamseeachanta/worldenergydata/blob/main/docs/modules/bsee/analysis/production/FDAS_V30/drilling_and_completion_days_v21_kc.csv">Data &amp; provenance ↗</a>
+    </div>
+    <p class="note">// self-contained — no external assets; every number traces to committed extractor output. The JSM diff links its open PR (#897) until merged.</p>
+  </footer>
+</div>
+</body>
+</html>

--- a/scripts/build_pages.py
+++ b/scripts/build_pages.py
@@ -561,6 +561,11 @@ def build_lower_tertiary(available_viz: dict[str, bool]) -> list[tuple]:
             encoding="utf-8",
         )
 
+    # --- World Oil April 2026 QA/QC report hub (committed self-contained page) ---
+    hub_html = REPORTS / "lower_tertiary" / "wo-april-2026-qaqc-hub.html"
+    if hub_html.exists():
+        shutil.copy2(hub_html, PUBLIC / "wo-april-2026-qaqc-hub.html")
+
     # --- World Oil April 2026 per-well D&C listing (matrix drill-down) ---
     perwell_md = REPORTS / "lower_tertiary" / "wo-april-2026-per-well-dc.md"
     if perwell_md.exists():
@@ -1096,6 +1101,14 @@ def build_index() -> None:
         cards.append(
             '<a class="card" href="portfolio.html"><h3>Portfolio Summary &rarr;</h3>'
             "<p>Field-by-field roll-up of the Lower-Tertiary play.</p></a>"
+        )
+    if (PUBLIC / "wo-april-2026-qaqc-hub.html").exists():
+        cards.append(
+            '<a class="card" href="wo-april-2026-qaqc-hub.html">'
+            "<h3>D&amp;C Days QA/QC Hub &rarr;</h3>"
+            "<p>One entry point to the whole reconciliation &mdash; matrix, "
+            "per-well listing, drilling-days resolution, lineage, and "
+            "provenance, each badged by evidence weight.</p></a>"
         )
     if (PUBLIC / "wo-april-2026-validation.html").exists():
         cards.append(

--- a/tests/unit/lower_tertiary/test_wo_qaqc_hub.py
+++ b/tests/unit/lower_tertiary/test_wo_qaqc_hub.py
@@ -1,0 +1,74 @@
+"""Gates for the committed D&C QA/QC report hub (wo-april-2026-qaqc-hub.html).
+
+The hub is the report-set entry point and the reference implementation of the
+self-contained report-hub design (evidence badges, tiered cards, guided path).
+These pins keep it self-contained and keep its numbers tied to the matrix.
+"""
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+HUB = REPO / "reports" / "lower_tertiary" / "wo-april-2026-qaqc-hub.html"
+
+
+def _text() -> str:
+    return HUB.read_text(encoding="utf-8")
+
+
+def test_hub_exists_and_is_a_full_document():
+    text = _text()
+    assert text.lstrip().lower().startswith("<!doctype html>")
+    assert "</html>" in text
+    assert "<title>D&C Days QA/QC — Report Hub</title>" in text
+
+
+def test_hub_is_self_contained():
+    """No external stylesheets, scripts, fonts, or images — CSS/SVG inline only."""
+    text = _text()
+    assert "<link" not in text
+    assert "<script" not in text
+    assert "<img" not in text
+    assert "@import" not in text
+    assert "fonts.googleapis" not in text
+
+
+def test_external_hrefs_are_github_only():
+    text = _text()
+    for url in re.findall(r'href="(https?://[^"]+)"', text):
+        assert url.startswith("https://github.com/vamseeachanta/worldenergydata"), url
+
+
+def test_relative_links_point_at_published_pages():
+    text = _text()
+    rel = {
+        u for u in re.findall(r'href="([^"#][^":]*)"', text) if not u.startswith("http")
+    }
+    expected = {
+        "index.html",
+        "wo-april-2026-validation.html",
+        "wo-april-2026-per-well-dc.html",
+        "fdas-revision-comparison.html",
+        "completion/verification.html",
+    }
+    assert rel == expected, rel
+
+
+def test_hub_carries_matrix_numbers():
+    text = _text()
+    for needle in (
+        "253 bores · 11 developments",
+        "25,404 D&amp;C days",
+        "211 bores · 21,944 days",
+        "+119",
+        "0<small>/253</small>",
+        "completion-boundary rule (#846) open",
+    ):
+        assert needle in text, needle
+
+
+def test_hub_has_both_theme_definitions():
+    text = _text()
+    assert "@media (prefers-color-scheme: dark)" in text
+    assert ':root[data-theme="dark"]' in text
+    assert ':root[data-theme="light"]' in text


### PR DESCRIPTION
## What

Lands the owner-approved report hub (reviewed as an artifact mockup) as a committed page: **`wo-april-2026-qaqc-hub.html`** — one entry point to the D&C QA/QC report set.

- Evidence-badged tiered cards (Understand / Explore / Open question / Source) over the matrix, per-well listing, drilling-days resolution, revision lineage, frozen verification, and committed-CSV provenance
- Disposition pill ("Reconciled to the article — completion-boundary rule (#846) open"), at-a-glance tiles (0/253 drilling stability, 7/10 exact, +119 JSM, 25 Buckskin), Δ-vs-article SVG chart, guided reading path
- **Fully self-contained**: inline CSS/SVG, light+dark themes via CSS tokens, system fonts, zero external assets; relative links to published pages; the JSM diff card links its open PR (#897) until merged
- Published verbatim by `build_pages.py` + featured index card; repo-structure allowlisted

This page is the reference implementation of the report-hub design system to be rolled across the worldwide field-data surfaces (epic to follow).

## Verification

- 6 gate tests: full-document + self-containment (no link/script/img/@import), external hrefs GitHub-only, relative links enumerate published pages exactly, matrix numbers pinned, both theme definitions present — 16/16 lower-tertiary wo-tests green
- `build_pages --domains lower_tertiary` → 17 pages incl. the hub; `cmp` byte-match report↔public
- black clean on new/changed files; flake8 delta vs main = 0 (21 pre-existing in build_pages.py untouched); repo-structure OK; legal PASS

Refs #846.