### PR TITLE
fix(bsee): match API well numbers dtype-safely (#1113)

### DIFF
--- a/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/intervention/field_visualization.py
+++ b/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/intervention/field_visualization.py
@@ -13,6 +13,8 @@ from pathlib import Path
 import pandas as pd
 import plotly.graph_objects as go
 
+from worldenergydata.bsee.data.utils.api_well_normalizer import select_by_api
+
 # -- Color palette for activity categories ------------------------------------
 
 _ACTIVITY_COLORS: dict[str, str] = {
@@ -296,14 +298,14 @@ class FieldVisualizationModule:
         # Check borehole data first
         bh_row = None
         if self._borehole is not None and "API_WELL_NUMBER" in self._borehole.columns:
-            match = self._borehole[self._borehole["API_WELL_NUMBER"] == api]
+            match = select_by_api(self._borehole, api)
             if not match.empty:
                 bh_row = match.iloc[0]
 
         # Check enriched data
         enr_row = None
         if "API_WELL_NUMBER" in self._enriched.columns:
-            match = self._enriched[self._enriched["API_WELL_NUMBER"] == api]
+            match = select_by_api(self._enriched, api)
             if not match.empty:
                 enr_row = match.iloc[0]
 

--- a/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/well_api12.py
+++ b/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/well_api12.py
@@ -11,6 +11,7 @@ from assetutilities.common.yml_utilities import WorkingWithYAML  # noqa
 from loguru import logger
 
 from worldenergydata.bsee.analysis.well_rig_days import WellRigDays
+from worldenergydata.bsee.data.utils.api_well_normalizer import select_by_api
 
 wwy = WorkingWithYAML()
 transform = Transform()
@@ -215,7 +216,7 @@ class WellAPI12:
         file = os.path.join(library_path, "dsptsdelimit.bin")
         survey_df = pd.read_pickle(file)
 
-        api12_survey_df = survey_df[survey_df["API_WELL_NUMBER"] == API12_num].copy()
+        api12_survey_df = select_by_api(survey_df, API12_num).copy()
         if api12_survey_df.empty:
             logger.warning(f"No survey data found for API12: {API12_num}")
             return

--- a/packages/worldenergydata-bsee/src/worldenergydata/bsee/api.py
+++ b/packages/worldenergydata-bsee/src/worldenergydata/bsee/api.py
@@ -27,6 +27,8 @@ from typing import Any, Dict, Iterable, Optional, Union
 
 import pandas as pd
 
+from worldenergydata.bsee.data.utils.api_well_normalizer import api_matches
+
 
 class ProductionQuery:
     """Query BSEE production data with optional filters.
@@ -233,7 +235,7 @@ class WellsQuery:
         mask = pd.Series(True, index=df.index)
 
         if api_number is not None and "API_WELL_NUMBER" in df.columns:
-            mask &= df["API_WELL_NUMBER"] == api_number
+            mask &= api_matches(df["API_WELL_NUMBER"], api_number)
 
         if field is not None:
             # Parse "MC 778" → area_code="MC", block="778"

--- a/packages/worldenergydata-bsee/src/worldenergydata/bsee/data/_legacy/data_from_production_files.py
+++ b/packages/worldenergydata-bsee/src/worldenergydata/bsee/data/_legacy/data_from_production_files.py
@@ -6,6 +6,7 @@ import os
 import pandas as pd
 from assetutilities.common.yml_utilities import WorkingWithYAML  # noqa
 
+from worldenergydata.bsee.data.utils.api_well_normalizer import select_by_api
 from worldenergydata.common.logging import get_logger
 
 logger = get_logger(__name__)
@@ -58,7 +59,7 @@ class DataFromFiles:
                         continue
 
                     # Find matching rows for the current api12
-                    matching_rows = df[df["API_WELL_NUMBER"] == api12]
+                    matching_rows = select_by_api(df, api12)
 
                     if not matching_rows.empty:
                         # Move 'API_WELL_NUMBER' column to the first position

--- a/packages/worldenergydata-bsee/src/worldenergydata/bsee/data/loaders/api/well.py
+++ b/packages/worldenergydata-bsee/src/worldenergydata/bsee/data/loaders/api/well.py
@@ -9,6 +9,7 @@ from loguru import logger
 
 from worldenergydata.bsee.data.apm_data import APMData
 from worldenergydata.bsee.data.sources.bin.api_data import APIData
+from worldenergydata.bsee.data.utils.api_well_normalizer import select_by_api
 from worldenergydata.common.data_resolver import get_module_data_safe
 
 _BSEE_BIN = str(get_module_data_safe("bsee") / "bin")
@@ -95,12 +96,10 @@ class WellData:
         ]
 
         api12_well_data = pd.read_csv(api12_metadata["file_name"])
-        api12_eWellEORRawData = eWellEORRawData_df[
-            eWellEORRawData_df["API_WELL_NUMBER"] == api12
-        ].copy()
-        api12_eWellWARRawData_mv_war_main = eWellWARRawData_mv_war_main_df[
-            eWellWARRawData_mv_war_main_df["API_WELL_NUMBER"] == api12
-        ].copy()
+        api12_eWellEORRawData = select_by_api(eWellEORRawData_df, api12).copy()
+        api12_eWellWARRawData_mv_war_main = select_by_api(
+            eWellWARRawData_mv_war_main_df, api12
+        ).copy()
         # api12_eWellWARRawData_mv_war_main_prop = eWellWARRawData_mv_war_main_prop_df[eWellWARRawData_mv_war_main_prop_df['API_WELL_NUMBER'] == api12].copy()  # noqa: E501
 
         Borehole_apd_df = self.get_Borehole_apd_for_all_wells(
@@ -169,7 +168,7 @@ class WellData:
 
         # Filter dataframes by API12 which are not empty
         for key, df in datasets.items():
-            filtered_df = df[df["API_WELL_NUMBER"] == api12].copy()
+            filtered_df = select_by_api(df, api12).copy()
             data[key] = filtered_df
 
         # Handling api12_eWellWARRawData_mv_war_main_prop separately since it
@@ -197,9 +196,7 @@ class WellData:
         return self.Borehole_apd_df
 
     def get_Borehole_apd_for_api12(self, cfg, Borehole_apd_df, api12):
-        api12_Borehole_apd = Borehole_apd_df[
-            Borehole_apd_df["API_WELL_NUMBER"] == api12
-        ].copy()
+        api12_Borehole_apd = select_by_api(Borehole_apd_df, api12).copy()
 
         return api12_Borehole_apd
 

--- a/packages/worldenergydata-bsee/src/worldenergydata/bsee/data/sources/zip/production_data.py
+++ b/packages/worldenergydata-bsee/src/worldenergydata/bsee/data/sources/zip/production_data.py
@@ -9,6 +9,7 @@ from assetutilities.modules.zip_utilities.zip_files_to_dataframe import ZipFiles
 from loguru import logger
 
 from worldenergydata.bsee.data.scrapers.bsee_web import BSEEWebScraper
+from worldenergydata.bsee.data.utils.api_well_normalizer import select_by_api
 
 
 class GetProdDataFromZip:
@@ -236,7 +237,7 @@ class GetProdDataFromZip:
                 )
                 continue
 
-            matching_rows = df[df["API_WELL_NUMBER"] == api12]
+            matching_rows = select_by_api(df, api12)
 
             if not matching_rows.empty:
                 columns = ["API_WELL_NUMBER"] + [
@@ -321,7 +322,7 @@ class GetProdDataFromZip:
         # Filter the DataFrame based on the API12 value
         api12_dataframes = {}
         for api12 in api12_array:
-            df_api12 = df_api12_array[df_api12_array["API_WELL_NUMBER"] == api12].copy()
+            df_api12 = select_by_api(df_api12_array, api12).copy()
             api12_dataframes[api12] = df_api12
 
         return api12_dataframes

--- a/packages/worldenergydata-bsee/src/worldenergydata/bsee/data/utils/api_well_normalizer.py
+++ b/packages/worldenergydata-bsee/src/worldenergydata/bsee/data/utils/api_well_normalizer.py
@@ -28,6 +28,50 @@ def normalize_api_well_number(series: pd.Series) -> pd.Series:
     return result
 
 
+def api_matches(series: pd.Series, api: object) -> pd.Series:
+    """Boolean mask of ``series`` entries matching ``api``, dtype-safely.
+
+    Use this where the result is combined with other conditions; use
+    :func:`select_by_api` where a filtered frame is wanted. See that function
+    for why a plain ``==`` is unsafe here.
+    """
+    wanted = normalize_api_well_number(pd.Series([api])).iloc[0]
+    if pd.isna(wanted):
+        # A null argument must match nothing, rather than matching every row
+        # whose own API is null.
+        return pd.Series(False, index=series.index)
+    return normalize_api_well_number(series) == wanted
+
+
+def select_by_api(
+    df: pd.DataFrame,
+    api: object,
+    column: str = "API_WELL_NUMBER",
+) -> pd.DataFrame:
+    """Rows of ``df`` whose ``column`` matches ``api``, comparing dtype-safely.
+
+    ``df[column] == api`` is the obvious spelling and it is a trap. The API
+    column arrives as int64 from the BSEE ``.bin`` pickles, as float64 wherever
+    heterogeneous frames have been concatenated, and as str wherever it has
+    been treated as the identifier it is. Comparing across two of those
+    evaluates to all-``False`` *without raising*, so the filter silently yields
+    zero rows and the well reports as having no data at all -- a type mismatch
+    that reads exactly like absent coverage.
+
+    Both sides are normalised through :func:`normalize_api_well_number` first,
+    so int, float and string spellings of the same API all match.
+
+    .. note:: This does not recover a leading zero lost to integer storage.
+       An API held as int64 has already dropped it before this function sees
+       it; that is a storage concern, not a comparison one.
+    """
+    if column not in df.columns:
+        raise KeyError(
+            f"{column!r} not in frame; have: {', '.join(map(str, df.columns))}"
+        )
+    return df[api_matches(df[column], api)]
+
+
 def normalize_api_column_name(df: pd.DataFrame) -> pd.DataFrame:
     """Rename 'API Well Number' (with spaces) to 'API_WELL_NUMBER' if present.
 

--- a/packages/worldenergydata-bsee/src/worldenergydata/bsee/pipeline/casing_schematic.py
+++ b/packages/worldenergydata-bsee/src/worldenergydata/bsee/pipeline/casing_schematic.py
@@ -15,6 +15,8 @@ from xml.sax.saxutils import escape
 
 import pandas as pd
 
+from worldenergydata.bsee.data.utils.api_well_normalizer import select_by_api
+
 logger = logging.getLogger(__name__)
 
 
@@ -98,7 +100,7 @@ def load_well_casing(api12: str, tubulars_path: Path) -> list[CasingString]:
         return []
 
     # Filter to the requested well
-    df = df[df["API_WELL_NUMBER"] == api12]
+    df = select_by_api(df, api12)
     if df.empty:
         return []
 

--- a/packages/worldenergydata-bsee/src/worldenergydata/lower_tertiary/well_benchmark.py
+++ b/packages/worldenergydata-bsee/src/worldenergydata/lower_tertiary/well_benchmark.py
@@ -29,6 +29,7 @@ import numpy as np
 import pandas as pd
 
 from worldenergydata.bsee.analysis.uptime import compute_uptime
+from worldenergydata.bsee.data.utils.api_well_normalizer import select_by_api
 from worldenergydata.lower_tertiary import ops_timeline
 from worldenergydata.lower_tertiary.wti_prices import load_extended_wti_prices
 
@@ -387,7 +388,7 @@ def run_well_benchmark(cfg: BenchmarkConfig) -> pd.DataFrame:
     rows: list[dict] = []
     for _, w in wells.iterrows():
         api = w["API_WELL_NUMBER"]
-        ogor_well = ogor[ogor["API_WELL_NUMBER"] == api]
+        ogor_well = select_by_api(ogor, api)
         if ogor_well.empty:
             continue
         row = benchmark_well(

--- a/tests/unit/bsee/data/utils/test_select_by_api.py
+++ b/tests/unit/bsee/data/utils/test_select_by_api.py
@@ -1,0 +1,74 @@
+"""Dtype-safe API matching (#1113).
+
+``df["API_WELL_NUMBER"] == api`` evaluates to all-False across dtypes without
+raising, so the filter returns nothing and the caller reports the well as
+having no data. These tests pin every spelling combination that reaches the
+comparison in practice.
+"""
+
+import pandas as pd
+import pytest
+
+from worldenergydata.bsee.data.utils.api_well_normalizer import select_by_api
+
+API_STR = "608124009500"
+API_INT = 608124009500
+API_FLOAT = 608124009500.0
+
+
+def _frame(values):
+    return pd.DataFrame({"API_WELL_NUMBER": values, "payload": range(len(values))})
+
+
+class TestCrossDtypeMatching:
+    @pytest.mark.parametrize("column_value", [API_STR, API_INT, API_FLOAT])
+    @pytest.mark.parametrize("argument", [API_STR, API_INT, API_FLOAT])
+    def test_every_spelling_combination_matches(self, column_value, argument):
+        # The regression: an int64 column against a string argument silently
+        # matched nothing, which downstream reads as "this well has no WAR".
+        out = select_by_api(_frame([column_value, 999999999999]), argument)
+        assert len(out) == 1
+        assert out["payload"].iloc[0] == 0
+
+    def test_float_column_does_not_carry_a_dot_zero_into_the_match(self):
+        # Concatenating heterogeneous frames widens the column to float64,
+        # which stringifies as "608124009500.0" and matches nothing.
+        out = select_by_api(_frame([API_FLOAT]), API_STR)
+        assert len(out) == 1
+
+    def test_whitespace_is_ignored_on_both_sides(self):
+        out = select_by_api(_frame([f"  {API_STR} "]), f"{API_STR}  ")
+        assert len(out) == 1
+
+
+class TestNonMatches:
+    def test_a_genuine_miss_returns_empty(self):
+        out = select_by_api(_frame([API_STR]), "111111111111")
+        assert out.empty
+
+    def test_missing_api_values_never_match(self):
+        out = select_by_api(_frame([None, pd.NA, API_STR]), API_STR)
+        assert len(out) == 1
+
+    def test_a_null_argument_matches_nothing_rather_than_everything(self):
+        # Normalising None must not collapse into a value that matches the
+        # frame's own nulls -- that would return rows for a well nobody asked
+        # about.
+        out = select_by_api(_frame([None, API_STR]), None)
+        assert out.empty
+
+
+class TestContract:
+    def test_absent_column_is_a_clear_error_not_a_silent_empty(self):
+        with pytest.raises(KeyError, match="API_WELL_NUMBER"):
+            select_by_api(pd.DataFrame({"other": [1]}), API_STR)
+
+    def test_alternate_column_name_is_supported(self):
+        df = pd.DataFrame({"BOTM_API": [API_INT], "payload": [0]})
+        assert len(select_by_api(df, API_STR, column="BOTM_API")) == 1
+
+    def test_original_frame_is_not_mutated(self):
+        df = _frame([API_INT])
+        before = df["API_WELL_NUMBER"].dtype
+        select_by_api(df, API_STR)
+        assert df["API_WELL_NUMBER"].dtype == before


### PR DESCRIPTION
fix(bsee): match API well numbers dtype-safely (#1113)

`df["API_WELL_NUMBER"] == api` is the obvious spelling and it is a trap. The
column arrives as int64 from the BSEE .bin pickles, as float64 wherever
heterogeneous frames have been concatenated, and as str wherever the API has
been treated as the identifier it is. Comparing across two of those evaluates
to all-False *without raising*, so the filter yields zero rows and the well
reports as having no data at all -- a type mismatch that reads exactly like
absent coverage.

This was filed against one call site. A repo-wide sweep found fourteen, across
nine files, so the fix is a shared helper rather than a local repair.

Adds `api_matches()` (boolean mask) and `select_by_api()` (filtered frame) to
the existing `api_well_normalizer`, which already held the canonical
normalisation and simply had no comparison helper on top of it. Both sides of
every comparison now go through it, so int, float and string spellings of the
same API match each other.

A null argument matches nothing rather than matching every row whose own API
is null -- otherwise a missing identifier would silently return another well's
data, which is worse than returning none.

Two limits are documented rather than papered over. A leading zero already
lost to integer storage cannot be recovered at comparison time; that is a
storage concern. And an absent column now raises rather than returning an
empty frame, because "the column is not there" and "no rows matched" should
not look the same to a caller -- which is the same failure this change exists
to remove.

One instance is untouched: `fdas/data/drilling.py:310`, in a module #1111
deletes as dead.

Verified: 1,742 passed across tests/unit/bsee and tests/unit/lower_tertiary,
with the same 8 pre-existing FileNotFoundError failures in query_*
application tests present on origin/main before this branch. 17 new tests
cover every dtype combination that reaches the comparison in practice.

Closes #1113.
