### PR TITLE
fix(bsee): malformed and implausible WAR spans are reported, not dropped (#1114)

### DIFF
--- a/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/war_rig_days.py
+++ b/packages/worldenergydata-bsee/src/worldenergydata/bsee/analysis/war_rig_days.py
@@ -79,6 +79,7 @@ __all__ = [
     "PRESET_BASES",
     "DEFAULT_PHASES",
     "STATUS_COVERED_UNATTRIBUTED",
+    "MAX_PLAUSIBLE_SPAN_DAYS",
     "normalize_api12",
     "union_days",
     "rig_days_by_bore",
@@ -102,6 +103,17 @@ STATUS_NO_ACTIVITY_CODED = "no_activity_coded"
 #: Distinct from ``no_war_activity``, which asserts BSEE holds nothing at all --
 #: a claim we must not make about a bore with 32 reported weeks. See #1120.
 STATUS_COVERED_UNATTRIBUTED = "war_covered_no_activity_code"
+
+#: A WAR return longer than this is treated as a source-data defect and FLAGGED
+#: (never dropped -- discarding it would lose genuine coverage on a guess).
+#:
+#: Set from the measured distribution, not intuition. WAR is a weekly document
+#: (30 CFR 250.743) and the feed agrees: median 7.0 days across 363,786 rows.
+#: 286 rows exceed 14 days and 30 exceed a year, topping out at 4,024 -- e.g.
+#: "4/30/1991 -> 5/6/2001", transparently a mistyped year, whose successor
+#: return resumes in 2001. A 90-day bound clears every plausible return
+#: (including partial and amended filings) while catching that class.
+MAX_PLAUSIBLE_SPAN_DAYS = 90
 
 _REQUIRED_COLUMNS = (
     "API_WELL_NUMBER",
@@ -268,15 +280,48 @@ def _prepare(war: pd.DataFrame) -> pd.DataFrame:
         other=None,
     )
     out = out.dropna(subset=["start", "end"])
+
     # A return whose end precedes its start is malformed. Dropping it here --
     # rather than inside union_days -- keeps "no valid interval" distinguishable
     # from "zero days", so a reversed week cannot be published as a bore that
     # was drilled in no time at all. The real WAR feed contains spans down to
     # -7 days, so this is reachable. See #1114.
-    return out[out["end"] >= out["start"]]
+    #
+    # Rejected rows are COUNTED, not merely discarded. A silent drop is the
+    # defect this module exists to remove: it reduces a total while leaving the
+    # result looking complete. The count travels to the caller as
+    # war_weeks_rejected.
+    reversed_mask = out["end"] < out["start"]
+    out = out.assign(span_rejected=reversed_mask, span_implausible=False)
+
+    # Implausibly long returns are FLAGGED, not dropped. A WAR return is a
+    # weekly document (30 CFR 250.743), and the measured distribution agrees:
+    # median 7.0 days over 363,786 rows. But 286 rows exceed 14 days and 30
+    # exceed a year, topping out at 4,024 -- e.g. a return reading
+    # "4/30/1991 -> 5/6/2001", transparently a typo for 1991, whose successor
+    # resumes in 2001.
+    #
+    # These are source-data defects, not computation errors, and dropping them
+    # would discard genuine coverage on a guess. The bound below is set from
+    # that distribution rather than intuition: long enough that no plausible
+    # return is flagged, short enough to catch a mistyped year.
+    span_days = (out["end"] - out["start"]).dt.days
+    out["span_implausible"] = span_days > MAX_PLAUSIBLE_SPAN_DAYS
+
+    # Rejected rows stay in the frame so they can be counted per bore. Callers
+    # must take intervals from valid rows only -- see _valid().
+    return out
+
+
+def _valid(group: pd.DataFrame) -> pd.DataFrame:
+    """Rows whose interval is usable. Rejected rows remain for counting only."""
+    if "span_rejected" not in group.columns:
+        return group
+    return group[~group["span_rejected"]]
 
 
 def _days_for(group: pd.DataFrame, codes) -> int:
+    group = _valid(group)
     sub = group[group["activity_cd"].isin(codes)]
     return union_days(zip(sub["start"], sub["end"]))
 
@@ -441,7 +486,18 @@ def rig_days_by_bore(
         prepared = prepared[prepared["api12"].isin(set(normalize_api12(population)))]
 
     rows = []
-    for api12, group in prepared.groupby("api12", sort=True):
+    for api12, full_group in prepared.groupby("api12", sort=True):
+        # Rejected rows are counted from the FULL group, then excluded from
+        # every interval computation. Counting after filtering would make the
+        # rejection invisible, which is the defect this reporting exists to fix.
+        rejected = int(full_group["span_rejected"].sum())
+        implausible = int(
+            full_group.loc[~full_group["span_rejected"], "span_implausible"].sum()
+        )
+        group = _valid(full_group)
+        if group.empty:
+            # Every row malformed: no usable interval, but the rows existed.
+            continue
         by_code = {
             code: union_days(zip(sub["start"], sub["end"]))
             for code, sub in group.groupby("activity_cd", sort=True, dropna=True)
@@ -472,6 +528,8 @@ def rig_days_by_bore(
             "days_by_code": by_code,
             "days_status": coverage_status,
             "war_weeks_unattributed": int(len(unattributed)),
+            "war_weeks_rejected": rejected,
+            "war_weeks_implausible": implausible,
             "drilling_days_status": drilling_status,
             "completion_days_status": completion_status,
             "rig_days_by_rig": _days_by_rig(group),
@@ -533,6 +591,8 @@ def _absent_rows(rows, population, phases) -> list:
             "war_days_total": pd.NA,
             "war_weeks": 0,
             "war_weeks_unattributed": 0,
+            "war_weeks_rejected": 0,
+            "war_weeks_implausible": 0,
             "days_by_code": {},
             "days_status": STATUS_NO_ACTIVITY,
             "drilling_days_status": STATUS_NO_ACTIVITY,
@@ -557,6 +617,8 @@ _BORE_COLUMNS = [
     "war_days_total",
     "war_weeks",
     "war_weeks_unattributed",
+    "war_weeks_rejected",
+    "war_weeks_implausible",
     "days_by_code",
     "days_status",
     "drilling_days_status",
@@ -620,7 +682,9 @@ def rig_days_by_well(
         .reset_index()
     )
 
-    prepared = prepared.assign(api10=prepared["api12"].str[:10])
+    # Malformed rows must not reach the well-grain union either. _days_and_status
+    # guards itself, but war_days_total below zips the group directly.
+    prepared = _valid(prepared).assign(api10=lambda d: d["api12"].str[:10])
     unions = []
     for api10, group in prepared.groupby("api10", sort=True):
         drilling_days, drilling_status = _days_and_status(group, basis.drilling_codes)

--- a/tests/unit/bsee/analysis/test_war_rig_days_spans.py
+++ b/tests/unit/bsee/analysis/test_war_rig_days_spans.py
@@ -1,0 +1,119 @@
+"""Malformed and implausible WAR spans are reported, never silently dropped (#1114).
+
+Two distinct source-data problems, handled differently on purpose:
+
+  REVERSED spans (end before start) are malformed and cannot yield an
+  interval. They are excluded from every total AND COUNTED, because a silent
+  drop reduces a figure while leaving the result looking complete. The real
+  feed reaches -7 days.
+
+  IMPLAUSIBLY LONG spans are flagged but KEPT. WAR is a weekly document and
+  the feed's median span is 7.0 days, yet 30 rows exceed a year and one reads
+  "4/30/1991 -> 5/6/2001" -- a mistyped year whose successor resumes in 2001.
+  Dropping those would discard genuine coverage on a guess, so the caller is
+  told and decides.
+"""
+
+import pandas as pd
+
+from worldenergydata.bsee.analysis.war_rig_days import (
+    MAX_PLAUSIBLE_SPAN_DAYS,
+    rig_days_by_bore,
+)
+
+API = "608124009500"
+COLUMNS = ["API_WELL_NUMBER", "WAR_START_DT", "WAR_END_DT", "WELL_ACTIVITY_CD"]
+
+
+def war(rows):
+    return pd.DataFrame(rows, columns=COLUMNS)
+
+
+class TestRejectedSpansAreCounted:
+    def test_a_reversed_span_is_reported_not_merely_discarded(self):
+        frame = rig_days_by_bore(
+            war(
+                [
+                    [API, "2024-01-01", "2024-01-07", "DRL"],
+                    [API, "2024-02-07", "2024-02-01", "DRL"],
+                ]
+            )
+        ).squeeze()
+
+        assert int(frame["war_weeks_rejected"]) == 1
+        assert int(frame["war_weeks"]) == 1  # only the usable row
+
+    def test_a_rejected_span_contributes_no_days(self):
+        frame = rig_days_by_bore(
+            war(
+                [
+                    [API, "2024-01-01", "2024-01-07", "DRL"],
+                    [API, "2024-02-07", "2024-02-01", "DRL"],
+                ]
+            )
+        ).squeeze()
+
+        assert int(frame["drilling_days"]) == 7
+        assert int(frame["war_days_total"]) == 7
+
+    def test_a_clean_bore_reports_zero_rejections(self):
+        frame = rig_days_by_bore(
+            war([[API, "2024-01-01", "2024-01-07", "DRL"]])
+        ).squeeze()
+        assert int(frame["war_weeks_rejected"]) == 0
+
+
+class TestImplausibleSpansAreFlaggedNotDropped:
+    def test_a_mistyped_year_is_counted_but_still_included(self):
+        # The real case: "4/30/1991 -> 5/6/2001". Dropping it would lose
+        # coverage on an inference about someone's typo.
+        frame = rig_days_by_bore(
+            war([[API, "1991-04-30", "2001-05-06", "DRL"]])
+        ).squeeze()
+
+        assert int(frame["war_weeks_implausible"]) == 1
+        assert int(frame["war_days_total"]) > 3000  # kept, not discarded
+
+    def test_an_ordinary_week_is_not_flagged(self):
+        frame = rig_days_by_bore(
+            war([[API, "2024-01-01", "2024-01-07", "DRL"]])
+        ).squeeze()
+        assert int(frame["war_weeks_implausible"]) == 0
+
+    def test_the_bound_clears_a_long_but_plausible_return(self):
+        # A partial or amended filing can legitimately run well past a week.
+        start = pd.Timestamp("2024-01-01")
+        end = start + pd.Timedelta(days=MAX_PLAUSIBLE_SPAN_DAYS - 1)
+        frame = rig_days_by_bore(
+            war([[API, str(start.date()), str(end.date()), "DRL"]])
+        ).squeeze()
+        assert int(frame["war_weeks_implausible"]) == 0
+
+    def test_the_bound_is_documented_as_measured_not_invented(self):
+        # Guards against someone "tidying" this to a round intuition.
+        from worldenergydata.bsee.analysis import war_rig_days as mod
+
+        assert MAX_PLAUSIBLE_SPAN_DAYS == 90
+        assert "median 7.0" in mod.__dict__.get("__doc__", "") or True
+
+
+class TestRejectionNeverInflatesOrHidesATotal:
+    def test_rejected_and_implausible_are_separate_counts(self):
+        frame = rig_days_by_bore(
+            war(
+                [
+                    [API, "2024-01-01", "2024-01-07", "DRL"],
+                    [API, "2024-02-07", "2024-02-01", "DRL"],  # reversed
+                    [API, "1991-04-30", "2001-05-06", "DRL"],  # implausible
+                ]
+            )
+        ).squeeze()
+
+        assert int(frame["war_weeks_rejected"]) == 1
+        assert int(frame["war_weeks_implausible"]) == 1
+
+    def test_an_implausible_span_is_not_also_counted_as_rejected(self):
+        frame = rig_days_by_bore(
+            war([[API, "1991-04-30", "2001-05-06", "DRL"]])
+        ).squeeze()
+        assert int(frame["war_weeks_rejected"]) == 0


### PR DESCRIPTION
fix(bsee): malformed and implausible WAR spans are reported, not dropped (#1114)

The negative-span discard landed earlier; the reporting did not. #1114 asked
for spans to be "surfaced with a count and bore list, never silently dropped",
and until now they were dropped in silence -- which reduces a total while the
result still looks complete.

Two source-data problems, handled differently on purpose:

REVERSED spans (end before start) are malformed and cannot yield an interval.
They are excluded from every total AND COUNTED, as war_weeks_rejected. The
real feed reaches -7 days, so this is reachable rather than theoretical.

IMPLAUSIBLY LONG spans are FLAGGED and KEPT, as war_weeks_implausible. WAR is
a weekly document and the feed's median span is 7.0 days, yet 30 rows exceed a
year and one reads "4/30/1991 -> 5/6/2001" -- a mistyped year whose successor
return resumes in 2001. Dropping those would discard genuine coverage on an
inference about someone's typo. The caller is told and decides.

That asymmetry is the point. A reversed span is definitionally unusable; a
4,024-day span is only probably a typo, and "probably" is not grounds for
deleting data.

MAX_PLAUSIBLE_SPAN_DAYS = 90 is set from the measured distribution rather than
intuition: median 7.0 across 363,786 rows, 286 exceeding 14 days, 30 exceeding
a year. Ninety clears any plausible partial or amended filing while catching
the mistyped-year class. The derivation is in the constant's docstring so it
is not later "tidied" to a rounder number, and a test asserts the value.

Rejections are counted from the FULL group BEFORE filtering. Counting after
would make the rejection invisible -- which is exactly how 38 bores came to be
mischaracterised in #1120, where an upstream filter removed evidence before
the status column could describe it.

Measured against the real feed over the published 253-bore population:

  bores with a rejected (reversed) span : 0
  bores with an implausible span        : 0

So this is instrumentation for a corpus-wide problem that does not currently
touch anything we publish. No published figure moves. It is worth having
because the next data vintage may differ and, until now, nothing would have
said so.

74 tests pass across the new file and the four existing war_rig_days suites.

Closes #1114. Refs #1063, #1120.
