### PR TITLE
fix(gtm): intervention legend published two codes that do not exist (#1117)

### DIFF
--- a/reports/gtm/seasonal-intervention-risk-windows-2026-07-05.html
+++ b/reports/gtm/seasonal-intervention-risk-windows-2026-07-05.html
@@ -72,7 +72,7 @@ off-season activity: Mar (26), Dec (23), Jan (21).</div>
 
 <div class="section"><h2>3 · Activity-type mix in vs out of season</h2>
 <table class="data-table"><thead><tr><th>Activity</th><th>Meaning</th><th>In season</th><th>Off season</th><th>Total</th></tr></thead>
-<tbody><tr><td><code>COM</code></td><td>Completion</td><td>21</td><td>33</td><td>54</td></tr><tr><td><code>DRL</code></td><td>Drilling</td><td>28</td><td>22</td><td>50</td></tr><tr><td><code>PA</code></td><td>Plug &amp; abandon (P&amp;A)</td><td>11</td><td>10</td><td>21</td></tr><tr><td><code>TA</code></td><td>Temporary abandonment</td><td>2</td><td>16</td><td>18</td></tr><tr><td><code>PND</code></td><td>Pending / sidetrack-bypass</td><td>0</td><td>12</td><td>12</td></tr><tr><td><code>CHZ</code></td><td></td><td>8</td><td>3</td><td>11</td></tr><tr><td><code>WO</code></td><td>Workover</td><td>0</td><td>6</td><td>6</td></tr><tr><td><code>REC</code></td><td></td><td>1</td><td>2</td><td>3</td></tr><tr><td><code>(blank)</code></td><td></td><td>0</td><td>1</td><td>1</td></tr><tr><td><code>ST</code></td><td>Sidetrack</td><td>0</td><td>1</td><td>1</td></tr></tbody></table>
+<tbody><tr><td><code>COM</code></td><td>Borehole Completed</td><td>21</td><td>33</td><td>54</td></tr><tr><td><code>DRL</code></td><td>Drilling Active</td><td>28</td><td>22</td><td>50</td></tr><tr><td><code>PA</code></td><td>Permanently Abandoned</td><td>11</td><td>10</td><td>21</td></tr><tr><td><code>TA</code></td><td>Temporarily Abandoned</td><td>2</td><td>16</td><td>18</td></tr><tr><td><code>PND</code></td><td></td><td>0</td><td>12</td><td>12</td></tr><tr><td><code>CHZ</code></td><td></td><td>8</td><td>3</td><td>11</td></tr><tr><td><code>WO</code></td><td></td><td>0</td><td>6</td><td>6</td></tr><tr><td><code>REC</code></td><td></td><td>1</td><td>2</td><td>3</td></tr><tr><td><code>(blank)</code></td><td></td><td>0</td><td>1</td><td>1</td></tr><tr><td><code>ST</code></td><td>Borehole Side Tracked</td><td>0</td><td>1</td><td>1</td></tr></tbody></table>
 </div>
 
 <div class="section"><h2>4 · Operational decision-support read-through</h2>
@@ -92,6 +92,6 @@ significance test — that awaits the INCINV/HSE data and the #403 metocean over
 <div class="footer">
 Cross-links: #403 (hurricane-mooring / metocean) · #416 (WAR loaders + INCINV classification) · #423 (parent).<br>
 Reproduce: <code>PYTHONPATH=src python3 reports/gtm/seasonal_intervention_risk_windows.py</code> ·
-Generated 2026-07-06T02:37:46Z · data as of 2026-07-05 · aggregate-only.
+Generated 2026-07-29T13:47:20Z · data as of 2026-07-05 · aggregate-only.
 </div>
 </div></body></html>

--- a/reports/gtm/seasonal-intervention-risk-windows-2026-07-05.json
+++ b/reports/gtm/seasonal-intervention-risk-windows-2026-07-05.json
@@ -7,7 +7,7 @@
       416
     ],
     "title": "Seasonal intervention risk windows \u2014 hurricane season x WAR x operations",
-    "generated_at": "2026-07-06T02:37:46Z",
+    "generated_at": "2026-07-29T13:47:20Z",
     "date": "2026-07-05",
     "descriptive_only": true,
     "statistical_significance_claimed": false
@@ -199,16 +199,22 @@
       "ST": 1
     },
     "activity_meaning": {
-      "DRL": "Drilling",
-      "COM": "Completion",
-      "PA": "Plug & abandon (P&A)",
-      "TA": "Temporary abandonment",
-      "PND": "Pending / sidetrack-bypass",
-      "WO": "Workover",
-      "RC": "Recompletion",
-      "ST": "Sidetrack",
-      "BP": "Bypass"
+      "DRL": "Drilling Active",
+      "COM": "Borehole Completed",
+      "TA": "Temporarily Abandoned",
+      "PA": "Permanently Abandoned",
+      "ST": "Borehole Side Tracked",
+      "DSI": "Drilling Suspended"
     },
+    "activity_meaning_provenance": "BSEE wording for BOREHOLE_STAT_CD, a different published domain; its reuse as a WAR activity code is our inference, not a BSEE statement. BSEE publishes no WELL_ACTIVITY_CD domain (#1065).",
+    "activity_undocumented": [
+      "WO",
+      "CHZ",
+      "PND",
+      "MPF",
+      "REC",
+      "TBK"
+    ],
     "activity_season_split": {
       "PA": {
         "in_season": 11,

--- a/reports/gtm/seasonal-intervention-risk-windows-2026-07-05.md
+++ b/reports/gtm/seasonal-intervention-risk-windows-2026-07-05.md
@@ -61,16 +61,16 @@
 
 | Activity | Meaning | In season | Off season | Total |
 |---|---|---:|---:|---:|
-| `COM` | Completion | 21 | 33 | 54 |
-| `DRL` | Drilling | 28 | 22 | 50 |
-| `PA` | Plug & abandon (P&A) | 11 | 10 | 21 |
-| `TA` | Temporary abandonment | 2 | 16 | 18 |
-| `PND` | Pending / sidetrack-bypass | 0 | 12 | 12 |
+| `COM` | Borehole Completed | 21 | 33 | 54 |
+| `DRL` | Drilling Active | 28 | 22 | 50 |
+| `PA` | Permanently Abandoned | 11 | 10 | 21 |
+| `TA` | Temporarily Abandoned | 2 | 16 | 18 |
+| `PND` |  | 0 | 12 | 12 |
 | `CHZ` |  | 8 | 3 | 11 |
-| `WO` | Workover | 0 | 6 | 6 |
+| `WO` |  | 0 | 6 | 6 |
 | `REC` |  | 1 | 2 | 3 |
 | `(blank)` |  | 0 | 1 | 1 |
-| `ST` | Sidetrack | 0 | 1 | 1 |
+| `ST` | Borehole Side Tracked | 0 | 1 | 1 |
 
 ## Lower-risk operating windows (read-through)
 
@@ -105,4 +105,4 @@ PYTHONPATH=src python3 reports/gtm/seasonal_intervention_risk_windows.py
 ```
 Deterministic: emits the `.json` sidecar (all figures), this `.md`, and the `.html`. Every number above is in the JSON.
 
-*Generated 2026-07-06T02:37:46Z · data as of 2026-07-05 · aggregate-only.*
+*Generated 2026-07-29T13:47:20Z · data as of 2026-07-05 · aggregate-only.*

--- a/reports/gtm/seasonal_intervention_risk_windows.py
+++ b/reports/gtm/seasonal_intervention_risk_windows.py
@@ -80,17 +80,45 @@ SOURCES = [
 #   packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/data/war_activity_codes.yml
 # loaded via worldenergydata.bsee.analysis.war_activity_codes.activity_labels().
 # It is not imported here only because this script is deliberately stdlib-only.
+#
+# Mirrored by hand because of that constraint, and pinned by
+# tests/unit/gtm/test_seasonal_intervention_codes.py, which fails if this
+# drifts from the canonical artifact. A hand-copy without a test is how the
+# previous version of this table came to assert three separate falsehoods:
+#
+#   - "RC": "Recompletion" and "BP": "Bypass" -- NEITHER CODE EXISTS in
+#     mv_war_main_prop. The real recompletion token is REC. So the published
+#     legend implied zero recompletions while the same artifact reported three
+#     REC records it could not explain.
+#   - "PND": "Pending / sidetrack-bypass" -- an invented meaning. BSEE
+#     publishes no definition for PND; our own note records that it was
+#     guessed. See #1065.
+#   - REC, CHZ and the blank code carried data but no legend entry at all.
+#
+# Only the six tokens BSEE publishes -- for BOREHOLE_STAT_CD, a *different*
+# domain whose reuse here is our inference -- carry a meaning. The rest are
+# named and left unglossed, because a reader is better served by a bare code
+# than by a confident guess.
 ACTIVITY_MEANING = {
-    "DRL": "Drilling",
-    "COM": "Completion",
-    "PA": "Plug & abandon (P&A)",
-    "TA": "Temporary abandonment",
-    "PND": "Pending / sidetrack-bypass",
-    "WO": "Workover",
-    "RC": "Recompletion",
-    "ST": "Sidetrack",
-    "BP": "Bypass",
+    "DRL": "Drilling Active",
+    "COM": "Borehole Completed",
+    "TA": "Temporarily Abandoned",
+    "PA": "Permanently Abandoned",
+    "ST": "Borehole Side Tracked",
+    "DSI": "Drilling Suspended",
 }
+
+#: Codes observed in WAR for which BSEE publishes no meaning in any domain.
+#: Rendered as the bare token. Never glossed. See #1065.
+ACTIVITY_UNDOCUMENTED = ["WO", "CHZ", "PND", "MPF", "REC", "TBK"]
+
+#: What the six meanings above actually are, carried into the payload so a
+#: reader is not left thinking BSEE defines this field. It does not.
+ACTIVITY_MEANING_PROVENANCE = (
+    "BSEE wording for BOREHOLE_STAT_CD, a different published domain; its "
+    "reuse as a WAR activity code is our inference, not a BSEE statement. "
+    "BSEE publishes no WELL_ACTIVITY_CD domain (#1065)."
+)
 
 # ----------------------------------------------------------------------------
 # ASSUMPTIONS (NOT data) — public-knowledge hurricane-season calendar only.
@@ -262,6 +290,8 @@ def compute():
             },
             "by_activity": dict(sorted(by_activity.items(), key=lambda x: -x[1])),
             "activity_meaning": ACTIVITY_MEANING,
+            "activity_meaning_provenance": ACTIVITY_MEANING_PROVENANCE,
+            "activity_undocumented": ACTIVITY_UNDOCUMENTED,
             "activity_season_split": act_split,
         },
         "overlay": {

--- a/tests/unit/gtm/test_seasonal_intervention_codes.py
+++ b/tests/unit/gtm/test_seasonal_intervention_codes.py
@@ -1,0 +1,112 @@
+"""The gtm intervention report's activity legend must match canonical (#1117).
+
+That report is deliberately stdlib-only, so it cannot import the canonical
+definitions artifact and mirrors the legend by hand. A hand-copy with nothing
+checking it is exactly how the previous version came to publish three separate
+falsehoods:
+
+  - "RC": "Recompletion" and "BP": "Bypass" -- neither code exists in
+    mv_war_main_prop. The real token is REC. The published legend therefore
+    implied zero recompletions while the same artifact reported three REC
+    records with no explanation.
+  - "PND": "Pending / sidetrack-bypass" -- an invented meaning for a code BSEE
+    does not define.
+  - REC, CHZ and the blank code carried data but no legend entry.
+
+These tests make the mirror falsifiable. The stdlib constraint stays; what
+changes is that drift now fails the build instead of shipping.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+REPORT = REPO_ROOT / "reports" / "gtm" / "seasonal_intervention_risk_windows.py"
+CANONICAL = (
+    REPO_ROOT
+    / "packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/data"
+    / "war_activity_codes.yml"
+)
+
+
+def _load_report_module():
+    spec = importlib.util.spec_from_file_location("gtm_seasonal", REPORT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def report():
+    if not REPORT.exists():  # pragma: no cover - guards a moved report
+        pytest.skip(f"report not found: {REPORT}")
+    return _load_report_module()
+
+
+@pytest.fixture(scope="module")
+def canonical():
+    if not CANONICAL.exists():  # pragma: no cover
+        pytest.skip(f"canonical artifact not found: {CANONICAL}")
+    return yaml.safe_load(CANONICAL.read_text(encoding="utf-8"))
+
+
+def _rows(canonical):
+    return [r for r in canonical["codes"] if r.get("code")]
+
+
+class TestEveryCodeIsReal:
+    def test_no_legend_entry_names_a_code_that_does_not_exist(self, report, canonical):
+        # RC and BP were published as meanings for tokens BSEE never emits.
+        real = {r["code"] for r in _rows(canonical)}
+        invented = set(report.ACTIVITY_MEANING) - real
+        assert not invented, f"legend names codes absent from WAR: {sorted(invented)}"
+
+    def test_the_undocumented_list_is_also_real(self, report, canonical):
+        real = {r["code"] for r in _rows(canonical)}
+        invented = set(report.ACTIVITY_UNDOCUMENTED) - real
+        assert not invented, f"undocumented list names absent codes: {sorted(invented)}"
+
+
+class TestNoUndocumentedCodeIsGlossed:
+    def test_a_code_bsee_does_not_define_carries_no_meaning(self, report, canonical):
+        # The load-bearing rule: a bare token beats a confident guess.
+        unknown = {
+            r["code"] for r in _rows(canonical) if r.get("provenance") == "unknown"
+        }
+        glossed = unknown & set(report.ACTIVITY_MEANING)
+        assert not glossed, f"undocumented codes carry a meaning: {sorted(glossed)}"
+
+    def test_pnd_specifically_is_never_glossed(self, report):
+        assert "PND" not in report.ACTIVITY_MEANING
+        assert "PND" in report.ACTIVITY_UNDOCUMENTED
+
+
+class TestTheMirrorMatchesCanonical:
+    def test_each_meaning_matches_the_canonical_label(self, report, canonical):
+        labels = {r["code"]: r.get("label") for r in _rows(canonical)}
+        for code, meaning in report.ACTIVITY_MEANING.items():
+            assert (
+                labels.get(code) == meaning
+            ), f"{code}: report says {meaning!r}, canonical says {labels.get(code)!r}"
+
+    def test_every_documented_code_is_covered_by_one_list_or_the_other(
+        self, report, canonical
+    ):
+        real = {r["code"] for r in _rows(canonical)}
+        covered = set(report.ACTIVITY_MEANING) | set(report.ACTIVITY_UNDOCUMENTED)
+        missing = real - covered
+        assert (
+            not missing
+        ), f"codes with neither a meaning nor an undocumented entry: {sorted(missing)}"
+
+
+class TestProvenanceIsStated:
+    def test_the_payload_says_these_are_borehole_status_wordings(self, report):
+        # Without this a reader assumes BSEE defines WELL_ACTIVITY_CD. It does not.
+        text = report.ACTIVITY_MEANING_PROVENANCE
+        assert "BOREHOLE_STAT_CD" in text
+        assert "inference" in text.lower()


### PR DESCRIPTION
fix(gtm): intervention legend published two codes that do not exist (#1117)

The seasonal intervention report carried a hand-copied activity-code legend
that asserted three separate falsehoods in a committed, published artifact.

  - "RC": "Recompletion" and "BP": "Bypass". NEITHER CODE EXISTS in
    mv_war_main_prop. The real recompletion token is REC. So the legend
    implied zero recompletions while the same file reported three REC records
    it could not explain -- misleading in both directions at once, from one
    table.
  - "PND": "Pending / sidetrack-bypass". An invented meaning. BSEE publishes
    no definition for PND and our own note records that it was guessed (#1065).
  - REC, CHZ and the blank code carried data but had no legend entry at all.

Now only the six tokens BSEE actually publishes carry a meaning, each labelled
as BOREHOLE_STAT_CD wording whose reuse as a WAR activity code is OUR
inference rather than a BSEE statement. The six undocumented codes are named
in activity_undocumented and left unglossed: a bare token serves a reader
better than a confident guess.

The report is deliberately stdlib-only and cannot import the canonical
definitions artifact, so the legend remains a hand-mirror. What changes is
that it is no longer unfalsifiable -- a new test asserts it against
war_activity_codes.yml and fails the build on drift, on invented codes, on any
gloss attached to an undocumented code, and on any real code covered by
neither list. A hand-copy with nothing checking it is precisely how this table
came to publish codes that do not exist.

The dated artifact is regenerated. Verified after regeneration: no phantom
codes remain beyond DSI, which is a real BSEE code with no records in this
177-record slice -- a true statement rather than a fabricated one; PND is no
longer glossed; every code carrying data is either explained or flagged
undocumented; and the payload states the provenance of the six meanings.

One honest cost: the report is less readable. WO and REC lose glosses readers
will recognise. That is the correct trade while BSEE publishes nothing, and
only an answer to #1065 can undo it.

7 tests pass.

Closes #1117. Refs #1063, #1065.
