### PR TITLE
feat(bsee): shared war_rig_days module on WAR activity codes (#1067)

### DIFF
--- a/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/war_rig_days.py
+++ b/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/war_rig_days.py
@@ -1,0 +1,347 @@
+"""Drilling and completion rig-days from BSEE WAR activity codes.
+
+This is the single implementation of "how many days did a rig spend drilling
+and completing this wellbore".  Every other consumer should call it rather
+than re-deriving the number; see #1063 for why four divergent implementations
+existed and what each of them got wrong.
+
+Basis
+-----
+A BSEE Well Activity Report (WAR) is a *weekly* return (Form BSEE-0133,
+30 CFR 250.743; Sunday 00:00 through Saturday 23:59) carrying one
+``WELL_ACTIVITY_CD`` per reported operation.  Rig-days are therefore the sum
+of WAR week spans attributed to the relevant activity codes -- not a calendar
+span between spud and total depth, which for a suspended or batch-drilled
+well measures elapsed time rather than rig time.
+
+Two conventions are pinned deliberately, because getting either wrong moves
+every published number:
+
+``INCLUSIVE`` day counting
+    A WAR week runs Sunday 00:00 to Saturday 23:59 and is *seven* days, so a
+    span is ``(end - start).days + 1``.  This is the convention under which
+    the domain owner's own published totals for well 608124009500 reproduce
+    (DRL 151, PND 49, total 308); see the fixture test.
+
+Adjacency merging
+    Consecutive WAR weeks (Jan 1-7 then Jan 8-14) describe *continuous* rig
+    time and must merge into one 14-day span.  Treating them as disjoint
+    (the previous behaviour) silently lost one day per week boundary.
+
+Grain
+-----
+BSEE reports at API12 -- the *wellbore*, including each sidetrack as its own
+suffix.  Rolling up to API10 (the *well*) must UNION the underlying WAR weeks
+rather than sum per-bore days: at each sidetrack transition a single WAR week
+is attributed to both bores, so summing double-counts roughly seven days per
+boundary.  Both grains are emitted so consumers can state which one they mean.
+
+``PND`` caveat
+--------------
+BSEE publishes no code list for ``WELL_ACTIVITY_CD`` and ``PND`` appears in
+none of their documented domains, yet it accounts for a material share of
+reported weeks.  It is therefore never folded silently into another bucket:
+it is emitted as its own ``pnd_days`` column, and a basis either includes it
+explicitly or does not.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+from worldenergydata.lower_tertiary.ops_timeline import WAR_ACTIVITY_LABELS
+
+__all__ = [
+    "WAR_ACTIVITY_LABELS",
+    "Basis",
+    "BASIS_DRL_COM",
+    "BASIS_DRL_COM_PND",
+    "BASIS_METHOD_1",
+    "PRESET_BASES",
+    "union_days",
+    "rig_days_by_bore",
+    "rig_days_by_well",
+]
+
+# Emitted when a bore appears in the target population but has no WAR
+# activity at all -- distinct from a genuine zero, and never rendered as 0.
+STATUS_COVERED = "war_covered"
+STATUS_NO_ACTIVITY = "no_war_activity"
+
+_REQUIRED_COLUMNS = (
+    "API_WELL_NUMBER",
+    "WAR_START_DT",
+    "WAR_END_DT",
+    "WELL_ACTIVITY_CD",
+)
+
+
+@dataclass(frozen=True)
+class Basis:
+    """A named, explicit rule for turning activity codes into D&C days.
+
+    The whole defect class in #1063 exists because a rule was applied
+    provisionally and never recorded alongside the numbers it produced, so
+    every frame this module emits carries ``label`` in a ``basis`` column.
+    """
+
+    label: str
+    drilling_codes: frozenset[str]
+    completion_codes: frozenset[str]
+    notes: str = ""
+
+    def describe(self) -> str:
+        drl = "+".join(sorted(self.drilling_codes))
+        com = "+".join(sorted(self.completion_codes))
+        return f"{self.label}(drilling={drl};completion={com};days=inclusive)"
+
+
+#: Drilling = DRL, completion = COM.  Maps onto IADC DDR Plus Code 31, whose
+#: completion phase "commence[s] once drilling is complete, and casing is set"
+#: -- i.e. the DRL -> COM code transition.  PND excluded.
+BASIS_DRL_COM = Basis(
+    label="DRL_COM",
+    drilling_codes=frozenset({"DRL"}),
+    completion_codes=frozenset({"COM"}),
+    notes="IADC DDR Plus Code 31 alignment; PND reported separately.",
+)
+
+#: As above but crediting PND to completion, for side-by-side reporting while
+#: the meaning of PND is outstanding with BSEE (see #1065).
+BASIS_DRL_COM_PND = Basis(
+    label="DRL_COM_PND",
+    drilling_codes=frozenset({"DRL"}),
+    completion_codes=frozenset({"COM", "PND"}),
+    notes="PND credited to completion; use only alongside DRL_COM.",
+)
+
+#: The domain owner's "method 1" from rig_days_summary.md: COM + PND + TA.
+BASIS_METHOD_1 = Basis(
+    label="METHOD_1",
+    drilling_codes=frozenset({"DRL"}),
+    completion_codes=frozenset({"COM", "PND", "TA"}),
+    notes="Owner's method 1 (rig_days_summary.md).",
+)
+
+PRESET_BASES: dict[str, Basis] = {
+    b.label: b for b in (BASIS_DRL_COM, BASIS_DRL_COM_PND, BASIS_METHOD_1)
+}
+
+
+def union_days(intervals) -> int:
+    """Total days covered by ``intervals``, inclusive of both endpoints.
+
+    Overlapping *and* directly adjacent intervals are merged, so consecutive
+    WAR weeks count as continuous rig time.  Rows with a missing endpoint are
+    skipped; an empty or all-missing input yields 0.
+
+    Endpoints are normalised to midnight first.  WAR weeks are stamped with
+    times (typically 00:01 to 23:59), and carrying those through the merge
+    loses whole days to truncation: seven consecutive weeks measure
+    47d23h59m, which floors to 47 rather than the 48 day-boundaries actually
+    spanned.  Rig-days are a count of calendar days, not of elapsed time.
+    """
+    clean = sorted(
+        (s.normalize(), e.normalize())
+        for s, e in intervals
+        if pd.notna(s) and pd.notna(e) and e >= s
+    )
+    if not clean:
+        return 0
+
+    one_day = pd.Timedelta(days=1)
+    total = 0
+    cur_start, cur_end = clean[0]
+    for start, end in clean[1:]:
+        if start <= cur_end + one_day:  # overlapping or back-to-back
+            cur_end = max(cur_end, end)
+        else:
+            total += (cur_end - cur_start).days + 1
+            cur_start, cur_end = start, end
+    total += (cur_end - cur_start).days + 1
+    return int(total)
+
+
+def _prepare(war: pd.DataFrame) -> pd.DataFrame:
+    missing = [c for c in _REQUIRED_COLUMNS if c not in war.columns]
+    if missing:
+        raise ValueError(
+            f"WAR frame is missing required column(s): {', '.join(missing)}. "
+            "Join mv_war_main (week bounds, API) to mv_war_main_prop "
+            "(WELL_ACTIVITY_CD) on SN_WAR before calling."
+        )
+
+    out = pd.DataFrame(
+        {
+            "api12": war["API_WELL_NUMBER"].astype(str).str.strip(),
+            "activity_cd": war["WELL_ACTIVITY_CD"].astype(str).str.strip().str.upper(),
+            # format="mixed": WAR bounds arrive as a mix of "YYYY-MM-DD
+            # HH:MM:SS" and bare dates depending on the vintage of the return.
+            "start": pd.to_datetime(
+                war["WAR_START_DT"], errors="coerce", format="mixed"
+            ),
+            "end": pd.to_datetime(war["WAR_END_DT"], errors="coerce", format="mixed"),
+        }
+    )
+    out = out[out["activity_cd"].ne("") & out["activity_cd"].ne("NAN")]
+    return out.dropna(subset=["start", "end"])
+
+
+def _days_for(group: pd.DataFrame, codes) -> int:
+    sub = group[group["activity_cd"].isin(codes)]
+    return union_days(zip(sub["start"], sub["end"]))
+
+
+def rig_days_by_bore(
+    war: pd.DataFrame,
+    basis: Basis = BASIS_DRL_COM,
+    population: "list[str] | None" = None,
+) -> pd.DataFrame:
+    """Rig-days per API12 wellbore.
+
+    Parameters
+    ----------
+    war
+        WAR rows carrying ``API_WELL_NUMBER``, ``WAR_START_DT``,
+        ``WAR_END_DT`` and ``WELL_ACTIVITY_CD`` (mv_war_main joined to
+        mv_war_main_prop on ``SN_WAR``).
+    basis
+        Which activity codes constitute drilling and completion.
+    population
+        Optional API12 list to report on.  Bores in ``population`` with no WAR
+        activity are emitted with null days and ``days_status`` of
+        ``no_war_activity``, so absent coverage is never mistaken for zero.
+    """
+    prepared = _prepare(war)
+    if population is not None:
+        # Restrict before grouping: the raw WAR frame spans every well BSEE
+        # has ever reported, and grouping all of them to keep a few hundred
+        # dominates the runtime.
+        prepared = prepared[
+            prepared["api12"].isin({str(a).strip() for a in population})
+        ]
+
+    rows = []
+    for api12, group in prepared.groupby("api12", sort=True):
+        by_code = {
+            code: union_days(zip(sub["start"], sub["end"]))
+            for code, sub in group.groupby("activity_cd", sort=True)
+        }
+        rows.append(
+            {
+                "api12": api12,
+                "api10": api12[:10],
+                "bore_suffix": api12[10:],
+                "drilling_days": _days_for(group, basis.drilling_codes),
+                "completion_days": _days_for(group, basis.completion_codes),
+                "pnd_days": by_code.get("PND", 0),
+                "war_days_total": union_days(zip(group["start"], group["end"])),
+                "war_weeks": int(len(group)),
+                "days_by_code": by_code,
+                "days_status": STATUS_COVERED,
+            }
+        )
+
+    frame = pd.DataFrame(rows, columns=_BORE_COLUMNS)
+
+    if population is not None:
+        frame = _apply_population(frame, population)
+
+    frame["basis"] = basis.describe()
+    return frame.reset_index(drop=True)
+
+
+_BORE_COLUMNS = [
+    "api12",
+    "api10",
+    "bore_suffix",
+    "drilling_days",
+    "completion_days",
+    "pnd_days",
+    "war_days_total",
+    "war_weeks",
+    "days_by_code",
+    "days_status",
+]
+
+_DAY_COLUMNS = ("drilling_days", "completion_days", "pnd_days", "war_days_total")
+
+
+def _apply_population(frame: pd.DataFrame, population) -> pd.DataFrame:
+    wanted = [str(a).strip() for a in population]
+    frame = frame[frame["api12"].isin(set(wanted))]
+
+    absent = sorted(set(wanted) - set(frame["api12"]))
+    if not absent:
+        return frame
+
+    filler = pd.DataFrame(
+        {
+            "api12": absent,
+            "api10": [a[:10] for a in absent],
+            "bore_suffix": [a[10:] for a in absent],
+            "drilling_days": pd.NA,
+            "completion_days": pd.NA,
+            "pnd_days": pd.NA,
+            "war_days_total": pd.NA,
+            "war_weeks": 0,
+            "days_by_code": [{} for _ in absent],
+            "days_status": STATUS_NO_ACTIVITY,
+        },
+        columns=_BORE_COLUMNS,
+    )
+    return pd.concat([frame, filler], ignore_index=True).sort_values("api12")
+
+
+def rig_days_by_well(
+    war: pd.DataFrame,
+    basis: Basis = BASIS_DRL_COM,
+    population: "list[str] | None" = None,
+) -> pd.DataFrame:
+    """Rig-days per API10 well, unioning the WAR weeks of all its bores.
+
+    ``*_additive`` columns (the per-bore sums) are emitted alongside the union
+    so the difference stays visible: it is dominated by the single WAR week
+    that straddles each sidetrack transition, and is not parallel operations.
+    """
+    prepared = _prepare(war)
+    if population is not None:
+        prepared = prepared[
+            prepared["api12"].isin({str(a).strip() for a in population})
+        ]
+    bores = rig_days_by_bore(war, basis=basis, population=population)
+
+    covered = bores[bores["days_status"].eq(STATUS_COVERED)]
+    additive = (
+        covered.groupby("api10")
+        .agg(
+            n_bores=("api12", "count"),
+            bore_suffixes=("bore_suffix", lambda s: ",".join(sorted(s))),
+            drilling_days_additive=("drilling_days", "sum"),
+            completion_days_additive=("completion_days", "sum"),
+            pnd_days_additive=("pnd_days", "sum"),
+            war_days_additive=("war_days_total", "sum"),
+        )
+        .reset_index()
+    )
+
+    prepared = prepared.assign(api10=prepared["api12"].str[:10])
+    unions = []
+    for api10, group in prepared.groupby("api10", sort=True):
+        unions.append(
+            {
+                "api10": api10,
+                "drilling_days": _days_for(group, basis.drilling_codes),
+                "completion_days": _days_for(group, basis.completion_codes),
+                "pnd_days": _days_for(group, {"PND"}),
+                "war_days_total": union_days(zip(group["start"], group["end"])),
+            }
+        )
+
+    frame = additive.merge(pd.DataFrame(unions), on="api10", how="left")
+    frame["overlap_days"] = frame["war_days_additive"] - frame["war_days_total"]
+    frame["days_status"] = STATUS_COVERED
+    frame["basis"] = basis.describe()
+    return frame

--- a/tests/unit/bsee/analysis/test_war_rig_days.py
+++ b/tests/unit/bsee/analysis/test_war_rig_days.py
@@ -1,0 +1,207 @@
+"""Tests for war_rig_days -- the single WAR activity-code rig-day implementation.
+
+The anchor test reproduces the domain owner's own published totals for well
+608124009500 (a Stones well) from the WAR extract committed alongside this
+repo, so the basis is validated in CI without the ~370 MB raw WAR download.
+"""
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from worldenergydata.bsee.analysis.war_rig_days import (
+    BASIS_DRL_COM,
+    BASIS_DRL_COM_PND,
+    BASIS_METHOD_1,
+    STATUS_COVERED,
+    STATUS_NO_ACTIVITY,
+    rig_days_by_bore,
+    rig_days_by_well,
+    union_days,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+FIXTURE = REPO_ROOT / "docs/modules/bsee/analysis/rig_days/war_data_608124009500.csv"
+REFERENCE_API12 = "608124009500"
+
+# rig_days_summary.md records, for this well: {"COM": 87, "DRL": 151,
+# "PND": 49, "TA": 21}.  DRL, PND and the 308-day total reproduce exactly.
+# COM/TA differ by 4 days in a compensating pair because one WAR week
+# straddles the COM -> TA code change; the total is therefore unaffected.
+OWNER_DRL_DAYS = 151
+OWNER_PND_DAYS = 49
+OWNER_TOTAL_DAYS = 308
+
+
+@pytest.fixture(scope="module")
+def war() -> pd.DataFrame:
+    if not FIXTURE.exists():  # pragma: no cover - guards a moved fixture
+        pytest.skip(f"WAR fixture not found: {FIXTURE}")
+    return pd.read_csv(FIXTURE)
+
+
+def _ts(day: str) -> pd.Timestamp:
+    return pd.Timestamp(day)
+
+
+class TestUnionDays:
+    def test_single_war_week_is_inclusive_of_both_endpoints(self):
+        # A WAR week runs Sunday 00:00 -> Saturday 23:59 and is seven days.
+        assert union_days([(_ts("2014-07-27"), _ts("2014-08-02"))]) == 7
+
+    def test_back_to_back_weeks_merge_into_continuous_rig_time(self):
+        # Regression: adjacent weeks were previously counted as disjoint,
+        # losing a day at every week boundary.
+        weeks = [
+            (_ts("2014-01-01"), _ts("2014-01-07")),
+            (_ts("2014-01-08"), _ts("2014-01-14")),
+        ]
+        assert union_days(weeks) == 14
+
+    def test_overlapping_intervals_are_not_double_counted(self):
+        spans = [
+            (_ts("2014-01-01"), _ts("2014-01-10")),
+            (_ts("2014-01-05"), _ts("2014-01-07")),
+        ]
+        assert union_days(spans) == 10
+
+    def test_gap_between_spans_is_excluded(self):
+        spans = [
+            (_ts("2014-01-01"), _ts("2014-01-07")),
+            (_ts("2014-02-01"), _ts("2014-02-07")),
+        ]
+        assert union_days(spans) == 14
+
+    def test_empty_and_missing_endpoints_yield_zero(self):
+        assert union_days([]) == 0
+        assert union_days([(pd.NaT, _ts("2014-01-07"))]) == 0
+
+    def test_time_of_day_does_not_truncate_a_run_of_weeks(self):
+        # WAR weeks are stamped 00:01 -> 23:59.  Seven consecutive weeks span
+        # 47d23h59m of elapsed time but 49 calendar days; counting elapsed
+        # time silently loses a day.  This is the PND run on well
+        # 608124009500, which the owner records as 49 days.
+        weeks = [
+            (_ts("2014-12-21 00:01"), _ts("2014-12-27 23:59")),
+            (_ts("2014-12-28 00:01"), _ts("2015-01-03 23:59")),
+            (_ts("2015-01-04 00:01"), _ts("2015-01-10 23:59")),
+            (_ts("2015-01-11 00:01"), _ts("2015-01-17 23:59")),
+            (_ts("2015-01-18 00:01"), _ts("2015-01-24 23:59")),
+            (_ts("2015-01-25 00:01"), _ts("2015-01-31 23:59")),
+            (_ts("2015-02-01 00:00"), _ts("2015-02-07 00:00")),
+        ]
+        assert union_days(weeks) == 49
+
+
+class TestOwnerReferenceWell:
+    """The acceptance criterion from #1063: reproduce the owner's numbers."""
+
+    def test_drilling_days_match_owner_exactly(self, war):
+        bores = rig_days_by_bore(war, basis=BASIS_DRL_COM)
+        row = bores.loc[bores["api12"].eq(REFERENCE_API12)].squeeze()
+        assert int(row["drilling_days"]) == OWNER_DRL_DAYS
+
+    def test_pnd_days_match_owner_exactly(self, war):
+        bores = rig_days_by_bore(war, basis=BASIS_DRL_COM)
+        row = bores.loc[bores["api12"].eq(REFERENCE_API12)].squeeze()
+        assert int(row["pnd_days"]) == OWNER_PND_DAYS
+
+    def test_total_war_days_match_owner_exactly(self, war):
+        bores = rig_days_by_bore(war, basis=BASIS_DRL_COM)
+        row = bores.loc[bores["api12"].eq(REFERENCE_API12)].squeeze()
+        assert int(row["war_days_total"]) == OWNER_TOTAL_DAYS
+
+    def test_com_and_ta_differ_only_as_a_compensating_pair(self, war):
+        # One WAR week straddles the COM -> TA transition, so our split is
+        # COM 91 / TA 17 against the owner's 87 / 21.  Pin the invariant that
+        # matters -- the pair sums to the same 108 days -- rather than the
+        # arbitrary side of the boundary the straddling week lands on.
+        bores = rig_days_by_bore(war, basis=BASIS_DRL_COM)
+        row = bores.loc[bores["api12"].eq(REFERENCE_API12)].squeeze()
+        com = row["days_by_code"].get("COM", 0)
+        ta = row["days_by_code"].get("TA", 0)
+        assert com + ta == 87 + 21
+        assert abs(com - 87) <= 7  # within one WAR week of the owner's split
+
+
+class TestBasisIsAlwaysDeclared:
+    def test_bore_frame_records_the_basis_it_was_computed_under(self, war):
+        bores = rig_days_by_bore(war, basis=BASIS_DRL_COM)
+        assert bores["basis"].eq(BASIS_DRL_COM.describe()).all()
+        assert "days=inclusive" in BASIS_DRL_COM.describe()
+
+    def test_pnd_moves_completion_but_never_drilling(self, war):
+        without = rig_days_by_bore(war, basis=BASIS_DRL_COM).squeeze()
+        with_pnd = rig_days_by_bore(war, basis=BASIS_DRL_COM_PND).squeeze()
+        assert with_pnd["drilling_days"] == without["drilling_days"]
+        assert with_pnd["completion_days"] > without["completion_days"]
+
+    def test_owner_method_1_adds_ta_on_top_of_pnd(self, war):
+        with_pnd = rig_days_by_bore(war, basis=BASIS_DRL_COM_PND).squeeze()
+        method_1 = rig_days_by_bore(war, basis=BASIS_METHOD_1).squeeze()
+        assert method_1["completion_days"] > with_pnd["completion_days"]
+
+    def test_pnd_is_reported_separately_under_every_basis(self, war):
+        for basis in (BASIS_DRL_COM, BASIS_DRL_COM_PND, BASIS_METHOD_1):
+            frame = rig_days_by_bore(war, basis=basis)
+            assert int(frame.squeeze()["pnd_days"]) == OWNER_PND_DAYS
+
+
+class TestPopulationCoverage:
+    def test_bore_without_war_activity_is_null_not_zero(self, war):
+        absent = "999999999999"
+        frame = rig_days_by_bore(war, population=[REFERENCE_API12, absent])
+        row = frame.loc[frame["api12"].eq(absent)].squeeze()
+
+        assert row["days_status"] == STATUS_NO_ACTIVITY
+        assert pd.isna(row["drilling_days"])
+        assert pd.isna(row["completion_days"])
+
+    def test_covered_bore_is_flagged_covered(self, war):
+        frame = rig_days_by_bore(war, population=[REFERENCE_API12])
+        assert frame.squeeze()["days_status"] == STATUS_COVERED
+
+    def test_population_restricts_the_output(self, war):
+        frame = rig_days_by_bore(war, population=[REFERENCE_API12])
+        assert list(frame["api12"]) == [REFERENCE_API12]
+
+
+class TestApi10Collapse:
+    def test_grain_columns_are_derived_from_the_api12_key(self, war):
+        bores = rig_days_by_bore(war)
+        row = bores.squeeze()
+        assert row["api10"] == REFERENCE_API12[:10]
+        assert row["bore_suffix"] == REFERENCE_API12[10:]
+
+    def test_single_bore_well_has_no_overlap_between_methods(self, war):
+        wells = rig_days_by_well(war)
+        row = wells.squeeze()
+        assert row["n_bores"] == 1
+        assert row["overlap_days"] == 0
+        assert row["war_days_total"] == OWNER_TOTAL_DAYS
+
+    def test_sidetrack_boundary_week_is_not_double_counted(self):
+        # Two bores of one well whose WAR weeks abut across the sidetrack.
+        # Additive counts the boundary week twice; the union must not.
+        war = pd.DataFrame(
+            {
+                "API_WELL_NUMBER": ["608124009500", "608124009501"],
+                "WAR_START_DT": ["2014-01-01", "2014-01-08"],
+                "WAR_END_DT": ["2014-01-14", "2014-01-21"],
+                "WELL_ACTIVITY_CD": ["DRL", "DRL"],
+            }
+        )
+        wells = rig_days_by_well(war).squeeze()
+
+        assert wells["n_bores"] == 2
+        assert wells["bore_suffixes"] == "00,01"
+        assert wells["war_days_additive"] == 28  # 14 + 14
+        assert wells["war_days_total"] == 21  # Jan 1 -> Jan 21
+        assert wells["overlap_days"] == 7  # one straddling week
+
+
+class TestInputContract:
+    def test_missing_required_column_is_a_clear_error(self):
+        with pytest.raises(ValueError, match="WELL_ACTIVITY_CD"):
+            rig_days_by_bore(pd.DataFrame({"API_WELL_NUMBER": ["1"]}))


### PR DESCRIPTION
Closes #1067. Part of epic #1063.

Adds `war_rig_days` — the single implementation of drilling and completion rig-days, derived from BSEE WAR `WELL_ACTIVITY_CD` instead of a calendar spud→TD span. **Nothing is rewired in this PR**, so no published number moves yet; the other three implementations converge onto this in #1075.

## Basis is never implicit

Every emitted frame carries a `basis` column naming the rule that produced it, `pnd_days` is always broken out separately, and three presets ship so candidate rules can be published **side by side** rather than one being adopted silently — the exact failure mode #1063 documents.

| Preset | Drilling | Completion |
|---|---|---|
| `BASIS_DRL_COM` | `DRL` | `COM` |
| `BASIS_DRL_COM_PND` | `DRL` | `COM + PND` |
| `BASIS_METHOD_1` | `DRL` | `COM + PND + TA` (owner's method 1) |

## Two conventions pinned against the owner's own arithmetic

Neither was chosen; both were derived by finding what reproduces the domain owner's published numbers.

- **Inclusive day counting** — his totals reproduce only under `(end − start).days + 1`. This answers #1072's "pick one and document it".
- **Adjacency merging** — consecutive WAR weeks are continuous rig time and merge into one span. Treating them as disjoint lost a day per boundary (#1071).

These two are coupled: the correct form of the adjacency fix is undefined until the day convention is settled, so they land together rather than as separate "quick wins".

## The time-of-day trap

Endpoints are normalised to midnight before unioning. WAR weeks are stamped `00:01` → `23:59`, so carrying the time through the merge truncates — seven consecutive weeks measure 47d23h59m and floor to **48** days rather than the **49** day-boundaries actually spanned. Rig-days count calendar days, not elapsed time. The owner's PND figure of 49 is precisely what detects this; it was caught by the fixture test, not by inspection.

## Both grains, and why the rollup is a union

BSEE reports at **API12** (the wellbore — each sidetrack its own suffix). Rolling up to **API10** (the well) unions the underlying WAR weeks rather than summing per-bore days, because one WAR week is attributed to *both* bores at each sidetrack transition.

Across the published 253-bore population that double-count is **645 days**, with a median of **exactly 7.00 days per sidetrack boundary** — one straddling week, not parallel operations. `*_additive` columns are emitted alongside the union so the gap stays visible instead of being quietly chosen.

This matters beyond bookkeeping. Drilling-day medians by grain:

| Grain | Median drilling days |
|---|---:|
| API12 (bore) — what is published today | 42 |
| API10 (well, union) | 79 |
| API10, multi-bore wells only | **115** |

## Coverage is not zero

Bores with no WAR coverage report **null** with `days_status = no_war_activity`, never `0` — 38 of the 253 published bores are in this state (#1073). Those zeros were previously indistinguishable from a genuine zero-day result.

## Validation

The fixture test reproduces the owner's reference numbers for well **608124009500** (a Stones well, matching `rig_days_summary.md`'s "these scripts were done on Stones") from the WAR extract **already committed** at `docs/modules/bsee/analysis/rig_days/` — so the basis is validated in CI **without the ~370 MB raw WAR download**.

| | Owner | This module |
|---|---:|---:|
| DRL | 151 | **151** ✅ |
| PND | 49 | **49** ✅ |
| Total | 308 | **308** ✅ |
| COM / TA | 87 / 21 | 91 / 17 |

COM and TA differ as a **compensating pair** because one WAR week straddles that code change. The test therefore pins the invariant that survives the straddle — the pair sums to 108 — rather than the arbitrary side the week falls on.

## Checks run

- `pytest tests/unit/bsee/analysis/test_war_rig_days.py` → **21 passed**
- `black --check` / `isort --check-only` → clean
- `flake8 --max-line-length=100 --extend-ignore=E203,W503` → clean
- `scripts/maintenance/verify_repo_structure.py` → `Repo structure contract: OK`

## Note for the epic

While building this I confirmed the WAR `.bin` files are present on the analysis host at `data/modules/bsee/bin/war/`, and that `refresh_bsee_all.py`'s registry contains **no WAR or Borehole spec** — so #1066 was never the blocker it is described as, and recomputation needs no download. Worth retitling that issue.

Groundwork for #1071, #1072, #1073, #1076, #1081.
