### PR TITLE
feat(bsee): port sidetrack, abandonment, rig and fluid-weight capability (#1112)

### DIFF
--- a/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/war_rig_days.py
+++ b/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/war_rig_days.py
@@ -77,6 +77,7 @@ __all__ = [
     "BASIS_DRL_COM_PND",
     "BASIS_METHOD_1",
     "PRESET_BASES",
+    "DEFAULT_PHASES",
     "normalize_api12",
     "union_days",
     "rig_days_by_bore",
@@ -237,6 +238,15 @@ def _prepare(war: pd.DataFrame) -> pd.DataFrame:
             "end": _parse_war_date(war["WAR_END_DT"]),
         }
     )
+    # Optional passengers, carried only when the caller supplied them. Absent
+    # columns must not fabricate a value -- a bore whose feed lacks RIG_NAME has
+    # unattributed days, which is different from days attributed to no rig.
+    for source, target in (
+        ("RIG_NAME", "rig_name"),
+        ("DRILL_FLUID_WGT", "drill_fluid_wgt"),
+    ):
+        if source in war.columns:
+            out[target] = war[source].values
     out = out[out["activity_cd"].ne("") & out["activity_cd"].ne("NAN")]
     out = out.dropna(subset=["start", "end"])
     # A return whose end precedes its start is malformed. Dropping it here --
@@ -252,6 +262,44 @@ def _days_for(group: pd.DataFrame, codes) -> int:
     return union_days(zip(sub["start"], sub["end"]))
 
 
+def _days_by_rig(group: pd.DataFrame) -> dict:
+    """Days attributed to each rig that reported on this bore.
+
+    Ported from the legacy ``ONGFDComponents`` (#1112), which is the only place
+    that carried rig attribution. Rebuilt on the union basis: the legacy code
+    summed per-rig interval days, double-counting any overlap.
+
+    Rigs are kept as structured identities rather than a joined display string,
+    so a consumer can attribute days rather than parse text. A row with no rig
+    name is grouped under ``None`` -- absent attribution, not a rig called
+    "unknown".
+    """
+    if "rig_name" not in group.columns:
+        return {}
+    out = {}
+    for rig, sub in group.groupby(group["rig_name"].fillna("__none__"), sort=True):
+        key = None if rig == "__none__" else str(rig)
+        out[key] = union_days(zip(sub["start"], sub["end"]))
+    return out
+
+
+def _max_drill_fluid_wgt(group: pd.DataFrame):
+    """Heaviest drilling fluid reported on this bore, in ppg.
+
+    Ported from the legacy ``ONGFDComponents`` (#1112). A wellbore
+    characteristic, not a duration -- it travels here because this is where the
+    WAR rows are already assembled.
+
+    Returns null, never 0, when nothing was reported: a bore with no recorded
+    fluid weight is not a bore drilled on water.
+    """
+    if "drill_fluid_wgt" not in group.columns:
+        return pd.NA
+    values = pd.to_numeric(group["drill_fluid_wgt"], errors="coerce").dropna()
+    values = values[values > 0]
+    return float(values.max()) if len(values) else pd.NA
+
+
 def _days_and_status(group: pd.DataFrame, codes):
     """Days coded to ``codes``, or (null, no_activity_coded) if none are.
 
@@ -265,10 +313,32 @@ def _days_and_status(group: pd.DataFrame, codes):
     return union_days(zip(sub["start"], sub["end"])), STATUS_COVERED
 
 
+#: Additional activity phases emitted alongside drilling and completion.
+#:
+#: Ported from the legacy ``ONGFDComponents`` (#1112), which measured sidetrack
+#: and abandonment as separate phases. That capability was real and is absent
+#: from the drilling/completion split; the legacy *arithmetic* was not ported,
+#: because it inferred days from gaps between WAR reports.
+#:
+#: Temporary and permanent abandonment stay separate. They are different
+#: operational outcomes, and collapsing them would discard the distinction the
+#: legacy code was careful to keep.
+#:
+#: Every code here has ``provenance: unknown`` or ``published_other_domain`` in
+#: ``war_activity_codes.yml`` -- the phase name is our reading of the token, not
+#: a BSEE definition. See #1065.
+DEFAULT_PHASES: dict[str, frozenset[str]] = {
+    "sidetrack": frozenset({"ST"}),
+    "temp_abandonment": frozenset({"TA"}),
+    "perm_abandonment": frozenset({"PA"}),
+}
+
+
 def rig_days_by_bore(
     war: pd.DataFrame,
     basis: Basis = BASIS_DRL_COM,
     population: "list[str] | None" = None,
+    phases: "dict[str, frozenset[str]] | None" = None,
 ) -> pd.DataFrame:
     """Rig-days per API12 wellbore.
 
@@ -285,6 +355,7 @@ def rig_days_by_bore(
         activity are emitted with null days and ``days_status`` of
         ``no_war_activity``, so absent coverage is never mistaken for zero.
     """
+    phases = DEFAULT_PHASES if phases is None else phases
     prepared = _prepare(war)
     if population is not None:
         # Restrict before grouping: the raw WAR frame spans every well BSEE
@@ -302,32 +373,82 @@ def rig_days_by_bore(
         completion_days, completion_status = _days_and_status(
             group, basis.completion_codes
         )
-        rows.append(
-            {
-                "api12": api12,
-                "api10": api12[:10],
-                "bore_suffix": api12[10:],
-                "drilling_days": drilling_days,
-                "completion_days": completion_days,
-                # pnd_days stays numeric: it is a diagnostic breakdown of the
-                # weeks we do hold, not a claim about the bore's history.
-                "pnd_days": by_code.get("PND", 0),
-                "war_days_total": union_days(zip(group["start"], group["end"])),
-                "war_weeks": int(len(group)),
-                "days_by_code": by_code,
-                "days_status": STATUS_COVERED,
-                "drilling_days_status": drilling_status,
-                "completion_days_status": completion_status,
-            }
-        )
+        row = {
+            "api12": api12,
+            "api10": api12[:10],
+            "bore_suffix": api12[10:],
+            "drilling_days": drilling_days,
+            "completion_days": completion_days,
+            # pnd_days stays numeric: it is a diagnostic breakdown of the
+            # weeks we do hold, not a claim about the bore's history.
+            "pnd_days": by_code.get("PND", 0),
+            "war_days_total": union_days(zip(group["start"], group["end"])),
+            "war_weeks": int(len(group)),
+            "days_by_code": by_code,
+            "days_status": STATUS_COVERED,
+            "drilling_days_status": drilling_status,
+            "completion_days_status": completion_status,
+            "rig_days_by_rig": _days_by_rig(group),
+            "max_drill_fluid_wgt": _max_drill_fluid_wgt(group),
+        }
+        for phase, codes in phases.items():
+            days, status = _days_and_status(group, codes)
+            row[f"{phase}_days"] = days
+            row[f"{phase}_days_status"] = status
+        rows.append(row)
 
-    frame = pd.DataFrame(rows, columns=_BORE_COLUMNS)
+    # Phase columns are configurable, so the schema is built rather than fixed.
+    # Passing a fixed `columns=` list would SILENTLY DROP every phase key --
+    # pd.DataFrame ignores dict keys absent from an explicit column list.
+    columns = list(_BORE_COLUMNS)
+    for phase in phases:
+        columns += [f"{phase}_days", f"{phase}_days_status"]
 
     if population is not None:
-        frame = _apply_population(frame, population)
+        # Build covered and uncovered rows into ONE frame. Concatenating an
+        # all-NA filler frame instead raises a pandas FutureWarning about
+        # dtype determination, and would change dtypes under a later pandas.
+        rows += _absent_rows(rows, population, phases)
+
+    frame = pd.DataFrame(rows, columns=columns)
+    if population is not None:
+        frame = frame.sort_values("api12")
 
     frame["basis"] = basis.describe()
     return frame.reset_index(drop=True)
+
+
+def _absent_rows(rows, population, phases) -> list:
+    """Filler rows for requested bores that WAR says nothing about.
+
+    Null days with ``no_war_activity`` -- absent coverage, never a zero.
+    """
+    present = {r["api12"] for r in rows}
+    absent = sorted(set(normalize_api12(population)) - present)
+
+    filler = []
+    for api12 in absent:
+        row = {
+            "api12": api12,
+            "api10": api12[:10],
+            "bore_suffix": api12[10:],
+            "drilling_days": pd.NA,
+            "completion_days": pd.NA,
+            "pnd_days": pd.NA,
+            "war_days_total": pd.NA,
+            "war_weeks": 0,
+            "days_by_code": {},
+            "days_status": STATUS_NO_ACTIVITY,
+            "drilling_days_status": STATUS_NO_ACTIVITY,
+            "completion_days_status": STATUS_NO_ACTIVITY,
+            "rig_days_by_rig": {},
+            "max_drill_fluid_wgt": pd.NA,
+        }
+        for phase in phases:
+            row[f"{phase}_days"] = pd.NA
+            row[f"{phase}_days_status"] = STATUS_NO_ACTIVITY
+        filler.append(row)
+    return filler
 
 
 _BORE_COLUMNS = [
@@ -343,37 +464,17 @@ _BORE_COLUMNS = [
     "days_status",
     "drilling_days_status",
     "completion_days_status",
+    "rig_days_by_rig",
+    "max_drill_fluid_wgt",
 ]
 
 _DAY_COLUMNS = ("drilling_days", "completion_days", "pnd_days", "war_days_total")
 
 
-def _apply_population(frame: pd.DataFrame, population) -> pd.DataFrame:
-    wanted = list(normalize_api12(population))
-    frame = frame[frame["api12"].isin(set(wanted))]
-
-    absent = sorted(set(wanted) - set(frame["api12"]))
-    if not absent:
-        return frame
-
-    filler = pd.DataFrame(
-        {
-            "api12": absent,
-            "api10": [a[:10] for a in absent],
-            "bore_suffix": [a[10:] for a in absent],
-            "drilling_days": pd.NA,
-            "completion_days": pd.NA,
-            "pnd_days": pd.NA,
-            "war_days_total": pd.NA,
-            "war_weeks": 0,
-            "days_by_code": [{} for _ in absent],
-            "days_status": STATUS_NO_ACTIVITY,
-            "drilling_days_status": STATUS_NO_ACTIVITY,
-            "completion_days_status": STATUS_NO_ACTIVITY,
-        },
-        columns=_BORE_COLUMNS,
-    )
-    return pd.concat([frame, filler], ignore_index=True).sort_values("api12")
+# _apply_population() lived here. Superseded by _absent_rows(), which builds
+# covered and uncovered bores into a single frame instead of concatenating an
+# all-NA filler -- that concat raised a pandas FutureWarning and would have
+# changed result dtypes on a later pandas.
 
 
 def rig_days_by_well(

--- a/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/war_rig_days.py
+++ b/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/war_rig_days.py
@@ -262,6 +262,35 @@ def _days_for(group: pd.DataFrame, codes) -> int:
     return union_days(zip(sub["start"], sub["end"]))
 
 
+def _reject_colliding_phases(phases) -> None:
+    """Refuse a phase whose generated columns would shadow an existing one.
+
+    ``phases={"drilling": ...}`` generates ``drilling_days``, overwriting the
+    basis-derived drilling days with the phase's codes -- so a caller asking
+    for an extra bucket would silently replace a core measurement, and the
+    frame would carry two columns of the same name. ``pnd`` collides the same
+    way. Raising is the only safe response: the shadowed value looks entirely
+    plausible.
+    """
+    reserved = set(_BORE_COLUMNS) | {"basis"}
+    seen: dict = {}
+    for phase in phases:
+        for suffix in ("_days", "_days_status"):
+            column = f"{phase}{suffix}"
+            if column in reserved:
+                raise ValueError(
+                    f"phase {phase!r} would generate column {column!r}, which "
+                    "already exists and would be silently overwritten. Choose "
+                    "a different phase name."
+                )
+            if column in seen:
+                raise ValueError(
+                    f"phases {seen[column]!r} and {phase!r} both generate "
+                    f"column {column!r}."
+                )
+            seen[column] = phase
+
+
 def _days_by_rig(group: pd.DataFrame) -> dict:
     """Days attributed to each rig that reported on this bore.
 
@@ -272,15 +301,37 @@ def _days_by_rig(group: pd.DataFrame) -> dict:
     Rigs are kept as structured identities rather than a joined display string,
     so a consumer can attribute days rather than parse text. A row with no rig
     name is grouped under ``None`` -- absent attribution, not a rig called
-    "unknown".
+    "unknown". A bore whose feed carries no rig column at all also yields
+    ``{None: days}``, so unattributed duration has one encoding rather than two.
+
+    Identities are matched on stripped, case-folded text, because ``"ENSCO 1"``
+    and ``" ensco 1 "`` are one rig and counting them separately would credit
+    the same days twice. The first spelling seen is kept for display.
+
+    .. note:: ``sum(...values())`` does **not** equal ``war_days_total`` and is
+       not meant to. Two rigs genuinely working overlapping weeks are each
+       credited; this is a per-rig credit, not a partition of calendar coverage.
     """
+    intervals = list(zip(group["start"], group["end"]))
     if "rig_name" not in group.columns:
-        return {}
-    out = {}
-    for rig, sub in group.groupby(group["rig_name"].fillna("__none__"), sort=True):
-        key = None if rig == "__none__" else str(rig)
-        out[key] = union_days(zip(sub["start"], sub["end"]))
-    return out
+        return {None: union_days(intervals)}
+
+    buckets: dict = {}
+    display: dict = {}
+    for (start, end), raw in zip(intervals, group["rig_name"]):
+        if pd.isna(raw):
+            key = None
+        else:
+            text = str(raw).strip()
+            key = text.casefold() or None
+        if key is not None:
+            display.setdefault(key, text)
+        buckets.setdefault(key, []).append((start, end))
+
+    return {
+        (display[k] if k is not None else None): union_days(v)
+        for k, v in buckets.items()
+    }
 
 
 def _max_drill_fluid_wgt(group: pd.DataFrame):
@@ -327,6 +378,12 @@ def _days_and_status(group: pd.DataFrame, codes):
 #: Every code here has ``provenance: unknown`` or ``published_other_domain`` in
 #: ``war_activity_codes.yml`` -- the phase name is our reading of the token, not
 #: a BSEE definition. See #1065.
+#:
+#: .. warning:: Phase columns are **not additive with basis columns**. Under
+#:    ``BASIS_METHOD_1`` completion includes ``TA``, so the same days appear in
+#:    both ``completion_days`` and ``temp_abandonment_days``. Nothing sums them
+#:    internally, and a consumer must not either: they answer different
+#:    questions over the same weeks.
 DEFAULT_PHASES: dict[str, frozenset[str]] = {
     "sidetrack": frozenset({"ST"}),
     "temp_abandonment": frozenset({"TA"}),
@@ -356,6 +413,7 @@ def rig_days_by_bore(
         ``no_war_activity``, so absent coverage is never mistaken for zero.
     """
     phases = DEFAULT_PHASES if phases is None else phases
+    _reject_colliding_phases(phases)
     prepared = _prepare(war)
     if population is not None:
         # Restrict before grouping: the raw WAR frame spans every well BSEE
@@ -413,6 +471,15 @@ def rig_days_by_bore(
     frame = pd.DataFrame(rows, columns=columns)
     if population is not None:
         frame = frame.sort_values("api12")
+
+    # Mixing real values with pd.NA leaves an `object` column, so a consumer
+    # gets Python ints from one call and objects from another depending only on
+    # whether any bore was uncovered. Pin the nullable types instead.
+    day_columns = ["drilling_days", "completion_days", "pnd_days", "war_days_total"]
+    day_columns += [f"{phase}_days" for phase in phases]
+    for column in day_columns:
+        frame[column] = frame[column].astype("Int64")
+    frame["max_drill_fluid_wgt"] = frame["max_drill_fluid_wgt"].astype("Float64")
 
     frame["basis"] = basis.describe()
     return frame.reset_index(drop=True)

--- a/tests/unit/bsee/analysis/test_war_rig_days_phases.py
+++ b/tests/unit/bsee/analysis/test_war_rig_days_phases.py
@@ -14,6 +14,7 @@ supports, which is the defect class this whole module exists to remove.
 """
 
 import pandas as pd
+import pytest
 
 from worldenergydata.bsee.analysis.war_rig_days import (
     DEFAULT_PHASES,
@@ -120,11 +121,13 @@ class TestRigAttribution:
         ).squeeze()
         assert frame["rig_days_by_rig"] == {None: 7}
 
-    def test_absent_column_yields_no_attribution_rather_than_a_guess(self):
+    def test_absent_column_yields_unattributed_days_not_an_empty_map(self):
+        # An empty map would lose the days entirely. The duration is real and
+        # known; only its attribution is missing, which is what None records.
         frame = rig_days_by_bore(
             war([[API, "2024-01-01", "2024-01-07", "DRL"]])
         ).squeeze()
-        assert frame["rig_days_by_rig"] == {}
+        assert frame["rig_days_by_rig"] == {None: 7}
 
 
 class TestDrillFluidWeight:
@@ -175,3 +178,65 @@ class TestNoRegression:
         assert int(frame["drilling_days"]) == 7
         assert int(frame["completion_days"]) == 7
         assert int(frame["war_days_total"]) == 14
+
+
+class TestAdversarialReviewFindings:
+    """Regressions for defects found by adversarial review of this port."""
+
+    def test_a_phase_cannot_shadow_a_core_column(self):
+        # phases={"drilling": ...} generated drilling_days and silently
+        # replaced the basis-derived measurement with the phase's codes.
+
+        with pytest.raises(ValueError, match="silently overwritten"):
+            rig_days_by_bore(
+                war([[API, "2024-01-01", "2024-01-07", "DRL"]]),
+                phases={"drilling": frozenset({"TA"})},
+            )
+
+    def test_pnd_is_also_protected(self):
+
+        with pytest.raises(ValueError, match="silently overwritten"):
+            rig_days_by_bore(
+                war([[API, "2024-01-01", "2024-01-07", "COM"]]),
+                phases={"pnd": frozenset({"COM"})},
+            )
+
+    def test_rig_identities_differing_only_by_case_or_space_are_one_rig(self):
+        # Two spellings created two identities, crediting the same days twice.
+        frame = rig_days_by_bore(
+            war(
+                [
+                    [API, "2024-01-01", "2024-01-07", "DRL", "ENSCO 1"],
+                    [API, "2024-01-01", "2024-01-07", "DRL", " ensco 1 "],
+                ],
+                columns=COLUMNS + ["RIG_NAME"],
+            )
+        ).squeeze()
+        assert frame["rig_days_by_rig"] == {"ENSCO 1": 7}
+
+    def test_unattributed_duration_has_one_encoding(self):
+        # A missing column yielded {} while a null value yielded {None: 7}.
+        no_column = rig_days_by_bore(
+            war([[API, "2024-01-01", "2024-01-07", "DRL"]])
+        ).squeeze()
+        null_value = rig_days_by_bore(
+            war(
+                [[API, "2024-01-01", "2024-01-07", "DRL", None]],
+                columns=COLUMNS + ["RIG_NAME"],
+            )
+        ).squeeze()
+        assert no_column["rig_days_by_rig"] == {None: 7}
+        assert null_value["rig_days_by_rig"] == {None: 7}
+
+    def test_day_dtypes_are_stable_whether_or_not_a_bore_is_uncovered(self):
+        # Mixing values with pd.NA left an object column, so the dtype depended
+        # on whether any requested bore happened to be uncovered.
+        covered = rig_days_by_bore(war([[API, "2024-01-01", "2024-01-07", "DRL"]]))
+        mixed = rig_days_by_bore(
+            war([[API, "2024-01-01", "2024-01-07", "DRL"]]),
+            population=[API, "999999999999"],
+        )
+        assert covered["drilling_days"].dtype == "Int64"
+        assert mixed["drilling_days"].dtype == "Int64"
+        assert mixed["sidetrack_days"].dtype == "Int64"
+        assert mixed["max_drill_fluid_wgt"].dtype == "Float64"

--- a/tests/unit/bsee/analysis/test_war_rig_days_phases.py
+++ b/tests/unit/bsee/analysis/test_war_rig_days_phases.py
@@ -1,0 +1,177 @@
+"""Capabilities ported out of the legacy ONGFDComponents (#1112).
+
+The legacy module measured sidetrack and abandonment as separate phases, and
+attributed days to the rig that reported them. Those capabilities were real and
+absent from the drilling/completion split. The legacy *arithmetic* was not
+ported: it summed per-rig intervals (double-counting overlaps) and inferred
+days from gaps between WAR reports.
+
+Not ported, deliberately: NPT. The legacy code inferred non-productive time
+from gaps between consecutive reports. A gap evidences missing reporting
+coverage, not an idle rig -- it equally means reporting cadence, rig release,
+suspension or extraction loss. Naming it NPT asserts far more than the data
+supports, which is the defect class this whole module exists to remove.
+"""
+
+import pandas as pd
+
+from worldenergydata.bsee.analysis.war_rig_days import (
+    DEFAULT_PHASES,
+    STATUS_COVERED,
+    STATUS_NO_ACTIVITY_CODED,
+    rig_days_by_bore,
+)
+
+API = "608124009500"
+COLUMNS = ["API_WELL_NUMBER", "WAR_START_DT", "WAR_END_DT", "WELL_ACTIVITY_CD"]
+
+
+def war(rows, columns=COLUMNS):
+    return pd.DataFrame(rows, columns=columns)
+
+
+class TestPhaseDurations:
+    def test_sidetrack_days_are_measured_separately(self):
+        frame = rig_days_by_bore(
+            war(
+                [
+                    [API, "2024-01-01", "2024-01-07", "DRL"],
+                    [API, "2024-02-01", "2024-02-07", "ST"],
+                ]
+            )
+        ).squeeze()
+        assert int(frame["drilling_days"]) == 7
+        assert int(frame["sidetrack_days"]) == 7
+        assert frame["sidetrack_days_status"] == STATUS_COVERED
+
+    def test_temporary_and_permanent_abandonment_stay_distinct(self):
+        # Different operational outcomes. The legacy code kept them apart and
+        # collapsing them here would discard that.
+        frame = rig_days_by_bore(
+            war(
+                [
+                    [API, "2024-01-01", "2024-01-07", "TA"],
+                    [API, "2024-03-01", "2024-03-14", "PA"],
+                ]
+            )
+        ).squeeze()
+        assert int(frame["temp_abandonment_days"]) == 7
+        assert int(frame["perm_abandonment_days"]) == 14
+
+    def test_an_absent_phase_is_null_not_zero(self):
+        # Same rule as drilling: no week coded to the phase is an absence of
+        # evidence, not a measurement of zero.
+        frame = rig_days_by_bore(
+            war([[API, "2024-01-01", "2024-01-07", "DRL"]])
+        ).squeeze()
+        assert pd.isna(frame["sidetrack_days"])
+        assert frame["sidetrack_days_status"] == STATUS_NO_ACTIVITY_CODED
+
+    def test_phases_are_configurable_rather_than_hardcoded(self):
+        frame = rig_days_by_bore(
+            war([[API, "2024-01-01", "2024-01-07", "WO"]]),
+            phases={"workover": frozenset({"WO"})},
+        ).squeeze()
+        assert int(frame["workover_days"]) == 7
+        assert "sidetrack_days" not in frame.index
+
+    def test_default_phases_cover_sidetrack_and_both_abandonments(self):
+        assert set(DEFAULT_PHASES) == {
+            "sidetrack",
+            "temp_abandonment",
+            "perm_abandonment",
+        }
+
+
+class TestRigAttribution:
+    COLS = COLUMNS + ["RIG_NAME"]
+
+    def test_days_are_attributed_to_the_reporting_rig(self):
+        frame = rig_days_by_bore(
+            war(
+                [
+                    [API, "2024-01-01", "2024-01-07", "DRL", "NOBLE JIM DAY"],
+                    [API, "2024-03-01", "2024-03-07", "DRL", "DEEPWATER TITAN"],
+                ],
+                columns=self.COLS,
+            )
+        ).squeeze()
+        assert frame["rig_days_by_rig"] == {"NOBLE JIM DAY": 7, "DEEPWATER TITAN": 7}
+
+    def test_overlapping_weeks_for_one_rig_are_unioned_not_summed(self):
+        # The legacy implementation summed, double-counting the overlap.
+        frame = rig_days_by_bore(
+            war(
+                [
+                    [API, "2024-01-01", "2024-01-10", "DRL", "RIG A"],
+                    [API, "2024-01-05", "2024-01-07", "DRL", "RIG A"],
+                ],
+                columns=self.COLS,
+            )
+        ).squeeze()
+        assert frame["rig_days_by_rig"] == {"RIG A": 10}
+
+    def test_a_missing_rig_name_is_unattributed_not_a_rig_called_unknown(self):
+        frame = rig_days_by_bore(
+            war(
+                [[API, "2024-01-01", "2024-01-07", "DRL", None]],
+                columns=self.COLS,
+            )
+        ).squeeze()
+        assert frame["rig_days_by_rig"] == {None: 7}
+
+    def test_absent_column_yields_no_attribution_rather_than_a_guess(self):
+        frame = rig_days_by_bore(
+            war([[API, "2024-01-01", "2024-01-07", "DRL"]])
+        ).squeeze()
+        assert frame["rig_days_by_rig"] == {}
+
+
+class TestDrillFluidWeight:
+    COLS = COLUMNS + ["DRILL_FLUID_WGT"]
+
+    def test_the_heaviest_reported_weight_is_carried(self):
+        frame = rig_days_by_bore(
+            war(
+                [
+                    [API, "2024-01-01", "2024-01-07", "DRL", 12.0],
+                    [API, "2024-01-08", "2024-01-14", "DRL", 14.5],
+                ],
+                columns=self.COLS,
+            )
+        ).squeeze()
+        assert frame["max_drill_fluid_wgt"] == 14.5
+
+    def test_nothing_reported_is_null_not_zero(self):
+        # A bore with no recorded fluid weight is not a bore drilled on water.
+        frame = rig_days_by_bore(
+            war(
+                [[API, "2024-01-01", "2024-01-07", "DRL", None]],
+                columns=self.COLS,
+            )
+        ).squeeze()
+        assert pd.isna(frame["max_drill_fluid_wgt"])
+
+    def test_zero_is_treated_as_unreported(self):
+        frame = rig_days_by_bore(
+            war(
+                [[API, "2024-01-01", "2024-01-07", "DRL", 0]],
+                columns=self.COLS,
+            )
+        ).squeeze()
+        assert pd.isna(frame["max_drill_fluid_wgt"])
+
+
+class TestNoRegression:
+    def test_existing_outputs_are_unchanged_by_the_port(self):
+        frame = rig_days_by_bore(
+            war(
+                [
+                    [API, "2024-01-01", "2024-01-07", "DRL"],
+                    [API, "2024-01-08", "2024-01-14", "COM"],
+                ]
+            )
+        ).squeeze()
+        assert int(frame["drilling_days"]) == 7
+        assert int(frame["completion_days"]) == 7
+        assert int(frame["war_days_total"]) == 14


### PR DESCRIPTION
feat(bsee): port sidetrack, abandonment, rig and fluid-weight capability (#1112)

The legacy ONGFDComponents is dead as a dependency -- verified by whole-repo
grep, it has zero consumers outside common/legacy/. But it measured things the
modern module does not, and those would have been lost on deletion. This ports
the capability; retirement of the legacy code follows.

Ported, rebuilt on the WAR interval-union basis rather than transcribed:

  - Sidetrack and abandonment phase durations. Temporary and permanent
    abandonment stay distinct: they are different operational outcomes and the
    legacy code was careful to keep them apart.
  - Per-rig day attribution. The legacy version summed per-rig intervals,
    double-counting any overlap; this unions them. Rigs are kept as structured
    identities rather than a joined display string, so a consumer attributes
    days instead of parsing text. A row with no rig name maps to None --
    unattributed, not a rig called "unknown".
  - Maximum drilling-fluid weight, a wellbore characteristic absent from the
    module entirely. Null, never 0: a bore with no reported weight is not a
    bore drilled on water. A reported 0 is treated as unreported.

Phases are configurable rather than hardcoded, so any activity bucket is one
argument away. The engine always supported it; nothing had asked.

NOT ported: NPT. The legacy code inferred non-productive time from gaps
between consecutive WAR reports, capped at 90 days. A gap evidences missing
reporting coverage, not an idle rig -- it equally means reporting cadence, rig
release, suspension or extraction loss. Naming it NPT asserts far more than
the data supports, which is the defect class this module exists to remove. The
rationale is recorded in the test module rather than only here, so the next
person to ask "why not?" finds it where they would look. Gap information, if
wanted, belongs as unobserved-coverage days with explicit provenance.

Two defects in this change, both caught by asserting on output rather than on
absence of error:

  - pd.DataFrame(rows, columns=FIXED) silently drops any dict key absent from
    the column list, so every computed phase column vanished. The schema is
    now built from the configured phases.
  - Concatenating the all-NA filler frame raised a pandas FutureWarning about
    dtype determination, which would have shifted the null-vs-zero semantics
    this module enforces. Covered and uncovered bores are now built into one
    frame and _apply_population is retired.

76 passed across the new file and the existing war_rig_days, robustness and
well_rig_days suites. No existing output changes.

Refs #1063, #1112.
