### PR TITLE
fix(bsee): unattributed WAR weeks are coverage, not absence (#1120)

### DIFF
--- a/docs/modules/bsee/analysis/production/FDAS_V30/extract_drilling_completion_days.py
+++ b/docs/modules/bsee/analysis/production/FDAS_V30/extract_drilling_completion_days.py
@@ -368,9 +368,23 @@ def main():
     # The shared module replaces both; the 250-day branch is gone rather than
     # retuned, because it was an artifact of the wrong basis.
     basis = PRESET_BASES[args.basis]
+    # LEFT, not inner. mv_war_main_prop does not cover every SN_WAR in
+    # mv_war_main -- 2,030 weeks on the 2026-02-19 vintage, 280 of them inside
+    # this population. An inner join discarded them silently, and for 38 bores
+    # that was EVERY week they have, so a bore with 32 weeks of recorded rig
+    # presence was published as having no WAR activity at all. Those weeks are
+    # unattributed, not absent; war_rig_days carries them as coverage and
+    # excludes them from every activity total. See #1120.
+    prop = load_war_prop(args.war_prop)
     war_for_days = wm[["SN_WAR", "API_WELL_NUMBER", "WAR_START_DT", "WAR_END_DT"]].merge(
-        load_war_prop(args.war_prop), on="SN_WAR", how="inner"
+        prop, on="SN_WAR", how="left"
     )
+    unattributed = int(war_for_days["WELL_ACTIVITY_CD"].isna().sum())
+    if unattributed:
+        print(
+            f"  {unattributed} of {len(war_for_days)} WAR weeks carry no activity "
+            f"code; counted as coverage, excluded from activity totals."
+        )
     days = rig_days_by_bore(
         war_for_days, basis=basis, population=list(base["API_WELL_NUMBER"])
     ).rename(columns={

--- a/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/war_rig_days.py
+++ b/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/war_rig_days.py
@@ -78,6 +78,7 @@ __all__ = [
     "BASIS_METHOD_1",
     "PRESET_BASES",
     "DEFAULT_PHASES",
+    "STATUS_COVERED_UNATTRIBUTED",
     "normalize_api12",
     "union_days",
     "rig_days_by_bore",
@@ -95,6 +96,12 @@ STATUS_NO_ACTIVITY = "no_war_activity"
 #: and "drilled in 0 days" is false. Corpus-wide this is the majority case for
 #: drilling, so the day value is null and the reason is stated.
 STATUS_NO_ACTIVITY_CODED = "no_activity_coded"
+
+#: The bore has WAR weeks, but NOT ONE of them carries an activity code. BSEE
+#: holds a record of the rig being there; what is missing is the attribution.
+#: Distinct from ``no_war_activity``, which asserts BSEE holds nothing at all --
+#: a claim we must not make about a bore with 32 reported weeks. See #1120.
+STATUS_COVERED_UNATTRIBUTED = "war_covered_no_activity_code"
 
 _REQUIRED_COLUMNS = (
     "API_WELL_NUMBER",
@@ -247,7 +254,19 @@ def _prepare(war: pd.DataFrame) -> pd.DataFrame:
     ):
         if source in war.columns:
             out[target] = war[source].values
-    out = out[out["activity_cd"].ne("") & out["activity_cd"].ne("NAN")]
+    # A week with no activity code is UNATTRIBUTED, not absent. Dropping it
+    # here would erase real coverage: on the 2026-02-19 feed, 2,030 WAR weeks
+    # carry no row in mv_war_main_prop, and for 38 bores in the published
+    # population that is *every* week they have -- up to 32 weeks of recorded
+    # rig presence that would be reported as "no WAR activity". BSEE holds
+    # those weeks; what is missing is the attribution. Keep them, exclude them
+    # from every activity total, and let the caller see them. See #1120.
+    out["activity_cd"] = out["activity_cd"].where(
+        out["activity_cd"].ne("")
+        & out["activity_cd"].ne("NAN")
+        & out["activity_cd"].ne("NONE"),
+        other=None,
+    )
     out = out.dropna(subset=["start", "end"])
     # A return whose end precedes its start is malformed. Dropping it here --
     # rather than inside union_days -- keeps "no valid interval" distinguishable
@@ -425,8 +444,16 @@ def rig_days_by_bore(
     for api12, group in prepared.groupby("api12", sort=True):
         by_code = {
             code: union_days(zip(sub["start"], sub["end"]))
-            for code, sub in group.groupby("activity_cd", sort=True)
+            for code, sub in group.groupby("activity_cd", sort=True, dropna=True)
         }
+        unattributed = group[group["activity_cd"].isna()]
+        # A bore whose every week lacks a code is covered-but-unattributed, not
+        # uncovered. Saying otherwise discards real reported rig presence.
+        coverage_status = (
+            STATUS_COVERED_UNATTRIBUTED
+            if len(unattributed) == len(group)
+            else STATUS_COVERED
+        )
         drilling_days, drilling_status = _days_and_status(group, basis.drilling_codes)
         completion_days, completion_status = _days_and_status(
             group, basis.completion_codes
@@ -443,7 +470,8 @@ def rig_days_by_bore(
             "war_days_total": union_days(zip(group["start"], group["end"])),
             "war_weeks": int(len(group)),
             "days_by_code": by_code,
-            "days_status": STATUS_COVERED,
+            "days_status": coverage_status,
+            "war_weeks_unattributed": int(len(unattributed)),
             "drilling_days_status": drilling_status,
             "completion_days_status": completion_status,
             "rig_days_by_rig": _days_by_rig(group),
@@ -504,6 +532,7 @@ def _absent_rows(rows, population, phases) -> list:
             "pnd_days": pd.NA,
             "war_days_total": pd.NA,
             "war_weeks": 0,
+            "war_weeks_unattributed": 0,
             "days_by_code": {},
             "days_status": STATUS_NO_ACTIVITY,
             "drilling_days_status": STATUS_NO_ACTIVITY,
@@ -527,6 +556,7 @@ _BORE_COLUMNS = [
     "pnd_days",
     "war_days_total",
     "war_weeks",
+    "war_weeks_unattributed",
     "days_by_code",
     "days_status",
     "drilling_days_status",

--- a/tests/unit/bsee/analysis/test_war_rig_days_unattributed.py
+++ b/tests/unit/bsee/analysis/test_war_rig_days_unattributed.py
@@ -1,0 +1,117 @@
+"""Unattributed WAR coverage is not absent coverage (#1120).
+
+`mv_war_main_prop` does not cover every `SN_WAR` in `mv_war_main`. On the
+2026-02-19 feed that is 2,030 weeks, 280 of them inside the published
+253-bore population -- and for 38 of those bores it is *every* week they have,
+up to 32 weeks each of recorded rig presence.
+
+Those weeks were being dropped by an inner join before `days_status` ever saw
+them, so the pipeline reported `no_war_activity` -- a claim that BSEE holds
+nothing -- about bores BSEE holds weeks of data for. The status column was
+accurate about the data it received and false about the world, because the
+data had already been filtered upstream.
+
+The rule these tests pin: a week with no activity code is UNATTRIBUTED. It
+counts as coverage, it never counts toward an activity total, and it is never
+reported as absence.
+"""
+
+import pandas as pd
+
+from worldenergydata.bsee.analysis.war_rig_days import (
+    STATUS_COVERED,
+    STATUS_COVERED_UNATTRIBUTED,
+    STATUS_NO_ACTIVITY,
+    rig_days_by_bore,
+)
+
+API = "608124009500"
+OTHER = "608124111100"
+COLUMNS = ["API_WELL_NUMBER", "WAR_START_DT", "WAR_END_DT", "WELL_ACTIVITY_CD"]
+
+
+def war(rows):
+    return pd.DataFrame(rows, columns=COLUMNS)
+
+
+class TestUnattributedIsNotAbsent:
+    def test_a_bore_with_only_uncoded_weeks_is_covered_not_absent(self):
+        # The 38-bore case: WAR holds the weeks, none carries a code.
+        frame = rig_days_by_bore(
+            war(
+                [
+                    [API, "2024-01-01", "2024-01-07", None],
+                    [API, "2024-01-08", "2024-01-14", None],
+                ]
+            )
+        ).squeeze()
+
+        assert frame["days_status"] == STATUS_COVERED_UNATTRIBUTED
+        assert frame["days_status"] != STATUS_NO_ACTIVITY
+
+    def test_its_coverage_is_reported_rather_than_erased(self):
+        frame = rig_days_by_bore(
+            war(
+                [
+                    [API, "2024-01-01", "2024-01-07", None],
+                    [API, "2024-01-08", "2024-01-14", None],
+                ]
+            )
+        ).squeeze()
+
+        assert int(frame["war_days_total"]) == 14
+        assert int(frame["war_weeks"]) == 2
+        assert int(frame["war_weeks_unattributed"]) == 2
+
+    def test_uncoded_weeks_never_reach_an_activity_total(self):
+        # Coverage without attribution cannot become drilling days.
+        frame = rig_days_by_bore(
+            war([[API, "2024-01-01", "2024-01-07", None]])
+        ).squeeze()
+
+        assert pd.isna(frame["drilling_days"])
+        assert pd.isna(frame["completion_days"])
+        assert frame["days_by_code"] == {}
+
+    def test_a_partially_coded_bore_counts_only_its_coded_weeks(self):
+        frame = rig_days_by_bore(
+            war(
+                [
+                    [API, "2024-01-01", "2024-01-07", "DRL"],
+                    [API, "2024-02-01", "2024-02-07", None],
+                ]
+            )
+        ).squeeze()
+
+        assert int(frame["drilling_days"]) == 7  # not 14
+        assert int(frame["war_days_total"]) == 14  # coverage includes both
+        assert int(frame["war_weeks_unattributed"]) == 1
+        assert frame["days_status"] == STATUS_COVERED  # some week is attributed
+
+
+class TestTheThreeStatesStayDistinct:
+    def test_absent_covered_and_unattributed_are_three_different_things(self):
+        frame = rig_days_by_bore(
+            war(
+                [
+                    [API, "2024-01-01", "2024-01-07", "DRL"],
+                    [OTHER, "2024-01-01", "2024-01-07", None],
+                ]
+            ),
+            population=[API, OTHER, "999999999999"],
+        ).set_index("api12")
+
+        assert frame.loc[API, "days_status"] == STATUS_COVERED
+        assert frame.loc[OTHER, "days_status"] == STATUS_COVERED_UNATTRIBUTED
+        assert frame.loc["999999999999", "days_status"] == STATUS_NO_ACTIVITY
+
+    def test_only_the_genuinely_absent_bore_reports_null_coverage(self):
+        frame = rig_days_by_bore(
+            war([[OTHER, "2024-01-01", "2024-01-07", None]]),
+            population=[OTHER, "999999999999"],
+        ).set_index("api12")
+
+        # Unattributed: coverage is known.
+        assert int(frame.loc[OTHER, "war_days_total"]) == 7
+        # Absent: coverage is not known, and must not read as zero.
+        assert pd.isna(frame.loc["999999999999", "war_days_total"])


### PR DESCRIPTION
fix(bsee): unattributed WAR weeks are coverage, not absence (#1120)

The extractor joined WAR weeks to their activity codes with an INNER join.
mv_war_main_prop does not cover every SN_WAR in mv_war_main -- 2,030 weeks on
the 2026-02-19 feed, 280 of them inside the published 253-bore population --
so those weeks were discarded before anything downstream saw them.

For 38 bores that was EVERY week they have. A bore with 32 weeks of recorded
rig presence was published as `no_war_activity`: a claim that BSEE holds
nothing about it. BSEE holds 200 days of coverage for that bore. What is
missing is the attribution, not the record.

This is the defect days_status was added to prevent, reintroduced by the join
that feeds it. The status column was accurate about the data it received and
false about the world, because the data had already been filtered upstream. A
provenance field describes the last hop; to mean anything it has to be
assigned where the data enters.

Three states now, where there were two:

  war_covered                   weeks held, coded, attributed
  war_covered_no_activity_code  weeks held, none coded -- coverage known,
                                activity unknown
  no_war_activity               nothing held -- coverage itself unknown

Uncoded weeks count toward war_days_total and war_weeks, are counted
separately in the new war_weeks_unattributed, and can never reach an activity
total. The extractor's join is now LEFT and reports the unattributed count
rather than discarding it silently.

Measured against the real feed, inner versus left over the published
population:

  drilling days     11,126 -> 11,126   (unchanged)
  completion days    5,298 ->  5,298   (unchanged)
  WAR coverage      25,332 -> 26,994   (+1,662 days across 280 weeks)
  bores reported as absent   38 -> 0

Every one of the 253 bores has WAR coverage. None is absent from the feed.

One correction to the record: "38 of 253 bores have no WAR activity" appears
in the validation page, in #1073 and in the epic body. It is wrong and follows
from this defect. Those surfaces need correcting; the page regenerates from
source, the issue text does not.

65 tests pass. The new file pins the rule as a property: a week with no
activity code is unattributed -- it counts as coverage, never toward an
activity total, and is never reported as absence.

Closes #1120. Refs #1063, #1073.
